### PR TITLE
fix(sonda): o SQL de sondagem julgava deploy só pelo `versao` — o bundle sem o mapa de fingerprints saía 'DEPLOY CONFIRMADO'

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -170,15 +170,26 @@ entre uma e outra. O padrão é disparar todas com `net.http_post` sobre um `VAL
 `jsonb_each_text('<colado>'::jsonb)`. Medido 2026-08-24 sondando a oitava leva (#1937).
 
 **Não digite esse SQL: gere-o.** `bun run sonda:sql <edge>… [--caro=<edge>,…]` lê o `VERSAO` de cada
-`supabase/functions/<edge>/versao.ts` e emite os quatro blocos prontos (disparo + leitura das
-baratas; disparo travado + leitura das caras). A lista `esperado(edge, versao_esperada)` transcrita
-na unha é o buraco que ele fecha: **marcador digitado errado produz veredito FALSO** — "BUNDLE
-VELHO" numa edge que está no ar (e o desfecho é redeployar edge de money-path à toa), ou o inverso.
-Edge sem `versao.ts` derruba a geração inteira (nada de SQL parcial em silêncio), e `--caro` que não
-casa um nome da leva também — o typo deixaria a edge cara no bloco SEM trava. Testes:
-`scripts/sonda-versao-sql.test.ts` (a falsificação sabota o `versao.ts` e exige que o marcador velho
-suma do SQL) + `scripts/mutcheck.d/sonda-versao-sql.mut`, que no CI prova que a suíte **pega** a
-trava trocada por `WHERE`, o `LEFT JOIN` virado `JOIN` e o marcador hardcoded.
+`supabase/functions/<edge>/versao.ts` **e o fingerprint de `_shared/sonda-fingerprints.ts`**, e emite
+os quatro blocos prontos (disparo + leitura das baratas; disparo travado + leitura das caras). A
+lista `esperado(edge, versao_esperada, fonte_esperada)` transcrita na unha é o buraco que ele fecha:
+**marcador digitado errado produz veredito FALSO** — "BUNDLE VELHO" numa edge que está no ar (e o
+desfecho é redeployar edge de money-path à toa), ou o inverso. Edge sem `versao.ts` **ou fora do
+mapa de fingerprints** derruba a geração inteira (nada de SQL parcial em silêncio), e `--caro` que
+não casa um nome da leva também — o typo deixaria a edge cara no bloco SEM trava.
+
+⚠️ **O veredito julga o `fonte`, não só o `versao` — e o ramo `DEPLOY PARCIAL` vem ANTES do de
+confirmação.** O `versao` sai do `versao.ts` da PRÓPRIA edge: um deploy que suba `index.ts` +
+`versao.ts` e deixe `_shared/sonda-fingerprints.ts` para trás (o risco do Passo 3 da skill
+`lovable-deploy-verify` — prompt que nomeia poucos arquivos) responde `versao` **certo** e
+`fonte: "nao-mapeada"`. Julgando só pelo `versao`, isso saía como **'DEPLOY CONFIRMADO'**: falso
+POSITIVO num money-path, a classe estritamente pior, porque **encerra** a verificação. Confirmação
+exige os dois campos batendo; `fonte` ausente é ramo próprio, e a dúvida cai sempre no lado que
+manda olhar de novo. Testes: `scripts/sonda-versao-sql.test.ts` (as falsificações GÊMEAS sabotam o
+`versao.ts` e a entrada do mapa, e exigem que o valor velho suma do SQL) +
+`scripts/mutcheck.d/sonda-versao-sql.mut`, que no CI prova que a suíte **pega** a trava trocada por
+`WHERE`, o `LEFT JOIN` virado `JOIN`, o marcador/fingerprint hardcoded, o ramo `DEPLOY PARCIAL`
+neutralizado e o `AND fonte = fonte_esperada` dispensado do `DEPLOY CONFIRMADO`.
 
 - ⚠️ **A trava do bloco perigoso tem de ser `CASE`, NÃO `WHERE`.** Quando parte da leva só pode ser sondada
   DEPOIS do deploy confirmado (bundle pré-sensor ignora o `probe` e dispara o run), a tentação é

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -16,5 +16,12 @@ PEGA      | timeout_milliseconds implicito (default 5s) | s/timeout_milliseconds
 PEGA      | --caro forasteira aceita em silencio       | s/!edges\.includes\(c\)/false/
 PEGA      | edge sem sensor degrada em vez de lancar   | s/if \(problemas\.length > 0\)/if (false)/
 PEGA      | eco probe:true dispensado no CONFIRMADO    | s/AND l\.corpo ->> 'probe' = 'true'/AND true/
+# Os 4 abaixo guardam o `fonte` — o campo que prova deploy VERBATIM (#2018). Sem eles a suíte
+# aceitava um veredito que julga só o `versao`, e o bundle que sobe index.ts+versao.ts SEM o
+# _shared/sonda-fingerprints.ts saía como 'DEPLOY CONFIRMADO': falso POSITIVO, a classe pior.
+PEGA      | ramo DEPLOY PARCIAL neutralizado (nao dispara) | s/COALESCE\(l\.corpo ->> 'fonte', 'nao-mapeada'\) = 'nao-mapeada'/false/
+PEGA      | CONFIRMADO dispensa o fonte (falso POSITIVO)   | s/AND l\.corpo ->> 'fonte' = l\.fonte_esperada/AND true/
+PEGA      | fingerprint hardcoded em vez de lido do mapa   | s/lit\(e\.fonte\)/lit('0'.repeat(64))/
+PEGA      | edge fora do mapa degrada em vez de lancar     | s/if \(!\(edge in mapa\)\)/if (false)/
 SOBREVIVE | timeout 20s -> 30s (valor nao e pinado)    | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
 SOBREVIVE | ORDER BY por posicao (cosmetico)           | s/ORDER BY l\.edge;/ORDER BY 1;/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 
 import { gerarSqlDaLeva, main, parsearArgs, resolverLeva } from './sonda-versao-sql';
 
@@ -12,14 +13,39 @@ afterEach(() => {
   for (const d of criadas.splice(0)) rmSync(d, { recursive: true, force: true });
 });
 
-/** Repo de mentira com `supabase/config.toml` + um `versao.ts` por edge pedida. */
+/**
+ * Repo de mentira com `supabase/config.toml`, um `versao.ts` por edge pedida e o mapa de
+ * fingerprints cobrindo TODAS elas — o estado sadio, do qual cada teste sabota UMA coisa.
+ */
 function fixture(edges: Record<string, string>, ref = 'refdementira000000ab'): string {
   const raiz = mkdtempSync(join(tmpdir(), 'sonda-sql-'));
   criadas.push(raiz);
   mkdirSync(join(raiz, 'supabase', 'functions'), { recursive: true });
   writeFileSync(join(raiz, 'supabase', 'config.toml'), `project_id = "${ref}"\n`);
   for (const [edge, versao] of Object.entries(edges)) escreverVersao(raiz, edge, versao);
+  escreverMapaFingerprints(
+    raiz,
+    Object.fromEntries(Object.keys(edges).map((edge) => [edge, fp(edge)])),
+  );
   return raiz;
+}
+
+/** Fingerprint de mentira na FORMA que o mapa exige (64 hex), determinístico pela semente. */
+function fp(semente: string): string {
+  return createHash('sha256').update(semente).digest('hex');
+}
+
+/** O mapa do repo de mentira, na MESMA forma que `sonda:fingerprint --write` grava o de verdade. */
+function escreverMapaFingerprints(raiz: string, mapa: Record<string, string>): void {
+  const dir = join(raiz, 'supabase', 'functions', '_shared');
+  mkdirSync(dir, { recursive: true });
+  const linhas = Object.entries(mapa).map(
+    ([edge, fingerprint]) => `  ${JSON.stringify(edge)}: ${JSON.stringify(fingerprint)},`,
+  );
+  writeFileSync(
+    join(dir, 'sonda-fingerprints.ts'),
+    `export const FONTE_SHA256: Record<string, string> = {\n${linhas.join('\n')}\n};\n`,
+  );
 }
 
 function escreverVersao(raiz: string, edge: string, versao: string): void {
@@ -64,6 +90,33 @@ describe('edge sem sensor não é sondável — falha ALTO, nunca SQL parcial', 
     const raiz = fixture({ boa: 'v1.0-sensor-inicial' });
     expect(() => gerarSqlDaLeva({ raiz, edges: ['boa', 'orfa'] })).toThrow(/orfa/);
   });
+
+  it('edge com sensor mas FORA do mapa de fingerprints derruba a geração inteira', () => {
+    const raiz = fixture({ boa: 'v1.0-sensor-inicial', 'edge-fora-do-mapa': 'v1.0-sensor-inicial' });
+    // SABOTAGEM: o mapa perde UMA entrada. Emitir SQL sem o fingerprint dela seria julgar deploy
+    // por `versao` sozinho — o falso POSITIVO que este campo existe para impedir.
+    escreverMapaFingerprints(raiz, { boa: fp('boa') });
+    expect(() => gerarSqlDaLeva({ raiz, edges: ['boa', 'edge-fora-do-mapa'] })).toThrow(
+      /edge-fora-do-mapa/,
+    );
+  });
+
+  it('mapa de fingerprints AUSENTE não degrada para vazio — falha ALTO', () => {
+    const raiz = fixture({ boa: 'v1.0-sensor-inicial' });
+    rmSync(join(raiz, 'supabase', 'functions', '_shared', 'sonda-fingerprints.ts'));
+    expect(() => gerarSqlDaLeva({ raiz, edges: ['boa'] })).toThrow(/boa/);
+  });
+
+  it('main devolve 1 e NÃO escreve SQL quando a edge está fora do mapa', () => {
+    const raiz = fixture({ boa: 'v1.0-sensor-inicial' });
+    escreverMapaFingerprints(raiz, {});
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const codigo = main(['boa'], { raiz, escrever: (t) => saida.push(t), erro: (t) => erros.push(t) });
+    expect(codigo).toBe(1);
+    expect(saida).toEqual([]);
+    expect(erros.join('')).toMatch(/sonda-fingerprints/);
+  });
 });
 
 describe('o marcador emitido SAI do versao.ts (falsificação por sabotagem)', () => {
@@ -85,8 +138,8 @@ describe('o marcador emitido SAI do versao.ts (falsificação por sabotagem)', (
   it('cada edge da leva leva o SEU marcador, não o da vizinha', () => {
     const raiz = fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
     const sql = gerarSqlDaLeva({ raiz, edges: ['edge-a', 'edge-b'] });
-    expect(sql).toMatch(/\('edge-a',\s*'v1\.0-alfa'\)/);
-    expect(sql).toMatch(/\('edge-b',\s*'v2\.0-beta'\)/);
+    expect(sql).toMatch(/\('edge-a',\s*'v1\.0-alfa',/);
+    expect(sql).toMatch(/\('edge-b',\s*'v2\.0-beta',/);
   });
 
   it('contra o repo REAL: o marcador emitido é o do arquivo, para toda edge instrumentada', () => {
@@ -102,12 +155,42 @@ describe('o marcador emitido SAI do versao.ts (falsificação por sabotagem)', (
     expect(edges.length).toBeGreaterThan(10); // controle: a varredura achou o conjunto real
 
     const sql = gerarSqlDaLeva({ raiz: RAIZ_REPO, edges });
+    const mapaReal = readFileSync(join(dir, '_shared', 'sonda-fingerprints.ts'), 'utf8');
     for (const edge of edges) {
       const fonte = readFileSync(join(dir, edge, 'versao.ts'), 'utf8');
       const marcador = /export const VERSAO = "([^"]+)"/.exec(fonte)?.[1];
       expect(marcador, `${edge} sem VERSAO legível`).toBeTruthy();
-      expect(sql).toContain(`('${edge}', '${marcador}')`);
+      // Parse INDEPENDENTE do mapa (não o leitor sob teste): senão o mesmo bug passaria nos dois.
+      const fingerprint = new RegExp(`^  "${edge}": "([0-9a-f]{64})",$`, 'm').exec(mapaReal)?.[1];
+      expect(fingerprint, `${edge} fora de _shared/sonda-fingerprints.ts`).toBeTruthy();
+      expect(sql).toContain(`('${edge}', '${marcador}', '${fingerprint}')`);
     }
+  });
+});
+
+describe('o fingerprint emitido SAI do mapa commitado (falsificação por sabotagem)', () => {
+  it('sabotar a entrada do mapa muda o SQL — o fingerprint velho não sobrevive', () => {
+    const raiz = fixture({ alvo: 'v1.0-sensor-inicial' });
+
+    const antes = gerarSqlDaLeva({ raiz, edges: ['alvo'] });
+    expect(antes).toContain(fp('alvo'));
+
+    // SABOTAGEM: só a ENTRADA DO MAPA muda; o `versao.ts` e o script ficam intactos.
+    escreverMapaFingerprints(raiz, { alvo: fp('alvo-SABOTADO') });
+    const depois = gerarSqlDaLeva({ raiz, edges: ['alvo'] });
+
+    // Implementação que chuta, cacheia ou IGNORA o fingerprint fica VERMELHA aqui.
+    expect(depois).not.toContain(fp('alvo'));
+    expect(depois).toContain(fp('alvo-SABOTADO'));
+    // Controle: a sabotagem isolou o campo certo — o marcador não se moveu.
+    expect(depois).toContain('v1.0-sensor-inicial');
+  });
+
+  it('cada edge da leva leva o SEU fingerprint, não o da vizinha', () => {
+    const raiz = fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
+    const sql = gerarSqlDaLeva({ raiz, edges: ['edge-a', 'edge-b'] });
+    expect(sql).toContain(`('edge-a', 'v1.0-alfa', '${fp('edge-a')}')`);
+    expect(sql).toContain(`('edge-b', 'v2.0-beta', '${fp('edge-b')}')`);
   });
 });
 
@@ -182,11 +265,45 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', (
     expect(sql).toMatch(/COALESCE\(r\.content::jsonb -> 'data', r\.content::jsonb\)/);
   });
 
-  it('os 5 ramos de veredito estão nomeados', () => {
+  it('os 6 ramos de veredito estão nomeados', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
-    for (const ramo of ['SEM ID', 'AGUARDE', 'DEPLOY CONFIRMADO', 'BUNDLE VELHO', 'PRE-SENSOR']) {
+    for (const ramo of [
+      'SEM ID',
+      'AGUARDE',
+      'DEPLOY CONFIRMADO',
+      'DEPLOY PARCIAL',
+      'BUNDLE VELHO',
+      'PRE-SENSOR',
+    ]) {
       expect(sql, `ramo ausente: ${ramo}`).toContain(ramo);
     }
+  });
+
+  it('a lista canônica carrega o fingerprint, e a saída projeta o que a edge respondeu', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('esperado(edge, versao_esperada, fonte_esperada)');
+    expect(sql).toMatch(/l\.corpo ->> 'fonte'\s+AS fonte_respondida/);
+  });
+
+  it('DEPLOY PARCIAL é ramo PRÓPRIO — e vem ANTES do de confirmação', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/COALESCE\(l\.corpo ->> 'fonte', 'nao-mapeada'\) = 'nao-mapeada'/);
+    expect(sql).toContain('DEPLOY PARCIAL');
+    // A ORDEM é o que impede o falso POSITIVO: depois do CONFIRMADO, este ramo nunca alcançaria a
+    // edge cujo `versao` bate — que é exatamente a assinatura do bundle parcial.
+    expect(sql.indexOf('DEPLOY PARCIAL')).toBeLessThan(sql.indexOf("THEN 'DEPLOY CONFIRMADO'"));
+  });
+
+  it('DEPLOY CONFIRMADO exige o fonte BATENDO — `versao` sozinho não prova deploy verbatim', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/corpo ->> 'fonte' = l\.fonte_esperada/);
+  });
+
+  it('o BUNDLE VELHO do ELSE cita os DOIS campos — respondido e esperado', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const senao = sql.slice(sql.indexOf("ELSE 'BUNDLE VELHO"));
+    expect(senao).toContain("', fonte=' || COALESCE(l.corpo ->> 'fonte', '?')");
+    expect(senao).toContain("l.versao_esperada || ' / ' || l.fonte_esperada");
   });
 
   it('rejeição (>=400) e execução (200 sem versao) NÃO caem no mesmo ramo', () => {
@@ -245,9 +362,9 @@ describe('subconjunto CARO — a trava é CASE, nunca WHERE', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
     const caro = blocoCaro(sql);
     expect(caro).toContain('-- PASSO 4');
-    expect(caro).toContain("('cara', 'v2.0-beta')");
+    expect(caro).toContain(`('cara', 'v2.0-beta', '${fp('cara')}')`);
     expect(caro).toMatch(/FROM esperado e\s*\n\s*LEFT JOIN ids i ON i\.edge = e\.edge/);
-    expect(caro).not.toContain("('barata', 'v1.0-alfa')");
+    expect(caro).not.toContain("('barata', 'v1.0-alfa'");
   });
 
   it('--caro de edge fora da leva falha ALTO — o typo mandaria a cara para o bloco barato', () => {
@@ -303,7 +420,7 @@ describe('CLI', () => {
     const erros: string[] = [];
     const codigo = main(['edge-a'], { raiz, escrever: (t) => saida.push(t), erro: (t) => erros.push(t) });
     expect(codigo).toBe(0);
-    expect(saida.join('')).toContain("('edge-a', 'v1.0-alfa')");
+    expect(saida.join('')).toContain(`('edge-a', 'v1.0-alfa', '${fp('edge-a')}')`);
     expect(erros).toEqual([]);
   });
 

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -10,14 +10,26 @@
  * transcrita dos `versao.ts` na unha. Um marcador digitado errado produz VEREDITO FALSO — "BUNDLE
  * VELHO" numa edge que está no ar (e o desfecho é redeployar edge de money-path à toa), ou a falsa
  * impressão de deploy confirmado. A fonte da verdade já está no repo; o script a lê.
+ *
+ * POR QUE O VEREDITO JULGA O `fonte`, E NÃO SÓ O `versao`: o `versao` sai do `versao.ts` da PRÓPRIA
+ * edge, então um deploy que suba `index.ts` + `versao.ts` e deixe `_shared/sonda-fingerprints.ts`
+ * para trás (o risco que a skill `lovable-deploy-verify` Passo 3 documenta — prompt que nomeia
+ * poucos arquivos) responde `versao` CERTO e `fonte: "nao-mapeada"` (o `?? "nao-mapeada"` de
+ * `criarRespostaSonda`). Julgar só pelo `versao` lê isso como DEPLOY CONFIRMADO: falso POSITIVO
+ * num money-path, a classe estritamente pior, porque ENCERRA a verificação. É o `fonte` bater que
+ * prova deploy VERBATIM — ele hasheia o fecho transitivo dos imports locais, não a disciplina de
+ * quem bumpou o marcador (#1998; validado ponta-a-ponta em prod no #2018).
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** Uma edge da leva, com o marcador lido do `versao.ts` dela. */
+import { ARQ_MAPA, lerMapaCommitado } from './sonda-fingerprint';
+
+/** Uma edge da leva, com o marcador do `versao.ts` dela e o fingerprint da FONTE dela. */
 export interface EdgeSondada {
   edge: string;
   versao: string;
+  fonte: string;
 }
 
 /** Caminho do `versao.ts` de uma edge, a partir da raiz do repo. */
@@ -42,23 +54,37 @@ export function extrairVersao(fonte: string): string | null {
  *
  * Acusa TODAS as edges problemáticas de uma vez: quem pediu 10 edges quer saber quais 3 faltam,
  * não descobrir uma por execução.
+ *
+ * O fingerprint sai do mapa COMMITADO (`_shared/sonda-fingerprints.ts`, o mesmo que a edge serve no
+ * campo `fonte`), pelo leitor que já é dono desse parse. Edge instrumentada fora do mapa derruba a
+ * geração inteira pelo mesmo motivo que o marcador ilegível: fingerprint ADIVINHADO — ou omitido do
+ * veredito — é veredito FALSO, e aqui o falso seria POSITIVO.
  */
 export function resolverLeva(raiz: string, edges: string[]): EdgeSondada[] {
+  const mapa = lerMapaCommitado(raiz);
   const semSensor: string[] = [];
   const semMarcador: string[] = [];
+  const semFingerprint: string[] = [];
   const resolvidas: EdgeSondada[] = [];
 
   for (const edge of edges) {
-    let fonte: string;
+    let textoVersao: string;
     try {
-      fonte = readFileSync(caminhoVersao(raiz, edge), 'utf8');
+      textoVersao = readFileSync(caminhoVersao(raiz, edge), 'utf8');
     } catch {
       semSensor.push(edge);
       continue;
     }
-    const versao = extrairVersao(fonte);
-    if (versao === null) semMarcador.push(edge);
-    else resolvidas.push({ edge, versao });
+    const versao = extrairVersao(textoVersao);
+    if (versao === null) {
+      semMarcador.push(edge);
+      continue;
+    }
+    if (!(edge in mapa)) {
+      semFingerprint.push(edge);
+      continue;
+    }
+    resolvidas.push({ edge, versao, fonte: mapa[edge] });
   }
 
   const problemas: string[] = [];
@@ -72,11 +98,15 @@ export function resolverLeva(raiz: string, edges: string[]): EdgeSondada[] {
       `versao.ts sem \`export const VERSAO = "..."\` legível: ${semMarcador.join(', ')}`,
     );
   }
