### PR TITLE
fix(authz): a contagem dos grupos de lacuna era prosa — vira DADO medido contra prod [money-path]

### DIFF
--- a/db/audit-rls-prod.ts
+++ b/db/audit-rls-prod.ts
@@ -11,6 +11,11 @@
  * operar este banco.
  *
  * Uso:   bun run authz:rls:prod ; echo $?   → 0 bate · 1 divergência · 2 não consegui medir
+ *
+ * O 4º eixo (2026-08-28) é o NEGATIVO dos outros três: mede se a declaração de lacuna em BLOCO
+ * (`LACUNAS_POR_GRUPO`) ainda descreve prod. Os eixos 1-3 reconciliam o contrato contra o banco;
+ * ninguém reconciliava a DECLARAÇÃO contra o banco, e uma migration que gateasse mais uma tabela
+ * por `cap_carteira_ler` deixava a contagem declarada falsa sem nada ficar vermelho (§7.2).
  * Dente: db/test-audit-rls-prod.sh (PG17 descartável — sabota cada regra, exige vermelho, exige o
  *        verde de volta, e prova o EFEITO da RLS sob SET ROLE authenticated + GUC do JWT)
  *
@@ -21,13 +26,15 @@ import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { compararRlsProd, type MedicaoRls, type MedPolicy } from '../scripts/lib/authz-rls';
+import { compararRlsProd, rotuloGrupo, type MedicaoRls, type MedPolicy } from '../scripts/lib/authz-rls';
 import {
   AUTHZ_RLS_ESPERADO,
   AUTHZ_RLS_PREDICADOS,
+  LACUNAS_POR_GRUPO,
   PREDICADOS_PLATAFORMA,
   type TabelaRls,
   type PredicadoEsperado,
+  type LacunaGrupo,
 } from '../scripts/authz-rls-esperado';
 
 const PSQL = process.env.PSQL_RO ?? join(homedir(), '.config', 'afiacao', 'psql-ro');
@@ -43,6 +50,10 @@ interface Contrato {
   contrato: Record<string, TabelaRls>;
   predicados: Record<string, PredicadoEsperado>;
   plataforma: ReadonlySet<string>;
+  grupos: LacunaGrupo[];
+  /** `true` quando o contrato veio de `AUTHZ_RLS_TEST_JSON`. Existe para que o piso de vacuidade
+   *  do eixo 4 valha só para o contrato REAL: o harness monta recortes deliberadamente pequenos. */
+  sintetico: boolean;
 }
 
 /** Contrato real, ou o sintético quando o harness PG17 injeta AUTHZ_RLS_TEST_JSON. */
@@ -53,6 +64,8 @@ function carregarContrato(): Contrato {
       contrato: AUTHZ_RLS_ESPERADO,
       predicados: AUTHZ_RLS_PREDICADOS,
       plataforma: PREDICADOS_PLATAFORMA,
+      grupos: LACUNAS_POR_GRUPO,
+      sintetico: false,
     };
   }
   console.log('⚠️  contrato de TESTE (AUTHZ_RLS_TEST_JSON) — não é o contrato real do repo.');
