### PR TITLE
fix(seguranca): `elevenlabs-transcribe` era a ÚNICA edge de IA paga aberta a qualquer JWT — cota fecha, gate trava

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **494** custom migrations totais
+- **495** custom migrations totais
 - **1711** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 513
@@ -4155,6 +4155,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.reposicao_cold_start_parametros` | — |
+
+### `20260828210014_ia_uso_limite_elevenlabs_transcribe.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 494
+-- Total de custom migrations: 495
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -535,7 +535,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260825225850', 'analytics_outbox_cron', '20260825225850_analytics_outbox_cron.sql'),
   ('20260826002244', 'telemetria_probes', '20260826002244_telemetria_probes.sql'),
   ('20260826020000', 'reposicao_param_fila_sensor', '20260826020000_reposicao_param_fila_sensor.sql'),
-  ('20260826021000', 'reposicao_cold_start_fusivel_graduacao', '20260826021000_reposicao_cold_start_fusivel_graduacao.sql')
+  ('20260826021000', 'reposicao_cold_start_fusivel_graduacao', '20260826021000_reposicao_cold_start_fusivel_graduacao.sql'),
+  ('20260828210014', 'ia_uso_limite_elevenlabs_transcribe', '20260828210014_ia_uso_limite_elevenlabs_transcribe.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/src/__tests__/ia-paga-sem-cota-gate.test.ts
+++ b/src/__tests__/ia-paga-sem-cota-gate.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+
+// ── GATE: edge de IA PAGA que não exige staff PRECISA consumir cota ─────────────
+//
+// Instância-âncora: `elevenlabs-transcribe`. Ela declarava `verify_jwt = false`,
+// validava a ASSINATURA do JWT (`getClaims`) e parava aí — sem checar role, sem
+// checar `is_approved` e sem cota, indo direto à ElevenLabs com áudio de até 10MB.
+// Como `/auth` é cadastro público e sem convite (`supabase.auth.signUp`), qualquer
+// pessoa da internet virava principal válido: um customer com `is_approved=false`,
+// barrado em TODA a UI, ainda assim debitava o orçamento da organização em laço.
+//
+// O RECORTE é a parte que custou a medir, e é o que mantém este gate honesto.
+// Medição de 2026-08-28 sobre `supabase/functions/`: 17 edges chamam provedor de
+// IA pago, e 13 delas NÃO consomem cota — mas todas as 13 exigem staff/master
+// (`authorizeCronOrStaff`/`authorizeMaster`). Entre staff, cota é controle de
+// CUSTO; a ausência dela não é falha de autorização, e transformar isso em
+// vermelho seria o defeito que ensina a ignorar o vermelho. O que discrimina não
+// é "chama IA paga", é "chama IA paga E aceita qualquer principal autenticado".
+//
+// Sob esse recorte a população é 3 — analyze-services, identify-tool e
+// elevenlabs-transcribe — e as 3 consomem cota. O gate nasce VERDE e SEM baseline:
+// não há dívida para apodrecer, e a próxima edge de IA aberta a qualquer JWT que
+// esquecer a cota sai vermelha na hora.
+//
+// A cota, do lado SQL, é fail-CLOSED por desenho: `ia_consumir_cota` devolve
+// `sem_limite` (→ HTTP 503) para função sem linha em `ia_uso_limite`. Portanto
+// ADICIONAR a chamada aqui SEM semear o limite em produção derruba a edge — a
+// ordem de entrega é seed primeiro, deploy depois.
+//
+// Comentário é removido com o stripper COMPARTILHADO antes de medir: um `//
+// consumirCota(...)` comentado, ou o nome citado em prosa, forjaria verde.
+
+const RAIZ = resolve(__dirname, '../..');
+const DIR_EDGES = 'supabase/functions';
+
+const PROVEDOR_PAGO =
+  /api\.elevenlabs\.io|api\.anthropic\.com|api\.openai\.com|generativelanguage\.googleapis|ai\.gateway\.lovable\.dev|@anthropic-ai\/sdk/;
+const EXIGE_STAFF = /\bauthorize(?:CronOrStaff|Master|Staff)\s*\(/;
+const CONSOME_COTA = /\bconsumirCota\s*\(/;
+
+interface Edge {
+  nome: string;
+  exigeStaff: boolean;
+  consomeCota: boolean;
+}
+
+function edgesDeIaPaga(): Edge[] {
+  const raiz = resolve(RAIZ, DIR_EDGES);
+  const achados: Edge[] = [];
+  for (const nome of readdirSync(raiz)) {
+    if (nome === '_shared' || nome.startsWith('.')) continue;
+    const dir = join(raiz, nome);
+    if (!statSync(dir).isDirectory()) continue;
+    const entrada = join(dir, 'index.ts');
+    if (!existsSync(entrada)) continue;
+
+    const fonte = removerComentarios(readFileSync(entrada, 'utf-8'));
+    if (!PROVEDOR_PAGO.test(fonte)) continue;
+
+    achados.push({
+      nome,
+      exigeStaff: EXIGE_STAFF.test(fonte),
+      consomeCota: CONSOME_COTA.test(fonte),
+    });
+  }
+  return achados.sort((a, b) => a.nome.localeCompare(b.nome));
+}
+
+describe('gate: IA paga aberta a qualquer JWT precisa de cota', () => {
+  it('toda edge de IA paga que não exige staff consome cota', () => {
+    const descobertas = edgesDeIaPaga()
+      .filter((e) => !e.exigeStaff && !e.consomeCota)
+      .map((e) => e.nome);
+
+    expect(
+      descobertas,
+      `Edge(s) chamando provedor de IA PAGO, aceitando qualquer principal ` +
+        `autenticado (sem authorizeCronOrStaff/authorizeMaster) e SEM consumirCota: ` +
+        `${descobertas.join(', ')}. Cadastro em /auth é público, então "JWT válido" ` +
+        `inclui customer não aprovado. Porte o par de identify-tool: ` +
+        `consumirCota(cliente, userId, '<slug>', '<rótulo>') + headersDeCota. ` +
+        `E SEMEIE ia_uso_limite ANTES do deploy — sem a linha, a RPC devolve 503.`,
+    ).toEqual([]);
+  });
+
+  // ── Sentinelas de vacuidade ───────────────────────────────────────────────────
+  // Sem estas, uma regex podre (provedor renomeado, import trocado) esvazia a
+  // população e o teste acima passa por CEGUEIRA, afirmando mais do que mediu.
+
+  it('ancora em instâncias conhecidas — regex podre não passa despercebida', () => {
+    const porNome = new Map(edgesDeIaPaga().map((e) => [e.nome, e]));
+
+    // As duas âncoras da classe: IA paga, abertas a qualquer JWT válido, com cota.
+    for (const nome of ['elevenlabs-transcribe', 'identify-tool']) {
+      const e = porNome.get(nome);
+      expect(e, `${nome} sumiu da população de IA paga — regex de provedor podre?`).toBeDefined();
+      expect(e!.exigeStaff, `${nome} passou a exigir staff — revise o recorte do gate`).toBe(false);
+      expect(e!.consomeCota, `${nome} perdeu a cota — é exatamente a regressão deste gate`).toBe(true);
+    }
+
+    // Âncora do lado isento: staff-gated sem cota é legítimo e precisa continuar visível.
+    const staffSemCota = edgesDeIaPaga().filter((e) => e.exigeStaff && !e.consomeCota);
+    expect(
+      staffSemCota.length,
+      'nenhuma edge staff-gated sem cota foi vista; a medição de 2026-08-28 achou 13 — regex podre?',
+    ).toBeGreaterThanOrEqual(8);
+  });
+
+  it('a população medida não colapsou', () => {
+    const todas = edgesDeIaPaga();
+    expect(
+      todas.length,
+      'medição de 2026-08-28: 17 edges de IA paga. Caiu abaixo de 12 — regex de provedor podre?',
+    ).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -768,6 +768,7 @@ export const MODULOS: ModuloApp[] = [
       "src/__tests__/tothrow-pelado-gate.test.ts",
       "src/__tests__/erro-colapsado-em-vazio-gate.test.ts",
       "src/__tests__/import-tint-formulas-aposentada-gate.test.ts",
+      "src/__tests__/ia-paga-sem-cota-gate.test.ts",
       "src/lib/gates/__tests__/**",
       "src/lib/escape-html.test.ts",
       "src/lib/invoke-function.test.ts",

--- a/supabase/functions/elevenlabs-transcribe/index.ts
+++ b/supabase/functions/elevenlabs-transcribe/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -31,6 +32,7 @@ Deno.serve(async (req) => {
 
     const token = authHeader.replace('Bearer ', '');
     const { data, error: authError } = await supabaseAuth.auth.getClaims(token);
+    const claims = data?.claims as Record<string, unknown> | undefined ?? {};
     if (authError || !data?.claims) {
       console.error('Auth error:', authError);
       return new Response(
@@ -72,6 +74,37 @@ Deno.serve(async (req) => {
       return new Response(
         JSON.stringify({ error: 'Formato de áudio não suportado' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // COTA — depois da validação (requisição malformada não queima cota do
+    // usuário) e antes da ElevenLabs. O gate acima só exige JWT VÁLIDO, e o
+    // cadastro em /auth é aberto: sem isto, qualquer conta recém-criada —
+    // inclusive customer com is_approved=false, barrado em toda a UI —
+    // esgota o orçamento da ORGANIZAÇÃO repetindo áudios de até 10MB.
+    // Mesmo par que identify-tool/copilot-analyze/analyze-services já usam.
+    const userId = typeof claims.sub === 'string' ? claims.sub : '';
+    if (!userId) {
+      return new Response(
+        JSON.stringify({ error: 'Token inválido' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseCota = createClient(supabaseUrl, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+    const cota = await consumirCota(
+      supabaseCota,
+      userId,
+      'elevenlabs-transcribe',
+      'transcrições de áudio',
+    );
+    if (!cota.permitido) {
+      return new Response(
+        JSON.stringify({ error: cota.mensagem }),
+        {
+          status: cota.http,
+          headers: { ...corsHeaders, ...headersDeCota(cota), 'Content-Type': 'application/json' },
+        }
       );
     }
 

--- a/supabase/migrations/20260828210014_ia_uso_limite_elevenlabs_transcribe.sql
+++ b/supabase/migrations/20260828210014_ia_uso_limite_elevenlabs_transcribe.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- ia_uso_limite — semeia a cota de `elevenlabs-transcribe`
+--
+-- PRÉ-REQUISITO do PR fix/ia-cota-elevenlabs-transcribe. A edge passa a chamar
+-- `ia_consumir_cota`, que é FAIL-CLOSED por desenho: função sem linha aqui
+-- devolve `sem_limite` → a edge responde HTTP 503. Sem este seed, a transcrição
+-- de voz PARA em produção assim que a edge for deployada.
+-- ORDEM: rodar este SQL ANTES do deploy da edge.
+--
+-- Limites: transcrição é método de ENTRADA (ditado), não ação deliberada como
+-- identify-tool (20/60). 60/hora ≈ uma transcrição por minuto sustentada, bem
+-- acima da cadência real de ditado; 300/dia. Folgado de propósito — a edge nunca
+-- foi instrumentada, então não há série histórica para calibrar (ia_uso_evento
+-- tem 0 eventos em 30 dias, mas só das 3 funções JÁ medidas). O objetivo aqui é
+-- LIMITAR o ilimitado sem arriscar quebrar fluxo real; aperte depois de uma
+-- semana de dado em ia_uso_evento.
+-- ============================================================
+
+INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia)
+VALUES ('elevenlabs-transcribe', 60, 300)
+ON CONFLICT (funcao) DO NOTHING;


### PR DESCRIPTION
## O achado

`elevenlabs-transcribe` declara `verify_jwt = false`, valida a **assinatura** do JWT via `getClaims` e **para aí**: sem checar `role`, sem checar `is_approved`, sem cota — indo direto à ElevenLabs (`scribe_v2`, áudio até 10MB).

Como `/auth` é cadastro **público e sem convite** (`supabase.auth.signUp`), "JWT válido" inclui um customer recém-criado com `is_approved = false` — barrado em toda a UI e ainda assim capaz de debitar o orçamento de IA da organização em laço.

## O recorte (a parte que custou a medir)

Das **17** edges que chamam provedor de IA pago, **13 não consomem cota** — mas todas as 13 exigem staff/master (`authorizeCronOrStaff`/`authorizeMaster`). Entre staff, cota é controle de **custo**, não autorização; transformar isso em vermelho seria o defeito que ensina a ignorar o vermelho.

O que discrimina não é "chama IA paga", é **"chama IA paga E aceita qualquer principal autenticado"**. Sob esse recorte a população é **3** — `analyze-services`, `identify-tool`, `elevenlabs-transcribe` — e esta era a **única sem cota**. O achado estreitou com a medição, em vez de virar varredura.

## A correção

Porta o par que `identify-tool`/`copilot-analyze`/`analyze-services` já usam: `consumirCota(...)` + `headersDeCota`, **depois** da validação do arquivo (requisição malformada não queima cota do usuário) e **antes** da ElevenLabs. `userId` sai de `claims.sub` com guard de tipo — claim ausente/não-string vira 401, em vez de virar string vazia e consumir cota de um user_id falso.

## Gate novo — `ia-paga-sem-cota-gate.test.ts`

Nasce **verde e sem baseline**: não há dívida para apodrecer, e a próxima edge de IA aberta a qualquer JWT que esquecer a cota sai vermelha na hora.

- Mede com o stripper **compartilhado** (`removerComentarios`) — um `consumirCota(` citado em comentário forjaria verde.
- **Três sentinelas de vacuidade**, porque regex de provedor podre esvazia a população e o gate passa por *cegueira*: âncora nominal (`elevenlabs-transcribe` + `identify-tool` existem, não exigem staff, consomem cota), piso do lado **isento** (≥8 staff-gated sem cota; medido 13) e piso da população total (≥12; medido 17).

**Falsificado nas duas direções:** remover a chamada de cota da edge → 2 vermelhos, um deles nomeando `SEM consumirCota: elevenlabs-transcribe`; apodrecer a regex de provedor → 2 vermelhos (`sumiu da população de IA paga`). Restaurado → 3/3 verde.

## ⚠️ ATENÇÃO: migration manual necessária — e ela vem ANTES do deploy

Este PR adiciona `supabase/migrations/20260828210014_ia_uso_limite_elevenlabs_transcribe.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

**A ordem importa e não é cosmética.** `ia_consumir_cota` é fail-CLOSED por desenho: função sem linha em `ia_uso_limite` devolve `sem_limite` → a edge responde **HTTP 503**. Deployar a edge sem o seed **derruba a transcrição de voz em produção**.

<details><summary>SQL pra aplicar (🟣 Lovable → SQL Editor → cola → Run)</summary>

```sql
INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia)
VALUES ('elevenlabs-transcribe', 60, 300)
ON CONFLICT (funcao) DO NOTHING;
```
</details>

Validação pós-apply (read-only):

```sql
SELECT CASE WHEN EXISTS (
  SELECT 1 FROM public.ia_uso_limite
  WHERE funcao = 'elevenlabs-transcribe' AND limite_hora = 60 AND limite_dia = 300
) THEN '✅ cota semeada' ELSE '❌ FALTANDO — a edge vai responder 503' END AS status;
```

Limites folgados de propósito: transcrição é método de **entrada** (ditado), não ação deliberada como `identify-tool` (20/60). Não há série histórica para calibrar — a edge nunca foi instrumentada. `ia_uso_evento` tem 0 eventos em 30 dias, mas **só das 3 funções já medidas**, então isso *não* é evidência de que a transcribe esteja ociosa. Apertar depois de uma semana de dado real.

Pré-voo: `wt:preflight` 🟢 sem colisão (176307 objetos concorrentes) · `psql-ro` confirma 0 linha para esta função em prod hoje.

## Evidência

`test:edges` 934/0 · `edges:typecheck` 0 crash · `typecheck` 0 · `lint` 0 · `manifesto.gate` 2/2 · gate novo 3/3 + 2 falsificações vermelhas com a mensagem certa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
