### PR TITLE
fix(seguranca): o bloco do `net` tirava o INSERT do WORKER do pg_net — os crons disparariam sem gravar resposta [money-path]

### DIFF
--- a/db/test-net-revoke-publico.sh
+++ b/db/test-net-revoke-publico.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Prova, num PG17 descartável, as asserções que decidem o bloco de REVOKE do schema `net`
+# enviado ao suporte do Lovable (docs/historico/revoke-que-nao-revoga.md).
+#
+# O que prova (executando, não criando — PL/pgSQL e ACL são late-bound):
+#   A) `INSERT ... RETURNING id` exige SELECT além de INSERT  → 42501 sem SELECT.
+#   B) Com SELECT re-concedido, o caminho do http_post passa (nextval + INSERT + RETURNING).
+#   C) `REVOKE INSERT,UPDATE,DELETE,TRUNCATE ... FROM PUBLIC` (o bloco COMO ENVIADO) deixa
+#      SELECT/TRIGGER/REFERENCES de pé para PUBLIC — o REVOKE parcial não fecha a tabela.
+#   D) `REVOKE ALL ... FROM PUBLIC` fecha as quatro.
+#   E) O worker do pg_net roda como `postgres` (GUC `pg_net.username=postgres`, medido em prod)
+#      e hoje só tem INSERT em `_http_response` VIA PUBLIC ⇒ o bloco como enviado o quebra.
+# Cada asserção negativa casa a SQLSTATE esperada e re-lança o resto (teste negativo com
+# `WHEN OTHERS THEN 'OK'` é teatro). No fim, FALSIFICA: sabota e exige vermelho.
+set -euo pipefail
+
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5449
+DATA="$(mktemp -d /tmp/pgtest-netrevoke.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U dono_admin -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-netrevoke.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U dono_admin netverify
+P() { "$PGBIN/psql" -v ON_ERROR_STOP=1 -p "$PORT" -h /tmp -U dono_admin -d netverify "$@"; }
+
+# ── Réplica da estrutura e do ACL de PROD (pg_net 0.19.5, medido 2026-08-27) ────────────
+P -q <<'SQL'
+CREATE ROLE chamador LOGIN;          -- ≈ postgres (não-dono, NÃO superuser) = cron E worker
+CREATE ROLE hostil   LOGIN;          -- ≈ anon / authenticated / claude_ro
+CREATE SCHEMA net;
+GRANT USAGE ON SCHEMA net TO PUBLIC;
+
+CREATE TABLE net.http_request_queue (
+  id bigserial PRIMARY KEY, method text, url text, headers jsonb, body bytea,
+  timeout_milliseconds integer);
+CREATE TABLE net._http_response (
+  id bigint PRIMARY KEY, status_code integer, content_type text, headers jsonb,
+  content text, timed_out boolean, error_msg text, created timestamptz DEFAULT now());
+
+-- ACL de prod: PUBLIC com ALL nas duas tabelas; PUBLIC com r/w/U na sequence.
+GRANT ALL ON net.http_request_queue, net._http_response TO PUBLIC;
+GRANT ALL ON SEQUENCE net.http_request_queue_id_seq TO PUBLIC;
+SQL
+
+falha=0
+esperar_sqlstate() { # $1=papel $2=sql $3=sqlstate esperada $4=rotulo
+  local got
+  got="$("$PGBIN/psql" -qtAX -p "$PORT" -h /tmp -U "$1" -d netverify \
+        -c "DO \$\$ BEGIN $2 ; RAISE EXCEPTION 'SEM_ERRO_INESPERADO'; EXCEPTION
+              WHEN sqlstate '$3' THEN RAISE NOTICE 'MARCA_OK'; END \$\$;" 2>&1 || true)"
+  case "$got" in
+    *MARCA_OK*) echo "  OK   [$4] barrou com SQLSTATE $3" ;;
+    *) echo "  FALHA[$4] esperava SQLSTATE $3; veio: $(printf '%s' "$got" | head -2 | tr '\n' ' ')"; falha=1 ;;
+  esac
+}
+esperar_ok() { # $1=papel $2=sql $3=rotulo
+  if "$PGBIN/psql" -qtAX -v ON_ERROR_STOP=1 -p "$PORT" -h /tmp -U "$1" -d netverify -c "$2" >/dev/null 2>&1
+  then echo "  OK   [$3] passou"; else echo "  FALHA[$3] deveria passar e falhou"; falha=1; fi
+}
+acl() { "$PGBIN/psql" -qtAX -p "$PORT" -h /tmp -U dono_admin -d netverify \
+        -c "SELECT coalesce(relacl::text,'NULL') FROM pg_class WHERE oid='net.http_request_queue'::regclass"; }
+priv() { "$PGBIN/psql" -qtAX -p "$PORT" -h /tmp -U dono_admin -d netverify \
+         -c "SELECT has_table_privilege('$1','$2','$3')"; }
+
+echo "== BASELINE (PUBLIC com tudo, como prod hoje) =="
+esperar_ok chamador "INSERT INTO net.http_request_queue(method,url) VALUES ('POST','x') RETURNING id" "baseline: caminho do http_post"
+esperar_ok hostil   "SELECT count(*) FROM net.http_request_queue" "baseline: hostil LE a fila (x-cron-secret)"
+
+echo
+echo "== C) O BLOCO COMO ENVIADO AO SUPORTE (REVOKE parcial) =="
+P -q <<'SQL'
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON net.http_request_queue FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON net._http_response     FROM PUBLIC;
+REVOKE ALL ON SEQUENCE net.http_request_queue_id_seq              FROM PUBLIC;
+GRANT INSERT, UPDATE, DELETE ON net.http_request_queue            TO chamador;
+GRANT USAGE, SELECT, UPDATE ON SEQUENCE net.http_request_queue_id_seq TO chamador;
+SQL
+for p in SELECT TRIGGER REFERENCES; do
+  v="$(priv hostil net.http_request_queue $p)"
+  if [ "$v" = "t" ]; then echo "  OK   [C:$p] REVOKE parcial DEIXOU $p com PUBLIC (t) - achado confirmado"
+  else echo "  FALHA[C:$p] esperava t, veio $v"; falha=1; fi
+done
+
+echo
+echo "== A) INSERT ... RETURNING id exige SELECT (o bloco corrigido quebraria sem isto) =="
+P -q -c "REVOKE SELECT ON net.http_request_queue FROM PUBLIC;"
+esperar_sqlstate chamador \
+  "DECLARE v bigint; BEGIN INSERT INTO net.http_request_queue(method,url) VALUES ('POST','x') RETURNING id INTO v; END" \
+  42501 "A: RETURNING sem SELECT"
+esperar_ok chamador "INSERT INTO net.http_request_queue(method,url) VALUES ('POST','x')" "A: INSERT puro (sem RETURNING) passa"
+
+echo
+echo "== B) com SELECT re-concedido, o caminho do http_post volta a passar =="
+P -q -c "GRANT SELECT ON net.http_request_queue TO chamador;"
+esperar_ok chamador "INSERT INTO net.http_request_queue(method,url) VALUES ('POST','x') RETURNING id" "B: INSERT+RETURNING com SELECT"
+
+echo
+echo "== E) o worker (roda como 'postgres' = chamador) perde a gravacao da resposta =="
+esperar_sqlstate chamador "INSERT INTO net._http_response(id,status_code) VALUES (1,200)" \
+  42501 "E: worker INSERT em _http_response"
+esperar_sqlstate chamador "DELETE FROM net._http_response WHERE id=1" \
+  42501 "E: worker DELETE (reaping do TTL de 6h)"
+
+echo
+echo "-- relacl ANTES do REVOKE ALL: $(acl) --"
+echo "== D) REVOKE ALL fecha as quatro (o conserto) =="
+P -q -c "REVOKE ALL ON net.http_request_queue FROM PUBLIC;"
+for p in SELECT TRIGGER REFERENCES INSERT; do
+  v="$(priv hostil net.http_request_queue $p)"
+  if [ "$v" = "f" ]; then echo "  OK   [D:$p] fechado para PUBLIC (f)"
+  else echo "  FALHA[D:$p] esperava f, veio $v"; falha=1; fi
+done
+
+echo
+echo "== FALSIFICACAO: devolver SELECT a PUBLIC tem de deixar C VERMELHO =="
+P -q -c "GRANT SELECT ON net.http_request_queue TO PUBLIC;"
+v="$(priv hostil net.http_request_queue SELECT)"
+if [ "$v" = "t" ]; then echo "  OK   [falsif] sabotagem detectada (voltou a t) - a assercao MEDE algo"
+else echo "  FALHA[falsif] sabotei e o teste nao viu"; falha=1; fi
+
+echo
+[ "$falha" -eq 0 ] && echo "RESULTADO: TODAS AS ASSERCOES PASSARAM" || echo "RESULTADO: HOUVE FALHA"
+exit "$falha"

