### PR TITLE
docs(claude-md): `bun run typecheck` não cobre `scripts/`+`db/` — o verde é ausência de dado, não aprovação

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,14 +66,14 @@ Todo PR não-draft **auto-mergeia (squash) quando o CI `validate` passa** (`.git
 
 ## Stack
 
-React 18 + TS 5.8 (**strict**) + Vite 5 + react-router 6 (lazy). Estado: `@tanstack/react-query` (`staleTime 60s`, sem refetch-on-focus, `retry 2`). UI: shadcn/ui sobre Radix; Tailwind 3 + tokens v3 em `src/index.css`. Tipografia Geist/Newsreader. Forms: react-hook-form + zod. Backend: **Supabase** (prod ref `fzvklzpomgnyikkfkzai`). Analytics PostHog (via `track()` de `@/lib/analytics`). PWA Workbox (offline-first picking/recebimento + fila de mutação). Toasts: **`sonner`** (único — `import { toast } from 'sonner'`). Cmd-K global ativo. Host: Lovable Cloud.
+React 18 + TS 5.8 (**strict**) + Vite 5 + react-router 6 (lazy). Estado: `@tanstack/react-query` (`staleTime 60s`, sem refetch-on-focus, `retry 2`). UI: shadcn/ui sobre Radix; Tailwind 3. Tipografia Geist/Newsreader. Forms: react-hook-form + zod. Backend: **Supabase** (prod ref `fzvklzpomgnyikkfkzai`). Analytics PostHog (via `track()` de `@/lib/analytics`). PWA Workbox (offline-first picking/recebimento + fila de mutação). Toasts: **`sonner`** (único — `import { toast } from 'sonner'`). Cmd-K global ativo. Host: Lovable Cloud.
 
 ### Scripts
 
 ```bash
 bun dev · bun build · bun lint
 bun run test        # vitest — CANÔNICO (é o que o CI roda); bun test (runner nativo) ≠ disto
-bun run typecheck   # tsc --noEmit -p tsconfig.app.json (strict). NÃO usar tsc cru (no-op: root tem files:[])
+bun run typecheck   # tsc -p tsconfig.app.json (strict) — só `src`; scripts/+db/ = `scripts:typecheck`. tsc cru = no-op (root files:[])
 heavy bun run test  # 'heavy' = semáforo de RAM (M2 8GB); prefixe test/build/typecheck/vitest
 ```
 


### PR DESCRIPTION
## Medido, não lembrado

Plantei um erro de tipo escancarado em `scripts/__eval-cobertura-typecheck.ts` e rodei os dois gates:

```
bun run typecheck          → exit 0   (VERDE, com o TS2322 no disco)
bun run scripts:typecheck  → exit 2   scripts/__eval-cobertura-typecheck.ts(1,14):
                                      error TS2322: Type 'string' is not assignable to type 'number'.
```

O segundo é o **controle positivo**, e é ele que faz a medição valer: sem ele, o verde do primeiro seria indistinguível de *"o erro que plantei não era erro"*. `tsconfig.app.json` tem `include: ["src"]`; `scripts/` e `db/` só são type-checados por `tsconfig.scripts.json` — gate `scripts:typecheck`, **blocking** em `ci.yml:146`.

## Por que no CLAUDE.md, se a lição já existe

Ela está escrita em **três** lugares — cabeçalho do `tsconfig.scripts.json`, comentário do `.github/workflows/ci.yml:21` — e em **nenhum** deles no momento da decisão. Quem vai rodar o gate está lendo o bloco `### Scripts` do CLAUDE.md, e era exatamente ali que o fato faltava. É problema de **roteamento**, não de documentação: uma quarta cópia em prosa repetiria o erro.

**Custo real do buraco, medido nesta sessão:** o `typecheck` verde foi reportado ao founder numa tabela de gates como evidência de uma mudança em `scripts/` (o PR #2052, que mexe só em `scripts/`). É a classe *"linter que não tem a regra é ausência de dado"* que o próprio CLAUDE.md já nomeia — aplicada, desta vez, ao gate que o agente estava rodando.

## Orçamento: pago DENTRO da própria seção

```diff
-bun run typecheck   # tsc --noEmit -p tsconfig.app.json (strict). NÃO usar tsc cru (no-op: root tem files:[])
+bun run typecheck   # tsc -p tsconfig.app.json (strict) — só `src`; scripts/+db/ = `scripts:typecheck`. tsc cru = no-op (root files:[])
```

Saiu de `## Stack` o trecho `tokens v3 em src/index.css` — fato que a `## Design System` **já possui** na primeira linha dela. Nenhuma outra seção encolhida, teto **não** subido: `## Stack` **156/158**, `bun run claude:size` verde. A armadilha do `tsc` cru continua na linha: pagar uma lição com outra é exatamente o que este teto existe para impedir.

## Fica de fora (decisão do founder)

A versão **estrutural** disto — um hook `PreToolUse` no molde do `.claude/hooks/edge-guardrail-nudge.sh`, que avisa ao editar `scripts/`/`db/` — está registrada como chip separado. O trade-off é real e não é meu para decidir: ruído em ~30 worktrees paralelas contra um CI que já é blocking. A cláusula deste PR é o mínimo que já se paga sozinho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
