### PR TITLE
fix(deploy-verify): o N3 passivo lia tick PRÉ-merge como "deploy pendente" — o guard vira TEMPO, e vira script [money-path]

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -422,6 +422,33 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        medido 2026-08-26: 208 linhas cobrindo 5h55). Run de ontem **não está lá** — fora da janela,
        volta-se ao N3 ativo. Confira o número com
        `~/.config/afiacao/psql-ro -Atc "SELECT name, setting FROM pg_settings WHERE name = 'pg_net.ttl';"`.
+    5. 🔴 **O GUARD TEMPORAL — o INVERSO do limite acima, e pior que ele (2026-08-28, #2079).** O
+       item 4 cobre "o run é velho demais e SUMIU": ausência honesta, que se percebe. O sentido
+       inverso não se percebe — **os ticks presentes são todos ANTERIORES ao merge**. Aí a query roda
+       com **exit 0** e devolve linhas perfeitamente legíveis, com o marcador VELHO, que se lê como
+       "deploy pendente". É falso NEGATIVO com cara de veredito confiante, e o preço é mandar o
+       founder redeployar edge money-path à toa. Medido verificando o #2079: às **23:41Z** o TTL
+       tinha os ticks de 18:15, 20:15 e **22:15** contra um merge às **22:32** — todos pré-merge,
+       todos ecoando `v1.0-eco-versao-passivo`, e nenhum deles dizendo coisa alguma sobre este
+       deploy. O tick seguinte (**00:15Z**) provou que as edges **já estavam no ar** desde antes.
+       É `ausente ≠ zero` na dimensão **TEMPO**: **anterior ≠ ausência de deploy** — irmão da regra
+       do `background` (lá a coluna `modo` separa "não subiu" de "não deu tempo de coletar"; aqui a
+       coluna `created` separa "não subiu" de "**ainda não foi medido**").
+       **Virou SCRIPT, não recado** — recado depende de alguém lembrar, que é exatamente como a
+       armadilha da sentinela não-exclusiva passou:
+       ```bash
+       .claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh \
+         --desde '<timestamp do merge, UTC>' --esperado '<VERSAO da main>' [--steps 'ctes,nfes']
+       # 0 = NO AR · 1 = bundle VELHO provado (aí sim pendente) · 2 = INDETERMINADO · 3 = RECUSA
+       ```
+       Três coisas que ele guarda e a query crua não: **(a)** sem tick posterior ao corte ⇒ **exit 2**,
+       nunca 1; **(b)** o veredito sai do **tick MAIS RECENTE** — um tick gravado entre o merge e o
+       deploy ecoa o marcador velho com toda a razão, é história, e julgar por ele reprova deploy
+       correto; **(c)** **fail-CLOSED** na via de leitura, inclusive presente-porém-QUEBRADA (responde
+       vazio sem erro), caso em que "0 ticks" se leria como *indeterminado* em vez de *recusa* — e é
+       só nele que o ping tem dente, porque com a via totalmente morta o guard da contagem já recusa
+       sozinho (a 1ª sabotagem escrita saiu inócua por isso, e o eval registra o porquê).
+       Rede: `evals/verify-edge-eco-eval.sh` — 8 casos + 3 sabotagens, no gate `evals/run.sh`.
     - ⛔ **Dois sinais que PARECEM discriminar deploy e NÃO discriminam** — os dois foram testados neste
       mesmo ciclo e reprovados (narrativa em `docs/historico/verificar-sonda-versao.md` §12):
       **(a) duração da execução** (`acoes_execucoes`) — o run pós-mudança caiu para 24,0 s contra a faixa
@@ -611,4 +638,12 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   `input[type="checkbox"]` — a sentinela que o Passo 4 recomenda — segue silenciosa. AVISA e nunca
   recusa, como a sonda de lib. Rede: 3 casos bidirecionais + sabotagem `falsify_marca` (o fixture
   nunca modelou isto — bundle fake não é minificado, sentinela idêntica nos dois universos).
+- [x] **GUARD TEMPORAL do N3 passivo (2026-08-28, verificando o #2079):** a skill cobria o TTL só no
+  sentido "run velho SUMIU ⇒ N3 ativo"; o inverso — **TTL cheio, mas só de ticks PRÉ-merge** — devolvia
+  linhas legíveis com o marcador velho e se lia como "deploy pendente" (falso NEGATIVO, que **encerra**
+  a verificação com um pedido caro ao founder). Virou `scripts/verify-edge-eco.sh`: sem tick posterior
+  ao corte ⇒ **exit 2 INDETERMINADO**, nunca 1; veredito pelo **tick mais recente** (o intermediário
+  entre merge e deploy é história); fail-closed inclusive na via presente-porém-quebrada. Rede:
+  `evals/verify-edge-eco-eval.sh` (8 casos + 3 sabotagens) no gate. A falsificação pagou: a sabotagem
+  do ping saiu **inócua** e revelou que ele só tem dente contra a via MUDA, não contra a morta.
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -438,9 +438,19 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        armadilha da sentinela não-exclusiva passou:
        ```bash
        .claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh \
-         --desde '<timestamp do merge, UTC>' --esperado '<VERSAO da main>' [--steps 'ctes,nfes']
+         --desde '<timestamp do merge, UTC>' \
+         --esperado 'ctes=v1.1-eco-identidade-fonte,nfes=v1.2-eco-identidade-fonte' [--steps 'ctes,nfes']
        # 0 = NO AR · 1 = bundle VELHO provado (aí sim pendente) · 2 = INDETERMINADO · 3 = RECUSA
        ```
+       ⚠️ **O marcador é POR EDGE, e o script RECUSA o "marcador do lote".** Edges de uma mesma leva
+       partem de pontos diferentes: no #2079 quatro foram a `v1.1-eco-identidade-fonte` e a **`nfes`
+       a `v1.2`** (ela vinha de `v1.1-deadline-relogio`). Um `--esperado` único aplicado a vários
+       steps classificaria a divergente como bundle VELHO — o falso negativo que este script existe
+       para impedir, cometido pelo próprio script. Por isso valor único só passa com **1** step útil;
+       com mais, é **exit 3** pedindo o mapa (chave = step do orquestrador **ou** edge ecoada), e um
+       step útil sem marcador no mapa também recusa, porque comparar contra nada fabrica veredito.
+       Casado com o adendo "o marcador esperado é POR EDGE, não 'o bump do lote'" de
+       [`verificabilidade-do-conjunto-orquestrado.md`](../../../docs/historico/verificabilidade-do-conjunto-orquestrado.md).
        Três coisas que ele guarda e a query crua não: **(a)** sem tick posterior ao corte ⇒ **exit 2**,
        nunca 1; **(b)** o veredito sai do **tick MAIS RECENTE** — um tick gravado entre o merge e o
        deploy ecoa o marcador velho com toda a razão, é história, e julgar por ele reprova deploy
@@ -448,7 +458,7 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        vazio sem erro), caso em que "0 ticks" se leria como *indeterminado* em vez de *recusa* — e é
        só nele que o ping tem dente, porque com a via totalmente morta o guard da contagem já recusa
        sozinho (a 1ª sabotagem escrita saiu inócua por isso, e o eval registra o porquê).
-       Rede: `evals/verify-edge-eco-eval.sh` — 8 casos + 3 sabotagens, no gate `evals/run.sh`.
+       Rede: `evals/verify-edge-eco-eval.sh` — 12 casos + 4 sabotagens, no gate `evals/run.sh`.
     - ⛔ **Dois sinais que PARECEM discriminar deploy e NÃO discriminam** — os dois foram testados neste
       mesmo ciclo e reprovados (narrativa em `docs/historico/verificar-sonda-versao.md` §12):
       **(a) duração da execução** (`acoes_execucoes`) — o run pós-mudança caiu para 24,0 s contra a faixa
@@ -644,6 +654,8 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   a verificação com um pedido caro ao founder). Virou `scripts/verify-edge-eco.sh`: sem tick posterior
   ao corte ⇒ **exit 2 INDETERMINADO**, nunca 1; veredito pelo **tick mais recente** (o intermediário
   entre merge e deploy é história); fail-closed inclusive na via presente-porém-quebrada. Rede:
-  `evals/verify-edge-eco-eval.sh` (8 casos + 3 sabotagens) no gate. A falsificação pagou: a sabotagem
-  do ping saiu **inócua** e revelou que ele só tem dente contra a via MUDA, não contra a morta.
+  `evals/verify-edge-eco-eval.sh` (12 casos + 4 sabotagens) no gate. A falsificação pagou DUAS vezes:
+  a sabotagem do ping saiu **inócua** e revelou que ele só tem dente contra a via MUDA (não contra a
+  morta, onde a contagem já recusa); e o `--esperado` único — que o script aceitava — reprovaria a
+  `nfes` (v1.2) como bundle velho num lote v1.1, então **valor único agora recusa** com >1 step útil.
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/evals/run.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/run.sh
@@ -2,9 +2,11 @@
 # run.sh — GATE de regressão da skill lovable-deploy-verify. Roda os DOIS evals:
 #   (1) classify        — classificação de diff do Passo 1 (classify.sh vs classify-eval.json)
 #   (2) verify-frontend — enumeração + exit codes do Passo 4 (harness local determinístico)
+#   (3) verify-edge-eco  — guard TEMPORAL do N3 passivo (só ticks pré-merge ⇒ indeterminado)
 # Exit 0 = tudo passou. Exit 1 = alguma divergência.
 # Falsificação (prova que os evals têm dente): --falsify sabota AMBOS e exige vermelho
-#   (classify inverte os esperados; verify-frontend sabota a enumeração). Exit 0 só se pegou tudo.
+#   (classify inverte os esperados; verify-frontend sabota a enumeração; verify-edge-eco arranca
+#   o guard temporal, o fail-closed do ping e o filtro do tick mais recente). Exit 0 só se pegou tudo.
 set -uo pipefail
 cd "$(dirname "$0")" || exit 2
 
@@ -46,6 +48,14 @@ if [ "$FALSIFY" = 1 ]; then
   bash verify-frontend-eval.sh --falsify || rc=1
 else
   bash verify-frontend-eval.sh || rc=1
+fi
+
+echo ""
+echo "== (3) verify-edge-eco — guard temporal do N3 passivo =="
+if [ "$FALSIFY" = 1 ]; then
+  bash verify-edge-eco-eval.sh --falsify || rc=1
+else
+  bash verify-edge-eco-eval.sh || rc=1
 fi
 
 echo ""

--- a/.claude/skills/lovable-deploy-verify/evals/verify-edge-eco-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-edge-eco-eval.sh
@@ -31,7 +31,13 @@ if [[ "$q" == *SONDA_COUNT_ANT* ]]; then echo "3"; exit 0; fi
 if [[ "$q" == *SONDA_COUNT* ]]; then
   case "$CENARIO" in
     sem_tick_posterior|psql_mudo) echo "0" ;;
+    leva_mista) echo "1" ;;
     count_lixo)         echo "isto-nao-e-numero" ;;
+    leva_mista)
+      # o caso REAL do #2079: nfes foi a v1.2 e as outras a v1.1. Marcador único aqui reprovaria
+      # a nfes como "bundle velho" — o falso negativo que o script existe para impedir.
+      echo "62431|ctes|respondido|v1.1-eco-identidade-fonte|omie-sync-ctes-recebidos"
+      echo "62431|nfes|respondido|v1.2-eco-identidade-fonte|omie-sync-nfes-recebidas" ;;
     tick_intermediario) echo "2" ;;
     *)                  echo "1" ;;
   esac
@@ -48,6 +54,11 @@ if [[ "$q" == *SONDA_ROWS* ]]; then
     todos_background)
       echo "62431|nfes|background|-|-"
       echo "62431|pedidos|background|-|-" ;;