--- a/docs/historico/revoke-que-nao-revoga.md
+++ b/docs/historico/revoke-que-nao-revoga.md
@@ -489,11 +489,16 @@ fila, tocaria **com o privilégio do chamador** — que o bloco revoga. As 7 res
 ou são puras (encode/urlencode/status do worker). Fechar `EXECUTE` nelas custaria os 52 crons e não
 compraria nada.
 
-⚠️ **REVISÃO INDEPENDENTE PENDENTE** (`money-path.md`, Caminho B). O ritual `/codex` sobre este bloco
-falhou por **cota esgotada** (`codex-async.sh` exit 75) e a auditoria acima é **minha**, do mesmo autor do
-bloco. Ela é medição reproduzível, não opinião — mas o que ela NÃO ataca é a **suposição de completude**,
-que é justamente a que o autor não enxerga: foi exatamente assim que o Achado 3 saiu invertido, e foi o
-`/codex` que virou a mesa. Enquanto o suporte não executar, a janela para a 2ª opinião continua aberta.
+✅ **REVISÃO INDEPENDENTE FEITA — 2026-08-27** (`gpt-5.6-sol`, xhigh, `CODEX_EXIT=0`). A tabela acima
+**se sustenta**: `secdef=false` nas 7, nenhuma enfileira nem acorda o worker. Mas a auditoria estava
+incompleta em dois eixos que ela não podia ver, e o veredito do bloco virou
+**`CORRECT BEFORE SUPPORT RUNS IT`** — ver a seção seguinte.
+
+Uma ressalva que o Codex acrescentou e que fica de pé: **`prosrc` de função `C` não prova ausência de efeito
+colateral** — ele só carrega o nome do símbolo. Das 7, três são C (`_urlencode_string`,
+`_encode_url_with_params_array`, `wait_until_running`); para elas a linha "não insere na fila" é *ausência
+de dado*, não medição. A conclusão sobrevive por outro caminho (o `secdef=false`, que é o eixo que decide),
+mas a **justificativa** por varredura de `prosrc` não vale para as três.
 
 O pedido carrega as 4 perguntas que o registro deixou em aberto, uma delas a que mais importa a longo
 prazo: **como impedir que um upgrade do pg_net restaure as ACLs públicas.** Enquanto não houver resposta,
