### PR TITLE
feat(authz): 3 tabelas que ARRASTAM predicado — as capabilities que audit nenhum congelava [money-path]

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-08-28T02:52:18.833Z",
-  "sourceHead": "3d629645051b796daaf4271176382bd68bff63a6",
+  "medidoEm": "2026-08-28T03:11:31.269Z",
+  "sourceHead": "011da0b8d65bcf6f5b6046124380fa6d0be6b8fc",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -48,9 +48,9 @@
     "rls": {
       "script": "authz:rls:prod",
       "exit": 0,
-      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 17 tabela(s) curada(s), 38 policy(ies) e 7 funcao(oes)-predicado batem com o contrato.",
+      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 20 tabela(s) curada(s), 50 policy(ies) e 10 funcao(oes)-predicado batem com o contrato.",
       "denominador": null,
-      "contratoFingerprint": "f4c86398c267641b537bb1c6b7d6615882d8f69efe0e627596f7703273ef50bd",
+      "contratoFingerprint": "59e42b0fbf6e4a0fa6a078b94a043354f36affc38f259d3668d34b2ac6cbb0cd",
       "auditorFingerprint": "451994e2e848a3cd54c2da9944907b3e3110a0e3ba9686765cf9e222a9d9165a",
       "achados": []
     }

--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -321,3 +321,68 @@ rodada com `motivo` de 23 caracteres (`'`auth.uid() = user_id`.'`), que foi escr
 > na primeira pessoa com pressa.* A diferença entre "o critério está escrito no cabeçalho" e "o
 > critério reprova o PR" é a diferença entre uma lista curada e um depósito — e o cabeçalho já
 > estava correto no dia em que foi escrito.
+
+---
+
+## 8. A 3ª rodada (2026-08-28) — escolher a tabela pelo predicado que ela ARRASTA
+
+Duas sessões paralelas mediram a mesma pergunta no mesmo dia. A §7 é uma; esta é a outra, reduzida
+ao **diferencial** depois que o #2068 mergeou (worktrees.md §Colisão de CÓDIGO: descobrir a
+colisão com o PR pronto custa dois PRs). **17 → 20 tabelas, 38 → 50 policies, 5 → 8 predicados.**
+
+As duas convergiram sozinhas em 5 tabelas — `commercial_roles`, `fin_permissoes`,
+`fin_contas_pagar`, `order_items`, `markup_policy` — o que é validação cruzada barata e vale
+registrar. Divergiram no resto, e a divergência tem uma lição dentro.
+
+### A tese: numa allowlist com eixo derivado, o valor de uma entrada é o que ela PUXA
+
+O audit descobre os predicados **a partir das tabelas curadas** (`unnest(tabs)` → `pg_policy` →
+`pg_depend`). Logo cada tabela que entra **obriga a declarar seus predicados**, e o alcance de um
+predicado é muito maior que o da tabela que o trouxe. As 3 desta rodada guardam pouco — duas estão
+**vazias** — e trazem três capabilities que audit nenhum congelava:
+
+| tabela | linhas | traz | alcance do predicado |
+| --- | --- | --- | --- |
+| `pedido_compra_item` | 2.404 | `private.cap_compras_ler` | **18 policies / 14 tabelas** |
+| `cliente_tier_preco` | 0 | `private.cap_preco_escrever` | 2 / 1 |
+| `venda_excecao_credito` | 0 | `private.cap_credito_escrever` | 1 / 1 |
+
+Curar **uma** tabela de 2.404 linhas põe 14 tabelas sob vigilância de eixo 3. Provado por
+falsificação dirigida: remover `pedido_compra_item` do contrato faz `cap_compras_ler` virar
+`PREDICADO_SUMIU` — a tabela é o que mantém o predicado dentro do alcance.
+
+### 🔴 A correção que a rodada trouxe: convergência medida sobre amostra selecionada por semelhança
+
+A §7 concluiu, do próprio resultado, que "a autorização deste banco converge para poucos gates" —
+10 tabelas novas trazendo **uma** função só. Esta rodada mediu o inverso: **3 tabelas trouxeram 3
+funções**. A diferença não está no banco, está no **método de seleção**. A 2ª rodada escolheu por
+*parentesco* com o que já estava curado (o resto do `fin_*`, o resto do que `cap_custo_ler`
+gateia) — e tabela irmã compartilha o gate da irmã **por construção**. A amostra confirmava a
+hipótese porque tinha sido selecionada por ela.
+
+> **Classe:** *uma amostra escolhida por semelhança com o que já se conhece não pode testar a
+> hipótese de que tudo se parece.* O resultado é verdadeiro sobre a amostra e não se estende — e o
+> jeito de perceber é medir o UNIVERSO (aqui: as 14 funções que gateiam policy em `public`, das
+> quais 8 estão congeladas), não crescer a amostra pela borda dela mesma.
+
+### Três armadilhas de medição, todas do tipo "verde por dado que não foi consultado"
+
+1. **`n_live_tup` é ESTIMATIVA do autovacuum, e mentiu.** `pg_stat_user_tables` dava `0` para
+   `commercial_roles`; `count(*)` dá **3**. Decidir escopo por ela teria descartado uma raiz da
+   autorização. É "ausente ≠ zero" numa forma nova: a estimativa lida como contagem.
+2. **O nome mente; a FK não.** `public.orders` parecia o pedido de venda — está **vazia e órfã**.
+   Os 70.489 `unit_price` estão em `order_items`, cuja FK aponta para **`sales_orders`**, já
+   curada: era o *filho* da tabela curada que estava de fora.
+3. **Tabela de CONCESSÃO vazia não é tabela sem risco.** `fin_permissoes`, `cliente_tier_preco` e
+   `venda_excecao_credito` têm 0 linhas, e é o **primeiro INSERT indevido** que é o dano. Um corte
+   por volume teria descartado as três.
+
+### E uma armadilha de FERRAMENTA, que quase virou um achado falso
+
+O primeiro teste de merge contra o PR paralelo usou **`FETCH_HEAD`** — que um `git fetch` disparado
+por um *hook* entre dois comandos havia sobrescrito. O merge rodou contra o branch **errado**,
+saiu limpo, e a leitura natural ("sem conflito, e as entradas do outro somem") teria sido reportada
+como achado grave. Refeito com ref nomeada estável (`origin/pr2068`): **conflito nos 3 arquivos**,
+que era a realidade. ⇒ **`FETCH_HEAD` é volátil e não pertence a você**: para comparar contra um
+branch alheio, materialize uma ref nomeada (`git fetch origin <branch>:refs/remotes/origin/<apelido>`)
+antes de qualquer operação que leve mais de um comando.