@@ -61,11 +74,14 @@ function carregarContrato(): Contrato {
       contrato: Record<string, TabelaRls>;
       predicados?: Record<string, PredicadoEsperado>;
       plataforma?: string[];
+      grupos?: LacunaGrupo[];
     };
     return {
       contrato: p.contrato,
       predicados: p.predicados ?? {},
       plataforma: new Set(p.plataforma ?? []),
+      grupos: p.grupos ?? [],
+      sintetico: true,
     };
   } catch (e) {
     erroFatal(`AUTHZ_RLS_TEST_JSON não é JSON válido: ${(e as Error).message}`);
@@ -73,7 +89,7 @@ function carregarContrato(): Contrato {
 }
 
 /**
- * Uma invocação do psql para as quatro medições. Cada uma sai em UMA linha, prefixada por
+ * Uma invocação do psql para as cinco medições. Cada uma sai em UMA linha, prefixada por
  * `JSON:<chave>|`, porque o `psqlrc` do psql-ro ecoa `SET` e qualquer parser precisa sobreviver a
  * linhas que não são dado.
  *
@@ -86,8 +102,45 @@ function carregarContrato(): Contrato {
  * `to_regclass` — nada de assumir `public`. O `LEFT JOIN` sobre `unnest` garante uma linha por
  * tabela DECLARADA mesmo quando ela não existe: ausência tem de virar dado, não silêncio.
  */
-function montarQuery(chaves: string[]): string {
-  const lista = chaves.map((x) => `'${x.replace(/'/g, "''")}'`).join(',');
+function sqlLit(x: string): string {
+  return `'${x.replace(/'/g, "''")}'`;
+}
+
+/** O `VALUES` do eixo 4, ou a lista vazia. Fail-closed na FORMA: um `tipo` que este montador não
+ *  conhece vira exceção, nunca um `CASE` que cai no `ELSE` e mede zero tabelas — medir zero se
+ *  apresentaria como "o grupo encolheu para 0", um diagnóstico plausível e errado. */
+function sqlGrupos(grupos: readonly LacunaGrupo[]): string {
+  if (grupos.length === 0) return `SELECT 'JSON:grupos|[]';`;
+  const linhas = grupos.map((g) => {
+    const rot = sqlLit(rotuloGrupo(g.def));
+    if (g.def.tipo === 'predicado') return `(${rot},'predicado',${sqlLit(g.def.predicado)})`;
+    if (g.def.tipo === 'prefixo') return `(${rot},'prefixo',${sqlLit(g.def.prefixo)})`;
+    throw new Error(`montarQuery: grupo com tipo desconhecido — ${JSON.stringify(g.def)}`);
+  });
+  // `starts_with` e NÃO `LIKE prefixo||'%'`: em LIKE o `_` é CORINGA de um caractere, então
+  // `fin_%` casaria `financeiro_x` e o grupo mediria a mais em silêncio. Medido: os dois devolvem
+  // 41 hoje por acaso (não há tabela `finX*`), o que é exatamente como esse bug sobreviveria.
+  return `
+SELECT 'JSON:grupos|'||coalesce(jsonb_agg(x ORDER BY x.grupo)::text,'[]') FROM (
+  SELECT g.rot AS grupo, coalesce(m.tabelas,'[]'::jsonb) AS tabelas
+    FROM (VALUES ${linhas.join(',')}) AS g(rot,tipo,arg)
+    LEFT JOIN LATERAL (
+      SELECT jsonb_agg(c.relname) AS tabelas
+        FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+       WHERE n.nspname='public' AND c.relkind='r'
+         AND CASE WHEN g.tipo='prefixo' THEN starts_with(c.relname, g.arg)
+                  ELSE EXISTS (SELECT 1 FROM pg_policy pol
+                                 JOIN pg_depend d ON d.classid='pg_policy'::regclass AND d.objid=pol.oid
+                                                 AND d.refclassid='pg_proc'::regclass
+                                 JOIN pg_proc p ON p.oid=d.refobjid
+                                 JOIN pg_namespace pn ON pn.oid=p.pronamespace
+                                WHERE pol.polrelid=c.oid AND pn.nspname||'.'||p.proname = g.arg)
+             END) m ON true) x;
+`;
+}
+
+function montarQuery(chaves: string[], grupos: readonly LacunaGrupo[]): string {
+  const lista = chaves.map(sqlLit).join(',');
   const tabs = `(SELECT ARRAY[${lista}]::text[])`;
   return `
 SELECT 'JSON:universal|'||jsonb_build_object(
@@ -125,7 +178,7 @@ SELECT 'JSON:predicados|'||coalesce(jsonb_agg(x)::text,'[]') FROM (
     JOIN pg_proc f ON f.oid = d.refobjid
     JOIN pg_namespace n ON n.oid = f.pronamespace
    ORDER BY 1) x;
-`;
+${sqlGrupos(grupos)}`;
 }
 
 /** Lê a linha `JSON:<chave>|…`. Chave ausente = medição quebrada = exit 2, jamais lista vazia. */
@@ -145,10 +198,10 @@ function extrair(saida: string, chave: string): unknown {
   }
 }
 
-function medir(chaves: string[]): MedicaoRls {
+function medir(chaves: string[], grupos: readonly LacunaGrupo[]): MedicaoRls {
   let saida: string;
   try {
-    saida = execFileSync(PSQL, ['-tA', '-c', montarQuery(chaves)], { encoding: 'utf8' });
+    saida = execFileSync(PSQL, ['-tA', '-c', montarQuery(chaves, grupos)], { encoding: 'utf8' });
   } catch (e) {
     // psql-ro ausente, sem rede, sintaxe rejeitada ou timeout caem todos aqui.
     erroFatal(`falha ao consultar o banco via psql-ro (${PSQL}): ${(e as Error).message}`);
@@ -158,6 +211,7 @@ function medir(chaves: string[]): MedicaoRls {
   const tabelas = extrair(saida, 'tabelas') as MedicaoRls['tabelas'];
   const policies = extrair(saida, 'policies') as MedPolicy[];
   const predicados = extrair(saida, 'predicados') as MedicaoRls['predicados'];
+  const gruposMed = extrair(saida, 'grupos') as MedicaoRls['grupos'];
 
   // Pisos de sanidade. Cada um existe porque o modo de falha que ele pega se apresenta como
   // sucesso: nenhuma tabela medida ⇒ nenhuma violação ⇒ ✅ sobre o vazio.
@@ -174,16 +228,33 @@ function medir(chaves: string[]): MedicaoRls {
         `a que não existe — vir menos significa que o parser ou a query quebrou.`,
     );
   }
-  return { universal, tabelas, policies, predicados };
+  if (gruposMed.length !== grupos.length) {
+    erroFatal(
+      `medição inconsistente: ${gruposMed.length} linha(s) de grupo para ${grupos.length} ` +
+        `declarado(s). O VALUES devolve uma linha por grupo DECLARADO sempre, inclusive para o ` +
+        `que não casa tabela nenhuma — vir menos significa que a query ou o parser quebrou.`,
+    );
+  }
+  return { universal, tabelas, policies, predicados, grupos: gruposMed };
 }
 
 function main(): void {
-  const { contrato, predicados, plataforma } = carregarContrato();
+  const { contrato, predicados, plataforma, grupos, sintetico } = carregarContrato();
   const chaves = Object.keys(contrato);
   if (chaves.length === 0) erroFatal('contrato de RLS vazio — não há o que reconciliar.');
+  // Piso de vacuidade do eixo 4, no contrato REAL: `for` sobre lista vazia não itera, então
+  // esvaziar `LACUNAS_POR_GRUPO` desligaria o eixo inteiro com ✅. (O gate estático de
+  // `scripts/authz-rls.test.ts` guarda o mesmo piso no CI, onde não há psql-ro; este aqui é o que
+  // vale na execução contra prod, que é onde o operador lê o verde.)
+  if (!sintetico && grupos.length === 0) {
+    erroFatal(
+      'LACUNAS_POR_GRUPO vazio — o eixo 4 não teria o que conferir e o ✅ afirmaria uma ' +
+        'declaração que não existe. Lista de grupos vazia é contrato quebrado, não "sem lacunas".',
+    );
+  }
 
-  const med = medir(chaves);
-  const findings = compararRlsProd(med, contrato, predicados, plataforma);
+  const med = medir(chaves, grupos);
+  const findings = compararRlsProd(med, contrato, predicados, plataforma, grupos);
   const erros = findings.filter((f) => f.level === 'error');
   const avisos = findings.filter((f) => f.level === 'warn');
 
@@ -199,10 +270,18 @@ function main(): void {
   }
   // O denominador vai na linha do veredito de propósito: "✅" sem denominador não distingue
   // "conferi 19 policies" de "conferi zero" (docs/historico/fase-sem-sinal.md).
+  // O eixo 4 entra no denominador com a UNIÃO distinta (os grupos se sobrepõem — `cap_carteira_ler`
+  // e `carteira_visivel_para` compartilham tabelas medidas), e com a subtração à vista: sem o
+  // "N curada(s)" o leitor não distingue "78 tabelas fora do contrato" de "78 conferidas e
+  // cobertas", que são afirmações opostas.
+  const uniao = new Set(med.grupos.flatMap((g) => g.tabelas));
+  const curadasNaUniao = [...uniao].filter((t) => `public.${t}` in contrato).length;
   console.log(
     `✅ audit-rls — ${med.universal.totalTabelas} tabela(s) em public com RLS ligada (0 desligada); ` +
       `${chaves.length} tabela(s) curada(s), ${med.policies.length} policy(ies) e ` +
-      `${med.predicados.length} funcao(oes)-predicado batem com o contrato.`,
+      `${med.predicados.length} funcao(oes)-predicado batem com o contrato; ` +
+      `${grupos.length} grupo(s) de lacuna conferido(s) — ${uniao.size} tabela(s) distinta(s) no ` +
+      `grafo, ${curadasNaUniao} curada(s), ${uniao.size - curadasNaUniao} lacuna(s).`,
   );
 }
 

--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-08-28T11:35:55.198Z",
-  "sourceHead": "5346daf2b5c30eb5ef8cffc8f8407ae17917e365",
+  "medidoEm": "2026-08-28T22:40:24.796Z",
+  "sourceHead": "de28d20da7afbedb250effe450c01ceca79625c9",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -48,10 +48,10 @@
     "rls": {
       "script": "authz:rls:prod",
       "exit": 0,
-      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 20 tabela(s) curada(s), 50 policy(ies) e 10 funcao(oes)-predicado batem com o contrato.",
+      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 20 tabela(s) curada(s), 50 policy(ies) e 10 funcao(oes)-predicado batem com o contrato; 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 6 curada(s), 72 lacuna(s).",
       "denominador": null,
-      "contratoFingerprint": "6dd89233e2e5bbee827edb71e759caa6afb379ee2698436ce58e0f4001f75efb",
-      "auditorFingerprint": "451994e2e848a3cd54c2da9944907b3e3110a0e3ba9686765cf9e222a9d9165a",
+      "contratoFingerprint": "894ad8c1d514c162e4735320229b0501ef3dfc951d5233c155c461eed5c9f720",
+      "auditorFingerprint": "7545fa3b23e157e1f5f7755d7f9628dddfbc4429cb29d35429e923f6d908986e",
       "achados": []
     }
   }

--- a/db/test-audit-rls-prod.sh
+++ b/db/test-audit-rls-prod.sh
@@ -119,13 +119,25 @@ CREATE POLICY zz_sel_staff ON public.zz_pedidos FOR SELECT TO authenticated
 CREATE POLICY zz_ins_staff ON public.zz_pedidos FOR INSERT TO authenticated
   WITH CHECK ((SELECT public.zz_gate((SELECT auth.uid()))));
 GRANT SELECT, INSERT ON public.zz_pedidos TO authenticated;
+
+-- zz_extra ≙ as 13 de cap_compras_ler que ficaram de FORA do contrato: gateada pelo mesmo
+-- predicado, e deliberadamente NÃO curada. Sem ela o grupo sintético teria zero lacunas e o
+-- estado limpo já nasceria acusando LACUNA_GRUPO_CURADO — o cenário mediria outra coisa.
+CREATE TABLE public.zz_extra (id int PRIMARY KEY);
+ALTER TABLE public.zz_extra ENABLE ROW LEVEL SECURITY;
+CREATE POLICY zz_sel_extra ON public.zz_extra FOR SELECT TO authenticated
+  USING ((SELECT public.zz_gate((SELECT auth.uid()))));
 SQL
 
 # ── contrato de teste, DERIVADO do estado limpo ────────────────────────────────────────────
 # Derivar (em vez de hardcodar md5) é o que mantém o harness honesto entre versões do PG: o
 # `pg_get_expr` re-renderiza a expressão, e um md5 fixo aqui viraria vermelho eterno no dia em que
 # o PG mudasse a impressão. O DENTE não vem do cenário A ser verde — vem de B..P exigirem vermelho.
-TEST_JSON="$(PT <<'SQL'
+# `$1` é a expressão SQL que produz o array `grupos` (eixo 4) — o resto do contrato é o mesmo
+# nas duas variantes, e duplicar esta query para trocar UMA chave seria plantar duas fontes que
+# divergem na primeira edição.
+derivar_json() {
+  PT <<SQL
 SELECT jsonb_build_object(
   'contrato', (SELECT jsonb_object_agg(t.tabela, jsonb_build_object(
                         'forceRls', t.force, 'motivo', 'sintetica do harness', 'policies', t.policies))
@@ -155,18 +167,74 @@ SELECT jsonb_build_object(
                          JOIN pg_proc pr ON pr.oid=d.refobjid
                          JOIN pg_namespace n2 ON n2.oid=pr.pronamespace
                         WHERE n2.nspname <> 'auth') f),
-  'plataforma', jsonb_build_array('auth.uid'))::text;
+  'plataforma', jsonb_build_array('auth.uid'),
+  'grupos', ($1))::text;
 SQL
-)"
+}
+
+# Um grupo do eixo 4, medido no estado limpo: `grupo_json <tipo> <arg>`.
+#
+# 🔴 `ORDER BY … COLLATE "C"` não é enfeite: o md5 que o audit compara é calculado em JS
+# (`md5Lista`, sort por code unit), e o `ORDER BY` do Postgres usa COLLATION — em ICU/pt_BR o `_`
+# é ignorado na comparação primária e `zz_p_a` × `zz_pa` trocam de lugar. Sem o COLLATE, este
+# harness casaria no locale C e reprovaria no pt_BR com o produto CORRETO: o falso-vermelho que a
+# lição #1483 manda procurar rodando nos DOIS.
+#
+# A chave do `def` tem o mesmo nome do tipo (`predicado`/`prefixo`), que é o que deixa o
+# `jsonb_build_object('tipo',$1,$1,$2)` servir aos dois sem ramo.
+grupo_json() {
+  local cond
+  case "$1" in
+    predicado) cond="EXISTS (SELECT 1 FROM pg_policy pol
+                               JOIN pg_depend d ON d.classid='pg_policy'::regclass AND d.objid=pol.oid
+                                               AND d.refclassid='pg_proc'::regclass
+                               JOIN pg_proc pr ON pr.oid=d.refobjid
+                               JOIN pg_namespace pn ON pn.oid=pr.pronamespace
+                              WHERE pol.polrelid=c.oid AND pn.nspname||'.'||pr.proname='$2')" ;;
+    prefixo)   cond="starts_with(c.relname,'$2')" ;;
+    *) echo "grupo_json: tipo desconhecido '$1'" >&2; exit 1 ;;
+  esac
+  printf '%s' "SELECT jsonb_build_object(
+     'def', jsonb_build_object('tipo','$1','$1','$2'),
+     'tabelasNoGrafo', count(*),
+     'tabelasMd5', md5(string_agg(relname, ',' ORDER BY relname COLLATE \"C\")),
+     'medidoEm', '2026-08-28',
+     'motivo', 'grupo sintetico do harness ($1 $2)')
+   FROM (SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+          WHERE n.nspname='public' AND c.relkind='r' AND $cond) t"
+}
+# 1 ou 2 grupos. Declarar o MESMO grupo duas vezes só para preencher a assinatura faria o audit
+# acusar duas vezes o mesmo objeto — ruído que o cenário leria como "acusou", sem ser o desenho.
+arr() {
+  if [ "$#" -eq 1 ]; then printf 'SELECT jsonb_agg(g) FROM (SELECT (%s) AS g) z' "$1"
+  else printf 'SELECT jsonb_agg(g) FROM (SELECT (%s) AS g UNION ALL SELECT (%s)) z' "$1" "$2"; fi
+}
+
+# Grupo de PREDICADO: zz_gate gateia {zz_pedidos (curada), zz_extra (lacuna)}.
+# Grupo de PREFIXO: `zz_p` casa {zz_papeis (lacuna), zz_pedidos (curada)} — e NÃO casa zz_extra,
+# então os dois grupos medem conjuntos diferentes e uma sabotagem não move os dois de graça.
+TEST_JSON="$(derivar_json "$(arr "$(grupo_json predicado public.zz_gate)" "$(grupo_json prefixo zz_p)")")"
+# Variante do cenário GH: um grupo (`zz_pe`) cujo ÚNICO membro é a tabela curada. Não dá para
+# produzi-la mutando o banco — ela é uma DECLARAÇÃO que virou mentira sem prod se mexer, que é
+# exatamente o defeito de §7.1 um nível acima.
+TEST_JSON_CURADO="$(derivar_json "$(arr "$(grupo_json prefixo zz_pe)")")"
+
 [ -n "$TEST_JSON" ] || { echo "❌ contrato de teste veio VAZIO — o harness mediria nada"; exit 1; }
 case "$TEST_JSON" in *zz_sel_staff*zz_gate*|*zz_gate*zz_sel_staff*) : ;;
   *) echo "❌ contrato de teste sem a policy ou sem o predicado: $TEST_JSON"; exit 1 ;; esac
+# Sonda do eixo 4, fail-CLOSED: sem `grupos` no JSON o audit cai em `?? []` e o eixo inteiro fica
+# INERTE — os cenários G* passariam a exigir vermelho de uma guarda desligada e reprovariam, mas o
+# modo de falha mais discreto (derivar `grupos: null` e seguir verde) é este check que pega.
+case "$TEST_JSON" in *'"grupos":'*'"tabelasMd5":'*) : ;;
+  *) echo "❌ contrato de teste sem o eixo 4 (grupos/tabelasMd5): $TEST_JSON"; exit 1 ;; esac
+case "$TEST_JSON_CURADO" in *'"grupos":'*'"tabelasMd5":'*) : ;;
+  *) echo "❌ variante CURADO sem o eixo 4: $TEST_JSON_CURADO"; exit 1 ;; esac
 
 run_audit() {
   local ec=0
   # `|| ec=$?` é obrigatório: sob `set -e`, o exit 1 que QUEREMOS mataria o harness antes da
   # asserção, e o teste passaria a nunca reprovar.
-  PSQL_RO="$WRAP" AUTHZ_RLS_TEST_JSON="$TEST_JSON" \
+  PSQL_RO="$WRAP" AUTHZ_RLS_TEST_JSON="${JSON_ATUAL:-$TEST_JSON}" \
     bun "$REPO_ROOT/db/audit-rls-prod.ts" > "$OUT" 2>&1 || ec=$?
   echo "$ec"
 }
@@ -255,6 +323,42 @@ esperar "R  FOR ALL com WITH CHECK ≠ USING → FOR_ALL_ASSIMETRICO (a armadilh
 P -c "DROP POLICY zz_ins_staff ON public.zz_pedidos;
       CREATE POLICY zz_ins_staff ON public.zz_pedidos FOR INSERT TO authenticated WITH CHECK ((SELECT public.zz_gate((SELECT auth.uid()))));"
 esperar "S  split por comando de volta → limpo  ← dente" 0 - FOR_ALL_ASSIMETRICO
+
+# ── eixo 4: a DECLARAÇÃO de lacuna em bloco ainda descreve prod? ────────────────────────────
+# Nenhum destes cenários mexe em autorização: mexe no que a declaração AFIRMA. É o eixo que os
+# outros três não têm como cobrir, porque eles reconciliam o contrato contra o banco e a
+# declaração de não-cobertura ninguém reconciliava (§7.2 do histórico).
+esperar "GA estado conforme → nenhum achado de grupo (exit 0)" 0 - LACUNA_GRUPO_MUDOU
+
+P -c "CREATE TABLE public.zz_gateada (id int);
+      ALTER TABLE public.zz_gateada ENABLE ROW LEVEL SECURITY;
+      CREATE POLICY p ON public.zz_gateada FOR SELECT TO authenticated
+        USING ((SELECT public.zz_gate((SELECT auth.uid()))));"
+esperar "GB migration gateia MAIS uma tabela pelo predicado do grupo → LACUNA_GRUPO_MUDOU" 1 LACUNA_GRUPO_MUDOU POLICY_NOVA
+P -c "DROP TABLE public.zz_gateada;"
+esperar "GC removida → a acusação SOME  ← dente" 0 - LACUNA_GRUPO_MUDOU
+
+P -c "CREATE TABLE public.zz_prefixada (id int); ALTER TABLE public.zz_prefixada ENABLE ROW LEVEL SECURITY;"
+esperar "GD tabela nova casa o PREFIXO do grupo (sem policy nenhuma) → LACUNA_GRUPO_MUDOU" 1 LACUNA_GRUPO_MUDOU RLS_DESLIGADA_FORA_DO_CONTRATO
+P -c "DROP TABLE public.zz_prefixada;"
+esperar "GE removida → limpo  ← dente" 0 - LACUNA_GRUPO_MUDOU
+
+# O buraco que a contagem sozinha deixa: uma sai, outra entra, e o total não se move. Aqui o
+# rename faz as duas coisas de uma vez — `zz_papeis` sai do grupo `zz_p` e `zz_papeis_novo` entra.
+P -c "ALTER TABLE public.zz_papeis RENAME TO zz_papeis_novo;"
+esperar "GF SUBSTITUIÇÃO: contagem IGUAL, conjunto outro → LACUNA_GRUPO_MUDOU pelo md5" 1 LACUNA_GRUPO_MUDOU -
+P -c "ALTER TABLE public.zz_papeis_novo RENAME TO zz_papeis;"
+esperar "GG nome de volta → limpo  ← dente (e o md5 é reproduzível)" 0 - LACUNA_GRUPO_MUDOU
+
+# O espelho de §7.1 um nível acima: a declaração passa a mentir na direção que finge NÃO cobrir.
+# A correção é OPOSTA à do MUDOU (apagar a entrada, não renovar o número), por isso o código é outro.
+# `JSON_ATUAL=… esperar …` (prefixo de env numa FUNÇÃO) seria dependente de shell: bash não-POSIX
+# e bash em modo POSIX discordam sobre a variável sobreviver à chamada, e o cenário GI leria o
+# JSON errado em metade dos ambientes. Set/unset explícito não tem essa ambiguidade.
+JSON_ATUAL="$TEST_JSON_CURADO"
+esperar "GH grupo com TODAS as tabelas curadas → LACUNA_GRUPO_CURADO, não MUDOU" 1 LACUNA_GRUPO_CURADO LACUNA_GRUPO_MUDOU
+unset JSON_ATUAL
+esperar "GI de volta ao contrato normal → limpo  ← controle: a acusação era da DECLARAÇÃO" 0 - LACUNA_GRUPO_CURADO
 
 # ── controles INÓCUOS: mudança real que NÃO pode acusar nada ────────────────────────────────
 P -c "ALTER TABLE public.zz_pedidos ADD COLUMN observacao text;"

--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -439,3 +439,85 @@ do carimbo → o teste de identidade dos QUATRO eixos reprova; F8 é o teste de 
 > guarda estava **correta no dia em que foi escrita**; quem a tornou falsa foi o crescimento
 > normal do sistema. Quando a afirmação pode ser expressa como **dado ao lado do dado que ela
 > descreve**, é essa forma que sobrevive.
+
+### 7.2 A mesma classe um nível acima: a CONTAGEM do grupo também era prosa
+
+O §7.1 tirou da prosa a lista de tabelas recusadas. O que ficou para trás, no mesmo cabeçalho,
+foram as lacunas em **bloco** — os grupos que não cabem como chave de tabela:
+
+> "as **22** tabelas de `private.cap_carteira_ler` e as **8** de `private.carteira_visivel_para`;
+> as **36** `fin_*` restantes (de 41; 5 curadas); e as outras **13** de `private.cap_compras_ler`
+> (de 14)."
+
+Medido em prod hoje (2026-08-28, psql-ro): **22 · 8 · 41 · 14**. O parágrafo estava **certo**, como
+estava certo o da §7.1 no dia em que foi escrito. A diferença entre os dois é só o **gatilho de
+apodrecimento**, e o do grupo é mais barato de puxar: a lista de tabelas apodrece quando uma
+rodada **cura**; a contagem do grupo apodrece quando uma **migration** gateia mais uma tabela pela
+mesma capability — o evento mais banal deste repo, e o que menos passa por revisão de autorização.
+Nos dois casos o texto seguiria verde afirmando um número que ninguém mede.
+
+**Por que um teste estático não resolvia.** O §7.1 fechou-se com um cruzamento de três linhas
+(`LACUNAS_DECLARADAS` × `AUTHZ_RLS_ESPERADO`), porque as duas pontas viviam no arquivo. Aqui a
+outra ponta é **prod**: só o banco sabe quantas tabelas `cap_carteira_ler` gateia hoje. O gate tem
+de ser o **audit**, não o CI — e isso põe o eixo 4 no lugar certo, junto do 1-3, com o mesmo
+psql-ro e o mesmo exit code.
+
+#### O desenho, e as três decisões que ele obrigou
+
+`LACUNAS_POR_GRUPO` é uma lista de `{def, tabelasNoGrafo, tabelasMd5, medidoEm, motivo}`, e
+`db/audit-rls-prod.ts` reconta o grupo em prod a cada execução (`pg_depend` para grupo de
+predicado, `starts_with` para grupo de prefixo), desconta as curadas e compara.
+
+1. **Duas formas de definir grupo, não uma.** Três dos quatro grupos são "as tabelas que chamam tal
+   capability" — uma aresta do grafo de `pg_depend`. O quarto (`fin_*`) é de **nome**, e reduzi-lo
+   ao predicado teria sido a armadilha: o gate comum do domínio financeiro
+   (`public.fin_user_can_access`) alcança **18** tabelas medidas, não 41. Uma `fin_nova` gateada
+   por outra função continuaria sendo lacuna do grupo, e um grupo definido pelo predicado **não a
+   veria entrar** — a mesma cegueira, com um sensor por cima dela.
+
+2. **Declarar o TOTAL, derivar a lacuna.** A forma óbvia seria congelar "36 lacunas". Ela tem um
+   cego exato: uma migration acrescenta uma tabela ao grupo (22→23) e uma rodada cura outra (0→1)
+   no mesmo dia — a subtração devolve 22 e nada fica vermelho. O total só se move por prod, que é
+   a única ponta que este eixo não controla; o número de lacunas é **recalculado** do contrato ao
+   lado a cada execução, e por isso não pode apodrecer. É a subtração que dá o denominador da linha
+   do veredito: `78 tabela(s) distinta(s) no grafo, 6 curada(s), 72 lacuna(s)`.
+
+3. **`tabelasMd5` ao lado da contagem, pelo mesmo argumento.** Se "duas mudanças opostas se
+   cancelam" justifica declarar o total, ela justifica fechar a **substituição**: uma tabela sai do
+   grupo e outra entra no mesmo intervalo, e o total não se move. O md5 da lista ordenada custa uma
+   linha por grupo e fecha isso; o achado imprime a **lista viva**, então o md5 nunca é o fim da
+   leitura. O sort é feito em **JS** e não em SQL de propósito — o `ORDER BY` do Postgres usa
+   colação, e `_` ordena antes de letra em `C` e é ignorado em ICU/pt_BR: o mesmo conjunto daria
+   md5 diferente conforme o locale do servidor. As duas computações (JS e
+   `md5(string_agg(… ORDER BY … COLLATE "C"))`) foram conferidas uma contra a outra antes de o
+   número entrar no contrato.
+
+**Dois códigos, não um.** `LACUNA_GRUPO_MUDOU` pede re-medir e renovar o número;
+`LACUNA_GRUPO_CURADO` pede **apagar** a entrada, porque o grupo deixou de ser lacuna — é o espelho
+exato de §7.1 um nível acima (a declaração mentindo na direção que finge **não** cobrir). Elas são
+correções opostas, como `POLICY_NOVA` × `POLICY_ALTERADA`.
+
+> 🔴 **A inversão perigosa, e o guard que ela obrigou.** `lacunas === 0` é verdade tanto para
+> "todas curadas" quanto para "a medição voltou vazia". Diagnosticar a segunda como a primeira
+> convidaria a **apagar a declaração por causa de uma query quebrada** — o pior desfecho possível
+> num eixo cuja função é impedir que a declaração suma. Lista vazia cai no `MUDOU`, que lê como
+> "o grupo encolheu para 0" e manda investigar.
+
+#### Falsificação
+
+Catálogo (harness PG17, `db/test-audit-rls-prod.sh`, **40 ok / 0 fail** nos dois locales): `GB`
+migration gateia mais uma tabela pelo predicado → `LACUNA_GRUPO_MUDOU`; `GD` tabela nova casa o
+prefixo → idem; `GF` **rename dentro do grupo** (contagem igual, conjunto outro) → acusa pelo md5;
+`GH` grupo inteiramente curado → `LACUNA_GRUPO_CURADO` e **não** `MUDOU`; e o dente de cada um
+(`GC`/`GE`/`GG`/`GI`: a acusação some quando o estado volta).
+
+Contrato e carimbo: contagem alterada à mão → o audit real acusa contra prod; eixo removido do
+`dadoDoContrato('rls')` → o teste de identidade dos **cinco** eixos reprova; `LACUNAS_POR_GRUPO`
+esvaziada → a sentinela de vacuidade grita nos **dois** lugares (o piso estático do CI e o
+`erroFatal` do runner contra prod), porque `for` sobre lista vazia passa por vacuidade.
+
+> **A classe, agora com três instâncias e um padrão de crescimento:** *prosa que descreve dado
+> apodrece* (§7.1) — e quando a prosa descreve **prod**, o gate não pode ser estático. A pergunta
+> que sobra de cada declaração é uma só: **qual é a outra ponta?** Se ela está no arquivo, o gate é
+> um teste; se está no banco, o gate é o audit. Escolher errado produz um gate que existe e não
+> mede — que é pior que não ter, porque parece cobertura.

--- a/scripts/authz-carimbo.test.ts
+++ b/scripts/authz-carimbo.test.ts
@@ -8,6 +8,7 @@ import {
   AUTHZ_RLS_ESPERADO,
   AUTHZ_RLS_PREDICADOS,
   LACUNAS_DECLARADAS,
+  LACUNAS_POR_GRUPO,
   PREDICADOS_PLATAFORMA,
 } from './authz-rls-esperado';
 
@@ -472,18 +473,21 @@ describe('chave `rls` — a quarta guarda enumerada', () => {
     expect(AUDITS.rls.contratoEmArquivo).toBeUndefined();
   });
 
-  it('o contrato que o carimbo USA carrega os QUATRO eixos, por identidade', () => {
+  it('o contrato que o carimbo USA carrega os CINCO eixos, por identidade', () => {
     // Exerce `dadoDoContrato`, não uma reconstrução do objeto: a primeira versão deste teste
     // montava `{tabelas, predicados, plataforma}` aqui e canonicalizava — remover um eixo da
     // função real seguia VERDE (pego na falsificação). Identidade de referência é o que faz
     // "esqueci de incluir o eixo" virar vermelho. O 4º (`lacunas`) entrou em 2026-08-28: é o que
-    // o contrato declara NÃO cobrir, e mudá-lo afrouxa o que o verde afirma.
+    // o contrato declara NÃO cobrir, e mudá-lo afrouxa o que o verde afirma. O 5º (`grupos`), no
+    // mesmo dia, é a lacuna em BLOCO — e afrouxa por UMA LINHA: baixar `tabelasNoGrafo` faz o
+    // audit deixar de acusar a tabela que ENTROU no grupo.
     const d = dadoDoContrato('rls') as Record<string, unknown>;
     expect(d.tabelas).toBe(AUTHZ_RLS_ESPERADO);
     expect(d.predicados).toBe(AUTHZ_RLS_PREDICADOS);
     expect(d.plataforma).toBe(PREDICADOS_PLATAFORMA);
     expect(d.lacunas).toBe(LACUNAS_DECLARADAS);
-    expect(Object.keys(d).sort()).toEqual(['lacunas', 'plataforma', 'predicados', 'tabelas']);
+    expect(d.grupos).toBe(LACUNAS_POR_GRUPO);
+    expect(Object.keys(d).sort()).toEqual(['grupos', 'lacunas', 'plataforma', 'predicados', 'tabelas']);
   });
 
   it('o canônico do contrato REAL representa o Set — o eixo que se serializaria como {}', () => {
@@ -495,6 +499,20 @@ describe('chave `rls` — a quarta guarda enumerada', () => {
     expect(canon).toContain('auth.uid');
     expect(canon).toContain('public.has_role');
     expect(canon).toContain('public.sales_orders');
+  });
+
+  it('baixar UMA contagem de grupo move o canônico — o afrouxamento de uma linha', () => {
+    // A falsificação mais barata do eixo 5, e a que o carimbo tem de ver: `tabelasNoGrafo: 22 → 21`
+    // não some com tabela nenhuma do contrato, não mexe em policy nenhuma, e faz o audit parar de
+    // acusar a tabela que entrou no grupo. Se o fingerprint não se movesse, o carimbo seguiria
+    // atestando uma declaração que já não é a medida.
+    const base = canonicalizar(dadoDoContrato('rls'));
+    const afrouxado = canonicalizar({
+      tabelas: AUTHZ_RLS_ESPERADO, predicados: AUTHZ_RLS_PREDICADOS,
+      plataforma: PREDICADOS_PLATAFORMA, lacunas: LACUNAS_DECLARADAS,
+      grupos: LACUNAS_POR_GRUPO.map((g, i) => (i === 0 ? { ...g, tabelasNoGrafo: g.tabelasNoGrafo - 1 } : g)),
+    });
+    expect(afrouxado).not.toBe(base);
   });
 
   it.each([

--- a/scripts/authz-rls-esperado.ts
+++ b/scripts/authz-rls-esperado.ts
@@ -55,6 +55,12 @@
  * das tabelas que este cabeçalho declarava como lacuna e o texto continuou afirmando o contrário,
  * sem nada ficar vermelho (§7.1 do histórico). Agora um teste cruza as duas listas.
  *
+ * O que foi recusado em BLOCO (um domínio inteiro, tudo que uma capability gateia) vive em
+ * `LACUNAS_POR_GRUPO`, também como dado — e ali a garantia é de outra natureza, porque o que
+ * apodrece é a CONTAGEM: `db/audit-rls-prod.ts` reconta o grupo em prod a cada execução
+ * (`pg_depend` para os de predicado, nome para os de prefixo) e acusa `LACUNA_GRUPO_MUDOU`. Um
+ * teste estático não bastaria — só prod sabe quantas tabelas a última migration gateou.
+ *
  * ═══ A REPRESENTAÇÃO, E O QUE ELA NÃO PEGA ═══
  *
  * `qual`/`with_check` são EXPRESSÕES. Guardá-las como texto e comparar string é frágil, então o
@@ -861,13 +867,11 @@ export const AUTHZ_RLS_ESPERADO: Record<string, TabelaRls> = {
  * que sobra: **"a raiz já está coberta" não é razão para recusar, porque raiz e predicado são
  * eixos diferentes** — a pergunta certa é se o gate da tabela já é congelado por ALGUÉM.
  *
- * Grupos (não cabem como chave de tabela e seguem como prosa, deliberadamente): as **22** tabelas
- * de `private.cap_carteira_ler` e as **8** de `private.carteira_visivel_para` — inteligência
- * comercial, e a RAIZ delas (`public.commercial_roles`) está curada; as **36** `fin_*` restantes
- * (de 41; 5 curadas) — agregados, logs e controle derivados, com as fontes e as duas raízes
- * curadas e o gate comum (`fin_user_can_access`) congelado; e as outras **13** de
- * `private.cap_compras_ler` (de 14 — `pedido_compra_item` entrou na 3ª rodada e já arrasta o
- * predicado). Contagens medidas em prod 2026-08-28.
+ * O que NÃO cabe como chave de tabela — as lacunas em BLOCO — vive em `LACUNAS_POR_GRUPO`, logo
+ * abaixo, e pela mesma razão: enquanto era este parágrafo, as contagens dos grupos eram texto, e
+ * texto não fica vermelho quando uma migration acrescenta uma tabela ao grupo. Nenhum número de
+ * grupo é repetido aqui de propósito — número em prosa ao lado do mesmo número em dado é a
+ * armadilha de novo, só que com duas fontes para divergir.
  */
 export const LACUNAS_DECLARADAS: Record<string, string> = {
   'public.carteira_assignments':
@@ -908,6 +912,128 @@ export const LACUNAS_DECLARADAS: Record<string, string> = {
     'Os membros do agrupamento acima, 0 linhas em prod. Mesma razão e mesmo gatilho — e o mesmo ' +
     'gate já congelado.',
 };
+
+/**
+ * Como um GRUPO de lacuna é definido. Duas formas, e não uma, porque os grupos que o contrato
+ * declara não são o mesmo tipo de conjunto — e reduzir os dois à mesma forma perderia exatamente
+ * o que cada um vigia:
+ *
+ *   · `predicado` — "as tabelas cuja policy CHAMA `private.cap_carteira_ler`". O conjunto é uma
+ *     aresta do grafo de `pg_depend`, o mesmo que o eixo 3 usa. Cresce quando uma migration nova
+ *     gateia mais uma tabela por aquela capability.
+ *   · `prefixo` — "as tabelas `fin_*`". O conjunto é de NOME, e é o certo para esse grupo porque
+ *     a afirmação declarada é sobre o domínio financeiro inteiro, não sobre quem o gateia: uma
+ *     `fin_nova` gateada por OUTRA função continua sendo uma lacuna do grupo, e um grupo definido
+ *     só por `fin_user_can_access` (18 tabelas medidas, não 41) não a veria entrar.
+ */
+export type DefinicaoGrupo =
+  | { tipo: 'predicado'; predicado: string }
+  | { tipo: 'prefixo'; prefixo: string };
+
+export interface LacunaGrupo {
+  def: DefinicaoGrupo;
+  /**
+   * Quantas tabelas de `public` o grupo tem em prod — o TOTAL medido, **não** o número de lacunas.
+   *
+   * A distinção é o que dá dente ao eixo. O número de lacunas é DERIVADO pelo runner (total menos
+   * as que estão em `AUTHZ_RLS_ESPERADO`), então ele não pode apodrecer: é recalculado a cada
+   * execução a partir do contrato ao lado. Já congelar a lacuna em vez do total abriria um cego
+   * exato — uma migration acrescenta uma tabela ao grupo (22→23) e uma rodada cura outra (0→1) no
+   * mesmo dia, a subtração devolve 22 de novo e nada fica vermelho. O total só se move por PROD,
+   * que é a única coisa que este eixo não controla.
+   */
+  tabelasNoGrafo: number;
+  /**
+   * md5 da lista de tabelas do grupo, ordenada e junta por `,` — a MESMA receita de
+   * `scripts/lib/authz-rls.ts` (`md5Lista`), medida em prod e conferida contra
+   * `md5(string_agg(relname, ',' ORDER BY relname COLLATE "C"))` no psql. Duas computações
+   * independentes que batem, não uma copiada da outra.
+   *
+   * Por que ele existe ao lado da contagem, que já detecta crescimento: SUBSTITUIÇÃO. Uma tabela
+   * sai do grupo (a policy dela deixa de chamar a capability) e outra entra pela migration do
+   * mesmo dia — o total não se move e a contagem sozinha não vê. É a mesma classe de "duas
+   * mudanças opostas se cancelam" que fez `tabelasNoGrafo` guardar o TOTAL em vez do número de
+   * lacunas; fechá-la num eixo e deixá-la aberta no outro seria arbitrário. A contagem continua
+   * sendo o número que um humano REVISA no diff do PR; o md5 é a evidência de que o conjunto por
+   * trás dela é o mesmo. O achado imprime a lista viva, então o md5 nunca é o fim da leitura.
+   */
+  tabelasMd5: string;
+  /** `YYYY-MM-DD` da medição via psql-ro. Data é dado de proveniência, não decoração: quem renovar
+   *  o número precisa saber se está comparando com uma medição de ontem ou de três meses atrás. */
+  medidoEm: string;
+  motivo: string;
+}
+
+/**
+ * O que ficou de fora do eixo curado em BLOCO, por grupo — a irmã de `LACUNAS_DECLARADAS` para o
+ * que não cabe como chave de tabela.
+ *
+ * Por que isto também é DADO. Estas contagens nasceram como prosa no cabeçalho de
+ * `LACUNAS_DECLARADAS`, e a prosa estava CERTA no dia em que foi escrita — como estava a lista de
+ * tabelas que apodreceu em 12 horas (§7.1 do histórico). A diferença é só o gatilho: a lista de
+ * tabelas apodrece quando uma rodada CURA; a contagem de grupo apodrece quando uma **migration**
+ * acrescenta uma tabela gateada pela mesma capability, que é o evento mais comum deste repo e o
+ * que menos passa por revisão de autorização. Nos dois casos o texto seguiria verde afirmando um
+ * número que ninguém mede. Como dado, `db/audit-rls-prod.ts` conta o grupo em prod a cada
+ * execução e acusa `LACUNA_GRUPO_MUDOU`.
+ *
+ * ⚠️ O que este eixo NÃO é: um pedido para curar o grupo. Curar as 78 tabelas destes quatro grupos
+ * transformaria a allowlist no depósito que o critério do cabeçalho existe para evitar. O eixo
+ * afirma uma coisa só, e ela é falsificável: **o grupo continua sendo o que a declaração diz**.
+ */
+export const LACUNAS_POR_GRUPO: LacunaGrupo[] = [
+  {
+    def: { tipo: 'predicado', predicado: 'private.cap_carteira_ler' },
+    tabelasNoGrafo: 22,
+    tabelasMd5: '360014844c8f72cb0a362ad98a93722b',
+    medidoEm: '2026-08-28',
+    motivo:
+      'Inteligência COMERCIAL (carteira, radar, farmer, visitas), não dinheiro/custo — o critério ' +
+      'deste contrato não a alcança, e a RAIZ do grupo (`public.commercial_roles`) está curada. ' +
+      'O gate comum não fica órfão no eixo 3 por outra via: `cap_carteira_ler` é chamada por ' +
+      'policy de 22 tabelas, nenhuma delas curada, então congelar o CORPO dela seria a única ' +
+      'cobertura — e é justamente o que a lacuna assume o custo de não ter. Gatilho de reentrada: ' +
+      'no dia em que comissão ou preço passarem a depender da carteira, o grupo vira membro (i)/(ii).',
+  },
+  {
+    def: { tipo: 'predicado', predicado: 'private.carteira_visivel_para' },
+    tabelasNoGrafo: 8,
+    tabelasMd5: 'a0dac67e9b90efb4f2b349efb07ed93c',
+    medidoEm: '2026-08-28',
+    motivo:
+      'O segundo gate de carteira (o que resolve cobertura temporária de carteira alheia), com ' +
+      'interseção medida de 6 tabelas com o grupo de `cap_carteira_ler` — os dois grupos se ' +
+      'sobrepõem de propósito, porque a pergunta "este predicado ainda gateia o mesmo conjunto?" ' +
+      'é por predicado, não por tabela. Mesma razão e mesmo gatilho do grupo acima; as duas ' +
+      'tabelas exclusivas dele (`carteira_assignments`, `visitas_agendadas`) são de carteira, não ' +
+      'de dinheiro.',
+  },
+  {
+    def: { tipo: 'prefixo', prefixo: 'fin_' },
+    tabelasNoGrafo: 41,
+    tabelasMd5: '2c1c3e68bfad4855870195ef496792b6',
+    medidoEm: '2026-08-28',
+    motivo:
+      'O domínio financeiro inteiro por NOME, do qual 5 estão curadas (as fontes: contas a ' +
+      'receber/pagar, movimentações, contas correntes, e a raiz `fin_permissoes`). As demais são ' +
+      'agregado, log e controle DERIVADOS dessas fontes, e o gate comum ' +
+      '(`public.fin_user_can_access`) já é predicado congelado — o eixo 3 as cobre sem que o ' +
+      'conteúdo delas entre na allowlist. Definido por prefixo e não pelo predicado de propósito: ' +
+      'uma `fin_*` nova gateada por outra função é lacuna do mesmo jeito, e o grupo tem de vê-la.',
+  },
+  {
+    def: { tipo: 'predicado', predicado: 'private.cap_compras_ler' },
+    tabelasNoGrafo: 14,
+    tabelasMd5: 'daf8a7a22f7ea9958dcf76928758a59c',
+    medidoEm: '2026-08-28',
+    motivo:
+      'Reposição/compras: parâmetro, log e run do motor. UMA delas (`pedido_compra_item`) foi ' +
+      'curada na 3ª rodada porque ARRASTA o predicado para o eixo 3 — congelar o corpo de ' +
+      '`cap_compras_ler` cobre as outras 13 sem curar o conteúdo delas, que é o melhor retorno ' +
+      'por entrada do arquivo inteiro. As 13 restantes são derivadas do motor, não a fonte do ' +
+      'número; o custo/preço que elas consomem mora em `product_costs`/`cmc_*`, já curadas.',
+  },
+];
 
 export interface PredicadoEsperado {
   /** `prosecdef`. Todas as 5 são SECDEF: é o que faz o predicado enxergar `user_roles`/

--- a/scripts/authz-rls.test.ts
+++ b/scripts/authz-rls.test.ts
@@ -16,14 +16,16 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { compararRlsProd, type MedicaoRls, type MedPolicy } from './lib/authz-rls';
+import { compararRlsProd, md5Lista, rotuloGrupo, type MedicaoRls, type MedPolicy } from './lib/authz-rls';
 import {
   AUTHZ_RLS_ESPERADO,
   LACUNAS_DECLARADAS,
+  LACUNAS_POR_GRUPO,
   AUTHZ_RLS_PREDICADOS,
   PREDICADOS_PLATAFORMA,
   type TabelaRls,
   type PredicadoEsperado,
+  type LacunaGrupo,
 } from './authz-rls-esperado';
 
 // ── cenário sintético: 1 tabela curada, 2 policies, 1 predicado ────────────────────────────────
@@ -62,6 +64,20 @@ const PREDICADOS: Record<string, PredicadoEsperado> = {
 
 const PLATAFORMA: ReadonlySet<string> = new Set(['auth.uid']);
 
+// Grupo sintético do eixo 4: `zz_gate` gateia DUAS tabelas, das quais só `zz_alvo` está curada —
+// uma curada e uma lacuna é o estado mínimo em que o eixo tem algo a afirmar. Com zero lacunas o
+// cenário limpo já nasceria acusando LACUNA_GRUPO_CURADO, e o teste mediria outra coisa.
+const GRUPO_TABS = ['zz_alvo', 'zz_outra'];
+const GRUPOS: LacunaGrupo[] = [
+  {
+    def: { tipo: 'predicado', predicado: 'public.zz_gate' },
+    tabelasNoGrafo: 2,
+    tabelasMd5: md5Lista(GRUPO_TABS),
+    medidoEm: '2026-08-28',
+    motivo: 'grupo sintético do teste',
+  },
+];
+
 function medLimpa(): MedicaoRls {
   return {
     universal: { totalTabelas: 10, tabelasSemRls: [] },
@@ -74,13 +90,14 @@ function medLimpa(): MedicaoRls {
       { funcao: 'public.zz_gate', secdef: true, cfg: 'search_path=public', srcMd5: SRC_FN },
       { funcao: 'auth.uid', secdef: false, cfg: '', srcMd5: 'd'.repeat(32) },
     ],
+    grupos: [{ grupo: 'public.zz_gate', tabelas: [...GRUPO_TABS] }],
   };
 }
 
 function rodar(mut: (m: MedicaoRls) => void = () => {}) {
   const m = medLimpa();
   mut(m);
-  return compararRlsProd(m, CONTRATO, PREDICADOS, PLATAFORMA);
+  return compararRlsProd(m, CONTRATO, PREDICADOS, PLATAFORMA, GRUPOS);
 }
 const codigos = (fs: ReturnType<typeof rodar>) => fs.map((f) => f.codigo);
 function pol(m: MedicaoRls, nome: string): MedPolicy {
@@ -174,7 +191,7 @@ describe('§1 comparador — cada eixo sabotado produz o código certo', () => {
     };
     const m = medLimpa();
     pol(m, 'zz_all').wcMd5 = null;
-    expect(compararRlsProd(m, contratoSemWc, PREDICADOS, PLATAFORMA)).toEqual([]);
+    expect(compararRlsProd(m, contratoSemWc, PREDICADOS, PLATAFORMA, GRUPOS)).toEqual([]);
   });
 
   it('forAllAssimetricoOk silencia o check estrutural — e SÓ ele', () => {
@@ -183,7 +200,7 @@ describe('§1 comparador — cada eixo sabotado produz o código certo', () => {
     };
     const m = medLimpa();
     pol(m, 'zz_all').wcMd5 = 'f'.repeat(32);
-    const fs = compararRlsProd(m, comEscape, PREDICADOS, PLATAFORMA);
+    const fs = compararRlsProd(m, comEscape, PREDICADOS, PLATAFORMA, GRUPOS);
     expect(fs.map((f) => f.codigo)).toEqual(['POLICY_ALTERADA']); // o drift do md5 continua acusado
   });
 
@@ -230,7 +247,7 @@ describe('§1 comparador — cada eixo sabotado produz o código certo', () => {
     const outraProsa: Record<string, TabelaRls> = {
       'public.zz_alvo': { ...CONTRATO['public.zz_alvo'], motivo: 'texto completamente diferente' },
     };
-    expect(compararRlsProd(medLimpa(), outraProsa, PREDICADOS, PLATAFORMA)).toEqual([]);
+    expect(compararRlsProd(medLimpa(), outraProsa, PREDICADOS, PLATAFORMA, GRUPOS)).toEqual([]);
   });
 
   it('controle inócuo — policy de tabela FORA do contrato não é reconciliada', () => {
@@ -241,6 +258,73 @@ describe('§1 comparador — cada eixo sabotado produz o código certo', () => {
       }),
     );
     expect(fs).toEqual([]); // o eixo 2 mede só o que foi curado — e diz isso na doc
+  });
+
+  // ── eixo 4 — a declaração de lacuna em BLOCO ────────────────────────────────────────────────
+  // Este eixo não afirma nada sobre autorização: afirma que a DECLARAÇÃO ainda descreve prod. Os
+  // três primeiros eixos reconciliam o contrato contra o banco; a declaração de não-cobertura
+  // ninguém reconciliava, e ela apodrece pelo evento mais banal do repo — uma migration que
+  // gateie mais uma tabela pela mesma capability.
+  it('grupo CRESCEU (a migration gateou mais uma) → LACUNA_GRUPO_MUDOU, com os dois números', () => {
+    const fs = rodar((m) => m.grupos[0].tabelas.push('zz_nova'));
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_MUDOU']);
+    expect(fs[0].objeto).toBe('public.zz_gate');
+    expect(fs[0].msg).toContain('CRESCEU');
+    expect(fs[0].msg).toContain('3 tabela(s) em prod contra 2 declarada(s)');
+    expect(fs[0].msg).toContain('zz_nova'); // a lista viva vai na mensagem, não só a contagem
+  });
+
+  it('grupo ENCOLHEU (uma rodada curou, ou a policy trocou de gate) → LACUNA_GRUPO_MUDOU', () => {
+    const fs = rodar((m) => (m.grupos[0].tabelas = ['zz_outra']));
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_MUDOU']);
+    expect(fs[0].msg).toContain('ENCOLHEU');
+  });
+
+  it('SUBSTITUIÇÃO — a contagem bate e o conjunto não → LACUNA_GRUPO_MUDOU pelo md5', () => {
+    // O buraco que a contagem sozinha deixa: uma tabela sai do grupo e outra entra no mesmo
+    // intervalo. É a mesma classe de "duas mudanças opostas se cancelam" que fez a declaração
+    // guardar o TOTAL em vez do número de lacunas.
+    const fs = rodar((m) => (m.grupos[0].tabelas = ['zz_alvo', 'zz_trocada']));
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_MUDOU']);
+    expect(fs[0].msg).toContain('a CONTAGEM bate (2) e o CONJUNTO não');
+    expect(fs[0].msg).toContain('zz_trocada');
+  });
+
+  it('grupo INTEIRAMENTE curado → LACUNA_GRUPO_CURADO (apagar a entrada, não renovar o número)', () => {
+    // O espelho, no nível do grupo, do defeito de §7.1: a declaração passa a mentir na direção
+    // que finge NÃO cobrir. A correção é oposta à do MUDOU, por isso o código é outro.
+    const contratoCompleto: Record<string, TabelaRls> = {
+      ...CONTRATO,
+      'public.zz_outra': { forceRls: false, policies: {}, motivo: 'curada depois' },
+    };
+    const m = medLimpa();
+    // A tabela recém-curada também passa a ser MEDIDA pelo eixo 2 — sem esta linha o teste
+    // acusaria TABELA_AUSENTE junto e mediria duas coisas ao mesmo tempo.
+    m.tabelas.push({ tabela: 'public.zz_outra', existe: true, rls: true, force: false });
+    const fs = compararRlsProd(m, contratoCompleto, PREDICADOS, PLATAFORMA, GRUPOS);
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_CURADO']);
+    expect(fs[0].msg).toContain('REMOVA a entrada');
+  });
+
+  it('medição VAZIA de um grupo não vira "curado" — o diagnóstico perigoso', () => {
+    // `lacunas === 0` é verdade tanto para "todas curadas" quanto para "a query não devolveu
+    // nada". Diagnosticar a segunda como a primeira convidaria a APAGAR a declaração por causa de
+    // uma medição quebrada. O guard manda a lista vazia para MUDOU, que é o honesto.
+    const fs = rodar((m) => (m.grupos[0].tabelas = []));
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_MUDOU']);
+    expect(fs[0].msg).toContain('ENCOLHEU');
+  });
+
+  it('grupo declarado SEM linha de medição → achado, nunca silêncio', () => {
+    const fs = rodar((m) => (m.grupos = []));
+    expect(codigos(fs)).toEqual(['LACUNA_GRUPO_MUDOU']);
+    expect(fs[0].msg).toContain('SEM linha de medição');
+  });
+
+  it('controle inócuo — a ORDEM em que prod devolve as tabelas do grupo não é achado', () => {
+    // O md5 ordena em JS antes de hashear justamente para isto: `jsonb_agg` não promete ordem.
+    const fs = rodar((m) => (m.grupos[0].tabelas = [...GRUPO_TABS].reverse()));
+    expect(fs).toEqual([]);
   });
 });
 
@@ -327,6 +411,45 @@ describe('§2 contrato do repo — invariantes conferíveis sem prod', () => {
     expect(Object.keys(LACUNAS_DECLARADAS).length).toBeGreaterThanOrEqual(8);
   });
 
+  // ── LACUNAS_POR_GRUPO — o que só o ARQUIVO pode garantir ────────────────────────────────────
+  // A verdade das CONTAGENS mora em prod e é conferida por `bun run authz:rls:prod` (eixo 4);
+  // aqui ficam as invariantes de forma, que rodam no CI, onde não há psql-ro. Sem elas o eixo 4
+  // seria conferível mas não confiável: um `tabelasNoGrafo: 0` ou um rótulo duplicado fazem o
+  // runner comparar contra lixo sem nada reclamar.
+  it('a lista de GRUPOS não pode ser esvaziada em silêncio', () => {
+    // A mesma sentinela de vacuidade da lista de tabelas, e pela mesma razão: o eixo 4 é um `for`
+    // sobre esta lista, e `for` sobre lista vazia não itera — o audit sairia ✅ tendo conferido
+    // zero grupos, que é o estado que esta rodada existiu para corrigir.
+    expect(LACUNAS_POR_GRUPO.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('todo grupo tem contagem POSITIVA, md5 de 32 hex, data ISO e razão de substância', () => {
+    for (const g of LACUNAS_POR_GRUPO) {
+      const rot = rotuloGrupo(g.def);
+      // `0` seria vacuidade disfarçada de medição: casaria com um grupo que sumiu de prod e com
+      // uma query quebrada, e as duas leituras são opostas.
+      expect(g.tabelasNoGrafo, `${rot}: contagem não-positiva`).toBeGreaterThan(0);
+      expect(g.tabelasMd5, `${rot}: md5 malformado`).toMatch(/^[0-9a-f]{32}$/);
+      expect(g.medidoEm, `${rot}: data de medição fora do ISO`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(g.motivo.trim().length, `${rot}: razão ausente ou rasa`).toBeGreaterThan(80);
+    }
+  });
+
+  it('o rótulo de grupo é único e QUALIFICADO, e não contém ":"', () => {
+    const qual = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/;
+    const vistos = new Set<string>();
+    for (const g of LACUNAS_POR_GRUPO) {
+      const rot = rotuloGrupo(g.def);
+      // O rótulo é a CHAVE que o runner casa entre declaração e medição: dois grupos com o mesmo
+      // rótulo fariam um deles ser conferido duas vezes e o outro nunca, em silêncio.
+      expect(vistos.has(rot), `rótulo duplicado: ${rot}`).toBe(false);
+      vistos.add(rot);
+      expect(rot).not.toContain(':'); // o idFinding do carimbo parte por ':'
+      if (g.def.tipo === 'predicado') expect(g.def.predicado).toMatch(qual);
+      else expect(g.def.prefixo.length, `prefixo vazio casaria TODA tabela de public`).toBeGreaterThan(2);
+    }
+  });
+
   it('nomes de tabela e de policy não contêm ":" — o idFinding do carimbo parte por ele', () => {
     for (const [chave, e] of entradas) {
       expect(chave).not.toContain(':');
@@ -363,7 +486,13 @@ describe('§2 contrato do repo — invariantes conferíveis sem prod', () => {
       predicados: Object.entries(AUTHZ_RLS_PREDICADOS).map(([funcao, p]) => ({
         funcao, secdef: p.secdef, cfg: p.cfg, srcMd5: p.srcMd5,
       })),
+      // O eixo 4 entra VAZIO aqui de propósito, e a razão é o que o eixo é: a verdade dele mora em
+      // PROD (quantas tabelas o grupo tem hoje), não no arquivo. Fabricar a medição a partir da
+      // declaração — reconstruir a lista de tabelas de um md5 é impossível, e inventar uma lista
+      // que casasse seria escrever a resposta antes da pergunta — provaria só que a igualdade é
+      // reflexiva. Quem prova o eixo 4 são os testes de §1 (comparador) e o harness PG17.
+      grupos: [],
     };
-    expect(compararRlsProd(med, AUTHZ_RLS_ESPERADO, AUTHZ_RLS_PREDICADOS, PREDICADOS_PLATAFORMA)).toEqual([]);
+    expect(compararRlsProd(med, AUTHZ_RLS_ESPERADO, AUTHZ_RLS_PREDICADOS, PREDICADOS_PLATAFORMA, [])).toEqual([]);
   });
 });

--- a/scripts/lib/authz-carimbo.ts
+++ b/scripts/lib/authz-carimbo.ts
@@ -57,6 +57,7 @@ import {
   AUTHZ_RLS_ESPERADO,
   AUTHZ_RLS_PREDICADOS,
   LACUNAS_DECLARADAS,
+  LACUNAS_POR_GRUPO,
   PREDICADOS_PLATAFORMA,
 } from '../authz-rls-esperado';
 
@@ -243,11 +244,15 @@ export function dadoDoContrato(chave: ChaveAudit): unknown {
       // AFROUXA o que o verde afirma. Tirar uma tabela de lá sem curá-la faz o contrato parar de
       // dizer "isto não é coberto" — e o carimbo passaria a atestar uma cobertura que ninguém
       // mediu, na direção que é mais difícil de notar (a de fingir que não há buraco).
+      // `LACUNAS_POR_GRUPO` (5º, 2026-08-28) é o mesmo argumento um nível acima: baixar
+      // `tabelasNoGrafo` de 22 para 21 faz o audit parar de acusar uma tabela que ENTROU no grupo,
+      // sem curar nada — afrouxa o que o verde afirma, e é a mudança de uma linha só.
       return {
         tabelas: AUTHZ_RLS_ESPERADO,
         predicados: AUTHZ_RLS_PREDICADOS,
         plataforma: PREDICADOS_PLATAFORMA,
         lacunas: LACUNAS_DECLARADAS,
+        grupos: LACUNAS_POR_GRUPO,
       };
   }
 }

--- a/scripts/lib/authz-rls.ts
+++ b/scripts/lib/authz-rls.ts
@@ -6,7 +6,7 @@
  * `db/audit-rls-prod.ts`; quem compara é este módulo, e por isso ele é testável sem banco
  * (`scripts/authz-rls.test.ts`, que roda no CI) e falsificável sem prod.
  *
- * ═══ OS TRÊS EIXOS, E POR QUE SÃO TRÊS ═══
+ * ═══ OS QUATRO EIXOS, E POR QUE SÃO QUATRO ═══
  *
  *   1. INTERRUPTOR (universal, sem allowlist) — `relrowsecurity` de TODA tabela de `public`.
  *      É o eixo que pega o `ALTER TABLE … DISABLE ROW LEVEL SECURITY` colado à mão, que é o vetor
@@ -16,6 +16,12 @@
  *   3. PREDICADO (derivado do eixo 2) — o md5 do `prosrc` das funções que as policies CHAMAM,
  *      descobertas por `pg_depend`. Existe porque o eixo 2 é CEGO a ele: reescrever
  *      `cap_pedido_escrever` para `SELECT true` deixa o texto do `qual` idêntico.
+ *   4. GRUPO DE LACUNA (o NEGATIVO dos outros três) — não mede autorização nenhuma: mede se a
+ *      DECLARAÇÃO de não-cobertura ainda descreve o que existe. Conta em prod as tabelas de cada
+ *      grupo de `LACUNAS_POR_GRUPO` e desconta as curadas. Existe porque os eixos 1-3 reconciliam
+ *      o contrato contra prod e ninguém reconciliava a declaração contra prod: uma migration que
+ *      gateie mais uma tabela por `cap_carteira_ler` deixava a contagem declarada falsa em
+ *      silêncio (§7.2 do histórico), verde em todos os gates.
  *
  * ═══ O QUE ESTA GUARDA NÃO PEGA (limites declarados, medidos e não deduzidos) ═══
  *
@@ -44,7 +50,15 @@
  *     mora no PG17 descartável (`db/test-audit-rls-prod.sh`), que exerce as policies sob
  *     `SET ROLE authenticated` + `request.jwt.claim.sub`.
  */
-import type { TabelaRls, PredicadoEsperado, PolicyEsperada } from '../authz-rls-esperado';
+import { createHash } from 'node:crypto';
+
+import type {
+  TabelaRls,
+  PredicadoEsperado,
+  PolicyEsperada,
+  LacunaGrupo,
+  DefinicaoGrupo,
+} from '../authz-rls-esperado';
 
 // Sem `export`, como o `GrantCodigo` de authz-grants.ts: os testes e o harness casam o CÓDIGO
 // como string literal delimitada por colchetes, não o tipo.
@@ -62,7 +76,12 @@ type RlsCodigo =
   // eixo 3 — o predicado
   | 'PREDICADO_NAO_DECLARADO'
   | 'PREDICADO_ALTERADO'
-  | 'PREDICADO_SUMIU';
+  | 'PREDICADO_SUMIU'
+  // eixo 4 — a declaração de lacuna em bloco. Dois códigos e não um, pela mesma razão de
+  // POLICY_NOVA vs POLICY_ALTERADA: as correções são OPOSTAS. `MUDOU` pede re-medir e renovar o
+  // número; `CURADO` pede APAGAR a entrada, porque o grupo deixou de ser lacuna.
+  | 'LACUNA_GRUPO_MUDOU'
+  | 'LACUNA_GRUPO_CURADO';
 
 export interface RlsFinding {
   level: 'error' | 'warn';
@@ -92,6 +111,28 @@ export interface MedicaoRls {
   policies: MedPolicy[];
   /** Eixo 3. Descoberto por `pg_depend` a partir das policies das tabelas do contrato. */
   predicados: { funcao: string; secdef: boolean; cfg: string; srcMd5: string }[];
+  /** Eixo 4. Uma entrada por grupo DECLARADO, com os `relname` (sem schema — todos de `public`)
+   *  que o grupo tem em prod. É a LISTA e não a contagem de propósito: a mensagem do achado
+   *  precisa nomear quem entrou e quem saiu, senão "22 → 23" manda o leitor refazer a query. */
+  grupos: { grupo: string; tabelas: string[] }[];
+}
+
+/** Rótulo estável de um grupo — é o `objeto` do finding e o identificador que o runner casa entre
+ *  a declaração e a medição, então ele NÃO pode conter `:` (o `idFinding` do carimbo parte por
+ *  ele). Derivado da definição, nunca declarado ao lado dela: um campo `id` escrito à mão seria
+ *  mais uma prosa capaz de divergir do dado que descreve, que é a classe inteira que este eixo
+ *  existe para fechar. */
+export function rotuloGrupo(def: DefinicaoGrupo): string {
+  return def.tipo === 'predicado' ? def.predicado : `${def.prefixo}*`;
+}
+
+/** md5 do conjunto de tabelas de um grupo. Ordena em JS de propósito, e NÃO em SQL: o
+ *  `ORDER BY` do Postgres usa COLLATION, e `_` ordena antes de letra em `C` e é ignorado em
+ *  ICU/pt_BR — o mesmo conjunto produziria md5 diferente conforme o locale do servidor. O sort
+ *  default de JS é por code unit, que para `[a-z0-9_]` é estável em qualquer ambiente (a lição
+ *  #1483, de falsificar em UM locale só, aplicada ANTES de o bug existir). */
+export function md5Lista(tabelas: readonly string[]): string {
+  return createHash('md5').update([...tabelas].sort().join(','), 'utf8').digest('hex');
 }
 
 /** Roles do contrato (array) reduzidas à mesma forma que a medição produz: ordenadas, `+`. */
@@ -176,6 +217,7 @@ export function compararRlsProd(
   contrato: Record<string, TabelaRls>,
   predicados: Record<string, PredicadoEsperado>,
   plataforma: ReadonlySet<string>,
+  grupos: readonly LacunaGrupo[],
 ): RlsFinding[] {
   const out: RlsFinding[] = [];
   const noContrato = new Set(Object.keys(contrato));
@@ -332,6 +374,83 @@ export function compararRlsProd(
         `a policy que a usava mudou de predicado (veja os achados de POLICY_*), ou a entrada ` +
         `envelheceu. Entrada que não vigia nada é cobertura só no papel.`,
     });
+  }
+
+  // ── EIXO 4 — a declaração de lacuna em BLOCO ────────────────────────────────────────────────
+  // Este eixo não mede autorização: mede se a DECLARAÇÃO ainda descreve prod. As curadas são
+  // DESCONTADAS aqui (do contrato ao lado, a cada execução) em vez de declaradas — número
+  // derivado não apodrece, e é o que dá o denominador da linha do veredito.
+  const medPorGrupo = new Map(med.grupos.map((g) => [g.grupo, g.tabelas]));
+  for (const g of grupos) {
+    const rot = rotuloGrupo(g.def);
+    const medidas = medPorGrupo.get(rot);
+    if (medidas === undefined) {
+      // Grupo declarado sem linha de medição. O runner tem piso para isto, mas repetir aqui é o
+      // que mantém o módulo puro fail-closed sozinho: ausência de dado NUNCA vira "bate".
+      out.push({
+        level: 'error',
+        codigo: 'LACUNA_GRUPO_MUDOU',
+        objeto: rot,
+        msg:
+          `${rot}: grupo declarado em LACUNAS_POR_GRUPO e SEM linha de medição. Não é "zero ` +
+          `divergências" — é medição que não aconteceu para este grupo.`,
+      });
+      continue;
+    }
+    const curadas = medidas.filter((t) => `public.${t}` in contrato).sort();
+    const lacunas = medidas.length - curadas.length;
+    const lista = () => [...medidas].sort().join(', ');
+
+    // CURADO vem ANTES de MUDOU quando os dois valem: se o grupo inteiro foi curado, renovar a
+    // contagem é a correção errada — a entrada tem de sair. O guard `medidas.length > 0` é o que
+    // impede a inversão perigosa: uma medição que volta VAZIA também tem `lacunas === 0`, e
+    // diagnosticá-la como "grupo curado" convidaria a apagar a declaração por causa de uma query
+    // quebrada. Lista vazia cai no MUDOU abaixo, que é o diagnóstico honesto.
+    if (medidas.length > 0 && lacunas === 0) {
+      out.push({
+        level: 'error',
+        codigo: 'LACUNA_GRUPO_CURADO',
+        objeto: rot,
+        msg:
+          `${rot}: as ${medidas.length} tabela(s) do grupo estão TODAS em AUTHZ_RLS_ESPERADO — o ` +
+          `grupo deixou de ser lacuna e a declaração passou a mentir na direção que finge NÃO ` +
+          `cobrir. REMOVA a entrada de LACUNAS_POR_GRUPO (não renove a contagem). Tabelas: ` +
+          `${lista()}.`,
+      });
+      continue;
+    }
+    if (medidas.length !== g.tabelasNoGrafo) {
+      const dir = medidas.length > g.tabelasNoGrafo ? 'CRESCEU' : 'ENCOLHEU';
+      out.push({
+        level: 'error',
+        codigo: 'LACUNA_GRUPO_MUDOU',
+        objeto: rot,
+        msg:
+          `${rot}: o grupo ${dir} — ${medidas.length} tabela(s) em prod contra ` +
+          `${g.tabelasNoGrafo} declarada(s) (medido em ${g.medidoEm}). ` +
+          `${curadas.length} curada(s), ${lacunas} lacuna(s) hoje. A declaração de não-cobertura ` +
+          `virou falsa: ou uma migration gateou/renomeou tabela no grupo, ou o grupo sumiu. ` +
+          `Confira se as novas merecem entrar no contrato pelo critério do cabeçalho ANTES de ` +
+          `renovar \`tabelasNoGrafo\` (e a data). Tabelas hoje: ${lista()}.`,
+      });
+      continue;
+    }
+    // Contagem bate. Falta a SUBSTITUIÇÃO: uma sai, outra entra, e o total não se move — a mesma
+    // classe de "duas mudanças opostas se cancelam" que fez a declaração guardar o TOTAL em vez
+    // do número de lacunas. O md5 da lista ordenada é o que fecha isso.
+    const md5Med = md5Lista(medidas);
+    if (md5Med !== g.tabelasMd5) {
+      out.push({
+        level: 'error',
+        codigo: 'LACUNA_GRUPO_MUDOU',
+        objeto: rot,
+        msg:
+          `${rot}: a CONTAGEM bate (${medidas.length}) e o CONJUNTO não — md5 ${md5Med} contra ` +
+          `${g.tabelasMd5} declarado (medido em ${g.medidoEm}). Houve substituição: uma tabela ` +
+          `saiu do grupo e outra entrou no mesmo intervalo, e só a contagem não veria. Tabelas ` +
+          `hoje: ${lista()}.`,
+      });
+    }
   }
 
   return out;