@@ -506,3 +511,133 @@ asserção ao lado — ver a seção anterior.
 ticket é exatamente o mesmo *Success* que este arquivo inteiro existe para desqualificar — com o agravante
 de que quem aplica não é quem consegue verificar. Por isso a query foi ao ticket com o **antes** colado ao
 lado do **depois esperado**.
+
+
+## O 2º par de olhos mudou o bloco — 2026-08-27 (ritual `/codex`, `CODEX_EXIT=0`)
+
+**Veredito: `BLOCK VERDICT: CORRECT BEFORE SUPPORT RUNS IT`.** Três defeitos novos, todos da MESMA
+família dos três anteriores — *revoguei um privilégio e re-concedi outro* — e o mais grave é de
+**disponibilidade silenciosa**, não de segurança. Cada um provado executando, em
+`db/test-net-revoke-publico.sh` (PG17 descartável, com falsificação).
+
+### D4 — o worker do pg_net roda como `postgres`, e o bloco tira o INSERT dele
+
+`SELECT name, setting FROM pg_settings WHERE name LIKE 'pg_net.%'` em prod devolve
+**`pg_net.username=postgres`** (e `pg_net.ttl=6 hours`, `pg_net.batch_size=200`). O worker **não** é
+`supabase_admin`, e `postgres` **não** é superuser ⇒ ele sofre ACL como qualquer um. Hoje o INSERT dele em
+`net._http_response` vem **só de PUBLIC** (`relacl = {supabase_admin=arwdDxtm/…, =arwdDxtm/…}`, sem grant
+nominal para `postgres`).
+
+O bloco enviado faz `REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON net._http_response FROM PUBLIC` e **não
+re-concede nada a ninguém nessa tabela**. Medido em PG17 com um papel não-dono/não-super:
+
+```
+[E: worker INSERT em _http_response]        barrou com SQLSTATE 42501
+[E: worker DELETE (reaping do TTL de 6h)]   barrou com SQLSTATE 42501
+```
+
+⇒ Os 52 crons **continuam disparando** (a fila é re-concedida), o HTTP **continua saindo** — e a resposta
+**não é gravada**, e o TTL de 6h **não limpa mais**. É pior que a queda: é queda do *sensor*. Cega a canária
+de deploy e a "verdade HTTP" que o `sync.md` manda ler em `net._http_response` — exatamente a tabela que
+este arquivo protegeu no Achado 5. O fecho de segurança teria apagado o instrumento que prova o fecho.
+
+### D5 — `REVOKE INSERT,UPDATE,DELETE,TRUNCATE` **não** fecha a tabela
+
+Um REVOKE por lista deixa de pé o que não está na lista. Medido:
+
+```
+relacl depois do bloco enviado:  =rxtm/…      (PUBLIC segue com SELECT, REFERENCES, TRIGGER, MAINTAIN)
+[C:SELECT]     REVOKE parcial DEIXOU SELECT com PUBLIC (t)
+[C:TRIGGER]    REVOKE parcial DEIXOU TRIGGER com PUBLIC (t)
+[C:REFERENCES] REVOKE parcial DEIXOU REFERENCES com PUBLIC (t)
+```
+
+E `SELECT` na fila **não é inócuo**: `net.http_request_queue` carrega os headers da requisição, e as chaves
+medidas em prod são `Content-Type, x-cron-secret` — os 52 crons montam esse header do Vault
+(`decrypted_secret` + `jsonb_build_object`, 52/52). ⇒ Depois do bloco, todo papel do projeto continuaria
+lendo **o segredo que autentica os 52 crons**, inclusive o `claude_ro`, que já perdeu `pg_read_all_data` e
+mesmo assim tem `queue_SELECT=true` — porque o alcance vem de PUBLIC, não do papel. É a tese deste arquivo
+inteiro, sobrevivendo ao próprio conserto.
+
+O `TRIGGER` é o vetor que o Codex levantou como o mais grave: com ele, um papel hostil anexa um
+`BEFORE INSERT` na fila e reescreve `NEW.url` quando o **cron** insere como `postgres` — SSRF sem precisar
+de `EXECUTE` em nada. **Rebaixei a severidade dele com medição:** `anon`, `authenticated`, `service_role` e
+`claude_ro` **não têm `CREATE` em schema nenhum** (só `postgres`, `dashboard_user`, `supabase_admin` e os
+`*_admin` têm), então não conseguem criar a função de trigger. É higiene de ACL / defesa em profundidade,
+não uma escalada alcançável hoje. Registro a discordância porque mandar ao suporte um "SSRF crítico" que
+não se sustenta queima o ticket.
+
+### D6 — sem transação e sem asserção de dono
+
+Todos os statements são transacionáveis, e nenhum é proibido dentro de `BEGIN`. Se o operador colar num
+runner que autocommita por statement, uma falha no meio deixa **os REVOKEs aplicados e os GRANTs não** —
+janela de outage com o revoke-primeiro. E `REVOKE` por não-dono é `WARNING`, não erro: o `BEGIN` **não**
+transforma o no-op do Achado 1 em falha. A asserção de `current_user` tem de estar dentro do batch.
+
+### O bloco corrigido
+
+```sql
+BEGIN;
+
+DO $$ BEGIN
+  IF current_user <> 'supabase_admin' THEN
+    RAISE EXCEPTION 'execute como supabase_admin; current_user=%', current_user;
+  END IF;
+END $$;
+
+-- 1) Funções
+REVOKE EXECUTE ON FUNCTION net.http_post(text,jsonb,jsonb,jsonb,integer)   FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION net.http_get(text,jsonb,jsonb,integer)          FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION net.http_delete(text,jsonb,jsonb,integer,jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION net.wake()                                      FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION net.worker_restart()                            FROM PUBLIC;
+
+-- 2) Tabelas e sequence: ALL, nunca lista parcial (D5)
+REVOKE ALL ON TABLE    net.http_request_queue         FROM PUBLIC;
+REVOKE ALL ON TABLE    net._http_response             FROM PUBLIC;
+REVOKE ALL ON SEQUENCE net.http_request_queue_id_seq  FROM PUBLIC;
+
+-- 3) Re-GRANT. SELECT na fila é OBRIGATÓRIO: http_post faz `INSERT … RETURNING id`,
+--    e RETURNING exige SELECT além de INSERT (provado: 42501 sem ele).
+GRANT EXECUTE ON FUNCTION net.http_post(text,jsonb,jsonb,jsonb,integer)   TO supabase_functions_admin, postgres;
+GRANT EXECUTE ON FUNCTION net.http_get(text,jsonb,jsonb,integer)          TO supabase_functions_admin, postgres;
+GRANT EXECUTE ON FUNCTION net.http_delete(text,jsonb,jsonb,integer,jsonb) TO supabase_functions_admin, postgres;
+GRANT EXECUTE ON FUNCTION net.wake()                                      TO supabase_functions_admin, postgres;
+GRANT INSERT, SELECT ON TABLE net.http_request_queue    TO supabase_functions_admin, postgres;
+GRANT USAGE ON SEQUENCE net.http_request_queue_id_seq   TO supabase_functions_admin, postgres;
+
+-- 4) O worker do pg_net (pg_net.username=postgres) grava a resposta e faz o reaping do TTL (D4)
+GRANT INSERT, SELECT, DELETE ON TABLE net._http_response TO postgres;
+
+-- 5) Resíduo ACEITO e declarado: a canária de deploy lê esta tabela (Achado 5)
+GRANT SELECT ON TABLE net._http_response TO PUBLIC;
+
+COMMIT;
+```
+
+**Duas mudanças de comportamento a decidir antes de enviar, não a esconder:**
+
+1. **`service_role` saiu do re-GRANT.** Não há consumidor medido: os 92 crons rodam como `postgres` (92/92)
+   e as 4 SECDEF rodam como `postgres` (o chamador não precisa de privilégio em `net`). E `service_role` é
+   alcançável por `SET ROLE` a partir do `authenticator` (`set_option=true`, medido) ⇒ mantê-lo no GRANT
+   deixaria o egress aberto para quem tiver a service_role key, esvaziando metade do propósito do bloco.
+   Contra: a varredura que diz "nenhum consumidor" é da mesma classe que o Codex mostrou ser incompleta por
+   construção. **Decisão do founder**, com reversão de uma linha.
+2. **`USAGE` sozinho basta para `nextval`** — o `SELECT, UPDATE` na sequence do bloco anterior era
+   sobra-concessão (permite `setval`). Idem `UPDATE, DELETE` na fila, que nenhuma das `http_*` usa.
+
+### O que o teste prova (`db/test-net-revoke-publico.sh`, `exit 0`)
+
+`INSERT … RETURNING` sem SELECT → **42501**, e `INSERT` puro sem RETURNING **passa** (a regra é do
+RETURNING, não do INSERT) · REVOKE parcial deixa `SELECT/TRIGGER/REFERENCES` · `REVOKE ALL` fecha as quatro
+· o papel do worker perde INSERT **e** DELETE em `_http_response`. Falsificação: devolver `SELECT` a PUBLIC
+tem de deixar a asserção vermelha.
+
+> ⚠️ **A lição de shell que este teste custou.** A 1ª rodada passou a falsificação e "confirmou" A e B —
+> tudo mentira: eu havia escrito `psql -d db "SQL"` **sem `-c`**. O argumento posicional do psql é o
+> *dbname*, não um comando ⇒ **no-op que retorna `exit 0`**, medido:
+> `psql -v ON_ERROR_STOP=1 -d d "SELECT 1/0;"` → `exit=0`; com `-c` → `exit=1`. Quatro passos do teste
+> nunca rodaram, e a falsificação "detectou" a sabotagem porque o valor **nunca tinha mudado**. Foi o dump
+> do `relacl` (`=rxtm`, com o `r` que eu acreditava ter revogado) que denunciou. Família
+> `evidencia-positiva-shell.md`: **`set -e` não pega no-op com exit 0** — a falsificação só vale se a
+> asserção tiver chegado a ficar verde por um motivo que você mediu.


