### PR TITLE
feat(authz): a carteira entra pelo que ARRASTA — 1 tabela, 3 gates congelados [money-path]

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-08-28T23:06:36.558Z",
-  "sourceHead": "45b1b254f6ede43ac60b8fcc8a93a833f2f42a00",
+  "medidoEm": "2026-08-28T23:49:46.372Z",
+  "sourceHead": "6cc3041bbd8a9a5d8e7c3670d9329b40382aaca6",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -48,9 +48,9 @@
     "rls": {
       "script": "authz:rls:prod",
       "exit": 0,
-      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 20 tabela(s) curada(s), 50 policy(ies) e 10 funcao(oes)-predicado batem com o contrato (fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao); 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 6 ",
+      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 21 tabela(s) curada(s), 54 policy(ies) e 13 funcao(oes)-predicado batem com o contrato (fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao); 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 7 ",
       "denominador": null,
-      "contratoFingerprint": "894ad8c1d514c162e4735320229b0501ef3dfc951d5233c155c461eed5c9f720",
+      "contratoFingerprint": "8f09f8737e150c53a13d24d49ece9a1144f2657a7d7f97203841467e09300e14",
       "auditorFingerprint": "f24bdcecdcf841257b1c817fbeecddf0b47b91ae42c8784d68e110b86a126986",
       "achados": []
     }

--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -636,3 +636,67 @@ funções do banco"); Z6 trava a armadilha do §4 com o nome numa string **e** n
 sem chamada. E a PARTE B ganhou o **B7**, que é o B5 um passo adiante: lá o corpo alterado era o
 da função que a policy CHAMA; aqui nem esse muda — policy, predicado direto e RLS idênticos, e o
 barrado passa a ver 2 linhas.
+
+## 10. A 4ª rodada (2026-08-28) — a carteira, e uma razão que era falsa quando foi escrita
+
+A §7.2 fechou a declaração dos grupos e deixou uma pendência nomeada: `cap_carteira_ler` (22
+tabelas) e `carteira_visivel_para` (8) eram os últimos gates de alcance grande com o **corpo não
+congelado** — nenhuma tabela curada os chamava, logo o eixo 3 não os alcançava.
+
+**A escolha, medida e não intuída.** A tese do §8 — *o valor de uma entrada é o que ela PUXA* —
+diz para procurar a tabela com mais arestas, não a mais importante. A medição achou **6** tabelas
+na interseção dos dois grupos, e todas as seis puxam **três** predicados de uma vez:
+`cap_carteira_ler` (22) · `cap_carteira_escrever` (15) · `carteira_visivel_para` (8). As seis são
+intercambiáveis nesse eixo — mesmas 4 policies, mesmos 3 predicados —, então o desempate teve de
+vir de outro lugar: `public.farmer_client_scores` foi a única com **número de margem**
+(`gross_margin_pct`, `avg_monthly_spend_180d`) **e** linha em prod (6.633). Uma entrada, quatro
+policies, três gates congelados.
+
+> **O que a rodada acrescenta ao §8:** a tese diz para maximizar arestas, e não diz como desempatar
+> quando o máximo empata. A resposta é **descer para o critério original** (i)/(ii)/(iii) como
+> desempate, não como porta de entrada. "Puxa mais" seleciona o conjunto; "guarda o número"
+> escolhe dentro dele.
+
+#### 🔴 O achado: uma razão declarada que já nascia falsa
+
+`LACUNAS_DECLARADAS['public.carteira_assignments']` justificava a recusa assim:
+
+> "O predicado dela não fica órfão: **já é congelado** por ser chamado pelas policies das tabelas
+> de carteira."
+
+Era **falso no dia em que foi escrito**. As policies das tabelas de carteira chamam
+`carteira_visivel_para`, sim — mas nenhuma dessas tabelas estava no contrato, e o eixo 3 só
+descobre predicado a partir de **policy curada**. O predicado não era congelado por ninguém.
+
+Isto é uma quarta instância da classe, e a mais desconfortável: as três anteriores (§7.1, §7.2)
+eram declarações **corretas que apodreceram**. Esta nunca foi correta. E nenhum gate a pegaria —
+os testes de §2 conferem que a lacuna tem razão **com substância** (>80 chars) e que ela não está
+curada; nenhum confere que a razão é **verdadeira**, porque "verdadeira" aqui é uma afirmação sobre
+o grafo de prod. A rodada a tornou verdadeira em vez de só corrigir o texto: curar
+`farmer_client_scores` arrasta exatamente o predicado que a razão dizia estar coberto.
+
+> **Lição:** *razão de recusa também é afirmação sobre prod, e envelhece igual — só que ela pode
+> nascer errada, não só ficar.* O gate barato existe e é o mesmo do resto: quando a razão diz
+> "já é congelado por X", isso é uma consulta (`AUTHZ_RLS_PREDICADOS`), não uma opinião.
+
+#### O que a rodada mediu e não mexeu
+
+`cap_carteira_ler` e `cap_carteira_escrever` têm o **mesmo `srcMd5`** (`836e8f46…`): hoje **quem
+lê a carteira também a escreve**. Não é bug a corrigir aqui — é o estado, e congelá-lo é o que faz
+o dia da divergência (ou o dia em que afrouxar a leitura arrastar a escrita junto) virar alarme. É
+o mesmo padrão do trio `cap_compras_ler`/`cap_preco_escrever`/`cap_credito_escrever` (`5faf2a21…`).
+
+As 4 policies são `roles = PUBLIC` (`polroles = {0}`), não `authenticated`: o gate é **inteiro** a
+expressão mais o GRANT de tabela.
+
+**Sessão paralela, e o que ela não mudou.** O §9 (fecho transitivo dos predicados) mergeou
+entre o §7.2 e esta rodada, no mesmo arquivo. Ele não alcança os gates de carteira e nem
+poderia: o fecho parte de **policy curada**, e nenhuma tabela de carteira estava no contrato —
+é a mesma razão pela qual a razão de recusa acima era falsa. A entrada foi conferida contra o
+auditor NOVO, que reporta `fecho transitivo, profundidade 1; 0 alcancada(s) so por outra
+funcao`: os três predicados entram como chamada DIRETA, não pelo fecho.
+
+**Efeito no eixo 4, sem editar uma linha dele:** as contagens declaradas (`tabelasNoGrafo`) não se
+movem — a tabela continua no grafo. O que muda é o número **derivado**, e ele mudou sozinho:
+`7 curada(s), 71 lacuna(s)` contra `6 / 72`. É a prova de que a decisão do §7.2 (declarar o total,
+derivar a lacuna) faz o que prometeu.

