### PR TITLE
docs(sonda): as 4 edges do `e5a484e2c` ESTÃO no ar — pendência fechada por eco passivo, sem sonda ativa

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -452,9 +452,21 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
       tick pós-deploy (id 61756) três steps trouxeram o marcador e **dois vieram `background`**
       (`nfes` 4/4 dos ticks, `pedidos` 3/4). O vazio do `background` é byte a byte o vazio do bundle
       pré-sensor: **só a coluna `modo` separa "não subiu" de "não deu tempo de coletar"** — projete
-      sempre as duas. Para o step que estoura, a prova continua sendo a sonda ativa, que é
-      justamente onde ela custa mais (bundle pré-sensor sondado dispara a varredura). Trate o eco
-      como cobertura PARCIAL e barata, não como substituto da sonda.
+      sempre as duas.
+      ✅ **Mas a régua se lê na JANELA, não no tick — corrigido 2026-08-28 com medição.** A frase
+      que estava aqui ("para o step que estoura, a prova continua sendo a sonda ativa") foi
+      REFUTADA: nos ticks 61860/61912/61997 (06:15, 08:15, 10:15Z) os dois steps dados como
+      inalcançáveis — `pedidos` e `nfes` — responderam sozinhos no tick das 10:15Z, sem sonda
+      nenhuma, fechando **5/5**. `background` não é propriedade do step, é **variância de latência**
+      contra o `STEP_TIMEOUT_MS` de 25s ⇒ a cobertura **converge com o número de ticks**. Como o
+      cron roda a cada 2h e o `pg_net.ttl` guarda 6h, **toda leitura nasce com ~3 tentativas de
+      graça**: acumule a janela (`respondido` em QUALQUER tick basta — o marcador não envelhece
+      dentro dela) em vez de julgar pelo tick mais recente. Só recorra à sonda ativa se o step vier
+      `background` na janela INTEIRA; aí a via passiva se esgotou. A assimetria não muda —
+      `respondido`+marcador **prova**, `background` é **INCONCLUSIVO** e nunca "bundle velho"; o que
+      mudou é o que se faz com o inconclusivo: **reler**, não sondar (e sondar é caro justamente
+      ali). Fecho e os 3 eixos da auditoria (identidade pela chave, exclusividade do marcador no
+      git, ar==`main`): `docs/historico/cron-teto-volume-vs-latencia.md`.
 
 ### Passo 4b — QA visual pós-Publish (Claude-in-Chrome na sessão logada do founder)
 

--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -452,21 +452,9 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
       tick pós-deploy (id 61756) três steps trouxeram o marcador e **dois vieram `background`**
       (`nfes` 4/4 dos ticks, `pedidos` 3/4). O vazio do `background` é byte a byte o vazio do bundle
       pré-sensor: **só a coluna `modo` separa "não subiu" de "não deu tempo de coletar"** — projete
-      sempre as duas.
-      ✅ **Mas a régua se lê na JANELA, não no tick — corrigido 2026-08-28 com medição.** A frase
-      que estava aqui ("para o step que estoura, a prova continua sendo a sonda ativa") foi
-      REFUTADA: nos ticks 61860/61912/61997 (06:15, 08:15, 10:15Z) os dois steps dados como
-      inalcançáveis — `pedidos` e `nfes` — responderam sozinhos no tick das 10:15Z, sem sonda
-      nenhuma, fechando **5/5**. `background` não é propriedade do step, é **variância de latência**
-      contra o `STEP_TIMEOUT_MS` de 25s ⇒ a cobertura **converge com o número de ticks**. Como o
-      cron roda a cada 2h e o `pg_net.ttl` guarda 6h, **toda leitura nasce com ~3 tentativas de
-      graça**: acumule a janela (`respondido` em QUALQUER tick basta — o marcador não envelhece
-      dentro dela) em vez de julgar pelo tick mais recente. Só recorra à sonda ativa se o step vier
-      `background` na janela INTEIRA; aí a via passiva se esgotou. A assimetria não muda —
-      `respondido`+marcador **prova**, `background` é **INCONCLUSIVO** e nunca "bundle velho"; o que
-      mudou é o que se faz com o inconclusivo: **reler**, não sondar (e sondar é caro justamente
-      ali). Fecho e os 3 eixos da auditoria (identidade pela chave, exclusividade do marcador no
-      git, ar==`main`): `docs/historico/cron-teto-volume-vs-latencia.md`.
+      sempre as duas. Para o step que estoura, a prova continua sendo a sonda ativa, que é
+      justamente onde ela custa mais (bundle pré-sensor sondado dispara a varredura). Trate o eco
+      como cobertura PARCIAL e barata, não como substituto da sonda.
 
 ### Passo 4b — QA visual pós-Publish (Claude-in-Chrome na sessão logada do founder)
 

