### PR TITLE
fix(authz): o audit de prod media 6 dos 8 privilégios — `REFERENCES`/`TRIGGER` eram declaráveis e nunca medidos

### DIFF
--- a/db/audit-grants-tabelas-fechadas.ts
+++ b/db/audit-grants-tabelas-fechadas.ts
@@ -52,17 +52,56 @@ function carregarAllowlist(): Record<string, TabelaFechada> {
 }
 
 /**
+ * Os 8 privilégios de TABELA que o contrato aceita declarar (`Priv`, em
+ * scripts/authz-tabelas-fechadas.ts) — TODOS medidos, e a exaustividade é obrigação de TIPO:
+ * `Record<Priv, …>` faz o `scripts:typecheck` reprovar se o contrato ganhar um 9º privilégio que
+ * este auditor não mediria.
+ *
+ * Por que isso é guarda e não decoração: `REFERENCES` e `TRIGGER` ficaram DECLARÁVEIS no
+ * `permitido` e nunca medidos até 2026-08-27 (medidos à MÃO uma única vez, em 2026-08-13). Nessa
+ * janela um `GRANT REFERENCES`/`GRANT TRIGGER` colado no SQL Editor passava por baixo das DUAS
+ * guardas — o gate estático lê migrations, e GRANT à mão não é migration nenhuma. Pior que a
+ * lacuna: declarar `permitido: { anon: ['REFERENCES'] }` fazia o contrato AFIRMAR uma cobertura
+ * inexistente, o modo de falha que o cabeçalho de scripts/authz-manifest.ts chama de "contrato
+ * falso é pior que lacuna".
+ *
+ * O valor é o `server_version_num` MÍNIMO em que `has_table_privilege` sabe responder aquele
+ * privilégio. MAINTAIN nasceu no Postgres 17 e ERRA (não devolve false — ERRA) em versão anterior;
+ * REFERENCES e TRIGGER existem desde sempre, por isso entram com 0, sem ramo de versão.
+ */
+const PRIV_DESDE: Record<Priv, number> = {
+  SELECT: 0,
+  INSERT: 0,
+  UPDATE: 0,
+  DELETE: 0,
+  TRUNCATE: 0,
+  REFERENCES: 0,
+  TRIGGER: 0,
+  MAINTAIN: 170000,
+};
+
+/** Privilégios que ESTA versão de servidor sabe responder. É a MESMA função que gera os ramos da
+ *  query e que dimensiona a conferência de cardinalidade — de propósito: enquanto foram duas
+ *  listas independentes (a query media 6 no PG17, o piso contava 5), perder um privilégio inteiro
+ *  da saída caía DENTRO da folga e passava batido. Uma lista só não pode divergir de si mesma. */
+function privsDaVersao(versao: number): Priv[] {
+  return (Object.keys(PRIV_DESDE) as Priv[]).filter((p) => versao >= PRIV_DESDE[p]);
+}
+
+/**
  * Uma query para toda a medição: produto cartesiano tabela × role × privilégio, cada linha
- * marcada com o prefixo `ROW|` para sobreviver ao eco de `SET` do psqlrc do psql-ro.
+ * marcada com o prefixo `ROW|` para sobreviver ao eco de `SET` do psqlrc do psql-ro. Antes delas
+ * vem UMA linha `VER|<server_version_num>` — não é enfeite: é ela que diz ao parser QUANTOS
+ * privilégios esta query mediu, e sem esse número a conferência de cardinalidade não existe.
  *
  * A tabela entra QUALIFICADA (`schema.name`, direto da chave da allowlist) — `has_table_privilege`
  * resolve o nome qualificado sozinho. Nada de assumir `public`: uma entrada futura em outro schema
  * mediria a tabela errada e o audit ficaria verde por comparar o objeto errado.
  *
- * MAINTAIN só existe no Postgres 17+; `has_table_privilege(...,'MAINTAIN')` ERRA em versão
- * anterior. Prod é 17.6 (medido 2026-08-13) e o `m` de `arwdDxtm` é justamente ele, então vale
- * medir — mas sob CASE de `server_version_num`, para o audit não quebrar se algum dia apontar
- * para um banco mais velho.
+ * Um ramo de CASE por LIMIAR de versão, do mais novo para o mais velho, GERADO de `PRIV_DESDE`: o
+ * primeiro que a versão do servidor alcança vence. Prod é 17.6 (medido 2026-08-27) e o `m` de
+ * `arwdDxtm` é justamente o MAINTAIN, então vale medir — o ramo existe para o audit não quebrar
+ * se algum dia apontar para um banco mais velho.
  *
  * O veredito sai como SIM/NAO de um CASE, não como o boolean cru: `'x'||has_table_privilege(...)`
  * imprime `true`/`false`, e um parser que espere `t`/`f` (o formato de COLUNA boolean) descarta
@@ -72,13 +111,19 @@ function carregarAllowlist(): Record<string, TabelaFechada> {
  */
 function montarQuery(chaves: string[]): string {
   const lista = (xs: readonly string[]) => xs.map((x) => `'${x.replace(/'/g, "''")}'`).join(',');
-  const privBase = ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE'];
-  return `SELECT 'ROW|'||t||'|'||r||'|'||p||'|'||(CASE WHEN has_table_privilege(r,t,p) THEN 'SIM' ELSE 'NAO' END)
+  const ramos = [...new Set(Object.values(PRIV_DESDE))]
+    .sort((a, b) => b - a)
+    .map(
+      (v) => `WHEN current_setting('server_version_num')::int >= ${v}
+                                 THEN ARRAY[${lista(privsDaVersao(v))}]`,
+    )
+    .join('\n                            ');
+  return `SELECT 'VER|'||current_setting('server_version_num')
+          UNION ALL
+          SELECT 'ROW|'||t||'|'||r||'|'||p||'|'||(CASE WHEN has_table_privilege(r,t,p) THEN 'SIM' ELSE 'NAO' END)
           FROM unnest(ARRAY[${lista(chaves)}]::text[]) t,
                unnest(ARRAY[${lista(ROLES)}]::text[]) r,
-               unnest((CASE WHEN current_setting('server_version_num')::int >= 170000
-                            THEN ARRAY[${lista([...privBase, 'MAINTAIN'])}]
-                            ELSE ARRAY[${lista(privBase)}] END)::text[]) p;`;
+               unnest((CASE ${ramos} END)::text[]) p;`;
 }
 
 function medir(al: Record<string, TabelaFechada>): MedicaoProd {
@@ -93,23 +138,44 @@ function medir(al: Record<string, TabelaFechada>): MedicaoProd {
   }
   const med: MedicaoProd = {};
   let lidas = 0;
+  let versao: number | null = null;
   for (const linha of saida.split('\n')) {
+    if (linha.startsWith('VER|')) {
+      versao = Number.parseInt(linha.slice(4), 10);
+      continue;
+    }
     if (!linha.startsWith('ROW|')) continue; // descarta o eco de SET e linhas em branco
     lidas++;
     const [, tabela, role, priv, tem] = linha.split('|');
     if (tem !== 'SIM') continue; // só o privilégio PRESENTE entra no mapa
     ((med[tabela] ??= {})[role as (typeof ROLES)[number]] ??= []).push(priv as Priv);
   }
-  // A query devolve tabelas × roles × privilégios linhas SEMPRE — inclusive quando a resposta é
-  // "não tem nenhum". Vir menos que o piso significa que a medição quebrou (parser, psqlrc,
-  // saída truncada), e medição quebrada lida como "nada divergente" é o falso-verde perfeito:
-  // um audit silencioso é indistinguível de um audit que aprovou. Ausência de dado sai 2.
-  const piso = chaves.length * ROLES.length * 5;
-  if (lidas < piso) {
+  // Sem a VER| não há denominador: não se sabe se a query mediu 7 privilégios ou 8, e a conferência
+  // abaixo deixa de existir. Ausência de dado não é aprovação — sai 2, como todo erro de execução.
+  if (versao === null || !Number.isFinite(versao)) {
     erroFatal(
-      `medição inconsistente: ${lidas} linha(s) ROW| lidas, mínimo esperado ${piso} ` +
-        `(${chaves.length} tabela(s) × ${ROLES.length} role(s) × 5 privilégios). ` +
-        `A saída do psql mudou de forma — NÃO trate como "tudo fechado".`,
+      'medição inconsistente: a linha VER| (server_version_num) não veio na saída do psql. ' +
+        'Sem ela não se sabe QUANTOS privilégios a query mediu, e a conferência de cardinalidade ' +
+        'deixa de existir. NÃO trate como "tudo fechado".',
+    );
+  }
+  // A query devolve tabelas × roles × privilégios linhas SEMPRE — inclusive quando a resposta é
+  // "não tem nenhum". Divergir da conta significa que a medição quebrou (parser, psqlrc, saída
+  // truncada), e medição quebrada lida como "nada divergente" é o falso-verde perfeito: um audit
+  // silencioso é indistinguível de um audit que aprovou. Ausência de dado sai 2.
+  //
+  // A conta é EXATA (`!==`) e não um piso (`<`), e a troca tem dente: o piso era o literal `5`, que
+  // não acompanhou a query — no PG17 ela já devolvia 6 privilégios, então perder TODAS as linhas de
+  // um privilégio deixava `lidas` em cima do piso e o audit seguia verde sobre medição incompleta.
+  // Piso comparado a literal escrito à mão envelhece sozinho a cada privilégio novo; a conta exata
+  // sai da MESMA lista que a query usou, e ainda pega duplicação de linha, que piso nenhum pega.
+  const nPrivs = privsDaVersao(versao).length;
+  const esperado = chaves.length * ROLES.length * nPrivs;
+  if (lidas !== esperado) {
+    erroFatal(
+      `medição inconsistente: ${lidas} linha(s) ROW| lidas, esperado EXATAMENTE ${esperado} ` +
+        `(${chaves.length} tabela(s) × ${ROLES.length} role(s) × ${nPrivs} privilégio(s) no ` +
+        `server_version_num ${versao}). A saída do psql mudou de forma — NÃO trate como "tudo fechado".`,
     );
   }
   return med;

--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "medidoEm": "2026-08-27T21:49:35.389Z",
-  "sourceHead": "c311c5d98fcfc554211bec1c336213581cc7affa",
+  "medidoEm": "2026-08-27T22:22:35.845Z",
+  "sourceHead": "f17832314fcd3d488414fcd12ccd062b2ff86a56",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -24,7 +24,7 @@
       "resumo": "✅ audit-grants — 3 tabela(s) conferida(s); prod bate com o contrato.",
       "denominador": null,
       "contratoFingerprint": "a30df79275ec861caa72d352a05739b1887871d14f26151102abce883ba54c64",
-      "auditorFingerprint": "23016f8e55bc15155b356b18a5392a7d4e547a101ec43cd6b376d418074aff83",
+      "auditorFingerprint": "c8bfa51c1f3b96b4466c8ca1cff352a2ad75d055db82c0b08f053ef32e4a42af",
       "achados": []
     },
     "audit": {

--- a/db/test-audit-grants-tabelas-fechadas.sh
+++ b/db/test-audit-grants-tabelas-fechadas.sh
@@ -13,7 +13,11 @@
 # ║   (D) GRANT INSERT,UPDATE,DELETE           → NAO_APLICADA (não DRIFT), exit 1   ║
 # ║   (E) GRANT MAINTAIN (PG17)                → DRIFT_PROD, exit 1                 ║
 # ║   (F) GRANT SELECT a anon                  → acusa anon (permitido [])          ║
-# ║   (G) revoga tudo                          → volta ao limpo, exit 0  ← dente    ║
+# ║   (G) GRANT REFERENCES a anon              → DRIFT_PROD nomeando REFERENCES     ║
+# ║   (H) GRANT TRIGGER a authenticated        → DRIFT_PROD nomeando TRIGGER        ║
+# ║   (I) revoga tudo                          → volta ao limpo, exit 0  ← dente    ║
+# ║   (J) saída com 1 privilégio ENGOLIDO      → exit 2, NÃO exit 0      ← dente    ║
+# ║   (K) saída sem a linha VER|               → exit 2 (sem denominador)           ║
 # ║                                                                                ║
 # ║  A allowlist entra por AUTHZ_GRANTS_TEST_JSON — o contrato real do repo não é   ║
 # ║  tocado, e o teste não quebra quando product_costs/omie_products mudarem.       ║
@@ -37,6 +41,8 @@ TMPD="$(mktemp -d "${TMPDIR:-/tmp}/pgtest-audit-grants.XXXXXX")"
 DATA="$TMPD/data"
 OUT="$TMPD/audit-saida.txt"
 WRAP="$TMPD/psql-ro-fake"
+WRAP_PERDA="$TMPD/psql-ro-fake-perda"
+WRAP_SEM_VER="$TMPD/psql-ro-fake-sem-ver"
 export LC_ALL="${LC_ALL:-C}" LANG="${LANG:-C}"
 
 [ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
@@ -65,6 +71,21 @@ exec "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "\$@"
 WRAPEOF
 chmod +x "$WRAP"
 
+# Wrappers DESONESTOS: o mesmo psql, com a saída MUTILADA de duas formas plausíveis (psql truncado,
+# psqlrc filtrando, pipe quebrado). Existem para provar que o audit REPROVA em vez de ler medição
+# incompleta como "nada divergente" — o falso-verde perfeito. `sed` (e não `grep -v`) porque grep
+# que não casa nada sai 1 e o erro viria do execFileSync, dando o exit certo pelo motivo errado.
+cat > "$WRAP_PERDA" <<WRAPEOF
+#!/usr/bin/env bash
+exec "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "\$@" | sed '/|MAINTAIN|/d'
+WRAPEOF
+chmod +x "$WRAP_PERDA"
+cat > "$WRAP_SEM_VER" <<WRAPEOF
+#!/usr/bin/env bash
+exec "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "\$@" | sed '/^VER|/d'
+WRAPEOF
+chmod +x "$WRAP_SEM_VER"
+
 # Roles do Supabase + a tabela no estado FECHADO do contrato.
 P <<'SQL'
 DO $$ BEGIN
@@ -83,9 +104,10 @@ TEST_JSON='{"public.zz_fechada_test":{"fechadaPor":"20260101000000_x.sql","permi
 
 # `|| ec=$?` é obrigatório: sob `set -e`, um audit que sai 1 (o caso que QUEREMOS) mataria o
 # harness antes da asserção, e o teste passaria a nunca reprovar.
+WRAP_ATUAL="$WRAP"   # trocado nos cenários J/K para um wrapper de saída MUTILADA
 run_audit() {
   local ec=0
-  PSQL_RO="$WRAP" AUTHZ_GRANTS_TEST_JSON="$TEST_JSON" \
+  PSQL_RO="$WRAP_ATUAL" AUTHZ_GRANTS_TEST_JSON="$TEST_JSON" \
     bun "$REPO_ROOT/db/audit-grants-tabelas-fechadas.ts" > "$OUT" 2>&1 || ec=$?
   echo "$ec"
 }
@@ -93,14 +115,19 @@ run_audit() {
 PASS=0
 FAIL=0
 # esperar <rótulo> <exit esperado> <código que DEVE aparecer|-> <código que NÃO pode aparecer|->
+#         [<trecho DELIMITADO que DEVE aparecer|->]
 # O 4º argumento é o que separa "acusou" de "acusou a coisa certa": casar só a presença deixaria
 # NAO_APLICADA e DRIFT_PROD indistinguíveis, e o operador aplicaria a correção errada.
+# O 5º é a mesma exigência um nível abaixo: o código DRIFT_PROD sozinho não distingue QUAL
+# privilégio vazou, então um cenário de REFERENCES ficaria verde com o audit acusando TRIGGER —
+# ou acusando qualquer sobra por outro motivo. Ele casa a marca do RAMO, não "acusou algo".
 esperar() {
-  local rotulo="$1" ec_esperado="$2" deve="$3" nao_deve="$4" ec erro=""
+  local rotulo="$1" ec_esperado="$2" deve="$3" nao_deve="$4" trecho="${5:--}" ec erro=""
   ec="$(run_audit)"
   [ "$ec" = "$ec_esperado" ] || erro="exit $ec (esperava $ec_esperado)"
   if [ "$deve" != "-" ] && ! command grep -q "$deve" "$OUT"; then erro="$erro | ausente: $deve"; fi
   if [ "$nao_deve" != "-" ] && command grep -q "$nao_deve" "$OUT"; then erro="$erro | presente indevido: $nao_deve"; fi
+  if [ "$trecho" != "-" ] && ! command grep -q "$trecho" "$OUT"; then erro="$erro | ausente: $trecho"; fi
   if [ -z "$erro" ]; then
     PASS=$((PASS + 1)); echo "  ✅ $rotulo"
   else
@@ -129,9 +156,36 @@ P -c "GRANT SELECT ON TABLE public.zz_fechada_test TO anon;"
 esperar "F: SELECT a anon (permitido vazio) → DRIFT_PROD (exit 1)" 1 DRIFT_PROD NAO_APLICADA
 
 P -c "REVOKE SELECT ON TABLE public.zz_fechada_test FROM anon;"
-esperar "G: tudo revogado → volta ao limpo (exit 0)" 0 - DRIFT_PROD
+# G e H são os privilégios que o contrato sempre aceitou DECLARAR e o audit nunca mediu (até
+# 2026-08-27): GRANT à mão no SQL Editor não é migration, então o gate estático também não os vê.
+# O 5º argumento casa o nome do privilégio no texto — sem ele os dois cenários passariam com o
+# audit acusando qualquer OUTRA sobra, e a extensão pareceria provada sem estar.
+P -c "GRANT REFERENCES ON TABLE public.zz_fechada_test TO anon;"
+esperar "G: REFERENCES a anon → DRIFT_PROD nomeando REFERENCES (exit 1)" 1 DRIFT_PROD NAO_APLICADA \
+  "anon tem REFERENCES"
+
+P -c "REVOKE REFERENCES ON TABLE public.zz_fechada_test FROM anon;"
+P -c "GRANT TRIGGER ON TABLE public.zz_fechada_test TO authenticated;"
+esperar "H: TRIGGER a authenticated → DRIFT_PROD nomeando TRIGGER (exit 1)" 1 DRIFT_PROD NAO_APLICADA \
+  "authenticated tem TRIGGER"
+
+P -c "REVOKE TRIGGER ON TABLE public.zz_fechada_test FROM authenticated;"
+esperar "I: tudo revogado → volta ao limpo (exit 0)" 0 - DRIFT_PROD
+
+# J/K medem a GUARDA DE CARDINALIDADE, não o contrato: o banco está limpo nos dois, e o que muda é
+# a saída do psql. J engole as linhas de UM privilégio — 1 tabela × 2 roles × 8 privilégios = 16
+# linhas ROW| viram 14. Era exatamente o buraco do piso literal `5` (mínimo 10): 14 ≥ 10 saía
+# `exit 0` e "✅ prod bate com o contrato" sobre uma medição incompleta. Com a conta EXATA sai 2.
+WRAP_ATUAL="$WRAP_PERDA"
+esperar "J: 1 privilégio engolido da saída → exit 2, não 0" 2 - DRIFT_PROD "medição inconsistente"
+
+# K tira o denominador: sem VER| o audit não sabe se a query mediu 7 privilégios ou 8, e conferir
+# cardinalidade contra um número desconhecido é teatro. Ausência de dado sai 2, não 0.
+WRAP_ATUAL="$WRAP_SEM_VER"
+esperar "K: saída sem a linha VER| → exit 2 (sem denominador)" 2 - DRIFT_PROD "VER|"
+WRAP_ATUAL="$WRAP"
 
 echo "──────────────"
 echo "RESULTADO: $PASS ok / $FAIL fail  (locale LC_ALL=$LC_ALL)"
 [ "$FAIL" = 0 ] || { echo "❌ VERMELHO"; exit 1; }
-echo "✅ audit de prod com DENTE: acusa reabertura, distingue NAO_APLICADA de DRIFT_PROD, mede MAINTAIN e anon, e reage à correção"
+echo "✅ audit de prod com DENTE: acusa reabertura, distingue NAO_APLICADA de DRIFT_PROD, mede os 8 privilégios (REFERENCES/TRIGGER/MAINTAIN inclusive) e anon, reage à correção e REPROVA medição incompleta"

--- a/docs/historico/sentinela-grants-tabelas-fechadas.md
+++ b/docs/historico/sentinela-grants-tabelas-fechadas.md
@@ -292,3 +292,88 @@ real. Entre os 10, um TS2307 que valeu a investigação: o #1201 deletou `src/li
 como "0 refs provadas" e quebrou `scripts/radar/carga.ts` — a ref era invisível ao knip (fora do
 `project`) **e** ao tsc (fora do `include`), e ficou verde por 5 semanas. Todos corrigidos; o gate
 entrou em zero, sem baseline.
+
+## 2026-08-27 — o audit media 6 dos 8 privilégios: `REFERENCES`/`TRIGGER` declaráveis e nunca medidos
+
+Achado do ritual `/codex` no PR #2044, verificado por leitura direta. `Priv`
+(`scripts/authz-tabelas-fechadas.ts`) aceita 8 privilégios de tabela no campo `permitido`; o audit
+de prod media 5 + `MAINTAIN` sob CASE de versão. `REFERENCES` e `TRIGGER` eram **declaráveis e
+invisíveis**.
+
+### Por que a lacuna não era inócua
+
+As duas camadas erravam pelo mesmo buraco, por caminhos diferentes: o gate estático lê **migrations**
+e um `GRANT REFERENCES` colado no SQL Editor não é migration nenhuma; o audit de prod lê o **banco**
+mas não olhava esses dois privilégios. Nenhum ente acusaria.
+
+Pior que a lacuna é o que ela fazia com o contrato: `permitido: { anon: ['REFERENCES'] }` era
+aceito, e a entrada passava a **AFIRMAR uma cobertura que não existia** — o modo de falha que o
+cabeçalho de `scripts/authz-manifest.ts` chama de "contrato falso é pior que lacuna". Os dois foram
+medidos à MÃO uma única vez (2026-08-13, `NAO` nas duas roles); o que faltava era a re-medição
+automática — e medição à mão não repetida é evidência com prazo de validade.
+
+### Duas listas independentes viraram uma, e a exaustividade virou tipo
+
+`PRIV_DESDE: Record<Priv, number>` mapeia privilégio → `server_version_num` mínimo em que
+`has_table_privilege` sabe respondê-lo (`MAINTAIN` = 170000, ele **erra** — não devolve `false` —
+em PG anterior; `REFERENCES`/`TRIGGER` existem desde sempre e entram com 0). A **mesma** função
+`privsDaVersao()` gera os ramos do `CASE` da query **e** dimensiona a conferência de cardinalidade.
+
+`Record<Priv, …>` é exaustivo por construção: um 9º privilégio no contrato reprova em
+`scripts:typecheck` em vez de reaparecer em silêncio. Foi assim que estes dois passaram — nada
+obrigava as duas listas a coincidirem.
+
+### O piso de cardinalidade estava calibrado abaixo da própria query
+
+O piso era o literal `5` enquanto a query já devolvia **6** no PG17 — a folga cabia um privilégio
+inteiro. Perder todas as linhas de `MAINTAIN` deixava `lidas` exatamente em cima do piso e o audit
+saía **0** com "✅ prod bate com o contrato" sobre uma medição incompleta.
+
+A troca não foi subir o número: **piso comparado a literal escrito à mão envelhece sozinho** a cada
+privilégio novo — é a mesma dívida, adiada. A query passou a emitir uma linha
+`VER|<server_version_num>` e o parser compara `!==` contra `tabelas × roles × privsDaVersao(versão)`.
+Conta exata pega perda parcial **e** duplicação de linha, que piso nenhum pega; e sem a `VER|` não
+há denominador — conferir cardinalidade contra número desconhecido é teatro, então falta de `VER|`
+sai **2**, não 0.
+
+### Falsificação (rodada contra o auditor anterior, não contra uma sabotagem inventada)
+
+Harness PG17 vai de 7 para 11 cenários. Restaurado o auditor pré-mudança, os 4 novos ficam
+**vermelhos** e os 7 antigos seguem verdes:
+
+| Cenário | Auditor anterior | Auditor novo |
+|---|---|---|
+| G `GRANT REFERENCES` a `anon` | exit 0, **sem** `DRIFT_PROD` | exit 1, `DRIFT_PROD` nomeando `REFERENCES` |
+| H `GRANT TRIGGER` a `authenticated` | exit 0, **sem** `DRIFT_PROD` | exit 1, `DRIFT_PROD` nomeando `TRIGGER` |
+| J saída com 1 privilégio engolido | **exit 0** ("prod bate com o contrato") | exit 2, `medição inconsistente` |
+| K saída sem a linha `VER|` | exit 0 | exit 2 |
+
+G e H casam o **nome do privilégio** no texto, não só o código `DRIFT_PROD`: o código sozinho não
+distingue QUAL privilégio vazou, e o cenário de `REFERENCES` ficaria verde com o audit acusando
+outra sobra qualquer. J e K medem a guarda de cardinalidade com o banco **limpo** — o que muda é a
+saída do psql, mutilada por wrappers desonestos (`sed`, não `grep -v`: grep que não casa nada sai 1
+e o erro viria do `execFileSync`, dando o exit certo pelo motivo errado).
+
+Verde nos dois locales (`LC_ALL=C` e `pt_BR.UTF-8`), 11/11.
+
+⚠️ Armadilha que a restauração destampou: a sabotagem foi `git checkout HEAD~1 -- <arquivo>`, que
+**escreve no índice**. `git checkout -- <arquivo>` restaura *do índice* e devolveu o arquivo
+sabotado — o harness seguiu 7/11 e teria virado "a mudança não funciona". Restaurar é
+`git checkout HEAD -- <arquivo>`, e quem pegou foi a conferência positiva (`grep -c PRIV_DESDE`),
+não a ausência de erro.
+
+### Estado de prod na entrega (`psql-ro`, 2026-08-27, PG 17.6)
+
+`REFERENCES` e `TRIGGER` = `NAO` nas 3 tabelas × 2 roles, confirmado por `relacl`. A extensão
+**fecha o buraco, não acusa dívida** — `bun run authz:grants:prod` sai 0. As 3 entradas batem com o
+contrato: `product_costs` e `omie_products` com `authenticated=r` e `anon` fora do `relacl`,
+`sales_orders` com `authenticated=ad` e `anon` fora — ou seja, o fecho de `product_costs` foi
+aplicado e o `anon=ad` do Achado 2 está revogado.
+
+### Acoplamento com o carimbo (PR #2044)
+
+`db/audit-grants-tabelas-fechadas.ts` é um dos `auditorFiles` do carimbo, então esta mudança altera
+o `auditorFingerprint` e invalida `db/authz-carimbo-prod.json` — **é o desenho funcionando**. O
+#2044 estava aberto e em conflito quando esta entrega saiu, então o carimbo ainda não existia na
+main para ser regravado: quem rebasear o #2044 sobre esta mudança precisa rodar
+`bun run authz:carimbo:gravar` (exige `psql-ro`) antes de o gate `authz:carimbo` passar.

--- a/docs/historico/sentinela-grants-tabelas-fechadas.md
+++ b/docs/historico/sentinela-grants-tabelas-fechadas.md
@@ -370,10 +370,20 @@ contrato: `product_costs` e `omie_products` com `authenticated=r` e `anon` fora 
 `sales_orders` com `authenticated=ad` e `anon` fora — ou seja, o fecho de `product_costs` foi
 aplicado e o `anon=ad` do Achado 2 está revogado.
 
-### Acoplamento com o carimbo (PR #2044)
+### O carimbo reprovou, como devia
 
-`db/audit-grants-tabelas-fechadas.ts` é um dos `auditorFiles` do carimbo, então esta mudança altera
-o `auditorFingerprint` e invalida `db/authz-carimbo-prod.json` — **é o desenho funcionando**. O
-#2044 estava aberto e em conflito quando esta entrega saiu, então o carimbo ainda não existia na
-main para ser regravado: quem rebasear o #2044 sobre esta mudança precisa rodar
-`bun run authz:carimbo:gravar` (exige `psql-ro`) antes de o gate `authz:carimbo` passar.
+`db/audit-grants-tabelas-fechadas.ts` é um dos `auditorFiles` do carimbo (PR #2044, mergeado
+enquanto esta entrega estava em voo), então mudar o auditor muda o `auditorFingerprint` e invalida
+`db/authz-carimbo-prod.json`. Rebaseado sobre a main com o carimbo, o gate acusou:
+
+```
+❌ [CARIMBO_AUDITOR_MUDOU] `grants`: o AUDITOR mudou desde a medição — o instrumento não é mais
+   o que produziu esta evidência. Rode `bun run authz:carimbo:gravar`.
+```
+
+**Isso é o desenho funcionando, não defeito**: evidência de prod colhida por um instrumento que já
+não existe não é evidência daquele instrumento. Regravado com `bun run authz:carimbo:gravar` (exige
+`psql-ro`; o runner recusa `PSQL_RO` alternativo e allowlist de teste, e pina o `system_identifier`
+do cluster). O diff do carimbo tem 3 linhas: `medidoEm`, `sourceHead` e o `auditorFingerprint` de
+`grants` — o `contratoFingerprint` fica intacto, porque esta entrega mexeu no INSTRUMENTO e não no
+contrato, e `achados: []` continua vazio.


### PR DESCRIPTION
## O buraco

`Priv` (`scripts/authz-tabelas-fechadas.ts:40`) aceita **8** privilégios de tabela no campo
`permitido`. `db/audit-grants-tabelas-fechadas.ts` media **6**: `SELECT,INSERT,UPDATE,DELETE,TRUNCATE`
+ `MAINTAIN` sob CASE de versão. `REFERENCES` e `TRIGGER` eram **declaráveis e nunca medidos**.

As duas camadas da sentinela erravam pelo mesmo ponto, por caminhos diferentes: o gate estático lê
**migrations**, e um `GRANT REFERENCES` colado à mão no SQL Editor não é migration nenhuma; o audit
de prod lê o **banco**, mas não olhava esses dois. Ninguém acusaria.

Pior que a lacuna é o que ela fazia com o contrato: `permitido: { anon: ['REFERENCES'] }` era aceito
e passava a **AFIRMAR uma cobertura inexistente** — o "contrato falso é pior que lacuna" do cabeçalho
de `scripts/authz-manifest.ts`. Achado do ritual `/codex` no #2044.

## O que mudou

**Uma lista, não duas.** `PRIV_DESDE: Record<Priv, number>` mapeia privilégio → `server_version_num`
mínimo em que `has_table_privilege` sabe respondê-lo. A **mesma** `privsDaVersao()` gera os ramos do
`CASE` da query **e** dimensiona a conferência de cardinalidade. `Record<Priv, …>` é exaustivo por
construção: um 9º privilégio no contrato reprova em `scripts:typecheck` em vez de reaparecer em
silêncio — foi por não haver essa amarra que estes dois passaram.

`MAINTAIN` segue com ramo de versão (ele **erra**, não devolve `false`, em PG < 17). `REFERENCES` e
`TRIGGER` existem desde sempre: entram com limiar 0, sem ramo.

**O piso de cardinalidade estava calibrado abaixo da própria query.** Era o literal `5` enquanto a
query já devolvia `6` no PG17 — a folga cabia um privilégio inteiro: perder todas as linhas de
`MAINTAIN` deixava `lidas` em cima do piso e o audit saía **0** com "✅ prod bate com o contrato"
sobre medição incompleta. A correção não foi subir o número (piso comparado a literal escrito à mão
envelhece sozinho a cada privilégio novo — é a mesma dívida adiada): a query passou a emitir
`VER|<server_version_num>` e o parser compara `!==` contra `tabelas × roles × privsDaVersao(versão)`.
Conta exata pega perda parcial **e** duplicação, que piso nenhum pega. Sem `VER|` não há
denominador ⇒ exit **2**, não 0.

## Falsificação — contra o auditor anterior, não contra uma sabotagem inventada

Harness PG17 vai de 7 para **11** cenários. Restaurado o auditor pré-mudança, os 4 novos ficam
vermelhos e os 7 antigos seguem verdes (`7 ok / 4 fail`):

| Cenário | Auditor anterior | Auditor novo |
|---|---|---|
| G `GRANT REFERENCES` a `anon` | exit 0, **sem** `DRIFT_PROD` | exit 1, `DRIFT_PROD` nomeando `REFERENCES` |
| H `GRANT TRIGGER` a `authenticated` | exit 0, **sem** `DRIFT_PROD` | exit 1, `DRIFT_PROD` nomeando `TRIGGER` |
| J saída com 1 privilégio engolido | **exit 0** | exit 2, `medição inconsistente` |
| K saída sem a linha `VER\|` | exit 0 | exit 2 |

G e H casam o **nome do privilégio** no texto, não só o código: `DRIFT_PROD` sozinho não distingue
QUAL privilégio vazou, e o cenário de `REFERENCES` ficaria verde com o audit acusando outra sobra.
J e K medem a guarda de cardinalidade com o banco **limpo** — o que muda é a saída do psql, mutilada
por wrappers desonestos (`sed`, não `grep -v`: grep que não casa nada sai 1 e o erro viria do
`execFileSync`, dando o exit certo pelo motivo errado).

## Estado de prod (re-medido, não deduzido)

`psql-ro`, 2026-08-27, PG 17.6: `REFERENCES` e `TRIGGER` = `NAO` nas 3 tabelas × 2 roles, confirmado
por `relacl`. **A extensão fecha o buraco, não acusa dívida.** As 3 entradas batem com o contrato —
inclusive o `anon=ad` de `sales_orders` (Achado 2), já revogado.

## Carimbo

O #2044 mergeou com esta entrega em voo. Rebaseado, `authz:carimbo` acusou
`CARIMBO_AUDITOR_MUDOU` — **o desenho funcionando**. Regravado com `authz:carimbo:gravar` sob
`psql-ro`; os 4 audits saíram 0. O diff do carimbo tem 3 linhas: `medidoEm`, `sourceHead` e o
`auditorFingerprint` de `grants`. O `contratoFingerprint` fica **intacto** — esta entrega mexeu no
INSTRUMENTO, não no contrato — e `achados` segue vazio.

## Validação

- `heavy bun run test` → **exit 0** (745 arquivos, 7370 testes)
- `bun run scripts:typecheck` · `bun run lint` (0 erros) · `bun run authz:check` · `bun run authz:carimbo` → exit 0
- Harness PG17 **11/11** nos dois locales (`LC_ALL=C` e `pt_BR.UTF-8`)
- `bun run authz:grants:prod` → exit 0 contra prod real

Nenhuma migration: `supabase/migrations/` é DR e nada aqui emite DDL. Diário em
`docs/historico/sentinela-grants-tabelas-fechadas.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