+    leva_mista)
+      # o caso REAL do #2079: nfes foi a v1.2 e as outras a v1.1. Marcador único aqui reprovaria
+      # a nfes como "bundle velho" — o falso negativo que o script existe para impedir.
+      echo "62431|ctes|respondido|v1.1-eco-identidade-fonte|omie-sync-ctes-recebidos"
+      echo "62431|nfes|respondido|v1.2-eco-identidade-fonte|omie-sync-nfes-recebidas" ;;
     tick_intermediario)
       # ORDER BY id DESC: o mais RECENTE (62431, novo) vem primeiro; o intermediário (62400,
       # velho) é história — foi gravado entre o merge e o deploy e não pode virar veredito.
@@ -61,10 +72,10 @@ FAKE
 chmod +x "$TMP/psql-fake"
 
 rc=0
-caso() { # nome cenario exit_esperado descricao
-  local nome="$1" cen="$2" esp="$3" desc="$4" got
+caso() { # nome cenario exit_esperado descricao [marcador]
+  local nome="$1" cen="$2" esp="$3" desc="$4" marc="${5:-v1.1-eco-identidade-fonte}" got
   CENARIO="$cen" PSQL_RO="$TMP/psql-fake" bash "$SCRIPT" --desde '2026-08-28 22:32:00+00' \
-    --esperado 'v1.1-eco-identidade-fonte' >"$TMP/out" 2>&1; got=$?
+    --esperado "$marc" >"$TMP/out" 2>&1; got=$?
   if [ "$got" -eq "$esp" ]; then printf '  [ok ] %-22s exit %s — %s\n' "$nome" "$got" "$desc"
   else printf '  [XX ] %-22s exit %s (esperado %s) — %s\n' "$nome" "$got" "$esp" "$desc"; rc=1; fi
 }
@@ -72,12 +83,20 @@ caso() { # nome cenario exit_esperado descricao
 echo "== verify-edge-eco — guard temporal =="
 caso sem_tick_posterior  sem_tick_posterior  2 "TTL só com ticks PRÉ-merge ⇒ INDETERMINADO, nunca 'pendente'"
 caso no_ar               no_ar               0 "marcador esperado num step respondido"
-caso bundle_velho        bundle_velho        1 "marcador VELHO respondido ⇒ deploy realmente pendente"
+caso bundle_velho        bundle_velho        1 "marcador VELHO respondido ⇒ deploy realmente pendente" \
+  'ctes=v1.1-eco-identidade-fonte,vendas=v1.1-eco-identidade-fonte'
 caso todos_background    todos_background    2 "houve tick, mas nenhum corpo coletado ⇒ INDETERMINADO"
 caso tick_intermediario  tick_intermediario  0 "tick velho intermediário é história; veredito é o mais recente"
 caso psql_morto          psql_morto          3 "via de leitura morta ⇒ RECUSA fail-closed, nunca veredito"
 caso count_lixo          count_lixo          3 "contagem não-numérica ⇒ RECUSA (vazio se leria como 'nenhum tick')"
 caso psql_mudo           psql_mudo           3 "via presente-porém-QUEBRADA (responde vazio) ⇒ RECUSA, não 'indeterminado'"
+caso leva_mista_lote     leva_mista          3 "marcador ÚNICO com 2 steps úteis ⇒ RECUSA ('o bump do lote' reprova)"
+caso leva_mista_mapa     leva_mista          0 "mapa por edge: nfes=v1.2 e ctes=v1.1 batem" \
+  'ctes=v1.1-eco-identidade-fonte,nfes=v1.2-eco-identidade-fonte'
+caso leva_mista_incompl  leva_mista          3 "mapa sem a nfes ⇒ RECUSA (comparar contra nada fabrica veredito)" \
+  'ctes=v1.1-eco-identidade-fonte'
+caso leva_mista_por_edge leva_mista          0 "chave do mapa pode ser a EDGE ecoada, não só o step" \
+  'omie-sync-ctes-recebidos=v1.1-eco-identidade-fonte,omie-sync-nfes-recebidas=v1.2-eco-identidade-fonte'
 
 # ── falsificação: sabota o guard EM CÓPIA e exige vermelho ──────────────────────────────────────
 if [ "${1:-}" = "--falsify" ]; then
@@ -122,6 +141,19 @@ if [ "${1:-}" = "--falsify" ]; then
       --desde '2026-08-28 22:32:00+00' --esperado 'v1.1-eco-identidade-fonte' >/dev/null 2>&1; sabrc=$?
     if [ "$sabrc" -ne 0 ]; then echo "  [ok ] veredito por tick qualquer -> o caso VIRA vermelho"; fals=$((fals+1))
     else echo "  [XX ] tick intermediário ignorado mesmo sem o filtro — caso não discrimina"; rc=1; fi
+  fi
+
+  # (4) recusa do "marcador do lote" arrancada: a leva mista voltaria a reprovar a nfes
+  total=$((total+1))
+  # shellcheck disable=SC2016  # literal do script-alvo, não deve expandir aqui
+  sed 's/^  \*) \[ "$N_UTEIS_PRE" -le 1 \].*/  *) : ;;/' "$SCRIPT" > "$TMP/sab4.sh"
+  if ! command grep -qE '^\s+\*\) : ;;$' "$TMP/sab4.sh"; then
+    echo "  [XX ] sabotagem 4 não aplicou"; rc=1
+  else
+    CENARIO=leva_mista PSQL_RO="$TMP/psql-fake" bash "$TMP/sab4.sh" \
+      --desde '2026-08-28 22:32:00+00' --esperado 'v1.1-eco-identidade-fonte' >/dev/null 2>&1; sabrc=$?
+    if [ "$sabrc" -ne 3 ]; then echo "  [ok ] recusa do marcador-de-lote arrancada -> a leva mista VIRA vermelha (exit $sabrc)"; fals=$((fals+1))
+    else echo "  [XX ] lote sabotado e ainda recusou — sabotagem inócua"; rc=1; fi
   fi
 
   echo "  falsificações que pegaram: $fals/$total"

--- a/.claude/skills/lovable-deploy-verify/evals/verify-edge-eco-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-edge-eco-eval.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# verify-edge-eco-eval.sh — rede de regressão do GUARD TEMPORAL (scripts/verify-edge-eco.sh).
+#
+# Determinístico e offline: um `psql` FALSO devolve fixtures por cenário, discriminando as queries
+# pelos marcadores de comentário SQL que o script emite (-- SONDA_PING / _COUNT / _COUNT_ANT / _ROWS).
+#
+# O caso que dá nome ao arquivo é o `sem_tick_posterior`: é a situação real de 2026-08-29 às 23:41Z
+# verificando o #2079 — TTL cheio de ticks, todos ANTERIORES ao merge. Sem guard, o marcador velho
+# deles vira "deploy pendente" e manda redeployar 5 edges money-path à toa.
+set -uo pipefail
+cd "$(dirname "$0")" || exit 2
+SCRIPT="../scripts/verify-edge-eco.sh"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# ── psql falso ──────────────────────────────────────────────────────────────────────────────────
+cat > "$TMP/psql-fake" <<'FAKE'
+#!/usr/bin/env bash
+q=""; prev=""
+for a in "$@"; do [ "$prev" = "-c" ] && q="$a"; prev="$a"; done
+case "${CENARIO:-}" in
+  psql_morto) exit 1 ;;
+esac
+if [[ "$q" == *SONDA_PING* ]]; then
+  # psql_mudo: presente-porém-QUEBRADO — sai 0 e não imprime nada. É o caso que dá dente ao
+  # ping: o guard do COUNT não o pega, porque o COUNT responde "0" normalmente, e "0 ticks"
+  # de uma via quebrada se leria como INDETERMINADO (degradar) em vez de RECUSA (guardar).
+  [ "${CENARIO:-}" = "psql_mudo" ] && exit 0
+  echo "PONG_ECO"; exit 0
+fi
+if [[ "$q" == *SONDA_COUNT_ANT* ]]; then echo "3"; exit 0; fi
+if [[ "$q" == *SONDA_COUNT* ]]; then
+  case "$CENARIO" in
+    sem_tick_posterior|psql_mudo) echo "0" ;;
+    count_lixo)         echo "isto-nao-e-numero" ;;
+    tick_intermediario) echo "2" ;;
+    *)                  echo "1" ;;
+  esac
+  exit 0
+fi
+if [[ "$q" == *SONDA_ROWS* ]]; then
+  case "$CENARIO" in
+    no_ar)
+      echo "62431|ctes|respondido|v1.1-eco-identidade-fonte|omie-sync-ctes-recebidos"
+      echo "62431|nfes|background|-|-" ;;
+    bundle_velho)
+      echo "62431|ctes|respondido|v1.0-eco-versao-passivo|omie-sync-ctes-recebidos"
+      echo "62431|vendas|respondido|v1.0-eco-versao-passivo|omie-sync-vendas-items" ;;
+    todos_background)
+      echo "62431|nfes|background|-|-"
+      echo "62431|pedidos|background|-|-" ;;
+    tick_intermediario)
+      # ORDER BY id DESC: o mais RECENTE (62431, novo) vem primeiro; o intermediário (62400,
+      # velho) é história — foi gravado entre o merge e o deploy e não pode virar veredito.
+      echo "62431|ctes|respondido|v1.1-eco-identidade-fonte|omie-sync-ctes-recebidos"
+      echo "62400|ctes|respondido|v1.0-eco-versao-passivo|omie-sync-ctes-recebidos" ;;
+  esac
+  exit 0
+fi
+exit 0
+FAKE
+chmod +x "$TMP/psql-fake"
+
+rc=0
+caso() { # nome cenario exit_esperado descricao
+  local nome="$1" cen="$2" esp="$3" desc="$4" got
+  CENARIO="$cen" PSQL_RO="$TMP/psql-fake" bash "$SCRIPT" --desde '2026-08-28 22:32:00+00' \
+    --esperado 'v1.1-eco-identidade-fonte' >"$TMP/out" 2>&1; got=$?
+  if [ "$got" -eq "$esp" ]; then printf '  [ok ] %-22s exit %s — %s\n' "$nome" "$got" "$desc"
+  else printf '  [XX ] %-22s exit %s (esperado %s) — %s\n' "$nome" "$got" "$esp" "$desc"; rc=1; fi
+}
+
+echo "== verify-edge-eco — guard temporal =="
+caso sem_tick_posterior  sem_tick_posterior  2 "TTL só com ticks PRÉ-merge ⇒ INDETERMINADO, nunca 'pendente'"
+caso no_ar               no_ar               0 "marcador esperado num step respondido"
+caso bundle_velho        bundle_velho        1 "marcador VELHO respondido ⇒ deploy realmente pendente"
+caso todos_background    todos_background    2 "houve tick, mas nenhum corpo coletado ⇒ INDETERMINADO"
+caso tick_intermediario  tick_intermediario  0 "tick velho intermediário é história; veredito é o mais recente"
+caso psql_morto          psql_morto          3 "via de leitura morta ⇒ RECUSA fail-closed, nunca veredito"
+caso count_lixo          count_lixo          3 "contagem não-numérica ⇒ RECUSA (vazio se leria como 'nenhum tick')"
+caso psql_mudo           psql_mudo           3 "via presente-porém-QUEBRADA (responde vazio) ⇒ RECUSA, não 'indeterminado'"
+
+# ── falsificação: sabota o guard EM CÓPIA e exige vermelho ──────────────────────────────────────
+if [ "${1:-}" = "--falsify" ]; then
+  echo ""
+  echo "== falsificação (sabota o guard, exige vermelho) =="
+  fals=0; total=0
+
+  # (1) guard temporal arrancado: count==0 passa a concluir "pendente" em vez de indeterminado
+  total=$((total+1))
+  sed 's/^  exit 2$/  exit 1/' "$SCRIPT" > "$TMP/sab1.sh"
+  if ! command grep -q '^  exit 1$' "$TMP/sab1.sh"; then
+    echo "  [XX ] sabotagem 1 não aplicou — o eval não estaria testando nada"; rc=1
+  else
+    CENARIO=sem_tick_posterior PSQL_RO="$TMP/psql-fake" bash "$TMP/sab1.sh" \
+      --desde '2026-08-28 22:32:00+00' --esperado 'v1.1-eco-identidade-fonte' >/dev/null 2>&1; sabrc=$?
+    if [ "$sabrc" -ne 2 ]; then echo "  [ok ] guard temporal arrancado -> o caso VIRA vermelho"; fals=$((fals+1))
+    else echo "  [XX ] guard arrancado e o caso seguiu verde — eval CEGO"; rc=1; fi
+  fi
+
+  # (2) fail-closed do ping removido: psql morto deixaria de recusar
+  total=$((total+1))
+  # shellcheck disable=SC2016  # literal do script-alvo, não deve expandir aqui
+  sed 's/\[ "${PING:-0}" -ge 1 \] || recusa/[ 1 -ge 0 ] || recusa/' "$SCRIPT" > "$TMP/sab2.sh"
+  if ! command grep -q '\[ 1 -ge 0 \]' "$TMP/sab2.sh"; then
+    echo "  [XX ] sabotagem 2 não aplicou"; rc=1
+  else
+    # psql_morto NÃO serve aqui: com a via morta o guard do COUNT recusa sozinho e a sabotagem
+    # sai inócua (medido). O ping só é o ÚNICO guard quando a via responde vazio SEM erro.
+    CENARIO=psql_mudo PSQL_RO="$TMP/psql-fake" bash "$TMP/sab2.sh" \
+      --desde '2026-08-28 22:32:00+00' --esperado 'v1.1-eco-identidade-fonte' >/dev/null 2>&1; sabrc=$?
+    if [ "$sabrc" -ne 3 ]; then echo "  [ok ] fail-closed do ping removido -> o caso VIRA vermelho (vira indeterminado)"; fals=$((fals+1))
+    else echo "  [XX ] ping sabotado e ainda recusou — sabotagem inócua"; rc=1; fi
+  fi
+
+  # (3) veredito pelo tick QUALQUER em vez do mais recente: o intermediário volta a reprovar
+  total=$((total+1))
+  sed 's/^ID_VEREDITO=.*/ID_VEREDITO=""/' "$SCRIPT" > "$TMP/sab3.sh"
+  if ! command grep -q '^ID_VEREDITO=""$' "$TMP/sab3.sh"; then
+    echo "  [XX ] sabotagem 3 não aplicou"; rc=1
+  else
+    CENARIO=tick_intermediario PSQL_RO="$TMP/psql-fake" bash "$TMP/sab3.sh" \
+      --desde '2026-08-28 22:32:00+00' --esperado 'v1.1-eco-identidade-fonte' >/dev/null 2>&1; sabrc=$?
+    if [ "$sabrc" -ne 0 ]; then echo "  [ok ] veredito por tick qualquer -> o caso VIRA vermelho"; fals=$((fals+1))
+    else echo "  [XX ] tick intermediário ignorado mesmo sem o filtro — caso não discrimina"; rc=1; fi
+  fi
+
+  echo "  falsificações que pegaram: $fals/$total"
+  [ "$fals" -eq "$total" ] || rc=1
+fi
+
+echo ""
+[ "$rc" -eq 0 ] && echo "✅ verify-edge-eco: OK" || echo "❌ verify-edge-eco: FALHOU"
+exit "$rc"

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# verify-edge-eco.sh — lê o N3 PASSIVO (eco de `versao` no corpo que o cron já gravou em
+# `net._http_response`) COM O GUARD TEMPORAL que faltava.
+#
+# POR QUE ESTE SCRIPT EXISTE (2026-08-29, verificando o #2079)
+# ------------------------------------------------------------
+# O N3 passivo lê respostas dentro do TTL do pg_net (6 h). A skill já registrava o limite no
+# sentido "o run é velho demais e SUMIU ⇒ volta ao N3 ativo" — ausência honesta, que se percebe.
+# O sentido INVERSO não estava coberto e é estritamente pior:
+#
+#     os ticks presentes são todos ANTERIORES ao merge.
+#
+# Aí a query roda com exit 0 e devolve linhas perfeitamente legíveis, com o marcador VELHO — que
+# se lê como "deploy pendente". É falso NEGATIVO com cara de veredito confiante, e o preço é
+# mandar o founder redeployar edge money-path à toa. Verificando o #2079 os três ticks do TTL
+# eram 18:15, 20:15 e 22:15Z contra um merge às 22:32Z: todos pré-merge, todos ecoando o marcador
+# velho, e nenhum deles dizia coisa alguma sobre o deploy. O tick seguinte (00:15Z) provou que a
+# edge JÁ estava no ar.
+#
+# É a família "ausente ≠ zero" na dimensão TEMPO: **anterior ≠ ausência de deploy**. E é o irmão
+# da regra do `background` que a skill já tem — lá a coluna `modo` separa "não subiu" de "não deu
+# tempo de coletar"; aqui a coluna `created` separa "não subiu" de "ainda não foi medido".
+#
+# EXIT CODES (mesma gramática do verify-frontend.sh)
+#   0 = PROVADO NO AR   — ≥1 step respondido com o marcador esperado
+#   1 = PROVADO VELHO   — ≥1 step respondido com marcador != esperado (aí sim, deploy pendente)
+#   2 = INDETERMINADO   — não dá para concluir NADA: nenhum tick posterior ao corte, ou todos os
+#                         steps posteriores vieram `background` (corpo não coletado). NUNCA leia
+#                         isto como "não está no ar".
+#   3 = RECUSA          — uso inválido ou via de leitura não provada (fail-CLOSED)
+set -uo pipefail
+
+PSQL_RO="${PSQL_RO:-$HOME/.config/afiacao/psql-ro}"
+DESDE=""; ESPERADO=""; STEPS=""
+
+recusa() { printf '❌ RECUSA: %s\n' "$1" >&2; exit 3; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --desde)    [ $# -ge 2 ] && [ -n "${2:-}" ] || recusa "--desde exige um timestamp"; DESDE="$2"; shift 2 ;;
+    --esperado) [ $# -ge 2 ] && [ -n "${2:-}" ] || recusa "--esperado exige um marcador"; ESPERADO="$2"; shift 2 ;;
+    --steps)    [ $# -ge 2 ] && [ -n "${2:-}" ] || recusa "--steps exige uma lista"; STEPS="$2"; shift 2 ;;
+    *) recusa "argumento desconhecido '$1'" ;;
+  esac
+done
+
+[ -n "$DESDE" ]    || recusa "falta --desde '<timestamp do merge, UTC>' — sem corte temporal este script não tem como guardar nada"
+[ -n "$ESPERADO" ] || recusa "falta --esperado '<marcador VERSAO da main>'"
+
+# ── fail-CLOSED na via de leitura ───────────────────────────────────────────────────────────────
+# `command -v` não basta: presente-porém-quebrado esvazia o guard igual. Exigimos resposta POSITIVA.
+PING=$("$PSQL_RO" -At -c "SELECT 'PONG_ECO'; -- SONDA_PING" 2>/dev/null | command grep -c '^PONG_ECO$' || true)
+[ "${PING:-0}" -ge 1 ] || recusa "a via de leitura não respondeu POSITIVAMENTE ($PSQL_RO). Sem ela, 'não achei tick' seria ausência de dado se passando por veredito."
+
+FORMA="r.status_code = 200 AND r.content IS NOT NULL AND left(ltrim(r.content),1) = '{' AND (r.content::jsonb) ? 'resultados' AND jsonb_typeof((r.content::jsonb)->'resultados') = 'object'"
+FILTRO_STEPS=""
+[ -n "$STEPS" ] && FILTRO_STEPS=" AND k = ANY (string_to_array('$STEPS', ','))"
+
+# ── O GUARD TEMPORAL ────────────────────────────────────────────────────────────────────────────
+N_POS=$("$PSQL_RO" -At -c "SELECT count(*) FROM net._http_response r WHERE r.created > '$DESDE'::timestamptz AND $FORMA; -- SONDA_COUNT" 2>/dev/null | command grep -E '^[0-9]+$' | head -1)
+[ -n "${N_POS:-}" ] || recusa "a contagem de ticks não devolveu número — leitura inutilizável, e um vazio aqui se leria como 'nenhum tick'."
+
+if [ "$N_POS" -eq 0 ]; then
+  N_ANT=$("$PSQL_RO" -At -c "SELECT count(*) FROM net._http_response r WHERE r.created <= '$DESDE'::timestamptz AND $FORMA; -- SONDA_COUNT_ANT" 2>/dev/null | command grep -E '^[0-9]+$' | head -1)
+  printf '⏳ INDETERMINADO — nenhum tick POSTERIOR a %s dentro do TTL.\n' "$DESDE"
+  printf '   Ticks anteriores na janela: %s. Eles ecoam o bundle de ANTES do corte e NÃO dizem nada\n' "${N_ANT:-?}"
+  printf '   sobre este deploy: ler o marcador velho deles como "deploy pendente" é falso NEGATIVO.\n'
+  printf '   Espere o próximo tick do cron, ou caia no N3 ATIVO (sonda gated).\n'
+  exit 2
+fi
+
+# O veredito sai do tick MAIS RECENTE com step utilizável — nunca de um tick intermediário.
+# O deploy pode ter acontecido DEPOIS do merge: um tick entre os dois ecoa o marcador velho com
+# toda a razão, e é história, não veredito. Julgar por ele reprova deploy correto.
+LINHAS=$("$PSQL_RO" -At -F '|' -c "SELECT r.id, k, coalesce((r.content::jsonb)->'resultados'->k->>'modo','-'), coalesce((r.content::jsonb)->'resultados'->k->'body'->>'versao','-'), coalesce((r.content::jsonb)->'resultados'->k->'body'->>'edge','-') FROM net._http_response r, jsonb_object_keys((r.content::jsonb)->'resultados') k WHERE r.created > '$DESDE'::timestamptz AND $FORMA$FILTRO_STEPS ORDER BY r.id DESC, k; -- SONDA_ROWS" 2>/dev/null | command grep -v '^SET$')
+
+# id do tick mais recente que traz ao menos um step respondido com marcador
+ID_VEREDITO=$(printf '%s\n' "$LINHAS" | awk -F'|' '$3=="respondido" && $4!="-" && $4!="" {print $1; exit}')
+
+UTEIS=0; NOVOS=0; VELHOS=0; MUDOS=0
+while IFS='|' read -r tid step modo versao edge; do
+  [ -z "${step:-}" ] && continue
+  # fora do tick do veredito = história; só conta se ainda não há veredito (aí tudo é mudo)
+  [ -n "${ID_VEREDITO:-}" ] && [ "$tid" != "$ID_VEREDITO" ] && continue
+  if [ "$modo" = "respondido" ] && [ "$versao" != "-" ] && [ -n "$versao" ]; then
+    UTEIS=$((UTEIS+1))
+    if [ "$versao" = "$ESPERADO" ]; then
+      NOVOS=$((NOVOS+1)); printf '  ✅ %-16s %s  (edge ecoada: %s)\n' "$step" "$versao" "$edge"
+    else
+      VELHOS=$((VELHOS+1)); printf '  ❌ %-16s %s  ← marcador VELHO (esperado %s)\n' "$step" "$versao" "$ESPERADO"
+    fi
+  else
+    MUDOS=$((MUDOS+1)); printf '  ⏳ %-16s modo=%s — corpo NÃO coletado: linha inutilizável, não é "não subiu"\n' "$step" "$modo"
+  fi
+done <<< "$LINHAS"
+
+printf '\n  ticks posteriores ao corte: %s · tick do veredito: %s · steps úteis: %s (novos %s / velhos %s) · mudos: %s\n' "$N_POS" "${ID_VEREDITO:-nenhum}" "$UTEIS" "$NOVOS" "$VELHOS" "$MUDOS"
+
+if [ "$UTEIS" -eq 0 ]; then
+  # shellcheck disable=SC2016  # crases são texto citado, não expansão
+  printf '⏳ INDETERMINADO — houve tick posterior, mas TODO step veio `background`/sem corpo.\n'
+  # shellcheck disable=SC2016  # crases são texto citado, não expansão
+  printf '   O vazio do `background` é byte a byte o vazio do bundle pré-sensor; só `modo` os separa,\n'
+  printf '   e ele diz que é o primeiro. Acumule ticks antes de pagar a sonda ativa.\n'
+  exit 2
+fi
+if [ "$VELHOS" -gt 0 ]; then
+  printf '❌ BUNDLE VELHO provado em %s step(s) respondido(s) — deploy REALMENTE pendente.\n' "$VELHOS"
+  exit 1
+fi
+printf '✅ NO AR — %s step(s) respondido(s) ecoando o marcador esperado (%s).\n' "$NOVOS" "$ESPERADO"
+exit 0

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-edge-eco.sh
@@ -47,6 +47,28 @@ done
 [ -n "$DESDE" ]    || recusa "falta --desde '<timestamp do merge, UTC>' — sem corte temporal este script não tem como guardar nada"
 [ -n "$ESPERADO" ] || recusa "falta --esperado '<marcador VERSAO da main>'"
 
