### PR TITLE
docs(sonda): o `background` é do TICK, não do STEP — 3 seguidos e o 4º provou, sem sonda ativa

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -441,7 +441,7 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
       o orquestrador devolve cada um em `resultados.<key>.body`:
       ```bash
       # ⌨️ seu terminal — troque os dois timestamps pela JANELA do run (nunca id chutado)
-      ~/.config/afiacao/psql-ro -c "SELECT r.id, r.created, k, (r.content::jsonb)->'resultados'->k->>'modo' AS modo, (r.content::jsonb)->'resultados'->k->'body'->>'versao' AS versao FROM net._http_response r, jsonb_object_keys((r.content::jsonb)->'resultados') k WHERE r.created BETWEEN '<inicio>' AND '<fim>' AND r.status_code = 200 AND r.content IS NOT NULL AND left(ltrim(r.content),1) = '{' AND (r.content::jsonb) ? 'resultados' ORDER BY r.id, k;"
+      ~/.config/afiacao/psql-ro -c "SELECT r.id, r.created, k, (r.content::jsonb)->'resultados'->k->>'modo' AS modo, (r.content::jsonb)->'resultados'->k->'body'->>'versao' AS versao FROM net._http_response r, jsonb_object_keys((r.content::jsonb)->'resultados') k WHERE r.created BETWEEN '<inicio>' AND '<fim>' AND r.status_code = 200 AND r.content IS NOT NULL AND left(ltrim(r.content),1) = '{' AND (r.content::jsonb) ? 'resultados' AND jsonb_typeof((r.content::jsonb)->'resultados') = 'object' ORDER BY r.id, k;"
       ```
       🔴 **Leia o `modo` ANTES do `versao`** — é a mesma armadilha da linha de timeout, uma casa acima: em
       `modo:"background"` o orquestrador abortou o cliente em 25s (`STEP_TIMEOUT_MS`), o corpo **não foi
@@ -455,6 +455,21 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
       sempre as duas. Para o step que estoura, a prova continua sendo a sonda ativa, que é
       justamente onde ela custa mais (bundle pré-sensor sondado dispara a varredura). Trate o eco
       como cobertura PARCIAL e barata, não como substituto da sonda.
+
+      ✅ **Mas o `background` é do TICK, não do STEP — acumule ticks antes de pagar a sonda ativa
+      (medido 2026-08-28).** O `pedidos` veio `background` em três ticks seguidos (02:15, 06:15 e
+      08:15Z) e **`respondido` com o marcador às 10:15Z** — mesma edge, mesmo bundle: o que varia é
+      a carga do Omie naquele tick, não o step. Ler um `background` como "este step só se prova com
+      sonda ativa" paga a sonda cara para responder o que o tick seguinte responde de graça. Regra:
+      diante de `background`, **releia a janela inteira do TTL** antes de invocar — e só então
+      conclua que o eco não alcança aquele step.
+      ⚠️ **Ao alargar a janela, o guard de TIPO deixa de ser opcional.** Outro emissor grava
+      `{"success":true,"processados":0,"resultados":[]}` — chave `resultados` como **array** (medida
+      às 09:00Z) — e o `jsonb_object_keys` sobre ela **aborta a query inteira** (`ERROR: cannot call
+      jsonb_object_keys on an array`): não é uma linha ruim ignorada, é o resultado todo perdido. O
+      `? 'resultados'` não separa os dois casos; `jsonb_typeof(...) = 'object'` separa — já embutido
+      na query acima. Falha ruidosa (exit 1), então não fabrica veredito — mas com janela estreita
+      ela dorme, e é exatamente ao acumular ticks que ela acorda.
 
 ### Passo 4b — QA visual pós-Publish (Claude-in-Chrome na sessão logada do founder)
 

--- a/docs/historico/verificabilidade-do-conjunto-orquestrado.md
+++ b/docs/historico/verificabilidade-do-conjunto-orquestrado.md
@@ -143,6 +143,7 @@ FROM net._http_response r, jsonb_object_keys((r.content::jsonb)->'resultados') k
 WHERE r.created BETWEEN '<inicio>' AND '<fim>' AND r.status_code = 200
   AND r.content IS NOT NULL AND left(ltrim(r.content),1) = '{'
   AND (r.content::jsonb) ? 'resultados'
