### PR TITLE
fix(pendencias): `cobertura: 2/39` saía com o mesmo exit 0 de 39/39 — e o cron só fala quando o exit muda

### DIFF
--- a/scripts/lib/pendencias-deploy.ts
+++ b/scripts/lib/pendencias-deploy.ts
@@ -167,3 +167,54 @@ export function julgar(
     linhasIgnoradas,
   };
 }
+
+/**
+ * Piso de cobertura, em %, abaixo do qual o relatório NÃO pode sair como "limpo".
+ *
+ * POR QUE EXISTE: medido em 2026-08-29, logo depois de eu provar 4 edges na mão. A varredura
+ * saiu `✅ confere — 2 · cobertura: 2/39 · exit 0`. Num cron que só fala quando o exit é
+ * diferente de zero, isso é SILÊNCIO — e silêncio, aqui, se lê como "39 edges conferidas".
+ * O relatório imprimia a cobertura, mas ninguém lê relatório que não toca a campainha.
+ *
+ * POR QUE EXIT 1 (pendência) E NÃO 2 (mecânica): o 2 diz "não consegui medir" — psql fora,
+ * mapa vazio. Cobertura baixa é outra coisa: a medição FUNCIONOU e informou que a maioria das
+ * edges não tinha sonda na janela. Isso é pendência com AÇÃO ÓBVIA (`bun run sonda:sql`), e
+ * classificá-la como defeito de mecânica mandaria o operador caçar um problema que não existe.
+ */
+export const PISO_COBERTURA_PADRAO = 50;
+
+/** Cobertura em % (0–100). Mapa vazio devolve 0 — nunca 100 por vacuidade. */
+export function coberturaPct(rel: Relatorio): number {
+  if (rel.totalMapeadas === 0) return 0;
+  return (rel.totalObservadas / rel.totalMapeadas) * 100;
+}
+
+/**
+ * O piso foi atingido?
+ *
+ * Comparação `>=` de propósito: piso 50 com cobertura exatamente 50% PASSA. E piso 0 desliga
+ * a regra (qualquer cobertura serve), que é a válvula para quem quer o comportamento antigo
+ * sem editar código.
+ */
+export function cobreOPiso(rel: Relatorio, piso: number): boolean {
+  return coberturaPct(rel) >= piso;
+}
+
+/**
+ * Lê o piso do ambiente, ou LANÇA.
+ *
+ * Fail-CLOSED: valor não-numérico, negativo ou acima de 100 lança em vez de cair no padrão
+ * silenciosamente. Um `PENDENCIAS_COBERTURA_MINIMA=cinquenta` que virasse 50 por omissão
+ * ensinaria que a variável funciona quando ela está sendo ignorada — e o dia em que alguém
+ * escrevesse `=90` esperando rigor, receberia 50 sem aviso.
+ */
+export function lerPiso(bruto: string | undefined, padrao = PISO_COBERTURA_PADRAO): number {
+  if (bruto === undefined || bruto.trim() === '') return padrao;
+  const n = Number(bruto);
+  if (!Number.isFinite(n) || n < 0 || n > 100) {
+    throw new Error(
+      `PENDENCIAS_COBERTURA_MINIMA inválido: ${JSON.stringify(bruto)}. Use um número de 0 a 100.`,
+    );
+  }
+  return n;
+}

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { julgar, parsearObservacoes, SEM_MAPA } from './lib/pendencias-deploy';
+import {
+  cobreOPiso,
+  coberturaPct,
+  julgar,
+  lerPiso,
+  parsearObservacoes,
+  PISO_COBERTURA_PADRAO,
+  SEM_MAPA,
+} from './lib/pendencias-deploy';
 
 const MAPA = { 'edge-a': 'aaa111', 'edge-b': 'bbb222' };
+const obs2 = (edge: string, fonte: string) => ({
+  edge,
+  fonte,
+  criado: '2026-08-27 21:00:00+00',
+  versao: 'v1',
+});
 const obs = (edge: string, fonte: string, criado = '2026-08-27 21:00:00+00', versao = 'v1') => ({
   edge,
   fonte,
@@ -84,5 +98,52 @@ describe('julgar', () => {
     const r = julgar(MAPA, [obs('edge-a', 'aaa111'), obs('edge-b', 'bbb222'), obs('fantasma', 'xxx')]);
     expect(r.vereditos.find((v) => v.edge === 'fantasma')?.estado).toBe('FORA_DO_MAPA');
     expect(r.totalDivergentes).toBe(1);
+  });
+});
+
+describe('piso de cobertura', () => {
+  const rel = (obs: number, mapeadas: number) =>
+    julgar(
+      Object.fromEntries(Array.from({ length: mapeadas }, (_, i) => [`e${i}`, `f${i}`])),
+      Array.from({ length: obs }, (_, i) => obs2(`e${i}`, `f${i}`)),
+    );
+
+  it('cobertura é observadas/mapeadas em %', () => {
+    expect(coberturaPct(rel(2, 39))).toBeCloseTo(5.13, 1);
+    expect(coberturaPct(rel(39, 39))).toBe(100);
+  });
+
+  it('mapa vazio devolve 0, NÃO 100 por vacuidade', () => {
+    expect(coberturaPct(julgar({}, []))).toBe(0);
+  });
+
+  it('O CASO REAL: 2/39 não cobre o piso padrão — era isto que saía exit 0 calado', () => {
+    expect(cobreOPiso(rel(2, 39), PISO_COBERTURA_PADRAO)).toBe(false);
+  });
+
+  it('cobertura exatamente no piso PASSA (comparação é >=)', () => {
+    expect(cobreOPiso(rel(5, 10), 50)).toBe(true);
+  });
+
+  it('piso 0 desliga a regra — válvula para o comportamento antigo', () => {
+    expect(cobreOPiso(rel(1, 39), 0)).toBe(true);
+  });
+
+  it('lerPiso: ausente/vazio cai no padrão', () => {
+    expect(lerPiso(undefined)).toBe(PISO_COBERTURA_PADRAO);
+    expect(lerPiso('  ')).toBe(PISO_COBERTURA_PADRAO);
+  });
+
+  it('lerPiso: número válido vence o padrão', () => {
+    expect(lerPiso('90')).toBe(90);
+    expect(lerPiso('0')).toBe(0);
+  });
+
+  it('lerPiso: LANÇA no inválido em vez de cair no padrão calado', () => {
+    for (const mau of ['cinquenta', '-1', '101', 'NaN']) {
+      expect(() => lerPiso(mau), `deveria lançar em ${mau}`).toThrow(
+        /PENDENCIAS_COBERTURA_MINIMA inválido/,
+      );
+    }
   });
 });

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -23,7 +23,10 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  cobreOPiso,
+  coberturaPct,
   julgar,
