### PR TITLE
feat(pendencias): "quais sessões faltam terminar?" não tem resposta — pendência não se lembra, se MEDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "docs:indice": "bun scripts/docs-indice-gate-check.ts",
     "docs:links": "bun scripts/docs-links-gate-check.ts",
     "sonda:sql": "bun scripts/sonda-versao-sql.ts",
+    "pendencias": "bash scripts/pendencias.sh",
+    "pendencias:deploy": "bun scripts/pendencias-deploy.ts",
     "mutcheck": "bash scripts/mutcheck-all.sh",
     "mutcheck:selftest": "bash scripts/mutcheck.sh --selftest",
     "wt": "bash scripts/new-worktree.sh",

--- a/scripts/lib/pendencias-deploy.ts
+++ b/scripts/lib/pendencias-deploy.ts
@@ -1,0 +1,169 @@
+/**
+ * pendencias-deploy.ts — julga DIVERGÊNCIA DE DEPLOY lendo o que prod já respondeu.
+ * ============================================================================================
+ *
+ * Irmão PASSIVO do `sonda:sql`. Aquele é o caminho ATIVO: gera SQL que o founder cola para
+ * disparar as sondas. Este não dispara nada — lê os corpos que o cron (ou uma sondagem
+ * anterior) JÁ gravou em `net._http_response` e compara o `fonte` observado com o mapa
+ * commitado. Custo zero, ninguém no circuito, e por isso pode virar cron.
+ *
+ * POR QUE PASSIVO IMPORTA: o ativo depende de alguém lembrar de rodar. Foi assim que o deploy
+ * pendente da `omie-vendas-sync` (commit 8c2a8b716) ficou semanas sem dono — nenhuma sessão
+ * tinha o item anotado, e o único jeito de descobrir era comparar prod contra a main. Pendência
+ * não se lembra; pendência se mede.
+ *
+ * AS TRÊS ARMADILHAS QUE MOLDARAM O VEREDITO — todas são "silêncio lido como aprovação":
+ *
+ *   1. NÃO OBSERVADA ≠ CONFERE. Uma edge sem sonda na janela do `pg_net.ttl` (6h) não produziu
+ *      dado nenhum. Contá-la como OK é fabricar veredito — o `ausente ≠ zero` do money-path na
+ *      sua forma mais barata de cometer. Ela tem estado PRÓPRIO e o relatório a nomeia.
+ *
+ *   2. `fonte: "nao-mapeada"` é DIVERGÊNCIA, não ausência. É o que o bundle responde quando o
+ *      `index.ts` subiu mas o `_shared/sonda-fingerprints.ts` ficou para trás (o prompt de deploy
+ *      que nomeia poucos arquivos — `lovable-deploy-verify` Passo 3). O `versao` sai CERTO nesse
+ *      caso, então quem julga só pelo marcador lê deploy incompleto como confirmado.
+ *
+ *   3. ZERO OBSERVAÇÕES é falha de MECÂNICA, nunca "tudo limpo". Query que não devolve linha e
+ *      query que devolve só linhas conformes têm a mesma cara num relatório que só lista
+ *      problemas. Por isso `julgar` devolve os totais e o CLI trata zero como exit 2.
+ */
+
+/** O que prod respondeu para uma edge, extraído de `net._http_response`. */
+export interface Observacao {
+  edge: string;
+  versao: string;
+  fonte: string;
+  criado: string;
+}
+
+export type Estado =
+  | 'CONFERE'
+  | 'DIVERGE'
+  | 'SEM_MAPA_NO_BUNDLE'
+  | 'NAO_OBSERVADA'
+  | 'FORA_DO_MAPA';
+
+export interface Veredito {
+  edge: string;
+  estado: Estado;
+  esperado: string | null;
+  observado: string | null;
+  versao: string | null;
+  criado: string | null;
+}
+
+export interface Relatorio {
+  vereditos: Veredito[];
+  /** Edges no mapa commitado (universo que este instrumento consegue julgar). */
+  totalMapeadas: number;
+  /** Edges do mapa que produziram resposta na janela. */
+  totalObservadas: number;
+  /** Edges que exigem ação: DIVERGE + SEM_MAPA_NO_BUNDLE. */
+  totalDivergentes: number;
+  /** Linhas da saída do psql que não casaram o formato — ruído é sintoma, não é para engolir. */
+  linhasIgnoradas: number;
+}
+
+/** O sentinela que `criarRespostaSonda` emite quando o bundle não traz o mapa de fingerprints. */
+export const SEM_MAPA = 'nao-mapeada';
+
+const CAMPOS = 4;
+
+/**
+ * Chatter do wrapper `psql-ro`, que emite `SET` ao fixar os parâmetros da sessão.
+ *
+ * Filtrado ANTES da contagem de ruído de propósito: contar o esperado como anomalia faria o aviso
+ * de `linhasIgnoradas` disparar em TODA execução, e aviso que toca contra a resposta certa é aviso
+ * desarmado no primeiro dia — o operador aprende a ignorá-lo, e então ele cala quando importa.
+ */
+const CHATTER = new Set(['SET', 'BEGIN', 'COMMIT', 'ROLLBACK']);
+
+/**
+ * Faz o parse da saída `psql -A -F'|' -t`.
+ *
+ * O wrapper `psql-ro` imprime linhas de `SET` antes do resultado, e uma linha malformada não pode
+ * virar observação silenciosa: linha que não tem exatamente 4 campos NÃO-VAZIOS é contada como
+ * ignorada e o total sobe para o relatório. Engolir ruído aqui produziria "NAO_OBSERVADA" numa
+ * edge que na verdade respondeu — ausência fabricada a partir de um parse frouxo.
+ */
+export function parsearObservacoes(saida: string): {
+  observacoes: Observacao[];
+  linhasIgnoradas: number;
+} {
+  const observacoes: Observacao[] = [];
+  let linhasIgnoradas = 0;
+
+  for (const bruta of saida.split('\n')) {
+    const linha = bruta.trim();
+    if (linha === '' || CHATTER.has(linha)) continue;
+
+    const campos = linha.split('|');
+    if (campos.length !== CAMPOS || campos.some((c) => c.trim() === '')) {
+      linhasIgnoradas += 1;
+      continue;
+    }
+
+    const [edge, versao, fonte, criado] = campos.map((c) => c.trim());
+    observacoes.push({ edge, versao, fonte, criado });
+  }
+
+  return { observacoes, linhasIgnoradas };
+}
+
+/**
+ * Cruza o mapa commitado com o observado em prod.
+ *
+ * `mapaCommitado` é a VERDADE do repo (`lerMapaCommitado`); `observacoes` é o que prod respondeu.
+ * Uma edge observada que não está no mapa vira `FORA_DO_MAPA` em vez de ser descartada: significa
+ * que prod serve uma edge instrumentada que a main não conhece mais (rename/remoção), e sumir com
+ * ela do relatório esconderia justamente a divergência.
+ */
+export function julgar(
+  mapaCommitado: Record<string, string>,
+  observacoes: Observacao[],
+  linhasIgnoradas = 0,
+): Relatorio {
+  const porEdge = new Map<string, Observacao>();
+  for (const o of observacoes) {
+    const anterior = porEdge.get(o.edge);
+    // A mais RECENTE ganha: a janela pode conter várias respostas da mesma edge.
+    if (!anterior || o.criado > anterior.criado) porEdge.set(o.edge, o);
+  }
+
+  const vereditos: Veredito[] = [];
+
+  for (const [edge, esperado] of Object.entries(mapaCommitado)) {
+    const obs = porEdge.get(edge);
+    if (!obs) {
+      vereditos.push({ edge, estado: 'NAO_OBSERVADA', esperado, observado: null, versao: null, criado: null });
+      continue;
+    }
+    const estado: Estado =
+      obs.fonte === SEM_MAPA ? 'SEM_MAPA_NO_BUNDLE' : obs.fonte === esperado ? 'CONFERE' : 'DIVERGE';
+    vereditos.push({ edge, estado, esperado, observado: obs.fonte, versao: obs.versao, criado: obs.criado });
+  }
+
+  for (const [edge, obs] of porEdge) {
+    if (edge in mapaCommitado) continue;
+    vereditos.push({
+      edge,
+      estado: 'FORA_DO_MAPA',
+      esperado: null,
+      observado: obs.fonte,
+      versao: obs.versao,
+      criado: obs.criado,
+    });
+  }
+
+  const conta = (e: Estado) => vereditos.filter((v) => v.estado === e).length;
+
+  return {
+    vereditos,
+    totalMapeadas: Object.keys(mapaCommitado).length,
+    totalObservadas: vereditos.filter(
+      (v) => v.estado !== 'NAO_OBSERVADA' && v.estado !== 'FORA_DO_MAPA',
+    ).length,
+    totalDivergentes: conta('DIVERGE') + conta('SEM_MAPA_NO_BUNDLE') + conta('FORA_DO_MAPA'),
+    linhasIgnoradas,
+  };
+}

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { julgar, parsearObservacoes, SEM_MAPA } from './lib/pendencias-deploy';
+
+const MAPA = { 'edge-a': 'aaa111', 'edge-b': 'bbb222' };
+const obs = (edge: string, fonte: string, criado = '2026-08-27 21:00:00+00', versao = 'v1') => ({
+  edge,
+  fonte,
+  criado,
+  versao,
+});
+
+describe('parsearObservacoes', () => {
+  it('o SET do wrapper NÃO conta como ruído — senão o aviso dispararia em toda execução', () => {
+    const { observacoes, linhasIgnoradas } = parsearObservacoes(
+      'SET\nSET\nedge-a|v1|aaa111|2026-08-27 21:00:00+00\n',
+    );
+    expect(observacoes).toEqual([obs('edge-a', 'aaa111')]);
+    expect(linhasIgnoradas).toBe(0);
+  });
+
+  it('mas ruído DE VERDADE continua contado — o filtro é do chatter conhecido, não de tudo', () => {
+    const { observacoes, linhasIgnoradas } = parsearObservacoes(
+      'SET\nERROR: alguma coisa\nedge-a|v1|aaa111|hoje\n',
+    );
+    expect(observacoes).toHaveLength(1);
+    expect(linhasIgnoradas).toBe(1);
+  });
+
+  it('CONTA a linha malformada — engolir ruído fabricaria NAO_OBSERVADA numa edge que respondeu', () => {
+    const { observacoes, linhasIgnoradas } = parsearObservacoes('edge-a|v1|\nedge-b|v1|bbb222|hoje\n');
+    expect(observacoes.map((o) => o.edge)).toEqual(['edge-b']);
+    expect(linhasIgnoradas).toBe(1);
+  });
+});
+
+describe('julgar', () => {
+  it('CONFERE só quando o fonte observado é igual ao commitado', () => {
+    const r = julgar(MAPA, [obs('edge-a', 'aaa111'), obs('edge-b', 'bbb222')]);
+    expect(r.vereditos.every((v) => v.estado === 'CONFERE')).toBe(true);
+    expect(r.totalDivergentes).toBe(0);
+  });
+
+  it('ARMADILHA 1 — edge sem sonda na janela é NAO_OBSERVADA, JAMAIS CONFERE', () => {
+    const r = julgar(MAPA, [obs('edge-a', 'aaa111')]);
+    const b = r.vereditos.find((v) => v.edge === 'edge-b');
+    expect(b?.estado).toBe('NAO_OBSERVADA');
+    expect(b?.estado).not.toBe('CONFERE');
+    // e ela NÃO conta como observada — senão a cobertura mentiria
+    expect(r.totalObservadas).toBe(1);
+  });
+
+  it('ARMADILHA 2 — fonte "nao-mapeada" é DIVERGÊNCIA, não ausência', () => {
+    const r = julgar(MAPA, [obs('edge-a', SEM_MAPA), obs('edge-b', 'bbb222')]);
+    expect(r.vereditos.find((v) => v.edge === 'edge-a')?.estado).toBe('SEM_MAPA_NO_BUNDLE');
+    expect(r.totalDivergentes).toBe(1);
+  });
+
+  it('ARMADILHA 3 — zero observações não vira relatório limpo', () => {
+    const r = julgar(MAPA, []);
+    expect(r.totalObservadas).toBe(0);
+    expect(r.totalDivergentes).toBe(0); // e é JUSTAMENTE por isso que o CLI trata 0 observações
+    expect(r.vereditos.every((v) => v.estado === 'NAO_OBSERVADA')).toBe(true); // como exit 2
+  });
+
+  it('fonte diferente do commitado é DEPLOY PENDENTE, com os dois lados no veredito', () => {
+    const r = julgar(MAPA, [obs('edge-a', 'ANTIGO0'), obs('edge-b', 'bbb222')]);
+    const a = r.vereditos.find((v) => v.edge === 'edge-a');
+    expect(a?.estado).toBe('DIVERGE');
+    expect(a?.esperado).toBe('aaa111');
+    expect(a?.observado).toBe('ANTIGO0');
+  });
+
+  it('a observação MAIS RECENTE vence quando a janela tem várias da mesma edge', () => {
+    const r = julgar(MAPA, [
+      obs('edge-a', 'ANTIGO0', '2026-08-27 10:00:00+00'),
+      obs('edge-a', 'aaa111', '2026-08-27 21:00:00+00'),
+      obs('edge-b', 'bbb222'),
+    ]);
+    expect(r.vereditos.find((v) => v.edge === 'edge-a')?.estado).toBe('CONFERE');
+  });
+
+  it('edge que prod serve e a main não mapeia aparece, em vez de sumir do relatório', () => {
+    const r = julgar(MAPA, [obs('edge-a', 'aaa111'), obs('edge-b', 'bbb222'), obs('fantasma', 'xxx')]);
+    expect(r.vereditos.find((v) => v.edge === 'fantasma')?.estado).toBe('FORA_DO_MAPA');
+    expect(r.totalDivergentes).toBe(1);
+  });
+});

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -22,7 +22,13 @@ import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { julgar, parsearObservacoes, type Relatorio } from './lib/pendencias-deploy';
+import {
+  julgar,
+  parsearObservacoes,
+  type Estado,
+  type Relatorio,
+  type Veredito,
+} from './lib/pendencias-deploy';
 import { lerMapaCommitado } from './sonda-fingerprint';
 
 const PSQL_RO = process.env.PSQL_RO ?? join(homedir(), '.config', 'afiacao', 'psql-ro');
