### PR TITLE
feat(authz): cap_carteira_escrever vira master-only — a 2ª opinião derrubou a versão anterior [money-path]

### DIFF
--- a/db/test-cap-carteira-escrever-master-only.sh
+++ b/db/test-cap-carteira-escrever-master-only.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PGVER=17
 PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
 PORT="${PGPORT_TEST:-5473}"     # mude se rodar em paralelo com outro harness (40 worktrees)
-SLUG="separar-cap-carteira-escrever"
+SLUG="cap-carteira-escrever-master-only"
 DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
 export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
 
@@ -150,7 +150,7 @@ SQL
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 2 — APLICAR A MIGRATION REAL (Lei #1: o .sql commitado, não um stub)
 # ══════════════════════════════════════════════════════════════════════════════
-MIG="$REPO_ROOT/supabase/migrations/20260828210836_separar_cap_carteira_escrever.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260828213000_cap_carteira_escrever_master_only.sql"
 P -q -f "$MIG"
 echo "migration aplicada: $(basename "$MIG")"
 
@@ -205,10 +205,13 @@ eq "A1 estrategico LÊ"                "$(ler  $UE)" "true"
 eq "A2 estrategico NÃO ESCREVE  ← a separação" "$(escr $UE)" "false"
 
 # ── quem não pode perder nada ──
-eq "A3 gerencial lê"     "$(ler  $UM)" "true"
-eq "A4 gerencial escreve" "$(escr $UM)" "true"
-eq "A5 super_admin lê"     "$(ler  $US)" "true"
-eq "A6 super_admin escreve" "$(escr $US)" "true"
+# master-only: os papéis COMERCIAIS leem e NÃO escrevem. Não é regressão de acesso — nenhum
+# usuário em prod tem estes papéis (medido: commercial_roles = farmer×2 + master×1), então o
+# acesso EFETIVO não muda. O que muda é o que a função DIZ quando o papel existir.
+eq "A3 gerencial lê"          "$(ler  $UM)" "true"
+eq "A4 gerencial NÃO escreve" "$(escr $UM)" "false"
+eq "A5 super_admin lê"          "$(ler  $US)" "true"
+eq "A6 super_admin NÃO escreve" "$(escr $US)" "false"
 eq "A7 master lê"     "$(ler  $UM2)" "true"
 eq "A8 master escreve" "$(escr $UM2)" "true"
 
@@ -232,6 +235,10 @@ ESCMD5=$(Pq -c "SELECT md5(regexp_replace(btrim(prosrc),'\s+',' ','g')) FROM pg_
                 WHERE n.nspname='private' AND p.proname='cap_carteira_escrever';")
 if [ "$ESCMD5" != "836e8f46f863eefd75b3b46a49eba81a" ]; then ok "A15 escrever DIVERGIU da leitura (era o mesmo md5)"
 else bad "A15 escrever ainda tem o md5 da leitura — a migration não separou nada"; fi
+# O corpo novo é BYTE-A-BYTE o do trio `cap_compras_ler`/`cap_preco_escrever`/`cap_credito_escrever`
+# (md5 5faf2a21…, documentado no contrato). Texto equivalente-porém-diferente criaria um QUARTO
+# md5 para a mesma regra — ruído no eixo 3. Este assert é o que garante a cópia fiel.
+eq "A15b escrever colapsou no md5 do trio master-only" "$ESCMD5" "5faf2a21a46209aaf0ffa75041af6b4b"
 
 # ── metadados que a policy depende: perdê-los quebra a autorização por BAIXO ──
 META=$(Pq -c "SELECT p.prosecdef::text||'|'||coalesce(array_to_string(p.proconfig,','),'') FROM pg_proc p
@@ -262,7 +269,10 @@ eq "A18 anon NÃO executa (PUBLIC segue revogado)" \
 echo "── falsificação (sabota → exige VERMELHO → restaura) ──"
 falsificou() { if [ "$1" = "$2" ]; then bad "F$3 sabotagem NÃO foi pega — o assert é teatro"; else ok "F$3 $4"; fi; }
 
-# F1 — devolve `estrategico` à lista: o assert A2 (a separação) TEM de mudar de valor.
+# F1 — devolve o corpo ANTIGO (o ramo inteiro do commercial_role, idêntico ao da leitura): os
+# asserts da assimetria TÊM de mudar de valor. Sabota-se o estado de ORIGEM, não um estado
+# inventado — é a única sabotagem que reproduz a regressão real (alguém recolar a versão velha no
+# SQL Editor, que é como este banco é operado).
 P -q -c "CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(_uid uuid)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS \$f\$
   SELECT COALESCE(_uid IS NOT NULL AND (public.has_role(_uid,'master'::public.app_role)
@@ -270,7 +280,8 @@ P -q -c "CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(_uid uuid)
       SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
         AND cr.commercial_role IN ('gerencial','estrategico','super_admin')))), false);
 \$f\$;"
-falsificou "$(escr $UE)" "false" 1 "reincluir 'estrategico' faz o estrategico ESCREVER de novo"
+falsificou "$(escr $UE)" "false" 1 "corpo antigo de volta faz o estrategico ESCREVER de novo"
+falsificou "$(escr $UM)" "false" "1b" "corpo antigo de volta faz o gerencial ESCREVER de novo"
 P -q -f "$MIG" >/dev/null   # restaura a versão verdadeira
 
 # F2 — o jeito ERRADO de aplicar: DROP + CREATE. O corpo fica igual (A2 segue verde!), e o que
@@ -283,7 +294,7 @@ P -q -c "DROP FUNCTION private.cap_carteira_escrever(uuid);
       SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
         AND cr.commercial_role IN ('gerencial','super_admin')))), false);
 \$f\$;"