### PR DESCRIPTION
## O defeito

O #2077 tirou da prosa a **lista** de tabelas recusadas do contrato de RLS. O que ficou no
cabeçalho foram as lacunas em **BLOCO** — três grupos, com as contagens escritas em texto:

> "as **22** de `cap_carteira_ler` e as **8** de `carteira_visivel_para`; as **36** `fin_*`
> restantes (de 41; 5 curadas); e as outras **13** de `cap_compras_ler` (de 14)."

Medido hoje via `psql-ro`: **22 · 8 · 41 · 14**. A prosa estava **certa** — como estava a do #2077
no dia em que foi escrita. O que muda é o **gatilho de apodrecimento**, e o do grupo é mais barato
de puxar: a lista de tabelas apodrece quando uma rodada **cura**; a contagem do grupo apodrece
quando uma **migration** gateia mais uma tabela pela mesma capability — o evento mais banal deste
repo, e o que menos passa por revisão de autorização.

**Um teste estático não resolveria: a outra ponta é PROD.** Só o banco sabe quantas tabelas
`cap_carteira_ler` gateia hoje. O gate vira o **audit** (eixo 4), não o CI.

## O que entra

`LACUNAS_POR_GRUPO` no contrato — `{def, tabelasNoGrafo, tabelasMd5, medidoEm, motivo}` — e
`bun run authz:rls:prod` reconta o grupo em prod a cada execução (`pg_depend` para grupo de
predicado, `starts_with` para grupo de prefixo), desconta as curadas e compara.