@@ -55,8 +61,10 @@ function consultar(): string {
 }
 
 function imprimir(rel: Relatorio): void {
-  const ordem = ['DIVERGE', 'SEM_MAPA_NO_BUNDLE', 'FORA_DO_MAPA', 'NAO_OBSERVADA', 'CONFERE'];
-  const rotulo: Record<string, string> = {
+  // Tipados como `Estado` de propósito: um estado novo na lib sem rótulo aqui — ou um nome
+  // digitado errado — vira erro de compilação, não seção que some calada do relatório.
+  const ordem: Estado[] = ['DIVERGE', 'SEM_MAPA_NO_BUNDLE', 'FORA_DO_MAPA', 'NAO_OBSERVADA', 'CONFERE'];
+  const rotulo: Record<Estado, string> = {
     DIVERGE: '🔴 DEPLOY PENDENTE',
     SEM_MAPA_NO_BUNDLE: '🔴 BUNDLE SEM O MAPA (_shared ficou para trás)',
     FORA_DO_MAPA: '🟠 prod serve edge que a main não mapeia',
@@ -65,7 +73,7 @@ function imprimir(rel: Relatorio): void {
   };
 
   for (const estado of ordem) {
-    const grupo = rel.vereditos.filter((v) => v.estado === estado);
+    const grupo: Veredito[] = rel.vereditos.filter((v) => v.estado === estado);
     if (grupo.length === 0) continue;
     console.log(`\n${rotulo[estado]} — ${grupo.length}`);
     for (const v of grupo) {

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+/**
+ * pendencias-deploy.ts — CLI da varredura PASSIVA de deploy divergente.
+ *
+ * Lê `net._http_response` pelo wrapper read-only e julga contra o mapa commitado. Não dispara
+ * sonda, não escreve, não precisa de secret: só do `psql-ro`. Feito para virar cron e só falar
+ * quando algo diverge.
+ *
+ * O julgamento puro vive em `lib/pendencias-deploy.ts` (testável sem rede). Aqui fica só a borda:
+ * shell, parse do exit e códigos de saída.
+ *
+ * EXIT CODES — e o 2 é o que impede este script de virar teatro:
+ *   0  nada divergente E houve observação positiva
+ *   1  divergência encontrada (há deploy pendente)
+ *   2  MECÂNICA não confiável: psql falhou, mapa vazio, ou ZERO observações na janela.
+ *      Zero observações NÃO é "tudo limpo" — é a janela do `pg_net.ttl` sem sonda nenhuma,
+ *      indistinguível de um instrumento quebrado. Um cron que devolvesse 0 aqui ensinaria o
+ *      operador a ler silêncio como aprovação, que é exatamente o hábito que a varredura existe
+ *      para desfazer.
+ */
+import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { julgar, parsearObservacoes, type Relatorio } from './lib/pendencias-deploy';
+import { lerMapaCommitado } from './sonda-fingerprint';
+
+const PSQL_RO = process.env.PSQL_RO ?? join(homedir(), '.config', 'afiacao', 'psql-ro');
+
+/**
+ * Só respostas de SONDA: `probe:true` + campo `edge`. O filtro textual roda ANTES do cast para
+ * jsonb de propósito — corpo não-JSON no meio da janela abortaria a query inteira, e uma varredura
+ * que morre por causa de uma linha alheia não serve de cron.
+ */
+const SQL = `
+SELECT r.c ->> 'edge', r.c ->> 'versao', coalesce(r.c ->> 'fonte', 'sem-campo'), r.created
+FROM (
+  SELECT (content::jsonb) AS c, created
+  FROM net._http_response
+  WHERE status_code = 200
+    AND content IS NOT NULL
+    AND left(ltrim(content), 1) = '{'
+    AND content LIKE '%"probe"%'
+    AND content LIKE '%"edge"%'
+) r
+WHERE r.c ? 'edge' AND r.c ? 'versao' AND (r.c ->> 'probe') = 'true'
+ORDER BY r.created DESC;
+`.trim();
+
+function consultar(): string {
+  return execFileSync(PSQL_RO, ['-A', '-F', '|', '-t', '-c', SQL], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+}
+
+function imprimir(rel: Relatorio): void {
+  const ordem = ['DIVERGE', 'SEM_MAPA_NO_BUNDLE', 'FORA_DO_MAPA', 'NAO_OBSERVADA', 'CONFERE'];
+  const rotulo: Record<string, string> = {
+    DIVERGE: '🔴 DEPLOY PENDENTE',
+    SEM_MAPA_NO_BUNDLE: '🔴 BUNDLE SEM O MAPA (_shared ficou para trás)',
+    FORA_DO_MAPA: '🟠 prod serve edge que a main não mapeia',
+    NAO_OBSERVADA: '⚪ sem sonda na janela (ausência de dado, NÃO é ok)',
+    CONFERE: '✅ confere',
+  };
+
+  for (const estado of ordem) {
+    const grupo = rel.vereditos.filter((v) => v.estado === estado);
+    if (grupo.length === 0) continue;
+    console.log(`\n${rotulo[estado]} — ${grupo.length}`);
+    for (const v of grupo) {
+      const det =
+        v.estado === 'DIVERGE'
+          ? `  esperado ${v.esperado?.slice(0, 16)}… · observado ${v.observado?.slice(0, 16)}…`
+          : v.estado === 'NAO_OBSERVADA'
+            ? ''
+            : `  ${v.versao ?? ''}`;
+      console.log(`   ${v.edge.padEnd(34)}${det}`);
+    }
+  }
+
+  console.log(
+    `\n─── cobertura: ${rel.totalObservadas}/${rel.totalMapeadas} edges mapeadas responderam na janela` +
+      ` (pg_net.ttl = 6h)`,
+  );
+  if (rel.linhasIgnoradas > 0) {
+    console.log(`⚠️  ${rel.linhasIgnoradas} linha(s) da saída do psql não casaram o formato`);
+  }
+}
+
+export function main(): number {
+  let mapa: Record<string, string>;
+  try {
+    mapa = lerMapaCommitado();
+  } catch (e) {
+    console.error(`❌ MECÂNICA: não li o mapa commitado — ${(e as Error).message}`);
+    return 2;
+  }
+  if (Object.keys(mapa).length === 0) {
+    console.error('❌ MECÂNICA: mapa de fingerprints VAZIO. Rode `bun run sonda:fingerprint`.');
+    return 2;
+  }
+
+  let saida: string;
+  try {
+    saida = consultar();
+  } catch (e) {
+    console.error(`❌ MECÂNICA: '${PSQL_RO}' falhou — ${(e as Error).message}`);
+    console.error('   Sem leitura de prod NÃO existe veredito. Isto não é "tudo limpo".');
+    return 2;
+  }
+
+  const { observacoes, linhasIgnoradas } = parsearObservacoes(saida);
+  const rel = julgar(mapa, observacoes, linhasIgnoradas);
+
+  if (rel.totalObservadas === 0) {
+    console.error(
+      `❌ MECÂNICA: ZERO das ${rel.totalMapeadas} edges mapeadas respondeu na janela de 6h.`,
+    );
+    console.error('   Isto é ausência de dado, não aprovação — dispare a leva com `bun run sonda:sql`.');
+    return 2;
+  }
+
+  imprimir(rel);
+  return rel.totalDivergentes > 0 ? 1 : 0;
+}
+
+if (import.meta.main) process.exit(main());

--- a/scripts/pendencias.sh
+++ b/scripts/pendencias.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# pendencias.sh — "o que ficou por terminar?", respondido por MEDIÇÃO e não por memória.
+#
+# Sessão é bancada, não livro-caixa. Sessão limpa não deixa registro e nunca será enumerável;
+# pendência deixa rastro em prod e no git, que são consultáveis e não têm memória seletiva.
+# Este script pergunta aos dois eixos e junta o veredito.
+#
+#   EIXO CÓDIGO   `wt:orfas`          — sessões mortas cujo trabalho não chegou na main
+#   EIXO DEPLOY   `pendencias:deploy` — edge cujo bundle em prod diverge da main (passivo)
+#
+# A REGRA QUE DEFINE ESTE SCRIPT: eixo que NÃO pôde ser consultado não vira "limpo". Ele é
+# nomeado como NÃO CONSULTADO e o exit vira 2. Um painel que responde verde varrendo metade
+# ensina o operador a ler silêncio como aprovação — o hábito exato que a varredura desfaz.
+# Por isso o resumo sempre imprime QUANTOS eixos responderam, e não só o que achou.
+#
+# EXIT: 0 = todos os eixos responderam e nada pendente · 1 = pendência encontrada
+#       2 = algum eixo não consultado (veredito INCOMPLETO, não aprovação)
+
+raiz="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$raiz" || { echo "erro: não entrei na raiz do repo" >&2; exit 2; }
+
+consultados=0
+falhos=0
+pendencias=0
+declare -a resumo=()
+
+# Roda um eixo preservando o exit REAL. Sem `| tail` e sem `echo` depois: os dois engolem o
+# código de saída, e é dele que sai o veredito (docs/historico/evidencia-positiva-shell.md).
+rodar_eixo() {
+  local nome="$1" descricao="$2"; shift 2
+  local saida rc
+  echo ""
+  echo "═══ $nome — $descricao"
+  saida="$("$@" 2>&1)"
+  rc=$?
+  printf '%s\n' "$saida"
+
+  case "$rc" in
+    0) consultados=$((consultados + 1)); resumo+=("✅ $nome: consultado, nada pendente") ;;
+    1) consultados=$((consultados + 1)); pendencias=$((pendencias + 1))
+       resumo+=("🔴 $nome: PENDÊNCIA encontrada") ;;
+    *) falhos=$((falhos + 1))
+       resumo+=("⚠️  $nome: NÃO CONSULTADO (exit $rc) — isto não é 'limpo'") ;;
+  esac
+}
+
+rodar_eixo "DEPLOY" "edge em prod divergente da main (passivo, sem secret)" \
+  bun scripts/pendencias-deploy.ts
+rodar_eixo "CÓDIGO" "sessões mortas com trabalho fora da main" \
+  bash scripts/wt-orfas.sh
+
+echo ""
+echo "════════════════════ RESUMO ════════════════════"
+for l in "${resumo[@]}"; do echo "  $l"; done
+echo "  eixos consultados: $consultados · não consultados: $falhos"
+
+if [ "$falhos" -gt 0 ]; then
+  echo "  ⇒ veredito INCOMPLETO: um eixo calou. Não leia isto como aprovação."
+  exit 2
+fi
+if [ "$pendencias" -gt 0 ]; then
+  echo "  ⇒ há pendência para fechar."
+  exit 1
+fi
+echo "  ⇒ nada pendente nos eixos consultados."
+exit 0

--- a/scripts/pendencias.sh
+++ b/scripts/pendencias.sh
@@ -24,29 +24,77 @@ falhos=0
 pendencias=0
 declare -a resumo=()
 
-# Roda um eixo preservando o exit REAL. Sem `| tail` e sem `echo` depois: os dois engolem o
-# código de saída, e é dele que sai o veredito (docs/historico/evidencia-positiva-shell.md).
+# ⚠️ NEM TODO EIXO CODIFICA PENDÊNCIA NO EXIT — e supor que sim já produziu um verde falso aqui.
+#
+# `pendencias-deploy` foi escrito para este contrato (0=limpo, 1=pendência, 2=mecânica). O
+# `wt:orfas` NÃO: ele é um RELATÓRIO, e devolve 0 para dizer "rodei", listando as candidatas no
+# corpo. Na primeira execução deste script ele imprimiu 35 CANDIDATAS e o resumo disse "nada
+# pendente" — o verde falso exato que a varredura existe para impedir, cometido pela varredura.
+#
+# Então cada eixo declara COMO se lê a pendência dele:
+#   exit   — o código de saída é o veredito
+#   linha  — a pendência está numa linha do corpo; o extrator devolve o número
+# E o modo `linha` é FAIL-CLOSED: se o padrão não casar, o eixo vira NÃO CONSULTADO em vez de
+# zero. Mudança no formato da saída se leria como "nada achei", que é o mesmo bug de novo.
+
+# Extrai "branches: 35 CANDIDATA(s)" -> 35. Silêncio (vazio) = não consegui ler, NÃO é zero.
+contar_candidatas() {
+  sed -n 's/.*branches:[[:space:]]*\([0-9][0-9]*\)[[:space:]]*CANDIDATA.*/\1/p' | head -1
+}
+
 rodar_eixo() {
-  local nome="$1" descricao="$2"; shift 2
-  local saida rc
+  local nome="$1" descricao="$2" modo="$3"; shift 3
+  local saida rc n
   echo ""
   echo "═══ $nome — $descricao"
   saida="$("$@" 2>&1)"
   rc=$?
   printf '%s\n' "$saida"
 
-  case "$rc" in
-    0) consultados=$((consultados + 1)); resumo+=("✅ $nome: consultado, nada pendente") ;;
-    1) consultados=$((consultados + 1)); pendencias=$((pendencias + 1))
-       resumo+=("🔴 $nome: PENDÊNCIA encontrada") ;;
-    *) falhos=$((falhos + 1))
-       resumo+=("⚠️  $nome: NÃO CONSULTADO (exit $rc) — isto não é 'limpo'") ;;
-  esac
+  # Exit >=2 é falha de mecânica em QUALQUER modo: o eixo não respondeu.
+  if [ "$rc" -ge 2 ]; then
+    falhos=$((falhos + 1))
+    resumo+=("⚠️  $nome: NÃO CONSULTADO (exit $rc) — isto não é 'limpo'")
+    return
+  fi
+
+  if [ "$modo" = "exit" ]; then
+    consultados=$((consultados + 1))
+    if [ "$rc" -eq 1 ]; then
+      pendencias=$((pendencias + 1)); resumo+=("🔴 $nome: PENDÊNCIA encontrada")
+    else
+      resumo+=("✅ $nome: consultado, nada pendente")
+    fi
+    return
+  fi
+
+  n="$(printf '%s\n' "$saida" | contar_candidatas)"
+  if [ -z "$n" ]; then
+    falhos=$((falhos + 1))
+    resumo+=("⚠️  $nome: NÃO CONSULTADO — não achei a linha de contagem; formato mudou?")
+  elif [ "$n" -gt 0 ]; then
+    consultados=$((consultados + 1)); pendencias=$((pendencias + 1))
+    resumo+=("🔴 $nome: $n candidata(s) para triar")
+  else
+    consultados=$((consultados + 1)); resumo+=("✅ $nome: consultado, nada pendente")
+  fi
 }
 