+# ── O marcador esperado é POR EDGE, nunca "o do lote" ───────────────────────────────────────────
+# Edges de uma mesma leva partem de marcadores DIFERENTES: no #2079 quatro foram a
+# v1.1-eco-identidade-fonte e a `nfes` a v1.2 (ela vinha de v1.1-deadline-relogio). Um `--esperado`
+# único aplicado a vários steps classificaria a `nfes` como bundle VELHO — o falso negativo que
+# este script existe para impedir, cometido pelo próprio script. Ver o adendo "o marcador esperado
+# é POR EDGE, não 'o bump do lote'" em docs/historico/verificabilidade-do-conjunto-orquestrado.md.
+# Forma canônica: --esperado 'ctes=v1.1-eco-identidade-fonte,nfes=v1.2-eco-identidade-fonte'
+# (a chave casa o STEP do orquestrador ou a EDGE ecoada). Valor único só é aceito para UM step.
+esperado_de() { # $1=step  $2=edge ecoada
+  local par k v
+  case "$ESPERADO" in
+    *=*)
+      local IFS=','
+      for par in $ESPERADO; do
+        k="${par%%=*}"; v="${par#*=}"
+        if [ "$k" = "$1" ] || [ "$k" = "$2" ]; then printf '%s' "$v"; return 0; fi
+      done
+      return 1 ;;
+    *) printf '%s' "$ESPERADO"; return 0 ;;
+  esac
+}
+
 # ── fail-CLOSED na via de leitura ───────────────────────────────────────────────────────────────
 # `command -v` não basta: presente-porém-quebrado esvazia o guard igual. Exigimos resposta POSITIVA.
 PING=$("$PSQL_RO" -At -c "SELECT 'PONG_ECO'; -- SONDA_PING" 2>/dev/null | command grep -c '^PONG_ECO$' || true)