**Três decisões que o desenho obrigou**, cada uma com o cego que ela fecha:

1. **Duas formas de grupo, não uma.** Três grupos são "as tabelas que chamam tal capability" — uma
   aresta de `pg_depend`. O quarto (`fin_*`) é de **nome**, e reduzi-lo ao predicado seria a
   armadilha: o gate comum do financeiro (`fin_user_can_access`) alcança **18** tabelas medidas,
   não 41. Uma `fin_nova` gateada por outra função continuaria sendo lacuna e o grupo **não a veria
   entrar** — a mesma cegueira, com um sensor por cima.
2. **Declara o TOTAL, deriva a lacuna.** Congelar "36 lacunas" tem cego exato: migration soma
   (22→23) e uma rodada cura (0→1) no mesmo dia, a subtração devolve 22 e nada fica vermelho. O
   total só se move por prod; o número de lacunas é recalculado do contrato ao lado.
3. **`tabelasMd5` pelo mesmo argumento.** Fecha a **substituição** (uma sai, outra entra, total
   igual). Sort em **JS** e não em SQL — o `ORDER BY` do PG usa colação, `_` ordena antes de letra
   em `C` e é ignorado em ICU/pt_BR. Os dois md5 (JS e `string_agg … COLLATE "C"`) foram conferidos
   um contra o outro **antes** de o número entrar no contrato.