-rodar_eixo "DEPLOY" "edge em prod divergente da main (passivo, sem secret)" \
+# --selftest: prova que o extrator lê o número E que ele CALA quando o formato muda.
+if [ "${1:-}" = "--selftest" ]; then
+  got="$(printf '  branches: 35 CANDIDATA(s) · 14 sem rastro\n' | contar_candidatas)"
+  [ "$got" = "35" ] || { echo "selftest FALHOU: extraiu '$got', esperava 35" >&2; exit 1; }
+  got="$(printf '  branches: trinta e cinco candidatas\n' | contar_candidatas)"
+  [ -z "$got" ] || { echo "selftest FALHOU: devia calar em formato novo, veio '$got'" >&2; exit 1; }
+  got="$(printf '  branches: 0 CANDIDATA(s)\n' | contar_candidatas)"
+  [ "$got" = "0" ] || { echo "selftest FALHOU: zero legítimo virou '$got'" >&2; exit 1; }
+  echo "selftest OK — extrai, cala no formato desconhecido, e distingue zero de ilegível"
+  exit 0
+fi
+
+rodar_eixo "DEPLOY" "edge em prod divergente da main (passivo, sem secret)" exit \
   bun scripts/pendencias-deploy.ts
-rodar_eixo "CÓDIGO" "sessões mortas com trabalho fora da main" \
+rodar_eixo "CÓDIGO" "sessões mortas com trabalho fora da main" linha \
   bash scripts/wt-orfas.sh
 
 echo ""