+  AND jsonb_typeof((r.content::jsonb)->'resultados') = 'object'
 ORDER BY r.id, k;
 ```
 
@@ -249,3 +250,42 @@ Em `supabase/functions/_shared/sonda-versao-contrato_test.ts`, além das 4 linha
   a receita de verificação usa em `resultados.<key>.body.versao`; chave errada devolve NULL, que é
   byte a byte a assinatura de "bundle pré-sensor". O gate falha nomeando a divergência quando o
   `omie-cron-diario` ganha um 6º step ou renomeia uma `key`.
+
+## Adendo 2026-08-28 — o `background` é do TICK, não do STEP (e a janela larga precisa de guard)
+
+A régua acima mediu **um** tick (id 61756, 02:15Z) e leu `pedidos` como um dos steps que o eco não
+alcança, concluindo que ali "a prova continua sendo a sonda ativa". Ao verificar o deploy do #2063
+no dia seguinte, quatro ticks contam outra história:
+
+| tick (UTC) | `modo` do `pedidos` | `versao` |
+|---|---|---|
+| 2026-08-28 02:15 | `background` | *(vazio)* |
+| 2026-08-28 06:15 | `background` | *(vazio)* |
+| 2026-08-28 08:15 | `background` | *(vazio)* |
+| **2026-08-28 10:15** | **`respondido`** | **`v1.0-eco-versao-passivo`** |
+
+Mesma edge, mesmo bundle, mesmo `STEP_TIMEOUT_MS`: o que varia é a carga do Omie naquele tick. Logo
+o `background` **não é propriedade do step** — é sorteio por execução, e três seguidos não são
+evidência de que o eco nunca alcança aquele step. Quem lê o primeiro `background` como "só a sonda
+ativa resolve" paga a sonda cara (que num bundle pré-sensor dispara o efeito real) para responder o
+que o tick seguinte responde de graça.
+
+**Regra:** diante de `background`, releia a **janela inteira do TTL** antes de invocar a sonda. A
+cobertura do eco não se mede num tick — ela CONVERGE ao longo deles.
+
+### O guard de tipo, que a janela estreita esconde
+
+Alargar a janela é o que ativa uma falha que o `BETWEEN` de 10 minutos vinha escondendo: o
+predicado `(content::jsonb) ? 'resultados'` também casa com **outro emissor**, que grava
+`{"success":true,"processados":0,"resultados":[]}` — `resultados` como **array** (1 linha, medida às
+09:00:03Z, contra 3 do orquestrador na mesma janela). O `jsonb_object_keys` sobre um array **aborta
+a query inteira**:
+
+```text
+ERROR:  cannot call jsonb_object_keys on an array
+```
+
+Não é uma linha ruim que se ignora: é o resultado todo perdido. A falha é **ruidosa** (exit 1), então
+não fabrica veredito — mas some com a leitura justamente quando se acumula ticks, que é a receita do
+adendo acima. `jsonb_typeof((content::jsonb)->'resultados') = 'object'` separa os dois emissores, e
+está embutido na query desta página e na da skill `lovable-deploy-verify`.


### PR DESCRIPTION
Verificando o deploy das edges mergeadas em 2026-08-27 (chip de `/fecho`), duas correções saíram da medição.

## 1. O `background` é do TICK, não do STEP

A régua do eco passivo mediu **um** tick (id 61756) e leu `pedidos` como step fora do alcance do eco, concluindo que ali *"a prova continua sendo a sonda ativa"*. Quatro ticks dizem outra coisa:

| tick (UTC) | `modo` | `versao` |
|---|---|---|
| 2026-08-28 02:15 | `background` | *(vazio)* |
| 2026-08-28 06:15 | `background` | *(vazio)* |
| 2026-08-28 08:15 | `background` | *(vazio)* |
| **2026-08-28 10:15** | **`respondido`** | **`v1.0-eco-versao-passivo`** |

Mesma edge, mesmo bundle: varia a carga do Omie no tick, não o step. Ler o primeiro `background` como veredito paga a sonda cara — que num bundle pré-sensor dispara o efeito real — para responder o que o tick seguinte responde de graça.

**Regra:** diante de `background`, releia a **janela inteira do TTL** antes de invocar. A cobertura do eco não se mede num tick, ela CONVERGE ao longo deles.

## 2. O guard de tipo que a janela estreita escondia

Alargar a janela é o que ativa a falha: `? 'resultados'` também casa com outro emissor, que grava `resultados` como **array** (`{"success":true,"processados":0,"resultados":[]}`, medido às 09:00:03Z — 1 linha contra 3 do orquestrador). O `jsonb_object_keys` sobre ele **aborta a query inteira**: não é linha ruim ignorada, é o resultado todo perdido.

Falsificado nos dois sentidos, mesma janela (08:00–11:00Z):

```
A) sem o guard -> exit 1 · ERROR: cannot call jsonb_object_keys on an array
B) com o guard -> exit 0 · 12 linhas, pedidos background (61912) e respondido (61997)
```

Guard `jsonb_typeof(...) = 'object'` embutido nas **duas** cópias da query (skill + histórico). Falha ruidosa, então não fabricava veredito — mas sumia com a leitura justamente ao acumular ticks.

## Contexto do chip

As 3 edges que o chip mandava verificar (#2049 `omie-nfe-reconcile`, #2043 `omie-sync-estoque`, #2054 `omie-vendas-sync`) **já estavam deployadas** — `fonte` batendo com a `main` por igualdade de string completa. Nenhum pedido de deploy foi necessário. Os 4 steps do #2063 também estão no ar, o `pedidos` sendo o que fecha este PR.

Gates verdes: `docs:indice` · `docs:citacoes` · `docs:links` · `claude:size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)