**Dois códigos, não um:** `LACUNA_GRUPO_MUDOU` (re-medir e renovar) × `LACUNA_GRUPO_CURADO`
(**apagar** a entrada — o grupo deixou de ser lacuna). Correções opostas, como
`POLICY_NOVA` × `POLICY_ALTERADA`.

> 🔴 **A inversão perigosa:** `lacunas === 0` é verdade para "todas curadas" **e** para "a medição
> voltou vazia". Diagnosticar a segunda como a primeira convidaria a **apagar a declaração por
> causa de uma query quebrada**. Lista vazia cai no `MUDOU`, que manda investigar.

Denominador na linha do veredito, no espírito do resto do audit:

```
✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 20 tabela(s) curada(s),
   50 policy(ies) e 10 funcao(oes)-predicado batem com o contrato; 4 grupo(s) de lacuna
   conferido(s) — 78 tabela(s) distinta(s) no grafo, 6 curada(s), 72 lacuna(s).
```

## Escopo — o que este PR NÃO faz

**Não cura** as 72 tabelas dos grupos. Curar seria o depósito que o critério do cabeçalho existe
para evitar. O eixo afirma uma coisa só, e ela é falsificável: **o grupo continua sendo o que a
declaração diz**.

## Falsificação (commit ANTES; restauração por `git checkout --`)