-eq "F2a controle: o COMPORTAMENTO não muda com DROP+CREATE" "$(escr $UE)" "false"
+eq "F2a controle: o COMPORTAMENTO (para estrategico) não muda com DROP+CREATE" "$(escr $UE)" "false"
 falsificou "$(Pq -c "SELECT has_function_privilege('anon','private.cap_carteira_escrever(uuid)','EXECUTE')::text;")" \
            "false" 2 "DROP+CREATE reseta o ACL e ABRE a função para anon/PUBLIC"
 # restaura o estado verdadeiro: ACL de prod + corpo da migration

--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -700,3 +700,49 @@ funcao`: os três predicados entram como chamada DIRETA, não pelo fecho.
 movem — a tabela continua no grafo. O que muda é o número **derivado**, e ele mudou sozinho:
 `7 curada(s), 71 lacuna(s)` contra `6 / 72`. É a prova de que a decisão do §7.2 (declarar o total,
 derivar a lacuna) faz o que prometeu.
+
+### 11.1 A 2ª opinião derrubou a escolha — e o motivo é reutilizável
+
+A separação do §11 removia **apenas** `estrategico` da capability de escrita. O ritual `/codex`
+(xhigh, conduzido sem o founder copiar/colar) derrubou isso com um argumento que se sustenta:
+
+> "Você provou a mecânica, não a regra de negócio. Remover somente `estrategico`, deixando
+> `gerencial` e `super_admin`, parece taxonomia inferida pelo nome, não política confirmada. O
+> teste vermelho ao reinseri-lo apenas congela essa suposição."
+
+Está certo, e o remédio dele é melhor: **`master`-only** reproduz o acesso **efetivo medido** (nenhum
+usuário possui os três papéis) e falha **fechado** para todo papel ainda não decidido. Se as duas
+opções são invenção, ganha a que **preserva comportamento por construção**.
+
+> **Lição:** *um teste que fica vermelho quando você desfaz a sua escolha prova que a escolha está
+> implementada, não que ela está certa.* Falsificação mede o **dente do assert**, nunca a
+> **correção da regra** — para essa, o oráculo é outro (revisão independente, ou o dado que
+> mostraria a política real).
+
+O custo foi pago com os olhos abertos e está no cabeçalho da migration:
+`20260718190000_authz_capability_matrix_e2.sql` **registrou** a intenção de que os três papéis
+tivessem carteira. `master`-only **descarta uma decisão registrada** — não apenas evita inventar
+uma. A troca: em autorização, o dia em que existir um `gerencial` de verdade é um dia melhor para
+decidir do que hoje, e nesse dia a negação é visível.
+
+O corpo novo foi copiado **byte-a-byte** de `private.cap_compras_ler`, e o harness trava isso
+(`A15b`): o md5 tem de colapsar em `5faf2a21…`, o trio que o contrato já documenta. Texto
+equivalente-porém-diferente criaria um **quarto md5 para a mesma regra** — ruído puro no eixo 3.
+
+#### Onde a 2ª opinião errou, por falta de contexto do repo — e o furo que apareceu ao verificar
+
+O Codex propôs, para a janela entre merge e apply, um contrato com `accepted = {antigo, novo}`.
+Não cabe: o contrato deste repo significa **"estado medido em prod"**, e mover o md5 antes do apply
+deixaria o gate do carimbo vermelho em **todo PR do repo**, não só no da mudança.
+
+Mas a preocupação tinha fundo, e verificá-la achou um buraco de verdade:
+
+> `docs/migrations-audit.md` registra esta migration como o objeto `function
+> private.cap_carteira_escrever` e a checa por **EXISTÊNCIA**. A função existe desde julho. Logo o
+> audit devolve ✅ **com ou sem o apply** — falso verde para **todo `CREATE OR REPLACE` de objeto
+> já existente**.
+
+É a mesma classe do arquivo inteiro, no mecanismo que existe justamente para pegar "mergeou e
+ninguém aplicou": **existência fazendo as vezes de estado**. Fica registrado como pendência com o
+formato da correção já claro — para objeto recriado, o inventário precisa guardar o md5 do corpo
+ESPERADO, não só o nome.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **496** custom migrations totais
-- **1712** objetos esperados (criados por estas migrations)
+- **497** custom migrations totais
+- **1713** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 514
+  - `function`: 515
   - `rls_policy`: 453
   - `index`: 250
   - `cron_job`: 168
@@ -4161,6 +4161,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ### `20260828210836_separar_cap_carteira_escrever.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `private.cap_carteira_escrever` | — |
+
+### `20260828213000_cap_carteira_escrever_master_only.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 496
+-- Total de custom migrations: 497
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -537,7 +537,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260826020000', 'reposicao_param_fila_sensor', '20260826020000_reposicao_param_fila_sensor.sql'),
   ('20260826021000', 'reposicao_cold_start_fusivel_graduacao', '20260826021000_reposicao_cold_start_fusivel_graduacao.sql'),
   ('20260828210014', 'ia_uso_limite_elevenlabs_transcribe', '20260828210014_ia_uso_limite_elevenlabs_transcribe.sql'),