--- a/scripts/authz-rls-esperado.ts
+++ b/scripts/authz-rls-esperado.ts
@@ -32,7 +32,8 @@
  *     é a única ou a principal barreira entre um `authenticated` qualquer e (i) dinheiro,
  *     (ii) custo/preço, ou (iii) a raiz da autorização.**
  *
- * Como o critério é aplicado (2ª rodada, 2026-08-27 — 7 → 17 tabelas, 19 → 38 policies). O
+ * Como o critério é aplicado (2ª rodada, 2026-08-27 — 7 → 17 tabelas, 19 → 38 policies;
+ * 3ª rodada, 2026-08-28 — 17 → 20 tabelas, 38 → 50 policies, 5 → 8 predicados). O
  * critério acima tem três membros e eles NÃO se aplicam do mesmo jeito, porque a alavanca é
  * diferente:
  *
@@ -77,7 +78,7 @@
  *     as 14 de `cap_compras_ler`** — aprovação, log e config. Os gates delas (`cap_credito_escrever`,
  *     `cap_compras_ler`) são, medido, `has_role(master)` puro: a raiz é `user_roles`, já curada.
  *
- * E as 311 tabelas restantes com policy (328 medidas com ≥1 policy, 17 curadas) seguem cobertas
+ * E as 308 tabelas restantes com policy (328 medidas com ≥1 policy, 20 curadas) seguem cobertas
  * pelo eixo universal (ninguém desliga a RLS delas em silêncio), com o CONTEÚDO não reconciliado
  * — lacuna declarada, não cobertura implícita.
  *