### PR DESCRIPTION
2ª opinião (`/codex`, `gpt-5.6-sol` xhigh, `CODEX_EXIT=0`) sobre o bloco de REVOKE do schema `net` **já enviado ao suporte e ainda não executado** (thread Gmail `1a03c0904655abf1`). Veredito do Codex: **`CORRECT BEFORE SUPPORT RUNS IT`**.

A janela para corrigir continua aberta enquanto o suporte não responde.

## Três defeitos novos — mesma família dos três anteriores (revogar um privilégio e re-conceder outro)

**D4 — o pior, e é de DISPONIBILIDADE.** `pg_settings` em prod: **`pg_net.username=postgres`**. O worker do pg_net não é o dono e `postgres` não é superuser ⇒ sofre ACL. O INSERT dele em `net._http_response` vinha **só de PUBLIC**, e o bloco revogava sem re-conceder a ninguém. Efeito: os 52 crons continuam disparando, o HTTP continua saindo, **a resposta não é gravada** e o TTL de 6h não limpa. É queda do **sensor**, não do serviço — cega a canária de deploy e a "verdade HTTP" que o `sync.md` manda ler ali. O fecho de segurança apagaria o instrumento que prova o fecho.

**D5 — `REVOKE INSERT,UPDATE,DELETE,TRUNCATE` não fecha a tabela.** Medido: sobra `relacl = =rxtm` (PUBLIC com SELECT, REFERENCES, TRIGGER, MAINTAIN). E `SELECT` na fila não é inócuo: `net.http_request_queue` carrega o header **`x-cron-secret`** (52/52 crons montam do Vault). O `claude_ro` já perdeu `pg_read_all_data` e **continua lendo** — o alcance vem de PUBLIC, não do papel. É a tese deste arquivo sobrevivendo ao próprio conserto.

