### PR TITLE
fix(audit): 20260826002244 (telemetria_probes) ficou fora do inventário de migrations

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **493** custom migrations totais
-- **1704** objetos esperados (criados por estas migrations)
+- **494** custom migrations totais
+- **1711** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 513
-  - `rls_policy`: 449
-  - `index`: 248
+  - `rls_policy`: 453
+  - `index`: 250
   - `cron_job`: 168
-  - `table`: 158
+  - `table`: 159
   - `trigger`: 88
   - `view`: 76
   - `enum_value`: 4
@@ -4126,6 +4126,18 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `cron_job` | `cron.analytics-outbox-drain` | — |
+
+### `20260826002244_telemetria_probes.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.telemetria_probes` | — |
+| `index` | `public.idx_telemetria_probes_device_recente` | `telemetria_probes` |
+| `index` | `public.idx_telemetria_probes_criado_em` | `telemetria_probes` |
+| `rls_policy` | `public.telemetria_probes_user_insert` | `telemetria_probes` |
+| `rls_policy` | `public.telemetria_probes_user_read` | `telemetria_probes` |
+| `rls_policy` | `public.telemetria_probes_master_read` | `telemetria_probes` |
+| `rls_policy` | `public.telemetria_probes_service_all` | `telemetria_probes` |
 
 ### `20260826020000_reposicao_param_fila_sensor.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 493
+-- Total de custom migrations: 494
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -533,6 +533,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260825124938', 'cron_metadados_timeout_240s', '20260825124938_cron_metadados_timeout_240s.sql'),
   ('20260825214545', 'analytics_outbox', '20260825214545_analytics_outbox.sql'),
   ('20260825225850', 'analytics_outbox_cron', '20260825225850_analytics_outbox_cron.sql'),
+  ('20260826002244', 'telemetria_probes', '20260826002244_telemetria_probes.sql'),
   ('20260826020000', 'reposicao_param_fila_sensor', '20260826020000_reposicao_param_fila_sensor.sql'),
   ('20260826021000', 'reposicao_cold_start_fusivel_graduacao', '20260826021000_reposicao_cold_start_fusivel_graduacao.sql')
 ),
@@ -2221,6 +2222,13 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('analytics_outbox', 'rls_policy', 'public', 'analytics_outbox_service_all', 'analytics_outbox'),
   ('analytics_outbox', 'rls_policy', 'public', 'analytics_outbox_master_read', 'analytics_outbox'),
   ('analytics_outbox_cron', 'cron_job', 'cron', 'analytics-outbox-drain', ''),
+  ('telemetria_probes', 'table', 'public', 'telemetria_probes', ''),
+  ('telemetria_probes', 'index', 'public', 'idx_telemetria_probes_device_recente', 'telemetria_probes'),
+  ('telemetria_probes', 'index', 'public', 'idx_telemetria_probes_criado_em', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_user_insert', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_user_read', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_master_read', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_service_all', 'telemetria_probes'),
   ('reposicao_param_fila_sensor', 'function', 'public', 'reposicao_param_fila_sensor', ''),
   ('reposicao_param_fila_sensor', 'view', 'public', 'v_reposicao_param_fila', ''),
   ('reposicao_param_fila_sensor', 'table', 'public', 'reposicao_param_fila_log', ''),
@@ -3962,6 +3970,13 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('analytics_outbox', 'rls_policy', 'public', 'analytics_outbox_service_all', 'analytics_outbox'),
   ('analytics_outbox', 'rls_policy', 'public', 'analytics_outbox_master_read', 'analytics_outbox'),
   ('analytics_outbox_cron', 'cron_job', 'cron', 'analytics-outbox-drain', ''),
+  ('telemetria_probes', 'table', 'public', 'telemetria_probes', ''),
+  ('telemetria_probes', 'index', 'public', 'idx_telemetria_probes_device_recente', 'telemetria_probes'),
+  ('telemetria_probes', 'index', 'public', 'idx_telemetria_probes_criado_em', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_user_insert', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_user_read', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_master_read', 'telemetria_probes'),
+  ('telemetria_probes', 'rls_policy', 'public', 'telemetria_probes_service_all', 'telemetria_probes'),
   ('reposicao_param_fila_sensor', 'function', 'public', 'reposicao_param_fila_sensor', ''),
   ('reposicao_param_fila_sensor', 'view', 'public', 'v_reposicao_param_fila', ''),
   ('reposicao_param_fila_sensor', 'table', 'public', 'reposicao_param_fila_log', ''),


### PR DESCRIPTION
## O buraco

`20260826002244_telemetria_probes.sql` mergeou na main sem entrar no inventário de migrations: nem `docs/migrations-audit.md` nem `scripts/audit-custom-migrations.sql` a conheciam. Efeito: o audit **não checava** `public.telemetria_probes`, seus 2 índices nem suas 3 policies de RLS — o objeto existe em prod e o verificador não sabia que devia procurá-lo.

Achado durante o pré-voo do ritual `/fecho` da sessão do #2044 (que não tocou migration nenhuma). As outras duas migrations da mesma janela — `20260826020000` e `20260826021000` — já estavam no inventário; só esta ficou de fora.

## O conserto

`bun run audit:migrations` (rc 0). O regenerador extraiu os 6 objetos da migration órfã:

| tipo | objeto |
|---|---|
| `table` | `public.telemetria_probes` |
| `index` | `idx_telemetria_probes_device_recente`, `idx_telemetria_probes_criado_em` |
| `rls_policy` | `telemetria_probes_user_insert`, `telemetria_probes_user_read`, `telemetria_probes_master_read` |

As 6 remoções do diff são só os contadores do sumário (493→494 migrations, 1704→1711 objetos).

## O que este PR NÃO faz

As 3 migrations da janela estão **aplicadas em prod** (medido: os 5 objetos existem, e as 2 funções `CREATE OR REPLACE` carregam os tokens novos no corpo vivo) mas **não registradas** em `supabase_migrations.schema_migrations`. O `INSERT` de reconciliação foi entregue ao founder para o SQL Editor — não sai daqui.

E o `database.md` §3 é explícito: reconciliar exige **três** passos. Este PR e o `INSERT` cobrem o (1), que conserta o *audit*. Ficam de fora o (2) re-gerar `schema-snapshot.sql` (conserta o *DR* — pedido no chat do Lovable) e o (3) `types.ts` (gerado pelo Lovable).

## Validação

```
RC[docs:indice]=0   RC[docs:links]=0   RC[docs:citacoes]=0
RC[scripts:typecheck]=0   RC[typecheck]=0   RC[lint]=0   RC[knip]=0
RC[test]=1  ← 746 passed / 1 failed
```

**O `test` não fechou verde local, e não vou maquiar isso.** O único vermelho foi
`src/__tests__/erro-colapsado-em-vazio-gate.test.ts` com **`Error: Test timed out in 20000ms`** — timeout, não asserção. Esse gate varre arquivos-fonte num loop de I/O, e esta máquina está com **5,6 GB em swap** e 40 worktrees; a suíte inteira levou 341s. Isolado no mesmo branch: **9/9, rc 0**. O arquivo não é tocado por este PR, cujo diff é 2 artefatos de audit.

Ou seja: a hipótese é pressão de RAM, e o CI é quem decide — se ele reprovar, o diagnóstico está errado e eu investigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