@@ -77,6 +99,14 @@ LINHAS=$("$PSQL_RO" -At -F '|' -c "SELECT r.id, k, coalesce((r.content::jsonb)->
 # id do tick mais recente que traz ao menos um step respondido com marcador
 ID_VEREDITO=$(printf '%s\n' "$LINHAS" | awk -F'|' '$3=="respondido" && $4!="-" && $4!="" {print $1; exit}')
 
+# 1ª passada: quantos steps ÚTEIS o tick do veredito traz — decide se o marcador único é legítimo
+N_UTEIS_PRE=$(printf '%s\n' "$LINHAS" | awk -F'|' -v id="${ID_VEREDITO:-}" \
+  '$1==id && $3=="respondido" && $4!="-" && $4!="" {n++} END {print n+0}')
+case "$ESPERADO" in
+  *=*) : ;;
+  *) [ "$N_UTEIS_PRE" -le 1 ] || recusa "--esperado veio como marcador ÚNICO, mas o tick traz $N_UTEIS_PRE steps úteis. Edges de uma mesma leva partem de marcadores DIFERENTES (no #2079 a nfes foi a v1.2 e as outras a v1.1): um valor único aqui classificaria a divergente como bundle VELHO — o falso negativo que este script existe para impedir. Use o mapa: --esperado 'ctes=v1.1-...,nfes=v1.2-...' (chave = step ou edge), ou restrinja com --steps." ;;
+esac
+
 UTEIS=0; NOVOS=0; VELHOS=0; MUDOS=0
 while IFS='|' read -r tid step modo versao edge; do
   [ -z "${step:-}" ] && continue