### PR DESCRIPTION
## O problema

Sessão limpa não deixa registro e **nunca será enumerável** — perseguir "quais sessões faltam terminar" é perseguir fantasma. Pendência, não: ela deixa rastro em prod e no git, que são consultáveis e não têm memória seletiva. Então o instrumento não persegue sessão, mede pendência.

O eixo de **código** já existia (`wt:orfas`). O de **deploy** existia só ATIVO (`sonda:sql`, que o founder cola) — e ativo depende de alguém lembrar. Foi assim que o deploy pendente da `omie-vendas-sync` (`8c2a8b716`) ficou sem dono: nenhuma sessão tinha o item anotado, e o único jeito de achá-lo era comparar prod contra a main.

## O que entra

- **`scripts/lib/pendencias-deploy.ts`** — julgamento PURO (testável sem rede).
- **`scripts/pendencias-deploy.ts`** — CLI passivo: lê `net._http_response` pelo `psql-ro` e compara o `fonte` com o mapa commitado. Sem secret, ninguém no circuito, pode virar cron.
- **`scripts/pendencias.sh`** — compositor dos dois eixos.

## Julga o `fonte`, não o `versao` — e prod mostrou por quê

Nas duas leituras da `omie-vendas-sync` o `versao` era `v1.0-sensor-inicial` — **idêntico** —, enquanto o `fonte` ia de `d0d0580c9b…` (bundle velho) para `47c046a598…` (= main). Quem julgasse pelo marcador não teria visto o deploy acontecer.