-  ('20260828210836', 'separar_cap_carteira_escrever', '20260828210836_separar_cap_carteira_escrever.sql')
+  ('20260828210836', 'separar_cap_carteira_escrever', '20260828210836_separar_cap_carteira_escrever.sql'),
+  ('20260828213000', 'cap_carteira_escrever_master_only', '20260828213000_cap_carteira_escrever_master_only.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2238,7 +2239,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_param_fila_sensor', 'cron_job', 'cron', 'reposicao-param-fila-sensor', ''),
   ('reposicao_param_fila_sensor', 'rls_policy', 'public', 'staff le fila log', 'reposicao_param_fila_log'),
   ('reposicao_cold_start_fusivel_graduacao', 'function', 'public', 'reposicao_cold_start_parametros', ''),
-  ('separar_cap_carteira_escrever', 'function', 'private', 'cap_carteira_escrever', '')
+  ('separar_cap_carteira_escrever', 'function', 'private', 'cap_carteira_escrever', ''),
+  ('cap_carteira_escrever_master_only', 'function', 'private', 'cap_carteira_escrever', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3987,7 +3989,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_param_fila_sensor', 'cron_job', 'cron', 'reposicao-param-fila-sensor', ''),
   ('reposicao_param_fila_sensor', 'rls_policy', 'public', 'staff le fila log', 'reposicao_param_fila_log'),
   ('reposicao_cold_start_fusivel_graduacao', 'function', 'public', 'reposicao_cold_start_parametros', ''),
-  ('separar_cap_carteira_escrever', 'function', 'private', 'cap_carteira_escrever', '')
+  ('separar_cap_carteira_escrever', 'function', 'private', 'cap_carteira_escrever', ''),
+  ('cap_carteira_escrever_master_only', 'function', 'private', 'cap_carteira_escrever', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260828213000_cap_carteira_escrever_master_only.sql
+++ b/supabase/migrations/20260828213000_cap_carteira_escrever_master_only.sql
@@ -1,0 +1,61 @@
+-- ============================================================================================
+-- cap_carteira_escrever_master_only — a ESCRITA da carteira passa a refletir o acesso EFETIVO.
+-- ============================================================================================
+--
+-- SUPERSEDE `20260828210836_separar_cap_carteira_escrever.sql` (mergeado no #2087 e NUNCA
+-- aplicado). Aquela migration removia apenas `estrategico` da lista de `commercial_role`. A 2ª
+-- opinião (Codex, xhigh) derrubou a escolha com um argumento que se sustenta: aquilo era
+-- TAXONOMIA INFERIDA DO NOME — "estratégico analisa, gerencial opera" é uma política que ninguém
+-- escreveu —, e o teste que a protegia apenas congelava o palpite. Se as duas opções são
+-- invenção, ganha a que PRESERVA COMPORTAMENTO e falha FECHADO.
+--
+-- Colar só ESTA. A anterior é inócua se colada antes (idempotente, e esta a sobrescreve), mas
+-- não precisa.
+--
+-- MUDANÇA: `master OR (employee AND commercial_role IN ('gerencial','estrategico','super_admin'))`
+--          → `master`. O corpo passa a ser BYTE-A-BYTE o de `private.cap_compras_ler` /
+--          `cap_preco_escrever` / `cap_credito_escrever` (o trio de md5 `5faf2a21…` que o contrato
+--          de RLS já documenta) — de propósito: um texto equivalente-porém-diferente criaria um
+--          quarto md5 para a mesma regra, e md5 distinto para regra idêntica é ruído no eixo 3.
+--
+-- ⚠️ POR QUE ISTO NÃO MUDA COMPORTAMENTO NENHUM HOJE — medido, não suposto:
+--   · `public.commercial_roles` tem 3 linhas em prod: `farmer`×2 e `master`×1. NINGUÉM tem
+--     `gerencial`, `estrategico` ou `super_admin`, então o ramo removido nunca concedeu nada.
+--     O acesso EFETIVO de escrita hoje já é `master` e só; esta migration passa a DIZER isso.
+--   · das 15 tabelas gateadas por esta capability, **0** têm GRANT de INSERT/UPDATE/DELETE para
+--     `authenticated` — quem escreve é `service_role` (edge/cron), que BYPASSA RLS.
+--
+-- ⚠️ O QUE ISTO DESCARTA, e é uma perda real: `20260718190000_authz_capability_matrix_e2.sql`
+--    REGISTROU a intenção de que os três papéis comerciais tivessem acesso à carteira. Esta
+--    migration descarta uma decisão registrada, não apenas evita inventar uma. A troca é
+--    deliberada: em autorização, o dia em que existir um `gerencial` de verdade é um dia melhor
+--    para decidir do que hoje — e nesse dia a negação é visível e explícita, não silenciosa.
+--    Reabrir é uma linha: devolver o ramo do `commercial_role` com a lista que for decidida.
+--
+-- ⚠️ O QUE ISTO NÃO TOCA: `private.cap_carteira_ler` fica INTACTA (segue com os três papéis), e
+--    o caminho por LINHA dos vendedores — `private.carteira_visivel_para`, que dá acesso à
+--    carteira própria e à cobertura ativa — também. Nenhum `farmer` perde nada: eles nunca
+--    passaram por esta capability.
+--
+-- 🔴 `CREATE OR REPLACE`, JAMAIS `DROP FUNCTION` + `CREATE`. O ACL em prod é
+--    `postgres=X | authenticated=X | service_role=X` — PUBLIC está REVOGADO. `DROP`+`CREATE`
+--    reseta o ACL para o default do Postgres, que é `EXECUTE` para PUBLIC: falha ABERTA, `anon`
+--    passaria a executar a capability. Provado executando (cenário F2 do harness).
+--
+-- Idempotente: pode ser colada quantas vezes for preciso.
+-- ============================================================================================
+
+CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(_uid uuid)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid, 'master'::public.app_role), false);
+$function$;
+
+COMMENT ON FUNCTION private.cap_carteira_escrever(uuid) IS
+  'Capability de ESCRITA da carteira: master-only. Reflete o acesso EFETIVO medido em '
+  '2026-08-28 (nenhum usuario possui os papeis comerciais que a versao anterior testava) e '
+  'falha FECHADO para todo papel ainda nao decidido. Estritamente mais estreita que '
+  'private.cap_carteira_ler, que segue com gerencial/estrategico/super_admin.';