--- a/docs/historico/cron-teto-volume-vs-latencia.md
+++ b/docs/historico/cron-teto-volume-vs-latencia.md
@@ -493,25 +493,15 @@ RESPONDE com `VERSAO` bootou; um bundle a que faltasse qualquer arquivo dessa ca
 bootaria**. O modo de falha do #2020 (prompt que nomeia só o `index.ts`) está descartado por
 construção — e é a razão de o eco provar mais do que aparenta.
 
-### A régua do eco se lê na JANELA, não no tick — `background` é sorteio, não propriedade
+### Por que `pedidos` levou 3 ticks para aparecer — e por que isso NÃO é sonda ativa
 
-O #2070 mediu o tick 61756 mais os 4 da janela, viu `nfes` background 4/4 e `pedidos` 3/4, e
-concluiu: *"para o step que estoura, a prova continua sendo a sonda ativa"*. **A medição de
-2026-08-28 refuta a conclusão** — nos ticks 06:15/08:15/10:15Z os DOIS steps que o #2070 dava como
-inalcançáveis responderam sozinhos, ambos no tick das 10:15Z, sem sonda nenhuma.
+O `pedidos` só ecoou no tick das 10:15Z; nos dois anteriores veio `background`. A régua que
+prescrevia sonda ativa para "o step que estoura" foi **refutada pela medição** e corrigida em
+[`verificabilidade-do-conjunto-orquestrado.md`](verificabilidade-do-conjunto-orquestrado.md) e na
+skill `lovable-deploy-verify` (PR #2073, sessão paralela, mesma janela de ticks): `background` é
+**variância de latência do tick**, não propriedade do step, então a cobertura do eco **converge**
+e a leitura certa acumula a janela inteira do TTL antes de invocar qualquer coisa.
 
-`background` não é propriedade do step: é **variância de latência do Omie** contra o
-`STEP_TIMEOUT_MS` de 25s. Logo a cobertura do eco **converge com o número de ticks**, e a leitura
-certa acumula a JANELA inteira — `respondido` em QUALQUER tick basta, porque o marcador não
-envelhece dentro dela. O cron roda a cada 2h e o `pg_net.ttl` guarda 6h: **toda leitura nasce com
-~3 tentativas de graça**, e julgar pelo tick mais recente joga duas fora.
-
-O que isso troca em custo: o caminho caro que o #2070 prescrevia — sonda ativa no 🟣 SQL Editor,
-bloco colado pelo founder, e justamente no step onde sondar um bundle pré-sensor dispara a
-varredura de ~185s — vira **esperar o próximo tick e reler**. Custo zero, sem founder no caminho.
-Só recorra à sonda ativa se o step vier `background` em **toda** a janela de 6h; aí sim a via
-passiva se esgotou.
-
-⚠️ A assimetria continua valendo: `respondido` + marcador **prova**; `background` é
-**INCONCLUSIVO**, nunca "bundle velho". O que mudou é o que se faz com o inconclusivo — **reler**,
-não sondar.
+Aqui fica só a consequência para **esta** pendência: ela se fechou sem sonda ativa, sem bloco no
+🟣 SQL Editor e sem o founder — o passo 1 do plano acima ("esperar a janela útil") era suficiente
+sozinho, e os passos 2-4 (sonda ativa, prompt de deploy) nunca precisaram ser executados.

--- a/docs/historico/cron-teto-volume-vs-latencia.md
+++ b/docs/historico/cron-teto-volume-vs-latencia.md
@@ -459,15 +459,59 @@ orquestrador pode não haver linha separada nenhuma. Antes de ler ausência como
 `cron.job`/`cron.job_run_details`: **sem run na janela, o método está INAPLICÁVEL** — que é
 diferente de "pendente", e muito diferente de "não subiu".
 
-### Como fechar (chip "Confirmar deploy das 4 edges do cron-diário (`e5a484e2c`)")
+### FECHADA em 2026-08-28: as quatro estão no ar, e o eco provou sozinho
 
-1. Esperar a janela útil: o `0 7 * * *` do `omie-sync-sku-items` é a próxima oportunidade barata.
-   Depois dele, ler o `fonte` e comparar com `bun run sonda:fingerprint` da `main`.
-2. Steps sem cron direto: sondar ativamente pelo 🟣 SQL Editor (`deploy.md` §Canárias), lendo
-   **pelo `request_id`** — nunca `ORDER BY id DESC LIMIT 1`, que pega o tick de outro cron.
-3. ⚠️ **Só sonde DEPOIS do deploy:** bundle anterior à sonda ignora o `probe` e **executa o fluxo
-   real** (sync Omie de verdade).
-4. Desatualizada → prompt de deploy nomeando **todos** os arquivos da tabela acima, `versao.ts`
-   novo e `_shared/sonda-fingerprints.ts` incluídos. Prompt que nomeia só o `index.ts` sobe função
-   que **não boota** (#2020).
-5. **Confirme antes de pedir** — a sessão dona do `e5a484e2c` pode já ter pedido o deploy.
+O deploy **já havia sido pedido** pela sessão dona do `e5a484e2c` — o passo 5 ("confirme antes de
+pedir") era o passo certo, e é o que evitou o pedido redundante. A prova saiu do **N3 PASSIVO**,
+sem sonda ativa, sem invocar nada e sem gastar o founder:
+
+| step (chave do orquestrador) | edge | `modo` | `versao` |
+|---|---|---|---|
+| `ctes` | `omie-sync-ctes-recebidos` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
+| `sku_items` | `omie-sync-sku-items` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
+| `vendas` | `omie-sync-vendas-items` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
+| `pedidos` | `omie-sync-pedidos-compra` | `respondido` **1/3** (tick 10:15Z) | `v1.0-eco-versao-passivo` |
+| `nfes` | `omie-sync-nfes-recebidas` | `respondido` **1/3** (tick 10:15Z) | `v1.1-deadline-relogio` |
+
+Ticks 61860 (06:15Z), 61912 (08:15Z), 61997 (10:15Z) — o 61756 do #2070 já havia expirado pelo
+`pg_net.ttl`, então a medição é **independente**, não releitura. Os três eixos da prova, auditados
+ANTES de declarar:
+
+1. **Identidade** — o eco não carrega `edge` (o furo #1 do Codex no #2070), logo a identidade é a
+   CHAVE que o pai escolhe. Conferida no orquestrador (`omie-cron-diario/index.ts:169-173`):
+   `pedidos`→`omie-sync-pedidos-compra`, `ctes`→`omie-sync-ctes-recebidos`,
+   `sku_items`→`omie-sync-sku-items`, `vendas`→`omie-sync-vendas-items`.
+2. **Exclusividade do marcador** — `v1.0-eco-versao-passivo` tem **0 ocorrências** em `e5a484e2c^`
+   e nasce no próprio `e5a484e2c`. É o análogo do guard `--pai` da `lovable-deploy-verify`: um eco
+   com esse marcador só pode vir do bundle pós-#2063.
+3. **Marcador do ar == marcador da `main`** — as quatro estão em `v1.0-eco-versao-passivo` na
+   `origin/main`, sem bump posterior pendente que o ar devesse estar servindo.
+
+**A fatia inteira subiu, não só o `index.ts`.** A cadeia de import é `index.ts` → `versao.ts` →
+`_shared/sonda-versao.ts` → `_shared/sonda-fingerprints.ts` (`FONTE_SHA256`). Uma função que
+RESPONDE com `VERSAO` bootou; um bundle a que faltasse qualquer arquivo dessa cadeia **não
+bootaria**. O modo de falha do #2020 (prompt que nomeia só o `index.ts`) está descartado por
+construção — e é a razão de o eco provar mais do que aparenta.
+
+### A régua do eco se lê na JANELA, não no tick — `background` é sorteio, não propriedade
+
+O #2070 mediu o tick 61756 mais os 4 da janela, viu `nfes` background 4/4 e `pedidos` 3/4, e
+concluiu: *"para o step que estoura, a prova continua sendo a sonda ativa"*. **A medição de
+2026-08-28 refuta a conclusão** — nos ticks 06:15/08:15/10:15Z os DOIS steps que o #2070 dava como
+inalcançáveis responderam sozinhos, ambos no tick das 10:15Z, sem sonda nenhuma.
+
+`background` não é propriedade do step: é **variância de latência do Omie** contra o
+`STEP_TIMEOUT_MS` de 25s. Logo a cobertura do eco **converge com o número de ticks**, e a leitura
+certa acumula a JANELA inteira — `respondido` em QUALQUER tick basta, porque o marcador não
+envelhece dentro dela. O cron roda a cada 2h e o `pg_net.ttl` guarda 6h: **toda leitura nasce com
+~3 tentativas de graça**, e julgar pelo tick mais recente joga duas fora.
+
+O que isso troca em custo: o caminho caro que o #2070 prescrevia — sonda ativa no 🟣 SQL Editor,
+bloco colado pelo founder, e justamente no step onde sondar um bundle pré-sensor dispara a
+varredura de ~185s — vira **esperar o próximo tick e reler**. Custo zero, sem founder no caminho.
+Só recorra à sonda ativa se o step vier `background` em **toda** a janela de 6h; aí sim a via
+passiva se esgotou.
+
+⚠️ A assimetria continua valendo: `respondido` + marcador **prova**; `background` é
+**INCONCLUSIVO**, nunca "bundle velho". O que mudou é o que se faz com o inconclusivo — **reler**,
+não sondar.


### PR DESCRIPTION
Fecha a pendência aberta em `docs/historico/cron-teto-volume-vs-latencia.md` ("Confirmar deploy das 4 edges do cron-diário, `e5a484e2c`") **com prova, e sem gastar o founder**. O deploy **já havia sido pedido** pela sessão dona do commit — o passo "confirme antes de pedir" era o passo certo, e é o que evitou o pedido redundante.

> ⚠️ **Escopo reduzido após colisão multi-sessão.** O #2073 (sessão paralela, mesma janela de ticks) chegou ao mesmo achado sobre a régua do eco e toca o mesmo trecho da `SKILL.md`. Núcleo em voo ⇒ **fechar > reconciliar**: revertida minha edição da skill e enxugada a seção duplicada. Este PR ficou com **1 arquivo** e **zero interseção** com o #2073, que é o dono da correção da régua.

## A prova (N3 PASSIVO — sem sonda ativa, sem 🟣 SQL Editor, sem invocar nada)

Ticks `61860`/`61912`/`61997` (06:15, 08:15, 10:15Z). O tick `61756` citado no #2070 **já expirara** pelo `pg_net.ttl = 6h` ⇒ medição **independente**, não releitura.

| step (chave) | edge | `modo` | `versao` |
|---|---|---|---|
| `ctes` | `omie-sync-ctes-recebidos` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
| `sku_items` | `omie-sync-sku-items` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
| `vendas` | `omie-sync-vendas-items` | `respondido` 3/3 | `v1.0-eco-versao-passivo` |
| `pedidos` | `omie-sync-pedidos-compra` | `respondido` **1/3** (10:15Z) | `v1.0-eco-versao-passivo` |
| `nfes` | `omie-sync-nfes-recebidas` | `respondido` **1/3** (10:15Z) | `v1.1-deadline-relogio` |

**5/5** — o conjunto inteiro do `omie-cron-diario`, incluindo a 5ª edge que o #2070 media como `background` 4/4.

### Os 3 eixos auditados ANTES de declarar

O eco **não carrega `edge`** (furo #1 do Codex no #2070), então o marcador sozinho não sustenta a prova:

1. **Identidade** — a chave É a identidade; conferida no orquestrador (`omie-cron-diario/index.ts:169-173`).
2. **Exclusividade** — `v1.0-eco-versao-passivo` tem **0 ocorrências** em `e5a484e2c^` e nasce no próprio commit. Análogo do guard `--pai`: um eco com esse marcador só pode vir do bundle pós-#2063.
3. **Ar == `main`** — as quatro em `v1.0-eco-versao-passivo` na `origin/main`, sem bump pendente que o ar devesse estar servindo.

**A fatia inteira subiu, não só o `index.ts`:** a cadeia `index.ts` → `versao.ts` → `_shared/sonda-versao.ts` → `_shared/sonda-fingerprints.ts` (`FONTE_SHA256`) significa que uma função que RESPONDE com `VERSAO` **bootou** — faltasse qualquer arquivo dela, não bootaria. O modo de falha do #2020 (prompt que nomeia só o `index.ts`) fica descartado **por construção**.

## Evidência da leitura

- **Controle**: marcador inventado → **0** linhas · marcador real → **10** (= ctes 3 + sku 3 + vendas 3 + pedidos 1) · 2 valores distintos ⇒ a query **discrimina**, não carimba verde.
- A 1ª query **abortou ruidosa** (`cannot call jsonb_object_keys on an array` — outro emissor grava `resultados` como array) e foi corrigida com filtro de tipo. Falha ruidosa, não veredito fabricado.
- `docs:citacoes` ✓ · `docs:indice` ✓ · `docs:links` ✓ (exit 0 os três, revalidados após o enxugamento).

Sem mudança de código de app/edge — **nada a deployar**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)