@@ -84,10 +114,11 @@ while IFS='|' read -r tid step modo versao edge; do
   [ -n "${ID_VEREDITO:-}" ] && [ "$tid" != "$ID_VEREDITO" ] && continue
   if [ "$modo" = "respondido" ] && [ "$versao" != "-" ] && [ -n "$versao" ]; then
     UTEIS=$((UTEIS+1))
-    if [ "$versao" = "$ESPERADO" ]; then
+    ESP_STEP=$(esperado_de "$step" "$edge") || recusa "o step '$step' (edge '$edge') veio no tick mas não tem marcador em --esperado. Comparar contra nada fabrica veredito: nomeie-o no mapa ou exclua-o com --steps."
+    if [ "$versao" = "$ESP_STEP" ]; then
       NOVOS=$((NOVOS+1)); printf '  ✅ %-16s %s  (edge ecoada: %s)\n' "$step" "$versao" "$edge"
     else
-      VELHOS=$((VELHOS+1)); printf '  ❌ %-16s %s  ← marcador VELHO (esperado %s)\n' "$step" "$versao" "$ESPERADO"
+      VELHOS=$((VELHOS+1)); printf '  ❌ %-16s %s  ← marcador VELHO (esperado %s)\n' "$step" "$versao" "$ESP_STEP"
     fi
   else
     MUDOS=$((MUDOS+1)); printf '  ⏳ %-16s modo=%s — corpo NÃO coletado: linha inutilizável, não é "não subiu"\n' "$step" "$modo"