## Os estados que impedem silêncio de virar aprovação

- `NAO_OBSERVADA` ≠ `CONFERE` — edge sem sonda na janela do `pg_net.ttl` não produziu dado; contá-la como OK é `ausente ≠ zero` na forma mais barata de cometer.
- `fonte: "nao-mapeada"` é **divergência** — é o bundle cujo `_shared/` ficou para trás, e aí o `versao` sai CERTO: falso positivo em money-path.
- **ZERO observações é exit 2**, nunca 0 — query vazia e query limpa têm a mesma cara num relatório que só lista problema.
- Eixo que não respondeu vira **NÃO CONSULTADO** + exit 2. Painel que dá verde varrendo metade ensina a ler silêncio como aprovação.

## O bug que a primeira execução real pegou — na própria varredura

O compositor tratava `wt:orfas` pelo contrato do `pendencias-deploy`. Mas `wt:orfas` é um RELATÓRIO: devolve `0` para dizer *"rodei"*. Resultado da 1ª execução: **35 CANDIDATAS no corpo** e **"nada pendente" no resumo** — o verde falso exato que a ferramenta existe para impedir.

Corrigido em `f4ad7cf75`: cada eixo declara **como** se lê a pendência dele (`exit` ou `linha`), e o modo `linha` é fail-CLOSED — padrão que não casa vira NÃO CONSULTADO, nunca zero.

## Evidência

| Portão | Resultado |
|---|---|
| `vitest` | `Tests 10 passed (10)` · exit 0 |
| **falsificação** | sabotando `NAO_OBSERVADA→CONFERE` → 2 testes vermelhos, exit 1 |
| `typecheck` · `eslint` · `shellcheck` | exit 0 |
| `pendencias.sh --selftest` | extrai, **cala** no formato desconhecido, distingue zero de ilegível |
| contra prod | `PENDENCIAS_EXIT=1` · DEPLOY limpo (4/35 na janela) · CÓDIGO 35 candidatas |

Todos revalidados **após** o rebase na main atual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)