### PR DESCRIPTION
## Reverte a decisão do [#2087](https://github.com/LucasSardenbergL/afiacao/pull/2087) — que estava mergeado e **nunca aplicado**

O #2087 removia **apenas** `estrategico` da capability de escrita. Conduzi o ritual `/codex`
(xhigh, em background) e ele derrubou a escolha com um argumento que se sustenta:

> "Você provou a mecânica, não a regra de negócio. Remover somente `estrategico`, deixando
> `gerencial` e `super_admin`, parece taxonomia inferida pelo nome, não política confirmada. O
> teste vermelho ao reinseri-lo apenas congela essa suposição."

> **A lição, que vale além deste PR:** *um teste que fica vermelho quando você desfaz a sua escolha
> prova que a escolha está **implementada**, não que ela está **certa**.* Falsificação mede o dente
> do assert, nunca a correção da regra.

## O que passa a valer

`private.cap_carteira_escrever` → **`master`-only**, copiado **byte-a-byte** de
`private.cap_compras_ler`.

Isso **reproduz o acesso efetivo medido** (`commercial_roles` em prod = `farmer`×2 + `master`×1;
ninguém tem `gerencial`/`estrategico`/`super_admin`) e falha **fechado** para todo papel ainda não
decidido. Se as duas opções são invenção, ganha a que preserva comportamento **por construção**.