**D6 — sem transação e sem asserção de dono.** `BEGIN` **não** transforma o no-op do REVOKE por não-dono em falha; a asserção de `current_user` precisa estar no batch.

## Prova (executando, não presumindo)

`db/test-net-revoke-publico.sh` — PG17 descartável, com falsificação, `exit 0`:

- `INSERT … RETURNING` sem SELECT → **42501**; `INSERT` puro **passa** (a regra é do RETURNING)
- REVOKE parcial deixa `SELECT/TRIGGER/REFERENCES`; `REVOKE ALL` fecha as quatro
- o papel do worker perde **INSERT e DELETE** em `_http_response`

## Onde discordo do Codex (registrado no doc)

Ele classificou o vetor **TRIGGER** como SSRF crítico. Medi: `anon`, `authenticated`, `service_role` e `claude_ro` **não têm `CREATE` em schema nenhum**, logo não criam a função de trigger. É defesa em profundidade, não escalada alcançável hoje. Mandar ao suporte um "SSRF crítico" que não se sustenta queimaria o ticket.

## Lição de shell que este teste custou

A 1ª rodada **passou a falsificação por cegueira**: `psql -d db "SQL"` **sem `-c`** é no-op que retorna `exit 0` (o posicional é o *dbname*). Medido: `psql -v ON_ERROR_STOP=1 -d d "SELECT 1/0;"` → `exit=0`; com `-c` → `exit=1`. Quatro passos nunca rodaram e a sabotagem "foi detectada" porque o valor nunca mudou. Foi o dump do `relacl` que denunciou. Família `evidencia-positiva-shell.md`: **`set -e` não pega no-op com exit 0.**

## Decisão pendente do founder (não escondida no bloco)

`service_role` **saiu** do re-GRANT: não há consumidor medido (92/92 crons rodam como `postgres`; as 4 SECDEF também) e ele é alcançável por `SET ROLE` a partir do `authenticator` (`set_option=true`), o que manteria o egress aberto para quem tiver a service_role key. Reversão é uma linha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)