### PR TITLE
fix(carimbo): a Issue do alarme dizia "três FATIAS" com cinco audits — contagem sai da mão

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,7 +614,7 @@ jobs:
               '',
               `Run: ${runUrl}`,
               '',
-              '⚠️ O carimbo atesta três FATIAS curadas da autorização, não a autorização inteira — pontos cegos declarados em `docs/agent/database.md` §1.',
+              `⚠️ O carimbo atesta ${(dados.audits || []).length} FATIAS curadas da autorização (${(dados.audits || []).join(', ')}), não a autorização inteira — pontos cegos declarados em \`docs/agent/database.md\` §1.`,
             ].join('\n');
             if (abertas.data.length > 0) {
               await github.rest.issues.createComment({ owner, repo, issue_number: abertas.data[0].number, body: corpo });

--- a/docs/agent/database.md
+++ b/docs/agent/database.md
@@ -28,7 +28,7 @@ Há um usuário **read-only** no Postgres de produção (`claude_ro`) acessível
 - **A leitura de `net._http_response` (ritual de canária, `deploy.md`) sobrevive a qualquer `REVOKE` em `net`:** `pg_read_all_data` dá `SELECT` **e USAGE de schema implícito**, fora do ACL — provado em prod (leio `cron.job`, 90 linhas, sem `USAGE` no `nspacl` de `cron`) e na falsificação PG17 (após o dono revogar `ALL … FROM PUBLIC`, `SELECT` continuou `t` e `EXECUTE`/`INSERT` viraram `f`).
 - **Como foi montado:** o Lovable NÃO expõe a connection string, mas dá pra montar (ref + user `claude_ro.<ref>` + senha definida no `CREATE ROLE` + região do pooler **descoberta por brute-force**: `aws-1-eu-west-1`). A conexão direta `db.<ref>.supabase.co` NÃO existe (projetos novos só têm o pooler Supavisor).
 
-### Cadência dos 3 audits de prod — o CARIMBO (desde 2026-08-25)
+### Cadência dos audits de prod — o CARIMBO (desde 2026-08-25)
 
 Os audits `authz:funcoes:prod` / `authz:grants:prod` / `authz:audit:prod` / `authz:claude-ro:prod` são a **única** guarda que
 enxerga `GRANT` colado à mão no SQL Editor e migration mergeada-e-nunca-aplicada — e não rodavam
@@ -50,7 +50,7 @@ a credencial é local. A ponte é o carimbo `db/authz-carimbo-prod.json`.
   virasse, uma falha de rede renovaria a data e a idade recomeçaria do zero.
 - ⚠️ **`primeiraVez` de um achado nunca é resetada por re-execução** — senão renovar o carimbo lava
   a dívida e o achado fica "conhecido e fresco" para sempre.
-- 🚨 **O carimbo atesta QUATRO FATIAS CURADAS, não "a autorização de prod".** Pontos cegos **medidos**:
+- 🚨 **O carimbo atesta as FATIAS CURADAS enumeradas em `AUDITS` (`scripts/lib/authz-carimbo.ts`), não "a autorização de prod".** A contagem NÃO é escrita à mão em lugar nenhum — o corpo da Issue a deriva do payload do gate. Ela já apodreceu: o texto dizia "três" depois do 4º e do 5º audit entrarem, e a mensagem errada é a que chega ao founder no alarme. Pontos cegos **medidos**:
   o audit de grants mede 6 dos 8 privilégios do tipo `Priv` (**`REFERENCES` e `TRIGGER` são
   declaráveis e nunca medidos**); ACL por **coluna** fica fora (`has_table_privilege` é table-level
   — e é o vetor que importa em `sales_orders`); **RLS vivo** (`relrowsecurity`, policies,

--- a/docs/historico/carimbo-evidencia-authz-prod.md
+++ b/docs/historico/carimbo-evidencia-authz-prod.md
@@ -46,7 +46,7 @@ achado que nenhum PR consegue consertar. Gate vermelho-na-chegada é gate que mo
 
 ## O desenho: a medição fica onde está a credencial, o sinal onde já há cadência
 
-`db/authz-carimbo-prod.json` é escrito **só** por `bun run authz:carimbo:gravar` (roda os 4 audits
+`db/authz-carimbo-prod.json` é escrito **só** por `bun run authz:carimbo:gravar` (roda os audits enumerados em `AUDITS`
 sob `psql-ro`) e lido por `bun run authz:carimbo` (roda no CI, sem banco).
 
 ### Duas severidades, divididas por uma pergunta

--- a/scripts/authz-carimbo-gate.ts
+++ b/scripts/authz-carimbo-gate.ts
@@ -18,6 +18,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 import {
+  AUDITS,
   AVISO_DIAS,
   CARIMBO_PATH,
   VENCIDO_DIAS,
@@ -51,7 +52,16 @@ try {
 }
 
 if (comoJson) {
-  console.log(JSON.stringify({ exigirFrescor, avisoDias: AVISO_DIAS, vencidoDias: VENCIDO_DIAS, vereditos }, null, 2));
+  // `audits` viaja no payload para o corpo da Issue NÃO escrever a contagem à mão. Ela já
+  // apodreceu uma vez: o texto dizia "três FATIAS" depois que o 4º e o 5º audit entraram —
+  // e a mensagem errada é justamente a que chega ao founder no momento do alarme.
+  console.log(
+    JSON.stringify(
+      { exigirFrescor, avisoDias: AVISO_DIAS, vencidoDias: VENCIDO_DIAS, audits: Object.keys(AUDITS), vereditos },
+      null,
+      2,
+    ),
+  );
 }
 
 const bloqueantes = vereditos.filter((v) => v.bloqueiaPR);

--- a/scripts/authz-carimbo.test.ts
+++ b/scripts/authz-carimbo.test.ts
@@ -536,3 +536,31 @@ describe('envDeTesteSetadas — a guarda que a lista literal já tinha deixado p
     expect(envDeTesteSetadas({ PSQL_RO: '/x', AUTHZ_TEST: '1', TEST_JSON: '1' })).toEqual([]);
   });
 });
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Anti-apodrecimento da CONTAGEM. Esta linha já esteve errada em produção: dizia "três FATIAS"
+// depois que o 4º (claudeRo) e o 5º (rls) audits entraram no AUDITS — e é a mensagem que chega ao
+// founder no momento do alarme. O conserto não foi trocar o número; foi tirá-lo da mão.
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+describe('a contagem de fatias NÃO pode voltar a ser escrita à mão', () => {
+  const ymlBruto = readFileSync(join(RAIZ, '.github', 'workflows', 'ci.yml'), 'utf8');
+
+  it('o corpo da Issue DERIVA a contagem do payload, não de um literal', () => {
+    const linha = ymlBruto.split('\n').find((l) => l.includes('FATIAS curadas'));
+    expect(linha, 'a linha das FATIAS sumiu do ci.yml').toBeDefined();
+    expect(linha).toContain('dados.audits');
+    // qualquer numeral ou número por extenso ANTES de "FATIAS" é reintrodução do bug
+    expect(linha).not.toMatch(/\b(um|dois|tr[êe]s|quatro|cinco|seis|\d+)\s+FATIAS/i);
+  });
+
+  it('o gate publica a lista de audits no JSON — sem ela o ci.yml não teria de onde derivar', () => {
+    const gate = readFileSync(join(RAIZ, 'scripts', 'authz-carimbo-gate.ts'), 'utf8');
+    expect(gate).toContain('audits: Object.keys(AUDITS)');
+  });
+
+  it('o doc aponta para a FONTE (AUDITS), em vez de repetir a contagem', () => {
+    const doc = readFileSync(join(RAIZ, 'docs', 'agent', 'database.md'), 'utf8');
+    expect(doc).toMatch(/FATIAS CURADAS enumeradas em `AUDITS`/);
+    expect(doc).not.toMatch(/atesta (TR[ÊE]S|QUATRO|CINCO) FATIAS/i);
+  });
+});


### PR DESCRIPTION
## O defeito, e onde ele aparecia

O corpo da Issue `authz-prod` — a mensagem que chega ao founder **no momento do alarme** — dizia:

> ⚠️ O carimbo atesta **três** FATIAS curadas da autorização

São **cinco**. Medido executando o módulo, não por grep: `AUDITS = 5 → funcoes, grants, audit, claudeRo, rls`.

O texto nasceu certo com 3 audits, ficou errado quando o `claudeRo` entrou (#2044, na mesma sessão) e ficou mais errado quando outra sessão entregou o `authz:rls:prod`. Foi visto no log do primeiro run **agendado** do sentinela (`run 33209880448`, `event=schedule`) — o mecanismo funcionando expôs o próprio defeito.

## O conserto não é o número

Trocar "três" por "cinco" reintroduz o bug na próxima vez. O número saiu da mão:

- `scripts/authz-carimbo-gate.ts` passa a publicar `audits: Object.keys(AUDITS)` no `--json`;
- `.github/workflows/ci.yml` **deriva** a contagem e a lista do payload (`dados.audits`);
- `docs/agent/database.md` e o histórico deixam de repetir a contagem e apontam para a FONTE (`AUDITS`).

Nota: o `authz:rls:prod` **já estava** no `AUDITS` — a sessão que o entregou seguiu a regra deixada em `docs/agent/database.md` §1 (*"audit de prod novo nasce sem cadência; acrescentá-lo a `AUDITS` é parte de criá-lo"*). A regra propagou; só o texto ficou para trás.

## Guarda (senão apodrece de novo)

3 asserções novas, e a que importa **protege o mecanismo, não o valor**: reintroduzir o literal escrito à mão reprova mesmo com o número CERTO.

**Falsificações — sabotei e EXIGI vermelho:**

| Sabotagem | Resultado |
|---|---|
| crase final do template literal escapada (quebra o JS do `github-script`) | **RC=1**, 3 testes caem, incluindo o que compila o script |
| literal à mão de volta, com o número **certo** (`cinco FATIAS`) | **RC=1** — o guarda dispara igual |

## Validação

```
RC[docs:indice]=0  RC[docs:links]=0  RC[docs:citacoes]=0  RC[claude:size]=0
RC[scripts:typecheck]=0  RC[typecheck]=0  RC[lint]=0  RC[knip]=0
RC[test]=0        747 passed (747) · 7427 tests · 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