**Intactas:** `cap_carteira_ler` (segue com os três papéis) e `carteira_visivel_para` (o acesso
linha-a-linha dos vendedores). **Nenhum `farmer` perde nada** — eles nunca passaram por esta
capability. Correção de uma afirmação minha no #2084: eu havia dito que "a autorização de carteira
é `has_role(master)` e mais nada"; `pg_depend` prova referência, não a expressão booleana, e a
policy tem `cap_carteira_ler(uid) OR carteira_visivel_para(...)`.

## O custo, pago de olhos abertos

`20260718190000_authz_capability_matrix_e2.sql` **registrou** a intenção de que os três papéis
comerciais tivessem carteira. Isto **descarta uma decisão registrada** — não apenas evita inventar
uma. Reabrir é uma linha, e no dia em que existir um `gerencial` de verdade a negação é visível e
explícita, em vez de silenciosa.

## Prova — `db/test-cap-carteira-escrever-master-only.sh`: **24 ok / 0 fail**

- **A4/A6** `gerencial` e `super_admin` leem e **não** escrevem · **A7/A8** `master` inalterado
- **A15b** o md5 **colapsa em `5faf2a21…`**, o trio que o contrato já documenta — trava a cópia
  fiel, porque texto equivalente-porém-diferente criaria um **quarto md5 para a mesma regra**
- **F1/F1b** devolvem o corpo **antigo** (a regressão real: recolar a versão velha no SQL Editor)
  e exigem vermelho · **F2** `DROP`+`CREATE` reseta o ACL e **abre** para `anon`

## 🔴 Furo achado ao verificar a 2ª opinião (registrado, não corrigido aqui)

O Codex propôs um contrato de transição (`accepted = {antigo, novo}`) para a janela merge→apply.
Não cabe aqui — o contrato deste repo significa **"estado medido em prod"**, e mover o md5 antes do
apply deixaria o gate do carimbo vermelho em **todo PR do repo**. Mas verificar a preocupação achou
outra coisa:

> `docs/migrations-audit.md` registra esta migration como o objeto `function
> private.cap_carteira_escrever` e a checa por **EXISTÊNCIA**. A função existe desde julho — logo o
> audit dá ✅ **com ou sem o apply**. Falso verde para **todo `CREATE OR REPLACE` de objeto já
> existente**, no mecanismo que existe justamente para pegar "mergeou e ninguém aplicou".

Correção com formato claro (inventário guarda o md5 do corpo esperado, não só o nome), fora do
escopo deste PR.

`bun run test` 7453 passed · shellcheck limpo · `wt:preflight` 🟡 (evolução serial).

## ⚠️ ATENÇÃO: migration manual necessária

**Cole só esta.** A do #2087 é inócua se colada antes (idempotente, e esta a sobrescreve), mas não
precisa.

<details><summary>SQL pra aplicar</summary>