| # | Sabotagem | Veredito exigido | Resultado |
|---|---|---|---|
| F1 | `tabelasNoGrafo: 22 → 21` | `authz:rls:prod` exit **1**, `LACUNA_GRUPO_MUDOU` | ✅ "o grupo CRESCEU — 22 em prod contra 21 declarada(s) … 0 curada(s), 22 lacuna(s)" |
| F2 | só o `tabelasMd5` (contagem intacta) | exit 1, acusa **substituição** | ✅ "a CONTAGEM bate (22) e o CONJUNTO não" |
| F3 | eixo removido do `dadoDoContrato('rls')` | teste de identidade dos **5** eixos reprova | ✅ 1 failed / 63 passed |
| F4 | `LACUNAS_POR_GRUPO = []` | sentinela nos **dois** lugares | ✅ vitest "expected 0 to be ≥ 3" **e** runner exit **2** contra prod |
| F5 | eixo 4 desligado no comparador | o harness PG17 fica **vermelho** | ✅ 36 ok / **4 fail** (GB, GD, GF, GH) — os cenários não são teatro |

F4 merece nota: com a lista vazia, **um** teste falhou — os outros passaram por **vacuidade**, que
é exatamente por que o piso existe.

## Evidência

- `bun run authz:rls:prod` → **exit 0** contra prod (cada número é medição via `psql-ro`).
- `db/test-audit-rls-prod.sh` → **40 ok / 0 fail** nos **dois** locales (`LC_ALL=C` e
  `LC_ALL=pt_BR.UTF-8`), com 9 cenários novos (`GA`..`GI`).
- `bun run test` → **7438 passed** · `bun run typecheck` e `bun lint` (0 erros) · `shellcheck` limpo.
- Carimbo regravado (`authz:carimbo:gravar`) — os dois fingerprints da chave `rls` se moveram;
  gate verde de novo.
- Rebase sobre `bcb0c7070` (#2078 tocou `authz-carimbo.test.ts`) — sem conflito, tudo re-verificado
  depois.

Registro: `docs/historico/rls-viva-fora-do-alcance-dos-audits.md` §7.2.

> **A classe, agora com três instâncias:** *prosa que descreve dado apodrece* — e quando a prosa
> descreve **prod**, o gate não pode ser estático. A pergunta que sobra de cada declaração é uma
> só: **qual é a outra ponta?** No arquivo → o gate é um teste. No banco → o gate é o audit.
> Escolher errado produz um gate que existe e não mede, que é pior que não ter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