@@ -138,8 +139,8 @@ export interface TabelaRls {
 }
 
 /**
- * Estado medido em prod (psql-ro, 2026-08-27; PG 17.6). 17 tabelas · 38 policies
- * (1ª rodada: 7 · 19 — as 10 tabelas da 2ª rodada estão marcadas pelos separadores abaixo).
+ * Estado medido em prod (psql-ro, 2026-08-27 + 2026-08-28; PG 17.6). 20 tabelas · 50 policies
+ * (1ª rodada: 7 · 19; 2ª: +10 · +19; 3ª: +3 · +12 — cada rodada marcada pelos separadores abaixo).
  *
  * ⚠️ Os md5 se REPETEM entre tabelas quando o predicado é literalmente o mesmo texto — p.ex.
  * `8ddd30b6…` é `has_role(auth.uid(), 'master'::app_role)` em `profiles` E em `user_roles`. O md5
@@ -713,6 +714,159 @@ export const AUTHZ_RLS_ESPERADO: Record<string, TabelaRls> = {
       },
     },
   },
+  // ── 3ª rodada: as tabelas escolhidas pelo PREDICADO que ARRASTAM (medida em prod
+  //    2026-08-28). As três abaixo guardam pouco; o que elas trazem para o eixo 3 é que
+  //    importa — `cap_compras_ler`, `cap_preco_escrever` e `cap_credito_escrever`, três
+  //    capabilities que audit nenhum congelava. Ver o bloco AUTHZ_RLS_PREDICADOS. ──────────
+  'public.venda_excecao_credito': {
+    forceRls: false,
+    motivo:
+      'A EXCEÇÃO de crédito: a linha que libera venda para cliente com título vencido. O valor não ' +
+      'está na tabela — está no que ela AUTORIZA, que é faturar contra risco já materializado. Entra ' +
+      'porque a escrita é gateada por `private.cap_credito_escrever`, uma capability que hoje não ' +
+      'está congelada por audit nenhum (0 linhas na tabela; o risco é latente, e o predicado é o que ' +
+      'importa). É o vetor exato do PR #2064: reescrever a capability deixa o texto da policy ' +
+      'idêntico e abre a concessão.',
+    policies: {
+      venda_excecao_insert_gestor: {
+        cmd: 'a',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: null,
+        withCheckMd5: 'ff1af097db9f598b8d168be213dcba8b',
+        motivo:
+          '`private.cap_credito_escrever(auth.uid())` — INSERT puro, sem `USING` (nada a filtrar na ' +
+          'entrada). Traz `cap_credito_escrever` para AUTHZ_RLS_PREDICADOS.',
+      },
+      venda_excecao_select_staff: {
+        cmd: 'r',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: '2ebe0c0b117eb89cd6b89791bbc868c1',
+        withCheckMd5: null,
+        motivo:
+          '`EXISTS (SELECT 1 FROM user_roles …)` INLINE — não chama `has_role`, repete a subquery à ' +
+          'mão. Por isso esta policy não contribui predicado nenhum ao eixo 3: o md5 do `qual` é ' +
+          'tudo o que existe para vigiar aqui.',
+      },
+      venda_excecao_service_all: {
+        cmd: '*',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: '28f2f9950c5ed7f660b39524ab6b864d',
+        withCheckMd5: null,
+        motivo:
+          '`(SELECT auth.role()) = service_role` — FOR ALL das engines. md5 DIFERENTE do `ea849457…` ' +
+          'das outras service-policies porque esta traz o wrap InitPlan `(SELECT auth.role())`: ' +
+          'mesma semântica, texto outro (§4). Sem `WITH CHECK`: simétrico por construção.',
+      },
+    },
+  },
+
+  // ── custo / preço (confidencialidade comercial) ────────────────────────────────────────────
+  'public.cliente_tier_preco': {
+    forceRls: false,
+    motivo:
+      'O TIER de preço do cliente — a linha que decide o desconto que ele paga. Vazia hoje (0 linhas, ' +
+      'contadas), e entra pelo mesmo motivo que `venda_excecao_credito`: a escrita é gateada por ' +
+      '`private.cap_preco_escrever`, capability que audit nenhum congelava. Uma tabela de CONCESSÃO ' +
+      'vazia não é uma tabela sem risco: é uma tabela cujo primeiro INSERT indevido é o dano.',
+    policies: {
+      cliente_tier_preco_delete_master: {
+        cmd: 'd',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: 'e133054e309de597df65e71951235297',
+        withCheckMd5: null,
+        motivo:
+          '`has_role((SELECT auth.uid()), master)` — md5 distinto do `8ddd30b6…` das outras policies ' +
+          'master-only porque esta tem o wrap InitPlan. Mesma semântica, texto outro: o md5 é da ' +
+          'EXPRESSÃO, e é por isso que ele é conservador por desenho.',
+      },
+      cliente_tier_preco_insert_gestor: {
+        cmd: 'a',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: null,
+        withCheckMd5: '94c32fa0338037174a4632338242c3e4',
+        motivo: '`private.cap_preco_escrever(auth.uid())` — INSERT puro, sem `USING`.',
+      },
+      cliente_tier_preco_select_staff: {
+        cmd: 'r',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: '41fa909ea11898d386285db45a4908e9',
+        withCheckMd5: null,
+        motivo: '`has_role(employee) OR has_role(master)` — broad-staff de leitura.',
+      },
+      cliente_tier_preco_service_all: {
+        cmd: '*',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: 'ea849457c1a771a3ea5e4fe3c0210590',
+        withCheckMd5: null,
+        motivo: '`auth.role() = service_role` — FOR ALL das engines, sem `WITH CHECK`: simétrico.',
+      },
+      cliente_tier_preco_update_gestor: {
+        cmd: 'w',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: '94c32fa0338037174a4632338242c3e4',
+        withCheckMd5: '94c32fa0338037174a4632338242c3e4',
+        motivo:
+          '`cap_preco_escrever` nos DOIS lados — a linha alterada tem de satisfazer o gate antes e ' +
+          'depois, o que impede mover um cliente para um tier melhor sem a capability.',
+      },
+    },
+  },
+
+  'public.pedido_compra_item': {
+    forceRls: false,
+    motivo:
+      'O item do pedido de COMPRA: 2.404 linhas com `preco_unitario`/`valor_linha`/`desconto_percentual` ' +
+      '— o custo na origem, antes de virar CMC (docs/agent/reposicao.md). Entra sobretudo pelo eixo 3: ' +
+      'é a porta por onde `private.cap_compras_ler` — que gateia 18 policies em 14 tabelas, mais do ' +
+      'que qualquer predicado hoje congelado exceto `has_role` — passa a ser vigiado. ⚠️ Medido e ' +
+      'digno de nota: a capability chamada `_ler` gateia também INSERT, UPDATE e DELETE aqui; o nome ' +
+      'diz leitura e o efeito é escrita. Está registrado, não corrigido — mudar isso é decisão de ' +
+      'produto, e o contrato mede o que É.',
+    policies: {
+      staff_pedido_compra_item_delete: {
+        cmd: 'd',
+        permissiva: true,
+        roles: ['authenticated'],
+        qualMd5: '53c61578bc6811739a0638a2df23462f',
+        withCheckMd5: null,
+        motivo: '`private.cap_compras_ler(auth.uid())` no `USING` — o lado que o DELETE consulta.',
+      },
+      staff_pedido_compra_item_insert: {
+        cmd: 'a',
+        permissiva: true,
+        roles: ['authenticated'],
+        qualMd5: null,
+        withCheckMd5: '53c61578bc6811739a0638a2df23462f',
+        motivo: '`cap_compras_ler` no `WITH CHECK` — INSERT puro. Mesmo md5: é a mesma expressão.',
+      },
+      staff_pedido_compra_item_select: {
+        cmd: 'r',
+        permissiva: true,
+        roles: ['authenticated'],
+        qualMd5: '53c61578bc6811739a0638a2df23462f',
+        withCheckMd5: null,
+        motivo: '`cap_compras_ler` — a leitura do custo de compra.',
+      },
+      staff_pedido_compra_item_update: {
+        cmd: 'w',
+        permissiva: true,
+        roles: ['authenticated'],
+        qualMd5: '53c61578bc6811739a0638a2df23462f',
+        withCheckMd5: '53c61578bc6811739a0638a2df23462f',
+        motivo: '`cap_compras_ler` nos dois lados — simétrico, então não há brecha de DELETE-por-UPDATE.',
+      },
+    },
+  },
+
+  // ── cadastro-base + aprovação ──────────────────────────────────────────────────────────────
 };
 
 export interface PredicadoEsperado {
@@ -736,13 +890,55 @@ export interface PredicadoEsperado {
  * `cap_custo_ler` chamada dentro de um `COALESCE`, e o §4 tem o registro de duas varreduras
  * textuais que produziram falso-positivo integral).
  *
- * Medido em prod 2026-08-27: as 38 policies referenciam 7 funções — estas 5 mais `auth.uid` e
- * `auth.role`, que ficam em `PREDICADOS_PLATAFORMA`. A 2ª rodada acrescentou UMA função só
- * (`private.is_super_admin`): 10 tabelas novas e só um predicado novo é o sinal de que a
- * autorização deste banco converge para poucos gates — o que torna o eixo 3 barato e o md5 do
- * corpo deles caro.
+ * Medido em prod (2026-08-27 + 2026-08-28): as 50 policies referenciam 10 funções — estas 8
+ * mais `auth.uid` e `auth.role`, que ficam em `PREDICADOS_PLATAFORMA`.
+ *
+ * ⚠️ A 2ª rodada leu o próprio resultado como convergência: 10 tabelas novas trazendo UMA função
+ * só (`is_super_admin`) sugeria que a autorização deste banco converge para poucos gates. A 3ª
+ * rodada mediu o contrário — 3 tabelas trouxeram 3 funções (`cap_compras_ler`,
+ * `cap_preco_escrever`, `cap_credito_escrever`) — e a razão é de MÉTODO, não do banco: a 2ª
+ * rodada escolheu tabelas por parentesco com as já curadas (o resto do `fin_*`, o resto do que
+ * `cap_custo_ler` gateia), e tabela irmã compartilha o gate da irmã por construção. A amostra
+ * confirmava a hipótese porque fora selecionada por ela. O grafo real tem 14 funções gateando
+ * policy em `public`; 8 estão congeladas aqui. ⇒ **Convergência medida sobre uma amostra
+ * escolhida por semelhança não é convergência — é o método se ouvindo falar.**
+ *
+ * ⚠️ `cap_compras_ler`, `cap_credito_escrever` e `cap_preco_escrever` têm o MESMO `srcMd5`
+ * (`5faf2a21…`): três capabilities distintas cujo corpo hoje é o mesmo `has_role(master)`. Não é
+ * duplicação a limpar — é o estado a congelar, e o dia em que uma divergir é o sinal que se quer.
  */
 export const AUTHZ_RLS_PREDICADOS: Record<string, PredicadoEsperado> = {
+  'private.cap_compras_ler': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '5faf2a21a46209aaf0ffa75041af6b4b',
+    motivo:
+      '`COALESCE(_uid IS NOT NULL AND has_role(master), false)` — master-only. O predicado de MAIOR ' +
+      'alcance que este contrato passa a congelar depois de `has_role`: 18 policies em 14 tabelas ' +
+      '(medido por pg_depend), das quais o contrato cura UMA (`pedido_compra_item`). Congelar o corpo ' +
+      'cobre as 14 no eixo 3 mesmo sem curar o conteúdo das outras 13 — é o melhor retorno por entrada ' +
+      'do arquivo inteiro. ⚠️ Corpo IDÊNTICO ao de `cap_preco_escrever`/`cap_credito_escrever`, logo o ' +
+      'mesmo md5 nas três: são capabilities distintas com a mesma regra hoje, e o dia em que uma ' +
+      'divergir é exatamente o que se quer ver.',
+  },
+  'private.cap_credito_escrever': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '5faf2a21a46209aaf0ffa75041af6b4b',
+    motivo:
+      'master-only, mesmo corpo (e mesmo md5) de `cap_compras_ler`. Gateia 1 policy: o INSERT de ' +
+      '`venda_excecao_credito`, que libera faturamento contra título vencido. Alcance pequeno, dano ' +
+      'grande — e era invisível aos quatro audits antes desta entrada.',
+  },
+  'private.cap_preco_escrever': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '5faf2a21a46209aaf0ffa75041af6b4b',
+    motivo:
+      'master-only, mesmo corpo dos dois acima. Gateia o INSERT e o UPDATE de `cliente_tier_preco`, ' +
+      'isto é, o desconto que cada cliente paga. Reescrevê-la para `true` deixa as duas policies ' +
+      'byte-a-byte idênticas e entrega a tabela de preços a qualquer autenticado.',
+  },
   'public.has_role': {
     secdef: true,
     cfg: 'search_path=public',


### PR DESCRIPTION
Complementar ao #2068, que mergeou enquanto esta sessão media a mesma pergunta. Reduzido ao **diferencial** assim que ele entrou (worktrees.md §Colisão de CÓDIGO) — zero sobreposição com o que já está na `main`.

**17 → 20 tabelas · 38 → 50 policies · 5 → 8 predicados.** Nenhum DDL: não havia o que corrigir, só o que passar a vigiar.

## A tese: o valor de uma entrada é o que ela PUXA, não o que ela guarda

O audit descobre predicados **a partir das tabelas curadas** (`unnest(tabs)` → `pg_policy` → `pg_depend`). Cada tabela que entra **obriga a declarar seus predicados** — e o alcance de um predicado é muito maior que o da tabela que o trouxe. As 3 desta rodada guardam pouco (duas estão **vazias**) e trazem três capabilities que audit nenhum congelava:

| tabela | linhas | traz | alcance |
| --- | --- | --- | --- |
| `pedido_compra_item` | 2.404 | `private.cap_compras_ler` | **18 policies / 14 tabelas** |
| `cliente_tier_preco` | 0 | `private.cap_preco_escrever` | 2 / 1 |
| `venda_excecao_credito` | 0 | `private.cap_credito_escrever` | 1 / 1 |

Curar **uma** tabela põe 14 sob vigilância de eixo 3. Tabela de concessão vazia não é tabela sem risco: o dano é o primeiro INSERT indevido.

## Correção a uma inferência do #2068

O #2068 concluiu, do próprio resultado, que "a autorização deste banco converge para poucos gates" — 10 tabelas novas trazendo **1** função. Aqui **3 tabelas trouxeram 3**. A diferença é de **método**, não do banco: aquela rodada escolheu por *parentesco* com o já curado (o resto do `fin_*`, o resto do que `cap_custo_ler` gateia), e tabela irmã compartilha o gate da irmã por construção — a amostra confirmava a hipótese porque fora selecionada por ela. O universo tem 14 funções gateando policy em `public`; 8 ficam congeladas com este PR. O cabeçalho do contrato foi corrigido.

## Evidência

- `authz:rls:prod` **exit 0** — 335 tabelas com RLS ligada (0 desligada), 20 curadas, 50 policies, 10 funções-predicado
- harness `db/test-audit-rls-prod.sh` **31/31** em `LC_ALL=C` **e** `LC_ALL=pt_BR.UTF-8`
- `bun run test` **747 arquivos / 7421 testes, exit 0** · typecheck (já cobrindo `scripts/`, #2069) · lint 0 errors
- carimbo regravado — vermelho `CARIMBO_CONTRATO_MUDOU` confirmado **antes**, verde depois; os 5 audits exit 0

**Falsificação dirigida às entradas novas**, cada uma exigindo o código certo:
1. md5 de policy de `pedido_compra_item` → `POLICY_ALTERADA`
2. md5 do corpo de `cap_compras_ler` → `PREDICADO_ALTERADO`
3. **remover `pedido_compra_item` do contrato → `PREDICADO_SUMIU`** — a prova da tese: a tabela é o que mantém o predicado dentro do alcance do audit

Verde de volta após cada restauração.

## Armadilhas de medição registradas em `docs/historico/`

- **`n_live_tup` é estimativa e mentiu** — `commercial_roles` aparecia com 0 linhas, tem 3. "Ausente ≠ zero" na forma de estimativa lida como contagem.
- **O nome mente; a FK não** — `public.orders` é órfã e vazia; os 70.489 `unit_price` estão em `order_items`, cuja FK aponta para `sales_orders`.
- **`FETCH_HEAD` sobrescrito por um hook** entre dois comandos fez o primeiro teste de merge rodar contra o branch errado e sair limpo — quase virou um achado falso. Refeito com ref nomeada: conflito nos 3 arquivos, que era a realidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
