### PR TITLE
fix(deploy-verify): o guard `--pai` mede a FONTE e a varredura mede o BUNDLE — sentinela delimitada passa os 3 guards e devolve "Publish pendente" sobre fix JÁ no ar

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -141,6 +141,8 @@ não só o `index.ts` (#2018).
 #        + "✓ CONTROLE_POSITIVO_OK — <entry> ainda devolve bytes e o mesmo grep acha '<agulha>'"
 #        + LIB_SEM_A_SENTINELA | SENTINELA_TAMBEM_NA_LIB | LIB_NAO_CONSULTADA (sonda do 2º emissor,
 #          pré-rede: AVISA e nunca muda o exit — node_modules é preditor, não prova)
+#        + SENTINELA_DELIMITADA (sonda da REPRESENTAÇÃO, pré-rede: o ALVO tem aspas nas PONTAS, que
+#          o bundler reescreve — AVISA, nunca muda o exit; volta no ramo exit 1)
 # exit 0 = no ar E o controle negativo passou · 1 = ausente E o controle POSITIVO provou que a
 #          sonda enxergava (Publish pendente / alvo não-literal)
 #      2 = a MECÂNICA da sonda não é confiável: enumeração quebrada, SONDA_NAO_DISCRIMINA (ramo
@@ -237,6 +239,33 @@ nosso* `input[type="checkbox"]` — a sentinela que esta própria seção recome
 (`readme.md`, `preflight.css` do tailwind, css de demo). Aviso que dispara contra a resposta certa é
 aviso desarmado no primeiro dia. Com o filtro: **~2 s**, e o mesmo alvo cai para 1 (`jsdom`). Detalhe
 e medições: [`docs/historico/sentinela-segundo-emissor.md`](../../../docs/historico/sentinela-segundo-emissor.md).
+
+**A 3ª exclusividade: a sentinela é REPRESENTÁVEL no bundle? (`SENTINELA_DELIMITADA`, 2026-08-27).**
+O `--pai` mede a **FONTE** (`git grep` em `src/`); a varredura mede o **BUNDLE MINIFICADO**. Para
+quase toda sentinela as duas formas coincidem — menos quando a sentinela é o literal **com** seus
+delimitadores: a fonte escreve `'oculta'` (aspas simples, prettier) e o esbuild emite `"oculta"`.
+Medido no chunk `StaffDashboard` servido: `'oculta'` = **0** ocorrências, `"oculta"` = **1**. As duas
+formas são **mutuamente exclusivas**, então nenhuma sentinela delimitada passa o guard **e** casa:
+
+| sentinela | `--pai` | varredura | veredito |
+|---|---|---|---|
+| `'oculta'` | **PASSA** (0 no pai, 2 no novo) | 0 chunks | **exit 1 FALSO** — pede Publish já feito |
+| `"oculta"` | **RECUSA** (0 no novo) | nem varre | exit 3 |
+
+O primeiro é o caro, e saiu com **os três guards verdes**: `✓ sentinela exclusiva` + `✓
+LIB_SEM_A_SENTINELA` + `✓ CONTROLE_POSITIVO_OK` → `❌ ALVO ausente nos 334 chunks: Publish pendente`.
+O controle positivo **não** cobre isto por construção — ele prova que a rede e o `grep` funcionam,
+não que a sentinela seja **representável**; são perguntas diferentes, e esta é a 3ª ortogonal
+(`--pai`: "é nova DENTRO do git?" · sonda de lib: "existe emissor FORA do git?" · esta: "a forma que
+eu procuro é a forma que o bundle emite?").
+
+> **A distinção que decide:** aspas como **DELIMITADOR** o bundler reescreve; aspas como **CONTEÚDO**
+> ele preserva. Só as **PONTAS** disparam — `input[type="checkbox"]` e `[role="button"]`, os "valores
+> nossos" que esta seção recomenda, seguem silenciosos. Um aviso que disparasse na resposta certa
+> estaria desarmado no primeiro dia (mesma lição da sonda de lib).
+
+**AVISA e nunca recusa**, como a sonda de lib: existe sentinela legítima cujo conteúdo traz as aspas
+nas bordas. E no ramo `exit 1` a marca volta, dizendo o que descartar **antes** de pedir Publish.
 
 **O guard não prova que a sonda sabe dizer "não" — isso é o CONTROLE NEGATIVO, e ele virou
 embutido (2026-08-24).** Um `exit 0` sozinho não distingue "está no ar" de "o script dá verde pra
@@ -533,4 +562,13 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   existia para provar o deploy. A lista sai do `git show --name-status` do merge (`A` = novo), não da
   memória. Exercitado no #2009 (`carteira-rebuild`): 3 arquivos de código, e o `fonte` da sonda
   pós-deploy batendo o `sonda:fingerprint` provou que o `_shared/` subiu junto (#2018).
+- [x] **3ª sonda — `SENTINELA_DELIMITADA` (2026-08-27):** o `--pai` mede a FONTE e a varredura mede o
+  BUNDLE MINIFICADO, e para o literal COM delimitadores as duas formas são **mutuamente exclusivas**
+  (medido no chunk servido: `'oculta'`=0, `"oculta"`=1) — `'oculta'` passa o guard e dá **exit 1
+  FALSO** ("Publish pendente" sobre fix JÁ no ar), `"oculta"` é recusada antes de varrer. Saiu com os
+  **três** guards verdes; o CONTROLE_POSITIVO não cobre por construção (prova que a rede/grep
+  funcionam, não que a sentinela seja REPRESENTÁVEL). Só as PONTAS disparam, então
+  `input[type="checkbox"]` — a sentinela que o Passo 4 recomenda — segue silenciosa. AVISA e nunca
+  recusa, como a sonda de lib. Rede: 3 casos bidirecionais + sabotagem `falsify_marca` (o fixture
+  nunca modelou isto — bundle fake não é minificado, sentinela idêntica nos dois universos).
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
@@ -459,6 +459,17 @@ sed '/^if \[ ! -d "\$_nm" \]; then$/,/^else$/ s/^  printf /  : /' "$SCRIPT_ABS" 
 falsify_marca "estado 'não consultei' silenciado -> worktree sem node_modules lê como limpa" \
               "$SAB_L" "$FIX/neutro" "LIB_OPTION_MARKER" "LIB_NAO_CONSULTADA" "CONTROLE_NEGATIVO_OK"
 
+# Sabotagem M: mata a comparação das PONTAS do detector de delimitador (vira `false`) -> a sentinela
+# delimitada volta a passar calada, e a ausência que ela causa se lê como "Publish pendente". É o
+# falso NEGATIVO medido em prod 2026-08-27 no #2037: os três guards verdes e o veredito errado.
+# O 6º arg exige que o script sabotado tenha CHEGADO ao veredito — sem ele, um SAB_M com erro de
+# sintaxe faria a marca sumir por nada ter rodado, e a sabotagem passaria pelo motivo errado.
+SAB_M="$FIX/sab_delimitador_morto.sh"
+# shellcheck disable=SC2016
+sed 's#\[ "\$_prim" = "\$_ult" \]#false#' "$SCRIPT_ABS" > "$SAB_M"
+falsify_marca "detector de delimitador morto -> sentinela delimitada passa calada e vira 'Publish pendente'" \
+              "$SAB_M" "$FIX/neutro" "'SENTINELA_DEEP_XYZ'" "SENTINELA_DELIMITADA" "ALVO ausente nos"
+
 echo ""
 if [ "$FAIL" -eq 0 ]; then echo "--falsify: $PASS/$((PASS+FAIL)) divergiram (harness tem dente)"; exit 0
 else echo "--falsify: $FAIL sabotagem(ns) NÃO pega(s) — harness cego"; exit 1; fi

--- a/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
@@ -271,6 +271,21 @@ if [ "$FALSIFY" = 0 ]; then
   # emissor FORA dele são compatíveis — o --pai passa e o verde ainda pode ser bytes da lib.
   run_case_cwd "exclusiva no git E com 2º emissor na lib: --pai aprova, a sonda avisa, exit segue 0" \
                "$REPO" 0 "SENTINELA_TAMBEM_NA_LIB" "SENTINELA_NAO_EXCLUSIVA" --pai "$SHA_PAI" "LIB_OPTION_MARKER" "$BASE/site"
+  # ---- sonda do DELIMITADOR: fonte e bundle são universos com REPRESENTAÇÕES diferentes ----
+  # Medido em prod 2026-08-27 (chunk StaffDashboard servido): 'oculta' = 0 ocorrências e "oculta" = 1.
+  # O guard --pai mede a FONTE e APROVA; a varredura mede o BUNDLE e não acha => exit 1 FALSO, com os
+  # três guards verdes (exclusiva + LIB_SEM_A_SENTINELA + CONTROLE_POSITIVO_OK). O controle positivo
+  # não cobre isso por construção: prova que a rede e o grep funcionam, não que a sentinela seja
+  # REPRESENTÁVEL. Sem sabotagem própria porque a sonda AVISA e nunca move o exit (igual à de lib) —
+  # a rede aqui é BIDIRECIONAL: detector sempre-falso derruba o 1º caso, sempre-verdadeiro os outros.
+  run_case_cwd "sentinela DELIMITADA ausente do bundle: avisa que a ausência pode ser de REPRESENTAÇÃO" \
+               "$FIX/neutro" 1 "SENTINELA_DELIMITADA" "" "'SENTINELA_DEEP_XYZ'" "$BASE/site"
+  run_case_cwd "sentinela SEM delimitador: a sonda CALA (não vira ruído no caso comum)" \
+               "$FIX/neutro" 0 "deep-DDD444" "SENTINELA_DELIMITADA" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  # Aspas no MEIO são CONTEÚDO e sobrevivem à minificação — input[type="checkbox"] é justamente a
+  # sentinela que o Passo 4 recomenda. Aviso que disparasse nela estaria desarmado no primeiro dia.
+  run_case_cwd "aspas no MEIO (o 'valor nosso' do Passo 4): a sonda CALA" \
+               "$FIX/neutro" 1 "" "SENTINELA_DELIMITADA" 'a[type="x"]b' "$BASE/site"
   echo ""
   if [ "$FAIL" -eq 0 ]; then echo "verify-frontend: $PASS/$((PASS+FAIL)) passaram"; exit 0
   else echo "verify-frontend: $FAIL FALHA(S) de $((PASS+FAIL))"; exit 1; fi

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
@@ -175,6 +175,45 @@ else
       "   Isto NÃO é 'a sentinela está limpa' — é AUSÊNCIA DE DADO, e um 2º emissor segue possível."
   fi
 fi
+
+# ---- sonda do DELIMITADOR: a sentinela é representável no bundle? (roda ANTES da rede) ----
+# A 3ª pergunta ortogonal às duas de cima. O --pai mede a FONTE (`git grep` em src/); a varredura
+# mede o BUNDLE MINIFICADO. Para quase toda sentinela as duas representações coincidem — mas NÃO
+# quando a sentinela é o literal COM seus delimitadores: a fonte escreve 'oculta' (aspas simples,
+# padrão do prettier deste repo) e o esbuild emite "oculta". Medido em prod 2026-08-27, no chunk
+# StaffDashboard servido: 'oculta' = 0 ocorrências, "oculta" = 1. As duas formas são MUTUAMENTE
+# EXCLUSIVAS, então nenhuma sentinela delimitada passa o guard E casa no bundle:
+#   'oculta'  -> --pai PASSA (0 no pai, 2 no novo) e a varredura dá 0  => exit 1 FALSO
+#   "oculta"  -> --pai RECUSA (0 no novo)                              => exit 3, nem varre
+# O primeiro é o caro: "Publish pendente" sobre fix JÁ no ar, com os três guards verdes (medido —
+# ✓ sentinela exclusiva + ✓ LIB_SEM_A_SENTINELA + ✓ CONTROLE_POSITIVO_OK). O controle positivo não
+# cobre isto por construção: ele prova que a rede e o grep funcionam, não que a sentinela seja
+# REPRESENTÁVEL. Perguntas diferentes.
+#
+# Só as PONTAS disparam, e a distinção é a que decide: aspas como DELIMITADOR o bundler reescreve;
+# aspas como CONTEÚDO ele preserva — por isso input[type="checkbox"] e [role="button"], os "valores
+# nossos" que o Passo 4 recomenda, seguem limpos (aspas no meio, não nas bordas).
+#
+# AVISA, NUNCA RECUSA — mesma disciplina da sonda de lib: existe sentinela legítima delimitada (um
+# texto de UI que contenha as aspas no próprio conteúdo). Preditor, não prova. Nada aqui toca o exit.
+_prim=${ALVO%"${ALVO#?}"}   # primeiro caractere
+_ult=${ALVO#"${ALVO%?}"}    # último caractere
+DELIMITADA=0
+if [ "${#ALVO}" -ge 2 ] && [ "$_prim" = "$_ult" ]; then
+  case "$_prim" in
+    \'|\"|\`)
+      DELIMITADA=1
+      _alt="\"${ALVO#?}"; _alt="${_alt%?}\""
+      [ "$_prim" = '"' ] && { _alt="'${ALVO#?}"; _alt="${_alt%?}'"; }
+      printf '%s\n' \
+        "⚠️  SENTINELA_DELIMITADA — o ALVO começa e termina com $_prim, então ele é o LITERAL COM as aspas." \
+        "   O guard --pai mede a FONTE; a varredura mede o BUNDLE MINIFICADO, e o bundler NORMALIZA o" \
+        "   delimitador — logo uma ausência abaixo pode ser de REPRESENTAÇÃO, não de Publish. Se der" \
+        "   ausente, repita sem as aspas ou com a outra forma: $_alt" \
+        "   (aspas no MEIO são conteúdo e sobrevivem: input[type=\"checkbox\"] segue sentinela boa.)"
+      ;;
+  esac
+fi
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -305,4 +344,12 @@ echo "→ ❌ ALVO ausente nos $N chunks: Publish pendente, OU o ALVO não é li
 echo "   CONTROLE_NEGATIVO_NAO_SE_APLICA: ele audita o falso POSITIVO, e este ramo é o outro — aqui"
 echo "   o risco é o falso NEGATIVO (sonda cega lê idêntico a 'Publish pendente'), e quem o cobre é"
 echo "   o CONTROLE_POSITIVO acima."
+if [ "$DELIMITADA" = 1 ]; then
+  # Aqui a hipótese deixa de ser genérica: o guard --pai já provou que o ALVO existe na FONTE, e a
+  # varredura acabou de não achá-lo no BUNDLE. Delimitador normalizado explica exatamente esse par,
+  # e é BARATO de descartar — por isso ele vai antes de qualquer pedido de Publish.
+  echo "   ⚠️  E o ALVO é DELIMITADO (ver SENTINELA_DELIMITADA acima): esta ausência tem uma causa"
+  echo "   mais provável que 'Publish pendente' — o bundler reescreveu as aspas. DESCARTE ISSO PRIMEIRO,"
+  echo "   repetindo sem as aspas, ANTES de pedir um Publish que pode já ter acontecido."
+fi
 exit 1


### PR DESCRIPTION
## De onde veio

Verificando se o fix do `useLastVisit` (#2037) tinha chegado aos usuários. **Tinha** — e a
verificação principal fechou verde (chunk `StaffDashboard-DEEPSBte.js`, entry `index-BM_UJQwt.js`,
exit 0). O buraco apareceu ao escolher a sentinela.

## O achado

O guard `--pai` mede a **FONTE** (`git grep` em `src/`). A varredura mede o **BUNDLE MINIFICADO**.
Para o literal **com** seus delimitadores as duas formas divergem — a fonte escreve `'oculta'`
(aspas simples, prettier) e o esbuild emite `"oculta"`. Medido no chunk servido por
`steu.lovable.app`:

```
'oculta'  -> 0 ocorrências
"oculta"  -> 1 ocorrência
```

Mutuamente exclusivas ⇒ **nenhuma** sentinela delimitada passa o guard *e* casa:

| sentinela | `--pai` | varredura | veredito |
|---|---|---|---|
| `'oculta'` | **PASSA** (0 no pai, 2 no novo) | 0 chunks | **exit 1 FALSO** |
| `"oculta"` | **RECUSA** (0 no novo) | nem varre | exit 3 |

O primeiro é o caro, e foi medido inteiro contra produção:

```
✓ sentinela exclusiva
✓ LIB_SEM_A_SENTINELA
✓ CONTROLE_POSITIVO_OK
→ ❌ ALVO ausente nos 334 chunks: Publish pendente          (exit 1)
```

**Os três guards verdes e o veredito falso**, sobre um fix cuja presença o mesmo script prova com
outra sentinela. O custo é pedir um Publish já feito — e o gatilho é a **própria receita** do Passo 4
("ancore por VALOR nosso"), cujos exemplos `input[type="checkbox"]` e `[role="button"]` têm aspas e
funcionam, reforçando a intuição errada de que aspas na sentinela são seguras.

O `CONTROLE_POSITIVO` não cobria isto **por construção**: ele prova que a rede e o `grep` funcionam,
não que a sentinela seja **representável**. É a 3ª pergunta ortogonal — `--pai`: "é nova DENTRO do
git?" · sonda de lib: "existe emissor FORA do git?" · esta: "a forma que eu procuro é a forma que o
bundle emite?".

## O que muda

`SENTINELA_DELIMITADA`, sonda pré-rede que **avisa e nunca recusa** (como a de lib: existe sentinela
legítima cujo conteúdo traz aspas nas bordas). Só as **PONTAS** disparam — aspas como *delimitador* o
bundler reescreve, aspas como *conteúdo* ele preserva, então os dois exemplos que o doc recomenda
seguem silenciosos. No ramo `exit 1` a marca volta, dizendo o que descartar antes de pedir Publish.

## Evidência

Gate nos dois modos, com o rc propagado (`| head` engole exit code):

```
bash evals/run.sh              -> 8/8 + 28/28 passaram   (exit 0)
bash evals/run.sh --falsify    -> 8/8 + 13/13 divergiram (exit 0)
shellcheck scripts/ evals/     -> exit 0
```

`--falsify` só roda com a flag: um `run.sh` pelado devolve **0** linhas "divergiu" — ler isso como
aprovação seria ausência de dado.

Rede no harness, que nunca modelou esta classe (fixture com sentinela idêntica nos dois universos, e
bundle fake não-minificado): 3 casos bidirecionais + sabotagem `falsify_marca` — o helper que existe
para sonda que não move o exit. Detector sempre-falso derruba o 1º caso, sempre-verdadeiro os outros.

Aceitação contra prod, no cenário original: o aviso sai pré-rede com a forma alternativa já
calculada, e volta no veredito — *"DESCARTE ISSO PRIMEIRO ... ANTES de pedir um Publish que pode já
ter acontecido"*.

---

**Draft de propósito** — não pedi o merge. Tirar do draft arma o auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)