--- a/scripts/authz-rls-esperado.ts
+++ b/scripts/authz-rls-esperado.ts
@@ -33,7 +33,8 @@
  *     (ii) custo/preço, ou (iii) a raiz da autorização.**
  *
  * Como o critério é aplicado (2ª rodada, 2026-08-27 — 7 → 17 tabelas, 19 → 38 policies;
- * 3ª rodada, 2026-08-28 — 17 → 20 tabelas, 38 → 50 policies, 5 → 8 predicados). O
+ * 3ª rodada, 2026-08-28 — 17 → 20 tabelas, 38 → 50 policies, 5 → 8 predicados; 4ª rodada,
+ * 2026-08-28 — 20 → 21 tabelas, 50 → 54 policies, 8 → 11 predicados). O
  * critério acima tem três membros e eles NÃO se aplicam do mesmo jeito, porque a alavanca é
  * diferente:
  *
@@ -118,7 +119,7 @@ export interface TabelaRls {
 }
 
 /**
- * Estado medido em prod (psql-ro, 2026-08-27 + 2026-08-28; PG 17.6). 20 tabelas · 50 policies
+ * Estado medido em prod (psql-ro, 2026-08-27 + 2026-08-28; PG 17.6). 21 tabelas · 54 policies
  * (1ª rodada: 7 · 19; 2ª: +10 · +19; 3ª: +3 · +12 — cada rodada marcada pelos separadores abaixo).
  *
  * ⚠️ Os md5 se REPETEM entre tabelas quando o predicado é literalmente o mesmo texto — p.ex.
@@ -846,6 +847,65 @@ export const AUTHZ_RLS_ESPERADO: Record<string, TabelaRls> = {
   },
 
   // ── cadastro-base + aprovação ──────────────────────────────────────────────────────────────
+  // ── 4ª rodada (2026-08-28): a carteira, escolhida pelo que ARRASTA ──────────────────────────
+  'public.farmer_client_scores': {
+    forceRls: false,
+    motivo:
+      'Scoring por CLIENTE do farmer, 6.633 linhas. Entra pelo eixo do §8 — o valor de uma entrada ' +
+      'é o que ela PUXA —, e esta puxa TRÊS predicados de uma vez (`cap_carteira_ler` 22 tabelas, ' +
+      '`cap_carteira_escrever` 15, `carteira_visivel_para` 8, medidos): eram os últimos gates de ' +
+      'alcance grande com o corpo NÃO congelado. O reforço de (ii) é medido e secundário: a tabela ' +
+      'guarda `gross_margin_pct` e `avg_monthly_spend_180d` por cliente — margem, ainda que ' +
+      'agregada de `order_items`/`product_costs`, que já estão curadas. Escolhida entre as 6 ' +
+      'candidatas da interseção (todas com as MESMAS 4 policies e os mesmos 3 predicados) por ser ' +
+      'a única com número de margem E linha em prod.',
+    policies: {
+      fcs_select_carteira: {
+        cmd: 'r',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: '4ce46ee9bbc5966f54317f7e446a452e',
+        withCheckMd5: null,
+        motivo:
+          'A leitura, e o único caminho por LINHA do contrato: `cap_carteira_ler(uid)` OR ' +
+          '`carteira_visivel_para(customer_user_id, uid)` — capability global ou a carteira daquele ' +
+          'cliente. ⚠️ `roles` é PUBLIC (polroles={0}), não `authenticated`: o gate é INTEIRO a ' +
+          'expressão mais o GRANT de tabela.',
+      },
+      fcs_insert_own_or_gestor: {
+        cmd: 'a',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: null,
+        withCheckMd5: 'e674af85831f3ebeeec81c0e2f9cc0a7',
+        motivo:
+          'INSERT puro: sem USING (o PG não consulta USING no INSERT), só WITH CHECK — ' +
+          '`cap_carteira_escrever(uid)` OR `farmer_id = uid` (escrever o PRÓPRIO score).',
+      },
+      fcs_update_own_or_gestor: {
+        cmd: 'w',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: 'e674af85831f3ebeeec81c0e2f9cc0a7',
+        withCheckMd5: 'e674af85831f3ebeeec81c0e2f9cc0a7',
+        motivo:
+          'USING e WITH CHECK IDÊNTICOS (mesmo md5) — simétrico, então não há brecha de mover ' +
+          'linha para fora do próprio escopo. É FOR UPDATE e não FOR ALL, logo o check estrutural ' +
+          'de assimetria não se aplica.',
+      },
+      fcs_delete_own_or_gestor: {
+        cmd: 'd',
+        permissiva: true,
+        roles: ['PUBLIC'],
+        qualMd5: 'e674af85831f3ebeeec81c0e2f9cc0a7',
+        withCheckMd5: null,
+        motivo:
+          'DELETE com o MESMO USING do UPDATE — e é o comando que só consulta o USING ' +
+          '(database.md §4). Split por comando em vez de FOR ALL é o que torna isso legível.',
+      },
+    },
+  },
+
 };
 
 /**
@@ -876,9 +936,12 @@ export const AUTHZ_RLS_ESPERADO: Record<string, TabelaRls> = {
 export const LACUNAS_DECLARADAS: Record<string, string> = {
   'public.carteira_assignments':
     'É raiz de verdade — `private.carteira_visivel_para` a lê —, mas raiz de INTELIGÊNCIA ' +
-    'COMERCIAL, não de dinheiro/custo. O predicado dela não fica órfão: já é congelado por ser ' +
-    'chamado pelas policies das tabelas de carteira. Gatilho de reentrada: no dia em que comissão ' +
-    'ou preço passarem a depender da carteira, ela vira membro (i)/(ii).',
+    'COMERCIAL, não de dinheiro/custo. ⚠️ A razão original dizia que "o predicado dela não fica ' +
+    'órfão: já é congelado pelas policies das tabelas de carteira" — e isso era FALSO quando foi ' +
+    'escrito: nenhuma tabela curada chamava `carteira_visivel_para`, logo ninguém congelava o ' +
+    'corpo dele. Virou verdade na 4ª rodada, que curou `farmer_client_scores` exatamente para ' +
+    'arrastá-lo. Gatilho de reentrada: no dia em que comissão ou preço passarem a depender da ' +
+    'carteira, ela vira membro (i)/(ii).',
   'public.carteira_coverage':
     'O SEGUNDO caminho de `carteira_visivel_para` (a cobertura temporária de carteira alheia). ' +
     'Mesma razão de `carteira_assignments`, e o mesmo gatilho. Nota medida: o INSERT dela permite ' +
@@ -989,11 +1052,12 @@ export const LACUNAS_POR_GRUPO: LacunaGrupo[] = [
     medidoEm: '2026-08-28',
     motivo:
       'Inteligência COMERCIAL (carteira, radar, farmer, visitas), não dinheiro/custo — o critério ' +
-      'deste contrato não a alcança, e a RAIZ do grupo (`public.commercial_roles`) está curada. ' +
-      'O gate comum não fica órfão no eixo 3 por outra via: `cap_carteira_ler` é chamada por ' +
-      'policy de 22 tabelas, nenhuma delas curada, então congelar o CORPO dela seria a única ' +
-      'cobertura — e é justamente o que a lacuna assume o custo de não ter. Gatilho de reentrada: ' +
-      'no dia em que comissão ou preço passarem a depender da carteira, o grupo vira membro (i)/(ii).',
+      'deste contrato não alcança o CONTEÚDO delas, e a RAIZ do grupo (`public.commercial_roles`) ' +
+      'está curada. O que a lacuna assume o custo de não ter é o eixo 2 (o conjunto de policies) ' +
+      'das 21 não-curadas; o eixo 3 dela está coberto desde a 4ª rodada, que curou ' +
+      '`farmer_client_scores` e ARRASTOU o corpo de `cap_carteira_ler` para o congelamento. ' +
+      'Gatilho de reentrada: no dia em que comissão ou preço passarem a depender da carteira, o ' +
+      'grupo vira membro (i)/(ii).',
   },
   {
     def: { tipo: 'predicado', predicado: 'private.carteira_visivel_para' },
@@ -1004,9 +1068,10 @@ export const LACUNAS_POR_GRUPO: LacunaGrupo[] = [
       'O segundo gate de carteira (o que resolve cobertura temporária de carteira alheia), com ' +
       'interseção medida de 6 tabelas com o grupo de `cap_carteira_ler` — os dois grupos se ' +
       'sobrepõem de propósito, porque a pergunta "este predicado ainda gateia o mesmo conjunto?" ' +
-      'é por predicado, não por tabela. Mesma razão e mesmo gatilho do grupo acima; as duas ' +
-      'tabelas exclusivas dele (`carteira_assignments`, `visitas_agendadas`) são de carteira, não ' +
-      'de dinheiro.',
+      'é por predicado, não por tabela. Mesma razão e mesmo gatilho do grupo acima, e o corpo dele ' +
+      'também foi arrastado para o eixo 3 pela 4ª rodada (`farmer_client_scores` chama os dois no ' +
+      'mesmo `USING`). As duas tabelas exclusivas dele (`carteira_assignments`, ' +
+      '`visitas_agendadas`) são de carteira, não de dinheiro.',
   },
   {
     def: { tipo: 'prefixo', prefixo: 'fin_' },
@@ -1056,7 +1121,7 @@ export interface PredicadoEsperado {
  * `cap_custo_ler` chamada dentro de um `COALESCE`, e o §4 tem o registro de duas varreduras
  * textuais que produziram falso-positivo integral).
  *
- * Medido em prod (2026-08-27 + 2026-08-28): as 50 policies referenciam 10 funções — estas 8
+ * Medido em prod (2026-08-27 + 2026-08-28): as 54 policies referenciam 13 funções — estas 11
  * mais `auth.uid` e `auth.role`, que ficam em `PREDICADOS_PLATAFORMA`.
  *
  * ⚠️ A 2ª rodada leu o próprio resultado como convergência: 10 tabelas novas trazendo UMA função
@@ -1066,7 +1131,7 @@ export interface PredicadoEsperado {
  * rodada escolheu tabelas por parentesco com as já curadas (o resto do `fin_*`, o resto do que
  * `cap_custo_ler` gateia), e tabela irmã compartilha o gate da irmã por construção. A amostra
  * confirmava a hipótese porque fora selecionada por ela. O grafo real tem 14 funções gateando
- * policy em `public`; 8 estão congeladas aqui. ⇒ **Convergência medida sobre uma amostra
+ * policy em `public`; 11 estão congeladas aqui. ⇒ **Convergência medida sobre uma amostra
  * escolhida por semelhança não é convergência — é o método se ouvindo falar.**
  *
  * ⚠️ `cap_compras_ler`, `cap_credito_escrever` e `cap_preco_escrever` têm o MESMO `srcMd5`
@@ -1074,6 +1139,39 @@ export interface PredicadoEsperado {
  * duplicação a limpar — é o estado a congelar, e o dia em que uma divergir é o sinal que se quer.
  */
 export const AUTHZ_RLS_PREDICADOS: Record<string, PredicadoEsperado> = {
+  'private.cap_carteira_ler': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '836e8f46f863eefd75b3b46a49eba81a',
+    motivo:
+      '`master` OU (`employee` E `commercial_roles` em gerencial/estrategico/super_admin) — corpo ' +
+      'lido de prod. O predicado de carteira de MAIOR alcance: 22 tabelas (medido por pg_depend), ' +
+      'das quais o contrato cura UMA. Congelar o corpo cobre as 22 no eixo 3 sem curar o conteúdo ' +
+      'das outras 21 — o mesmo retorno que `cap_compras_ler` deu na 3ª rodada. ⚠️ Corpo IDÊNTICO ' +
+      'ao de `cap_carteira_escrever`: hoje LER e ESCREVER carteira são a mesma autorização.',
+  },
+  'private.cap_carteira_escrever': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '836e8f46f863eefd75b3b46a49eba81a',
+    motivo:
+      'Gate de ESCRITA da carteira em 15 tabelas (medido). O `srcMd5` é o MESMO de ' +
+      '`cap_carteira_ler` — não é duplicação a limpar, é o estado a congelar: quem hoje LÊ a ' +
+      'carteira também a ESCREVE, e o dia em que os dois divergirem (ou em que afrouxar a leitura ' +
+      'arrastar a escrita junto) é exatamente o sinal que se quer ver. Perder o SECDEF aqui quebra ' +
+      'a autorização por BAIXO: a policy fica idêntica e passa a negar para todo mundo.',
+  },
+  'private.carteira_visivel_para': {
+    secdef: true,
+    cfg: 'search_path=public',
+    srcMd5: '76de7734fc459d344be3ea86265a0267',
+    motivo:
+      'O caminho por LINHA: `master` OU dono da carteira (`carteira_assignments.eligible`) OU ' +
+      'cobertura ativa dentro da janela (`carteira_coverage.active` e `valid_until` nulo ou ' +
+      'futuro). É o predicado que LÊ as duas tabelas declaradas como lacuna nominal — congelá-lo é ' +
+      'o que torna VERDADEIRA a razão que aquelas duas entradas dão para não serem curadas, e que ' +
+      'antes desta rodada era falsa: nenhuma tabela curada o chamava, logo ninguém o congelava.',
+  },
   'private.cap_compras_ler': {
     secdef: true,
     cfg: 'search_path=public',


### PR DESCRIPTION
## A pendência

O [#2080](https://github.com/LucasSardenbergL/afiacao/pull/2080) fechou a declaração dos grupos e
deixou uma pendência nomeada: `cap_carteira_ler` (**22** tabelas), `cap_carteira_escrever` (**15**)
e `carteira_visivel_para` (**8**) eram os gates de maior alcance com o **corpo não congelado** —
nenhuma tabela curada os chamava, logo o eixo 3 não os alcançava. O
[#2081](https://github.com/LucasSardenbergL/afiacao/pull/2081) (fecho transitivo) não os alcança e
**nem poderia**: o fecho parte de policy **curada**.

## A escolha, medida e não intuída

A tese do §8 — *o valor de uma entrada é o que ela PUXA* — manda procurar **arestas**, não
importância. A medição achou **6** tabelas na interseção dos dois grupos de carteira, e todas as
seis puxam os **três** predicados de uma vez. Sendo intercambiáveis nesse eixo (mesmas 4 policies,
mesmos 3 predicados), o desempate teve de vir de outro lugar: **`public.farmer_client_scores`** é a
única com número de **margem** (`gross_margin_pct`, `avg_monthly_spend_180d`) **e** linha em prod
(6.633). Uma entrada, 4 policies, 3 gates congelados.

> **O que a rodada acrescenta ao §8:** a tese diz para maximizar arestas, e não diz como desempatar
> quando o máximo **empata**. A resposta é descer para o critério original (i)/(ii)/(iii) como
> **desempate**, não como porta de entrada. "Puxa mais" seleciona o conjunto; "guarda o número"
> escolhe dentro dele.

## 🔴 O achado: uma razão de recusa que já NASCIA falsa

`LACUNAS_DECLARADAS['public.carteira_assignments']` justificava a recusa assim:

> "O predicado dela não fica órfão: **já é congelado** por ser chamado pelas policies das tabelas
> de carteira."

**Falso no dia em que foi escrito.** As policies de carteira chamam `carteira_visivel_para`, sim —
mas nenhuma dessas tabelas estava no contrato, e o eixo 3 só descobre predicado a partir de policy
**curada**. Ninguém congelava aquele corpo.

É a **4ª instância da classe** e a mais desconfortável: as três anteriores (§7.1, §7.2) eram
declarações **corretas que apodreceram**; esta **nunca foi correta**. E nenhum gate a pegaria — os
testes de §2 conferem que a razão tem substância (>80 chars) e que a tabela não está curada;
nenhum confere que a razão é **verdadeira**, porque isso é uma afirmação sobre o grafo de prod.
A rodada a torna verdadeira em vez de só corrigir o texto.

## Medido e NÃO mexido

`cap_carteira_ler` e `cap_carteira_escrever` têm o **mesmo `srcMd5`** (`836e8f46…`): hoje **quem lê
a carteira também a escreve**. Não é bug a corrigir aqui — é o estado, e congelá-lo é o que faz o
dia da divergência virar alarme. As 4 policies são `roles = PUBLIC` (`polroles = {0}`), então o
gate é **inteiro** a expressão mais o GRANT de tabela.

## O eixo 4 não precisou de uma linha de edição

`tabelasNoGrafo` não se move (a tabela segue no grafo); o número **derivado** mudou sozinho:

```
… 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 7 curada(s), 71 lacuna(s).
                                                                        ↑ era 6 / 72
```

É a decisão do #2080 (declarar o total, derivar a lacuna) fazendo o que prometeu.

## Falsificação (commit ANTES; restauração por `git checkout --`)

| # | Sabotagem | Resultado |
|---|---|---|
| G1 | md5 da policy de leitura | `[POLICY_ALTERADA] public.farmer_client_scores » fcs_select_carteira`, exit 1 |
| G2 | `srcMd5` de `carteira_visivel_para` | `[PREDICADO_ALTERADO] private.carteira_visivel_para`, exit 1 |
| G3 | **remover a tabela** do contrato | `PREDICADO_SUMIU` nos **três** — a prova de que o ARRASTA é real: uma entrada sustenta os 3 gates |

## Evidência

- `bun run authz:rls:prod` → **exit 0** com o auditor **novo** do #2081: 21 tabelas · 54 policies ·
  13 predicados, `fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao` — os três
  entram como chamada **direta**. Todo md5 bateu com prod na primeira tentativa.
- `db/test-audit-rls-prod.sh` → **50 ok / 0 fail** nos **dois** locales.
- `bun run test` → **7442 passed** · typecheck limpo · carimbo regravado.

⚠️ **Nota de multi-sessão:** o #2081 mergeou no mesmo arquivo entre o #2080 e este PR. A branch foi
reconstruída sobre a `main` atual e reduzida ao **diferencial** (só `authz-rls-esperado.ts`, o doc
e o carimbo — o #2081 não tocou o contrato). Tudo re-verificado depois, contra o auditor dele.

Registro: `docs/historico/rls-viva-fora-do-alcance-dos-audits.md` §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