```sql
-- ============================================================================================
-- cap_carteira_escrever_master_only — a ESCRITA da carteira passa a refletir o acesso EFETIVO.
-- ============================================================================================
--
-- SUPERSEDE `20260828210836_separar_cap_carteira_escrever.sql` (mergeado no #2087 e NUNCA
-- aplicado). Aquela migration removia apenas `estrategico` da lista de `commercial_role`. A 2ª
-- opinião (Codex, xhigh) derrubou a escolha com um argumento que se sustenta: aquilo era
-- TAXONOMIA INFERIDA DO NOME — "estratégico analisa, gerencial opera" é uma política que ninguém
-- escreveu —, e o teste que a protegia apenas congelava o palpite. Se as duas opções são
-- invenção, ganha a que PRESERVA COMPORTAMENTO e falha FECHADO.
--
-- Colar só ESTA. A anterior é inócua se colada antes (idempotente, e esta a sobrescreve), mas
-- não precisa.
--
-- MUDANÇA: `master OR (employee AND commercial_role IN ('gerencial','estrategico','super_admin'))`
--          → `master`. O corpo passa a ser BYTE-A-BYTE o de `private.cap_compras_ler` /
--          `cap_preco_escrever` / `cap_credito_escrever` (o trio de md5 `5faf2a21…` que o contrato
--          de RLS já documenta) — de propósito: um texto equivalente-porém-diferente criaria um
--          quarto md5 para a mesma regra, e md5 distinto para regra idêntica é ruído no eixo 3.
--
-- ⚠️ POR QUE ISTO NÃO MUDA COMPORTAMENTO NENHUM HOJE — medido, não suposto:
--   · `public.commercial_roles` tem 3 linhas em prod: `farmer`×2 e `master`×1. NINGUÉM tem
--     `gerencial`, `estrategico` ou `super_admin`, então o ramo removido nunca concedeu nada.
--     O acesso EFETIVO de escrita hoje já é `master` e só; esta migration passa a DIZER isso.
--   · das 15 tabelas gateadas por esta capability, **0** têm GRANT de INSERT/UPDATE/DELETE para
--     `authenticated` — quem escreve é `service_role` (edge/cron), que BYPASSA RLS.
--
-- ⚠️ O QUE ISTO DESCARTA, e é uma perda real: `20260718190000_authz_capability_matrix_e2.sql`
--    REGISTROU a intenção de que os três papéis comerciais tivessem acesso à carteira. Esta
--    migration descarta uma decisão registrada, não apenas evita inventar uma. A troca é
--    deliberada: em autorização, o dia em que existir um `gerencial` de verdade é um dia melhor
--    para decidir do que hoje — e nesse dia a negação é visível e explícita, não silenciosa.
--    Reabrir é uma linha: devolver o ramo do `commercial_role` com a lista que for decidida.
--
-- ⚠️ O QUE ISTO NÃO TOCA: `private.cap_carteira_ler` fica INTACTA (segue com os três papéis), e
--    o caminho por LINHA dos vendedores — `private.carteira_visivel_para`, que dá acesso à
--    carteira própria e à cobertura ativa — também. Nenhum `farmer` perde nada: eles nunca
--    passaram por esta capability.
--
-- 🔴 `CREATE OR REPLACE`, JAMAIS `DROP FUNCTION` + `CREATE`. O ACL em prod é
--    `postgres=X | authenticated=X | service_role=X` — PUBLIC está REVOGADO. `DROP`+`CREATE`
--    reseta o ACL para o default do Postgres, que é `EXECUTE` para PUBLIC: falha ABERTA, `anon`
--    passaria a executar a capability. Provado executando (cenário F2 do harness).
--
-- Idempotente: pode ser colada quantas vezes for preciso.
-- ============================================================================================

CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(_uid uuid)
 RETURNS boolean
 LANGUAGE sql
 STABLE SECURITY DEFINER
 SET search_path TO 'public'
AS $function$
  SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid, 'master'::public.app_role), false);
$function$;

COMMENT ON FUNCTION private.cap_carteira_escrever(uuid) IS
  'Capability de ESCRITA da carteira: master-only. Reflete o acesso EFETIVO medido em '
  '2026-08-28 (nenhum usuario possui os papeis comerciais que a versao anterior testava) e '
  'falha FECHADO para todo papel ainda nao decidido. Estritamente mais estreita que '
  'private.cap_carteira_ler, que segue com gerencial/estrategico/super_admin.';
```
</details>

Validação pós-apply:

```sql
SELECT CASE WHEN EXISTS (
  SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
   WHERE n.nspname = 'private' AND p.proname = 'cap_carteira_escrever'
     AND md5(regexp_replace(btrim(p.prosrc), '\s+', ' ', 'g')) = '5faf2a21a46209aaf0ffa75041af6b4b'
) THEN '✅ cap_carteira_escrever master-only (md5 do trio)'
  ELSE '❌ NÃO aplicada — o corpo não é o esperado' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