+  lerPiso,
   parsearObservacoes,
   type Estado,
   type Relatorio,
@@ -97,6 +100,14 @@ function imprimir(rel: Relatorio): void {
 }
 
 export function main(): number {
+  let piso: number;
+  try {
+    piso = lerPiso(process.env.PENDENCIAS_COBERTURA_MINIMA);
+  } catch (e) {
+    console.error(`❌ MECÂNICA: ${(e as Error).message}`);
+    return 2;
+  }
+
   let mapa: Record<string, string>;
   try {
     mapa = lerMapaCommitado();
@@ -130,7 +141,21 @@ export function main(): number {
   }
 
   imprimir(rel);
-  return rel.totalDivergentes > 0 ? 1 : 0;
+
+  if (rel.totalDivergentes > 0) return 1;
+
+  // Nada divergiu ENTRE AS OBSERVADAS — que é uma frase muito mais fraca que "nada divergiu".
+  // Sem o piso, 2 de 39 edges saía com o mesmo exit 0 de 39 de 39, e o cron calava nos dois.
+  if (!cobreOPiso(rel, piso)) {
+    console.error(
+      `\n⚠️  COBERTURA ABAIXO DO PISO: ${coberturaPct(rel).toFixed(0)}% < ${piso}%.` +
+        ` Nada divergiu entre as ${rel.totalObservadas} observadas, mas as outras` +
+        ` ${rel.totalMapeadas - rel.totalObservadas} não foram vistas.`,
+    );
+    console.error('   Dispare a leva com `bun run sonda:sql <edge>…` e rode de novo.');
+    return 1;
+  }
+  return 0;
 }
 
 if (import.meta.main) process.exit(main());


### PR DESCRIPTION
## O defeito, medido

Logo depois de provar 4 edges na mão, rodei a varredura:

```
✅ confere — 2
─── cobertura: 2/39 edges mapeadas responderam na janela
EXIT=0
```

O relatório **imprimia** a cobertura. Mas num cron que só toca a campainha quando o exit muda, `exit 0` é silêncio — e silêncio ali se lê como "39 edges conferidas".

*"Nada divergiu entre as observadas"* é uma frase muito mais fraca que *"nada divergiu"*, e o exit não distinguia as duas.

## A correção

Abaixo do piso (padrão **50%**), o veredito passa a ser **exit 1** com a ação junto:

```
⚠️  COBERTURA ABAIXO DO PISO: 5% < 50%. Nada divergiu entre as 2 observadas,
    mas as outras 37 não foram vistas.
   Dispare a leva com `bun run sonda:sql <edge>…` e rode de novo.
```

**Por que exit 1 e não 2:** o `2` quer dizer *"não consegui medir"* — psql fora, mapa vazio. Cobertura baixa é o oposto: a medição **funcionou** e informou que a maioria das edges não tinha sonda na janela do `pg_net.ttl`. É pendência com ação óbvia, e chamá-la de falha de mecânica mandaria o operador caçar defeito inexistente.

## Detalhes de desenho

- `PENDENCIAS_COBERTURA_MINIMA` ajusta o piso; **`=0` desliga a regra** — válvula para o comportamento antigo sem editar código.
- `lerPiso` é **fail-CLOSED**: não-numérico, negativo ou `>100` **lança**. Cair no padrão calado ensinaria que a variável funciona quando está sendo ignorada — e quem escrevesse `=90` esperando rigor receberia 50 sem aviso.
- `coberturaPct` de mapa vazio é **0**, não 100 por vacuidade.
- Comparação é `>=`: cobertura exatamente no piso passa.

## Evidência

| Portão | Resultado |
|---|---|
| `vitest` | `Tests 18 passed (18)` · exit 0 |
| **falsificação** | `cobreOPiso` → `return true` derruba exatamente o teste do caso real (2/39) |
| contra prod, padrão | `EXIT=1` + o aviso acima ✅ |
| contra prod, `=0` | `EXIT=0` (válvula funciona) |
| contra prod, `=cinquenta` | `EXIT=2` + `❌ MECÂNICA: … inválido` (fail-closed) |
| `typecheck` · `eslint` · `knip` | 0 · 0 · 0 |

Todos revalidados após o rebase na main atual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)