+  if (semFingerprint.length > 0) {
+    problemas.push(`sem entrada no mapa ${ARQ_MAPA}: ${semFingerprint.join(', ')}`);
+  }
   if (problemas.length > 0) {
     throw new Error(
       `Edge não sondável — ${problemas.join(' | ')}. ` +
         'Edge sem sensor não tem como provar versão: instrumente-a (ver _shared/sonda-versao.ts) ' +
-        'antes de sondar. Nenhum SQL foi emitido.',
+        'antes de sondar. Edge fora do mapa não tem como provar deploy VERBATIM: rode ' +
+        '`bun run sonda:fingerprint -- --write` e commite o mapa. Nenhum SQL foi emitido.',
     );
   }
   return resolvidas;
@@ -115,9 +145,9 @@ function valuesAlvos(leva: EdgeSondada[]): string {
   return leva.map((e) => `  (${lit(e.edge)})`).join(',\n');
 }
 
-/** Lista `('nome', 'marcador'),` para o `VALUES` da lista canônica do bloco de leitura. */
+/** Lista `('nome', 'marcador', 'fingerprint'),` para o `VALUES` da lista canônica da leitura. */
 function valuesEsperado(leva: EdgeSondada[]): string {
-  return leva.map((e) => `  (${lit(e.edge)}, ${lit(e.versao)})`).join(',\n');
+  return leva.map((e) => `  (${lit(e.edge)}, ${lit(e.versao)}, ${lit(e.fonte)})`).join(',\n');
 }
 
 /** A chamada `net.http_post`, idêntica nos dois blocos de disparo. */