@@ -108,5 +139,5 @@ if [ "$VELHOS" -gt 0 ]; then
   printf '❌ BUNDLE VELHO provado em %s step(s) respondido(s) — deploy REALMENTE pendente.\n' "$VELHOS"
   exit 1
 fi
-printf '✅ NO AR — %s step(s) respondido(s) ecoando o marcador esperado (%s).\n' "$NOVOS" "$ESPERADO"
+printf '✅ NO AR — %s step(s) respondido(s) ecoando o marcador esperado de CADA edge.\n' "$NOVOS"
 exit 0


### PR DESCRIPTION
## O furo

Verificando o [#2079](https://github.com/LucasSardenbergL/afiacao/pull/2079) (5 edges do `omie-cron-diario`, merge às 22:32Z), a leitura do N3 passivo às **23:41Z** devolveu — com `exit 0` e seis linhas perfeitamente legíveis — o marcador **velho** `v1.0-eco-versao-passivo`:

| tick | ctes | sku_items | vendas |
|---|---|---|---|
| 18:15Z | v1.0 | v1.0 | v1.0 |
| 20:15Z | v1.0 | v1.0 | v1.0 |
| 22:15Z | v1.0 | v1.0 | v1.0 |

Lido como veredito, isso manda o founder redeployar **5 edges money-path** à toa. Mas os três ticks eram **todos anteriores ao merge** — não diziam nada sobre este deploy. O tick seguinte (**00:15Z**) veio `v1.1-eco-identidade-fonte` com o `fonte` idêntico ao da main: as edges **já estavam no ar** desde antes.

A skill cobria o TTL de 6 h só no sentido *"o run é velho demais e **sumiu** ⇒ N3 ativo"* — ausência honesta, que se percebe. O inverso não se percebe, e é pior: dado **presente**, **legível**, e obsoleto por construção.

É `ausente ≠ zero` na dimensão **tempo**: **anterior ≠ ausência de deploy**. Irmão da regra do `background` que a skill já tem — lá a coluna `modo` separa "não subiu" de "não deu tempo de coletar"; aqui a coluna `created` separa "não subiu" de "**ainda não foi medido**".

## A correção

Vira **script, não recado** — recado depende de alguém lembrar, que é exatamente como a armadilha da sentinela não-exclusiva passou.

```bash
scripts/verify-edge-eco.sh --desde '<merge, UTC>' --esperado '<VERSAO da main>' [--steps 'ctes,nfes']
# 0 = NO AR · 1 = bundle VELHO provado (aí sim pendente) · 2 = INDETERMINADO · 3 = RECUSA
```

Três coisas que ele guarda e a query crua não:

- **(a)** sem tick posterior ao corte ⇒ **exit 2**, nunca 1;
- **(b)** o veredito sai do **tick mais recente** — um tick gravado *entre* o merge e o deploy ecoa o marcador velho com toda a razão, é história, e julgar por ele reprova deploy correto;
- **(c)** **fail-closed** na via de leitura, inclusive presente-porém-**quebrada** (responde vazio sem erro), onde "0 ticks" se leria como *indeterminado* em vez de *recusa*.

## A falsificação pagou o próprio custo

A sabotagem do ping saiu **inócua** — e o motivo é o achado: com a via totalmente morta, o guard da contagem já recusa sozinho, então o ping só tem dente contra a via **muda**. O eval passou a modelar esse cenário em vez de esconder a redundância.

## Verde

- gate completo com `--falsify`: **8/8 + 13/13 + 3/3**
- `shellcheck` limpo · `docs:citacoes` · `docs:indice` · `docs:links`
- exercitado contra o **banco real** nos 3 cenários (corte no merge → 0; corte no futuro → 2; corte antigo → 0 pelo tick mais recente) e nas 4 recusas
- rede: `evals/verify-edge-eco-eval.sh` (8 casos + 3 sabotagens) plugado em `evals/run.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 📌 Pendência levantada no `/fecho` desta sessão (destino durável do chip)

O ritual de fecho detectou uma **edge de terceiro** mergeada na janela desta sessão, ainda **sem confirmação de deploy**. Chip aberto: **"Confirmar deploy da edge elevenlabs-transcribe"**. Como chip é destino perecível (morre com a sessão), o prompt fica registrado aqui.

**Commit** `a8c3e0c47` — *fix(seguranca): `elevenlabs-transcribe` era a ÚNICA edge de IA paga aberta a qualquer JWT* — mergeou em 2026-08-29 ~00:17Z tocando `supabase/functions/elevenlabs-transcribe/index.ts`. Merge não deploya edge neste repo.

**Por que importa:** antes da correção, qualquer conta com JWT válido — inclusive customer com `is_approved=false`, barrado em toda a UI — podia esgotar o orçamento de IA da organização repetindo áudios de até 10 MB. Enquanto a edge não subir, o buraco segue aberto.

**Estado medido em 2026-08-29 01:10Z:**
- N1 (existência): ✅ servida — mas N1 **não** prova versão.
- Migration irmã do mesmo commit (`20260828210014_ia_uso_limite_elevenlabs_transcribe.sql`): ✅ **aplicada** (`ia_uso_limite` tem `elevenlabs-transcribe` com 60/300). Isso prova que o SQL foi colado, **não** que a edge subiu — camadas independentes.
- Versão da edge: **não provada**. O gate de cota roda depois da validação de JWT, então o sensor exige chamada autenticada (ver `docs/historico/fail-closed-como-sensor-de-deploy.md`).

**Confirmar antes de pedir.** Se não estiver no ar, o pedido para o chat do Lovable:

> Edit the edge function `elevenlabs-transcribe` and update it from the `main` branch using the current contents of `supabase/functions/elevenlabs-transcribe/index.ts`. Deploy it **verbatim** — do NOT modify, reinterpret, "improve", or reformat the code. After deploying, confirm it shows **Active**.

O commit tocou **um** arquivo de código; `_shared/ia-cota.ts` já existia na main (usado por `identify-tool`/`copilot-analyze`/`analyze-services`), então a função boota sem ele no pedido.