@@ -174,17 +204,22 @@ function blocoDisparo(
  * do bloco errado devolve ZERO linhas — e zero linhas lê-se como "nada a reportar", não como erro.
  * Mesmo motivo do `LEFT JOIN` contra `net._http_response`: sem ele, "a resposta ainda não chegou"
  * e "veredito negativo" ficam indistinguíveis.
+ *
+ * O ramo DEPLOY PARCIAL vem ANTES do de confirmação de propósito: `versao` certo com `fonte`
+ * ausente é a assinatura do bundle que subiu `index.ts` + `versao.ts` sem o mapa de fingerprints, e
+ * ler isso como CONFIRMADO seria o falso POSITIVO que encerra a verificação. Confirmação exige os
+ * DOIS campos; a dúvida cai sempre no lado que manda olhar de novo.
  */
 function blocoLeitura(leva: EdgeSondada[]): string {
   return (
-    `WITH esperado(edge, versao_esperada) AS (VALUES\n${valuesEsperado(leva)}\n),\n` +
+    `WITH esperado(edge, versao_esperada, fonte_esperada) AS (VALUES\n${valuesEsperado(leva)}\n),\n` +
     `ids AS (\n` +
     `  -- ⬅️ COLE AQUI, no lugar do {}, a célula única devolvida pelo passo de disparo.\n` +
     `  SELECT chave AS edge, valor::bigint AS request_id\n` +
     `  FROM jsonb_each_text('{}'::jsonb) AS t(chave, valor)\n` +
     `),\n` +
     `lidas AS (\n` +
-    `  SELECT e.edge, e.versao_esperada, i.request_id, r.status_code,\n` +
+    `  SELECT e.edge, e.versao_esperada, e.fonte_esperada, i.request_id, r.status_code,\n` +
     `         COALESCE(r.content::jsonb -> 'data', r.content::jsonb) AS corpo\n` +
     `  FROM esperado e\n` +
     `  LEFT JOIN ids i ON i.edge = e.edge\n` +
@@ -196,6 +231,7 @@ function blocoLeitura(leva: EdgeSondada[]): string {
     `       l.corpo ->> 'edge'   AS edge_respondida,\n` +
     `       l.corpo ->> 'versao' AS versao_respondida,\n` +
     `       l.versao_esperada,\n` +
+    `       l.corpo ->> 'fonte'  AS fonte_respondida,\n` +
     `       CASE\n` +
     `         WHEN l.request_id IS NULL\n` +
     `           THEN 'SEM ID — esta edge não saiu no JSON colado (bloco errado, ou trava fechada)'\n` +
@@ -205,13 +241,17 @@ function blocoLeitura(leva: EdgeSondada[]): string {
     `           THEN 'BUNDLE VELHO — recusou o request (HTTP ' || l.status_code || '), NADA executou'\n` +
     `         WHEN l.corpo ->> 'versao' IS NULL\n` +
     `           THEN 'PRE-SENSOR — HTTP 200 sem versao: ignorou o probe e RODOU O FLUXO REAL'\n` +
+    `         WHEN COALESCE(l.corpo ->> 'fonte', 'nao-mapeada') = 'nao-mapeada'\n` +
+    `           THEN 'DEPLOY PARCIAL — subiu index.ts+versao.ts, mas _shared/sonda-fingerprints.ts NAO'\n` +
     `         WHEN l.corpo ->> 'versao' = l.versao_esperada\n` +
+    `              AND l.corpo ->> 'fonte' = l.fonte_esperada\n` +
     `              AND l.corpo ->> 'probe' = 'true'\n` +
     `              AND l.corpo ->> 'edge' = l.edge\n` +
     `           THEN 'DEPLOY CONFIRMADO'\n` +
     `         ELSE 'BUNDLE VELHO — respondeu versao=' || COALESCE(l.corpo ->> 'versao', '?') ||\n` +
+    `              ', fonte=' || COALESCE(l.corpo ->> 'fonte', '?') ||\n` +
     `              ', edge=' || COALESCE(l.corpo ->> 'edge', '?') ||\n` +
-    `              ' (esperado ' || l.versao_esperada || ')'\n` +
+    `              ' (esperado ' || l.versao_esperada || ' / ' || l.fonte_esperada || ')'\n` +
     `       END AS veredito\n` +
     `FROM lidas l\n` +
     `ORDER BY l.edge;\n`


### PR DESCRIPTION
## O buraco

`bun run sonda:sql <edge>` emitia um `CASE` que julga o deploy por `corpo->>'versao'` (+ eco `probe` + `edge`) e **ignora o campo `fonte`**.

O `versao` sai do `versao.ts` da **própria edge**. Então o bundle PARCIAL — o Lovable sobe `index.ts` + `versao.ts` e deixa `_shared/sonda-fingerprints.ts` para trás, exatamente o risco que o **Passo 3 da skill `lovable-deploy-verify`** documenta (prompt que nomeia poucos arquivos) — responde:

```
versao = "v1.0-sensor-inicial"   ← certo, porque o versao.ts subiu
fonte  = "nao-mapeada"           ← o `?? "nao-mapeada"` do criarRespostaSonda
```

…e o `CASE` devolvia **'DEPLOY CONFIRMADO'**. Falso **POSITIVO** num money-path — a classe estritamente pior, porque **encerra** a verificação.

Não é hipotético: verificando a `omie-vendas-sync` (#2026, `231425fa5`) o SQL gerado teve de ser corrigido **à mão** para incluir o `fonte`. E o #2018 já havia medido em prod, na `carteira-rebuild`, que é o **`fonte` bater** — SHA-256 do fecho transitivo dos imports locais — que prova que o Lovable deployou VERBATIM. Faltava o **gerador** saber disso.

## O que mudou

- **Lê o fingerprint do mapa commitado** via `lerMapaCommitado` de `scripts/sonda-fingerprint.ts`, reusando quem **já é dono** desse parse em vez de criar uma segunda verdade. Esse leitor é fail-open num arquivo ausente (devolve `{}`), então o fail-**closed** mora no `resolverLeva`: edge instrumentada fora do mapa — ou mapa ausente — derruba a geração **inteira**, com o conserto nomeado (`sonda:fingerprint -- --write`). Fingerprint ADIVINHADO seria o mesmo veredito falso que o marcador digitado errado.
- **No SQL:** `fonte_esperada` no `VALUES` de `esperado(...)`, `fonte_respondida` na projeção, ramo **`DEPLOY PARCIAL` ANTES** do de confirmação, `DEPLOY CONFIRMADO` exigindo os **dois** campos, `ELSE` citando ambos. O `FROM esperado LEFT JOIN ids` invertido segue intacto.
- **Falsificação GÊMEA** da que já existia: sabota a entrada do **mapa** e exige que o fingerprint velho **suma** do SQL. Mais 4 mutações no contrato `.mut`.

## Evidência

| gate | resultado |
|---|---|
| `bun run test` | exit 0 — 743 arquivos, 7299 testes, 1 skip |
| `bun run typecheck` | exit 0 |
| `bun run scripts:typecheck` | exit 0 (o `typecheck` só olha `src`) |
| `scripts/sonda-versao-sql.test.ts` | 47 passaram (eram 39), verde **pós-rebase** |
| `mutcheck` | exit 0 — 16 mutações · 14 pegas · 2 sobreviventes esperadas · 0 inválidas |

As 4 mutações novas **pegam** — antes delas o `AND fonte = fonte_esperada` podia sumir com a suíte inteira verde:

```
PEGA  ramo DEPLOY PARCIAL neutralizado (nao dispara)  ✓ PEGA
PEGA  CONFIRMADO dispensa o fonte (falso POSITIVO)    ✓ PEGA
PEGA  fingerprint hardcoded em vez de lido do mapa    ✓ PEGA
PEGA  edge fora do mapa degrada em vez de lancar      ✓ PEGA
```

Cruzamento independente: `bun run sonda:sql carteira-rebuild` emite `fonte_esperada = 8d2589d0…986eb78a`, **idêntico** ao valor que o #2018 mediu em produção nessa edge.

## Nota honesta sobre a ordem dos ramos

Um bundle anterior ao campo `fonte` (que nem emite o campo) agora lê **`DEPLOY PARCIAL`**, não `BUNDLE VELHO` — o `COALESCE(...,'nao-mapeada')` alcança tanto o `NULL` quanto o literal. Nenhum dos dois é falso positivo, e as colunas `versao_respondida`/`versao_esperada` mostram o descasamento; só a *causa nomeada* na mensagem pode não ser a única.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
