### PR TITLE
feat(sonda): `analytics-outbox-drain` não era sondável — edge fora do mapa SOME do denominador, não reprova

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -167,6 +167,15 @@ FROM r;
 
 ⚠️ **Número de EXEMPLO no `WHERE id =` erra CALADO — é PIOR que o placeholder.** Variante da anterior, mordida 2026-08-23/24 na MESMA verificação, e é a Lei de Ferro #5 (`zero placeholders`) pelo avesso: o `<VALOR>` não substituído falha **ruidoso** — `<nome-da-edge>` deixado na URL rendeu dois `404 {"code":"NOT_FOUND"}` do **gateway** (ids 58965/58966): 2 chamadas perdidas e **zero veredito falso**. Já a "correção" que trocou o marcador por um id PLAUSÍVEL (`WHERE id = 58967`) não falhou — devolveu uma linha REAL de outro emissor. O probe era o **58977** (`{"ok":true,"probe":true,"versao":"v1.0-prompt-invertido-cacheado","edge":"analyze-unified-order"}`, verde); o 58967 era o tick do watchdog de 01:20:00Z, e `{"modo":"watchdog","conciliacao":0,"duracao_ms":193}` projeta `edge NULL, status_code 200, versao NULL` — **byte a byte** a assinatura de bundle pré-sensor. Deploy CORRETO lido como ausente, mesmo desfecho da ⚠️ acima (redeployar edge money-path à toa), e **nada na saída denuncia** que se leu o alvo errado. Não é azar: medido nesta tabela em 2026-08-24, **198 respostas em 355 min — uma nova a cada ~1,8 min, e ZERO delas emitindo `edge`** ⇒ id vizinho é tick alheio por padrão. **Regra: em receita de verificação, o campo que o founder substitui NUNCA carrega valor de EXEMPLO** — deixe-o sintaticamente inválido de propósito (`COLE_AQUI_O_REQUEST_ID` devolve `ERROR: column "cole_aqui_o_request_id" does not exist`, que ecoa a própria instrução), ou leia pelo `edge` do corpo com o guard de zero-linhas acima. Vale para TODA receita, não só esta: `id`, timestamp, ref de projeto, nº de PR. ⚠️ **"Inválido" é a regra do bloco que só LÊ** — no bloco que DISPARA (lote, abaixo) o placeholder é VÁLIDO e a trava real vai no `CASE`: lá o inválido aborta o batch inteiro por rollback, o que protege por ACIDENTE e mata a leitura junto. O eixo não é a sintaxe, é o que o campo errado CUSTA: numa leitura, ler a linha de outro emissor; num disparo, executar o efeito.
 
+⚠️ **Edge NOVA nasce fora do radar, e nenhum gate de sonda reclama.** O universo de `sonda:bump` e
+`sonda:fingerprint` são as edges **instrumentadas**, e o denominador de `pendencias:deploy` sai do
+**mapa commitado** — quem nunca entrou na lista não reprova, some. A `analytics-outbox-drain` (#2035)
+passou assim e o deploy dela só se provou por arqueologia (N1 + uma string de erro que estava no corpo
+por acaso). Ao criar edge com cron próprio, a régua barata é conferir se ela **aparece** em
+`bun run pendencias:deploy`; e se ela é chamada por `net.http_post`, ecoe `versao`/`edge`/`fonte` em
+TODA resposta — o corpo já cai em `net._http_response`, e o N3 passivo sai de graça. →
+`docs/historico/verificar-sonda-versao.md` §14
+
 #### Sondar VÁRIAS edges numa tacada (leva inteira) — e as 3 armadilhas do SQL Editor
 
 Uma leva tem 5–10 edges, e repetir o par disparo/leitura por edge convida ao erro de trocar o `request_id`

--- a/docs/historico/verificar-sonda-versao.md
+++ b/docs/historico/verificar-sonda-versao.md
@@ -767,3 +767,81 @@ cobre, e ele não viaja ali"): lá a canária da `omie-vendas-sync` ecoa `versao
 isso não cobre `_shared/`; aqui a sonda ecoa o `fonte`, e é justamente ele que fecha o degrau. Ao
 projetar uma sonda nova, **o `fonte` não é enfeite ao lado do `versao` — é o único campo que responde
 "a fatia inteira subiu?"**.
+
+---
+
+## 14. Edge fora do mapa não REPROVA — ela some do denominador (2026-08-28)
+
+A `analytics-outbox-drain` (#2035, `d5d79cf11`) nasceu **no mesmo dia** em que este doc já tinha 13
+seções sobre sondar edge, e mesmo assim chegou sem `versao.ts` e fora de `_shared/sonda-fingerprints.ts`.
+O interessante não é a omissão — é que **nenhum dos três gates de sonda reclamou**, e por desenho:
+
+| gate | universo dele | o que ele fez com a edge ausente |
+|---|---|---|
+| `sonda:bump` | as edges **instrumentadas** que a fatia tocou | não a viu: sem `versao.ts` ela não é instrumentada |
+| `sonda:fingerprint` | as edges **instrumentadas** | idem — o mapa e a lista nascem do mesmo `versao.ts` |
+| `sonda:sql <edge>` | a leva que você **pediu** | recusou (exit 1, "Edge não sondável — sem sensor") |
+| `pendencias:deploy` | o **mapa commitado** (`lerMapaCommitado`) | tirou 39 do denominador — a 40ª não existia para ele |
+
+Os quatro estão certos. O buraco é de **classe**: quando o universo de um gate é uma lista derivada de
+um artefato **opt-in**, quem nunca entrou na lista não reprova — desaparece. `cobertura: 39/39` era
+`39/40`, e um denominador que se ajusta sozinho ao que já foi instrumentado **não pode** acusar o que
+falta. É o gêmeo exato do #2089 (`cobertura: 2/39` saindo com o mesmo exit 0 de `39/39`), um degrau
+acima: lá o numerador mentia, aqui o denominador.
+
+O piso que existia — o gate "nenhuma edge que serve o `paginate.ts` fica SEM prova de deploy" — não a
+alcança e **não é furo dele**: ele se declara piso e ancora no consumo de um helper específico, que
+esta edge não importa. Um piso ancorado em helper cobre quem usa o helper; o resto é grafo que ele não
+enxerga (a mesma lição de `enumerar-consumidores-de-helper.md`, §9ª leva).
+
+### O custo real: a verificação do deploy virou arqueologia
+
+Em 2026-08-28 provar que a edge estava no ar exigiu montar o caminho na hora — **N1** (`verify-edge.sh`:
+OPTIONS 200 + controle negativo em 404, que separa "existe" de "qualquer nome responde") somado ao **N3
+passivo** de `net._http_response`, onde o corpo trazia uma string literal exclusiva do `index.ts`.
+
+Funcionou **por acaso**: a edge estava respondendo 500 com uma mensagem distintiva. Isto é a §12 (N3
+passivo pela FORMA do JSON) com a pré-condição da §13.1 satisfeita por sorte e não por desenho — a
+forma só discrimina se o diff **mudar a forma**, e uma fatia futura interna a esta edge (trocar o teto
+do lote, mexer no backoff, mudar a partição) não mudaria campo nenhum. Da segunda vez não teria dado.
+
+### O que a instrumentação trouxe, e por que o ECO aqui é mais barato que nos 5 steps do #2063
+
+A edge entrou no padrão inteiro (`VERSAO`/`EFEITO`/`EDGE`/`FONTE`, `criarRespostaSonda`, sonda logo
+após o `authorizeCronOrStaff` e antes do `createClient`). O que ela acrescenta ao padrão é a via do
+**eco**: os 5 steps do cron diário dependem de o `omie-cron-diario` fazer `JSON.parse` do corpo deles e
+devolvê-lo em `resultados.<key>.body` — a identidade passa pelo **pai**, e a amostra é o tick de 2 h.
+Aqui o cron `analytics-outbox-drain` (`*/5`) faz `net.http_post` **direto na edge**, então o corpo que
+cai em `net._http_response` já é o dela, sem intermediário, com **~72 amostras** dentro da janela de
+~6 h do `pg_net.ttl`. É o N3 passivo mais barato do repo.
+
+Por isso os 5 gates de eco do contrato deixaram de varrer `STEPS_CRON_DIARIO` e passaram a varrer
+`ECOAM_VERSAO`: a propriedade exigida nunca foi "ser step do `omie-cron-diario`" — é **o corpo desta
+edge chegar a `net._http_response`**. Lista extraída, e não um segundo bloco de asserts para a edge
+nova: duas cópias do mesmo gate envelhecem separado, e a que não for mantida é a que deixa de valer.
+
+### O custo de sondar aqui é COMPARATIVO — e é o que a separa da `carteira-rebuild`
+
+Um `{"probe":true}` num bundle pré-sensor desta edge roda `drenar()`: claim de 200 linhas, envio ao
+PostHog, marcação do desfecho (e quarentena no 400/413). Parece caro até se notar que **o cron chama
+esse mesmo caminho, com os mesmos defaults, a cada 5 minutos**: sondar às cegas aqui **adianta um
+tick**, não cria efeito de classe nova. Ou seja, esta edge não entrou pelo critério do efeito — entrou
+pelo da sexta leva, o único que ainda vale sozinho: *barato de chamar* e *possível de verificar* são
+propriedades diferentes, e só o marcador dá a segunda.
+
+### Falsificação (as 5, cada uma nomeando a edge na mensagem)
+
+Gate verde numa edge recém-adicionada é indistinguível de gate que não a varre. As sabotagens, todas
+com vermelho e a edge citada no erro: eco sem `edge`/`fonte`; `EDGE` ≠ nome do diretório; sonda que
+**classifica e não responde** (`console.log` no lugar do `return` — o furo da §9); `FONTE` transcrito à
+mão em vez de derivado de `respostaSonda`; e a entrada removida do mapa (aí quem fica vermelho é o
+`sonda:fingerprint`, "instrumentada mas AUSENTE do mapa"). Script: commitar **antes**, porque o
+`restaurar()` é `git checkout --`.
+
+### Assinatura para varredura futura
+
+O que sobra como pergunta aberta é o denominador: **95 diretórios de edge, 40 instrumentadas**. Não é
+dívida — a maioria é leitura pura, para quem a sonda não resolve problema nenhum (o critério da 3ª
+leva). O que falta é o gate que force a **DECISÃO** no nascimento da edge: instrumentar, ou declarar
+por que não. Enquanto ele não existir, a régua barata é conferir, ao criar edge com cron próprio, se
+ela entra em `bun run pendencias:deploy` — edge que não aparece nem como pendência é edge fora do radar.

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -15,6 +15,7 @@
 export const FONTE_SHA256: Record<string, string> = {
   "ai-ops-agent": "e99f44ce40dc938f4f3d832096151c8ad3c8084baa378f408ad1eb302ea9acfa",
   "algorithm-a-audit": "5154d12e9b869e5c56b33a775a68accc18e2f675466bec50c7132d2f4997a24b",
+  "analytics-outbox-drain": "ba221806ade7ecf143b1c9b91ea99dcf29362dd47de8b2a4756a6b2dee0593bc",
   "analyze-unified-order": "51560d34ee92ebddc17ce8bb949c15ec87ad26ec6b848982372d594323f79171",
   "calculate-scores": "2c908fd2fe753c6d1e4d37998baa25c8999a895837363fa53cdbec408b1db963",
   "carteira-positivacao-snapshot": "5c6e6bfb423e86de7ecfb69e7e4046fbcfd7d378ba814b37f3a03e7ea11a0fab",

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -50,6 +50,7 @@ import * as syncCtes from "../omie-sync-ctes-recebidos/versao.ts";
 import * as syncPedidosCompra from "../omie-sync-pedidos-compra/versao.ts";
 import * as syncSkuItems from "../omie-sync-sku-items/versao.ts";
 import * as syncVendasItems from "../omie-sync-vendas-items/versao.ts";
+import * as outboxDrain from "../analytics-outbox-drain/versao.ts";
 
 /**
  * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
@@ -182,6 +183,16 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   { nome: "omie-sync-ctes-recebidos", mod: syncCtes },
   { nome: "omie-sync-sku-items", mod: syncSkuItems },
   { nome: "omie-sync-vendas-items", mod: syncVendasItems },
+  // Décima primeira leva (2026-08-28): a edge que nasceu DEPOIS do padrão e ficou fora dele. A
+  // `analytics-outbox-drain` (#2035) não tinha `versao.ts` nem entrada no mapa de fingerprints, e o
+  // efeito disso não é reprovar em lugar nenhum — é DESAPARECER: `sonda:sql` recusa por falta de
+  // sensor, e `pendencias:deploy` tira o denominador do mapa commitado, então ela não entrava nem
+  // como pendência. O critério que a traz é o da `carteira-rebuild` invertido: aqui sondar o bundle
+  // pré-sensor é BARATO (o cron `*/5` chama o mesmo caminho com os mesmos defaults, então sondar
+  // adianta um tick), e mesmo assim o deploy era inverificável — em 2026-08-28 ele só se provou por
+  // N1 + uma string literal de erro que estava no corpo por ACASO. Barato de chamar e possível de
+  // verificar seguem sendo propriedades diferentes (sexta leva); só o marcador dá a segunda.
+  { nome: "analytics-outbox-drain", mod: outboxDrain },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
@@ -263,6 +274,12 @@ const FORMA_NORMALIZADA = [
   // grafado caindo no fluxo real é o rebuild completo (lease + ~6909 upserts). Fica FORA de
   // GATE_PROPRIO: o gate dela é `authorizeCronOrStaff`, que já aceita o `x-cron-secret`.
   "carteira-rebuild",
+  // Décima primeira leva: entra na varredura estrutural mesmo sendo a de MENOR custo por disparo
+  // acidental. A FORMA não tem a ver com o preço (o bloco de abertura já dizia isso) — o que se
+  // exige é fail-closed, IO-free e nunca sem auth, e uma edge que nasce hoje nasce nessa forma ou
+  // não nasce. Fica FORA de GATE_PROPRIO: o gate dela é `authorizeCronOrStaff`, que já aceita o
+  // `x-cron-secret` com que o SQL Editor sonda.
+  "analytics-outbox-drain",
 ];
 
 /**
@@ -1099,6 +1116,25 @@ const STEPS_CRON_DIARIO: Array<{ edge: string; key: string }> = [
   { edge: "omie-sync-vendas-items", key: "vendas" },
 ];
 
+/**
+ * TODA edge cuja resposta carrega o marcador, e não só a da sonda — o conjunto que os gates de ECO
+ * abaixo varrem.
+ *
+ * Os 5 steps do cron diário o estrearam, mas a propriedade que os gates exigem não é "ser step do
+ * `omie-cron-diario`": é o corpo desta edge chegar a `net._http_response`, onde se lê PASSIVAMENTE.
+ * A `analytics-outbox-drain` (#2035, instrumentada em 2026-08-28) cumpre isso por uma via mais
+ * curta e mais frequente que a dos steps — o cron dela faz `net.http_post` DIRETO nela a cada 5
+ * minutos, sem orquestrador no meio, então nem a identidade depende da `key` que um pai escolheu.
+ *
+ * Extrair a lista, em vez de dar um gate próprio à edge nova, é o que impede o eco de virar duas
+ * verdades: um segundo bloco de asserts envelheceria separado, e a metade sem teste é a que deixa
+ * de valer.
+ */
+const ECOAM_VERSAO: string[] = [
+  ...STEPS_CRON_DIARIO.map((s) => s.edge),
+  "analytics-outbox-drain",
+];
+
 /** O helper de resposta anexa o marcador a TODO corpo, e não só ao da sonda? */
 function ecoaVersaoEmTodaResposta(codigo: string): boolean {
   // O helper é `function jsonRes(...) { return new Response(JSON.stringify({ ...body, versao: VERSAO }), …) }`.
@@ -1107,14 +1143,19 @@ function ecoaVersaoEmTodaResposta(codigo: string): boolean {
   return /\.\.\.\s*\w+\s*,\s*versao:\s*VERSAO/.test(codigo);
 }
 
-Deno.test("os 5 steps do cron diário ECOAM `versao` em toda resposta, não só na da sonda", () => {
+Deno.test("as edges do ECO carregam `versao` em toda resposta, não só na da sonda", () => {
   // O ponto principal da décima leva, e a metade que dispensa invocação. O `omie-cron-diario` faz
   // `JSON.parse` do corpo de cada step e o devolve inteiro em `resultados.<key>.body`, então o
   // marcador viaja para `net._http_response` no tick de 2h do jobid 52 — prova de deploy sem
   // chamar nada, sem cron secret e sem pagar o efeito caro. Sem este eco sobra só a sonda, e
   // sondar um bundle PRÉ-sensor nestas edges DISPARA o fluxo real (nenhuma roteia por `action`):
   // a única prova barata só serviria DEPOIS do deploy que ela existe para verificar.
-  for (const { edge } of STEPS_CRON_DIARIO) {
+  //
+  // A `analytics-outbox-drain` entrou depois (2026-08-28) por uma via mais curta: o cron dela bate
+  // DIRETO na edge a cada 5 minutos, sem orquestrador, então o corpo daqui já É o que fica em
+  // `net._http_response`. Nela o argumento do custo não vale (sondar adianta um tick do `*/5`) — o
+  // que vale é o outro: sem eco, uma fatia interna à edge não deixa discriminador nenhum.
+  for (const edge of ECOAM_VERSAO) {
     const codigo = codigoDaEdge(edge);
     if (!ecoaVersaoEmTodaResposta(codigo)) {
       throw new Error(
@@ -1161,13 +1202,18 @@ Deno.test("CALIBRAÇÃO: o gate do eco reprova o marcador que só a sonda carreg
   }
 });
 
-Deno.test("décima leva: o corpo do Request é lido UMA vez só", () => {
+Deno.test("edges do ECO: o corpo do Request é lido UMA vez só", () => {
   // Mesmo motivo do gate homônimo da oitava leva: a sonda obrigou o parse a SUBIR para antes do
   // client, e toda leitura que existia depois teve de passar a reusar a variável. Um `req.json()`
-  // a mais reintroduz o bug em SILÊNCIO — nestas quatro ele faria `empresa`/`dias`/`trigger` do
-  // corpo serem ignorados, e o step mudaria de escopo (ou de modo incremental×completo) sem erro
-  // nenhum. É a classe "ausente ≠ zero" na leitura de parâmetro.
-  for (const { edge } of STEPS_CRON_DIARIO) {
+  // a mais reintroduz o bug em SILÊNCIO — nos steps do cron diário ele faria `empresa`/`dias`/
+  // `trigger` do corpo serem ignorados, e o step mudaria de escopo (ou de modo
+  // incremental×completo) sem erro nenhum. É a classe "ausente ≠ zero" na leitura de parâmetro.
+  //
+  // Na `analytics-outbox-drain` o gate é PREVENTIVO e não corretivo: ela não lia o corpo antes da
+  // sonda, então a única leitura é a que a sonda trouxe. É justamente aí que a segunda leitura
+  // entra sem ninguém notar — o primeiro parâmetro que essa edge vier a aceitar (um `p_limite` do
+  // SQL Editor, digamos) nasceria lido de um corpo já consumido, ou seja, vazio.
+  for (const edge of ECOAM_VERSAO) {
     const ocorrencias = trechoDoHandler(edge).match(/req\.json\(\)/g) ?? [];
     if (ocorrencias.length !== 1) {
       throw new Error(
@@ -1208,7 +1254,7 @@ Deno.test("o ECO identifica a edge e a FONTE — `versao` sozinho não diz QUEM 
   // 2. `fonte` — fatia que chegue INTEIRA por `_shared/` não move o `VERSAO` (o `sonda:bump` exclui
   //    `_shared/` por medição), e o eco responderia idêntico nos dois bundles. O `fonte` é derivado
   //    do fecho transitivo e o CI o regrava, então não depende de disciplina.
-  for (const { edge } of STEPS_CRON_DIARIO) {
+  for (const edge of ECOAM_VERSAO) {
     const codigo = codigoDaEdge(edge);
     if (!/\.\.\.\s*\w+\s*,\s*versao:\s*VERSAO\s*,\s*edge:\s*EDGE\s*,\s*fonte:\s*FONTE/.test(codigo)) {
       throw new Error(
@@ -1223,7 +1269,7 @@ Deno.test("o ECO identifica a edge e a FONTE — `versao` sozinho não diz QUEM 
 Deno.test("o EDGE declarado é o nome do diretório da function", () => {
   // Um `EDGE` errado é pior que nenhum: o eco passa a AFIRMAR identidade falsa, e o veredito aponta
   // para a edge errada com toda a confiança.
-  for (const { edge } of STEPS_CRON_DIARIO) {
+  for (const edge of ECOAM_VERSAO) {
     const fonte = Deno.readTextFileSync(`supabase/functions/${edge}/versao.ts`);
     const m = /export const EDGE = "([^"]+)"/.exec(fonte);
     if (!m) throw new Error(`${edge}: versao.ts não exporta EDGE`);
@@ -1237,7 +1283,7 @@ Deno.test("o FONTE do eco sai da MESMA fábrica que a sonda serve", () => {
   // Se o `FONTE` fosse uma cópia literal do hash, ele congelaria: o CI regrava o mapa, e um valor
   // transcrito à mão passaria a mentir silenciosamente na primeira mudança de `_shared/` — que é
   // exatamente o furo que este campo existe para fechar.
-  for (const { edge } of STEPS_CRON_DIARIO) {
+  for (const edge of ECOAM_VERSAO) {
     const fonte = Deno.readTextFileSync(`supabase/functions/${edge}/versao.ts`);
     if (!/export const FONTE = respostaSonda\(VERSAO\)\.fonte;/.test(removerComentarios(fonte))) {
       throw new Error(

--- a/supabase/functions/analytics-outbox-drain/index.ts
+++ b/supabase/functions/analytics-outbox-drain/index.ts
@@ -26,6 +26,15 @@ import {
   resumirErro,
   TETO_EVENTOS_POR_LOTE,
 } from "./payload.ts";
+import {
+  classificarSonda,
+  EDGE,
+  EFEITO,
+  erroSondaAmbigua,
+  FONTE,
+  respostaSonda,
+  VERSAO,
+} from "./versao.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -52,17 +61,35 @@ interface DbRpc {
   ): Promise<{ data: unknown; error: { message: string } | null }>;
 }
 
+// TODA resposta carrega `versao`/`edge`/`fonte` — não só a da sonda. É a metade da prova de deploy
+// que dispensa invocação: o cron `analytics-outbox-drain` faz `net.http_post` DIRETO nesta edge a
+// cada 5 minutos, então o corpo daqui cai em `net._http_response` e o marcador se lê PASSIVAMENTE,
+// sem chamar nada, sem cron secret e sem pagar efeito. Ver versao.ts.
+function jsonRes(corpo: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify({ ...corpo, versao: VERSAO, edge: EDGE, fonte: FONTE }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
 
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;
 
-  const json = (corpo: unknown, status = 200) =>
-    new Response(JSON.stringify(corpo), {
-      status,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+  // ⚠️ SONDA DE VERSÃO — logo após o gate (que já aceita x-cron-secret) e ANTES do createClient, do
+  // claim e de qualquer POST ao PostHog. Esta edge NÃO lia o corpo do request; o parse nasce aqui
+  // já no lugar certo, e o `catch` mantém o caminho do cron (corpo `{}` → fluxo real) intacto.
+  // Ver versao.ts / _shared/sonda-versao.ts.
+  const body = await req.json().catch(() => ({}));
+
+  const decisaoSonda = classificarSonda(body);
+  if (decisaoSonda.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);
+  // Fail-CLOSED: `probe` com valor não reconhecido NUNCA cai no fluxo real por omissão.
+  if (decisaoSonda.tipo === "ambiguo") {
+    return jsonRes({ erro: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
+  }
 
   // ⚠️ Chave ausente é falha de CONFIGURAÇÃO e sai com status de erro. Degradar
   // em silêncio aqui produziria exatamente a leitura envenenada que este
@@ -71,7 +98,7 @@ Deno.serve(async (req) => {
   const ingestKey = Deno.env.get("POSTHOG_INGEST_KEY");
   if (!ingestKey) {
     console.error("[analytics-outbox-drain] POSTHOG_INGEST_KEY ausente — nada foi drenado");
-    return json({ erro: "POSTHOG_INGEST_KEY nao configurado" }, 500);
+    return jsonRes({ erro: "POSTHOG_INGEST_KEY nao configurado" }, 500);
   }
 
   const db = createClient(
@@ -87,12 +114,12 @@ Deno.serve(async (req) => {
       () => drenar(db as unknown as DbRpc, ingestKey),
       (r) => ({ ...r }),
     );
-    return json(resultado);
+    return jsonRes({ ...resultado });
   } catch (e) {
     // mensagemDeErro evita o "[object Object]" que esconde a causa no painel.
     const msg = mensagemDeErro(e) ?? "(sem mensagem)";
     console.error("[analytics-outbox-drain] falhou:", msg);
-    return json({ erro: msg }, 500);
+    return jsonRes({ erro: msg }, 500);
   }
 });
 

--- a/supabase/functions/analytics-outbox-drain/versao.ts
+++ b/supabase/functions/analytics-outbox-drain/versao.ts
@@ -1,0 +1,75 @@
+// Marcador de versão da edge `analytics-outbox-drain`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// POR QUE ELA CHEGOU SEM SENSOR — e o que a omissão custou (medido 2026-08-28): a edge nasceu no
+// #2035 (d5d79cf11) já DEPOIS de o padrão existir, e mesmo assim ficou fora dele. Sem `versao.ts`
+// ela não entra no `sonda:bump`, não entra no mapa de `_shared/sonda-fingerprints.ts`,
+// `bun run sonda:sql analytics-outbox-drain` RECUSA ("Edge não sondável — sem sensor"), e ela some
+// das edges de `bun run pendencias:deploy` — cujo denominador sai do MAPA commitado, então edge
+// fora do mapa não aparece nem como pendência. Não é que ela reprovasse: ela sumia do radar.
+//
+// Verificar o deploy dela exigiu um caminho AD-HOC: N1 (`verify-edge.sh`, OPTIONS 200 + controle
+// negativo em 404) somado ao N3 passivo lendo `net._http_response`, onde o corpo trazia uma string
+// literal exclusiva do `index.ts`. Funcionou por ACASO — a edge respondia 500 com uma mensagem
+// distintiva. É a §12 de `docs/historico/verificar-sonda-versao.md` (N3 passivo pela FORMA do JSON)
+// com a pré-condição dela satisfeita por sorte, não por desenho: a §13.1 já registra que a forma só
+// discrimina se o diff MUDA a forma, e uma fatia futura interna a esta edge não mudaria nada.
+//
+// EFEITO de um `probe` mal grafado num bundle PRÉ-sensor: ele ignora o parâmetro e roda `drenar()`
+// — claim de até `TETO_EVENTOS_POR_LOTE = 200` linhas da `analytics_outbox` (`FOR UPDATE SKIP
+// LOCKED`, com o backoff aplicado NO claim), envio ao PostHog, e marcação do desfecho. Evento
+// entregue não se retira, e o desfecho de rejeição definitiva (400/401/403/413) põe as linhas em
+// QUARENTENA, que PARA de tentar. Ele também grava execução no slug `analytics_outbox.drenar` via
+// `comRegistro`, então a sonda às cegas mente no `<UltimaExecucao>` da tela.
+//
+// ⚠️ A leitura HONESTA desse custo é comparativa, e é ela que define de que lado esta edge cai: o
+// cron `analytics-outbox-drain` (`*/5 * * * *`) chama exatamente este caminho a cada 5 minutos, com
+// os MESMOS defaults. Sondar o bundle velho aqui ADIANTA um tick — não cria efeito de classe nova.
+// Isso a põe ao lado da `omie-analytics-sync` (sondar é barato) e não da `carteira-rebuild`
+// (sondar é catastrófico). O que a sonda resolve nesta edge não é risco de efeito colateral: é a
+// ausência de DISCRIMINADOR — "qual bundle está no ar?" não tinha resposta nenhuma.
+//
+// O gate desta edge é o `authorizeCronOrStaff` de `_shared/auth.ts`, que JÁ aceita `x-cron-secret`:
+// a sonda entra logo APÓS ele, sem gate próprio — daí ela ficar fora de `GATE_PROPRIO` no contrato.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("analytics-outbox-drain");
+
+/** Nome do diretório da function — o `edge` que o ECO carrega. */
+export const EDGE = "analytics-outbox-drain";
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/**
+ * O fingerprint da FONTE, para o ECO carregá-lo também — não só a sonda.
+ *
+ * Derivado de `respostaSonda`, nunca transcrito: o CI regrava o mapa a cada mudança de `_shared/`,
+ * e um hash copiado à mão congelaria e passaria a mentir na primeira fatia que chegasse por lá —
+ * exatamente o furo que este campo existe para fechar.
+ */
+export const FONTE = respostaSonda(VERSAO).fonte;
+
+/**
+ * O ECO em TODA resposta — e por que esta edge o merece ainda mais que as cinco que o estrearam.
+ *
+ * Os 5 steps do `omie-cron-diario` (#2063) ecoam `versao/edge/fonte` porque o ORQUESTRADOR grava o
+ * corpo deles em `net._http_response` no tick de 2h: prova de deploy sem chamar nada, sem cron
+ * secret e sem pagar efeito. Aqui não há orquestrador — o cron `analytics-outbox-drain` faz
+ * `net.http_post` DIRETO nesta edge a cada 5 minutos (`timeout_milliseconds := 55000` explícito),
+ * então o corpo que cai em `net._http_response` é o desta função, sem intermediário e sem depender
+ * da chave que um pai escolheu. Dentro da janela de ~6 h do `pg_net.ttl` sempre há ~72 amostras:
+ * é o N3 passivo mais barato do repo, e é o que garante que a PRÓXIMA fatia desta edge se prove
+ * sozinha, sem repetir a arqueologia ad-hoc de 2026-08-28.
+ */
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge reivindica até 200 linhas da analytics_outbox (FOR UPDATE SKIP LOCKED, backoff " +
+  "aplicado no claim) e as ENVIA ao PostHog — evento entregue não se retira, e a rejeição " +
+  "definitiva (400/401/403/413) põe as linhas em QUARENTENA, que para de tentar; ela também grava " +
+  "execução no slug analytics_outbox.drenar, então um disparo acidental mente no <UltimaExecucao>. " +
+  "O custo é o de ADIANTAR um tick do cron */5, não o de uma operação de classe nova";


### PR DESCRIPTION
A `analytics-outbox-drain` (#2035, `d5d79cf11`) nasceu **no mesmo dia** em que o repo já tinha 13 seções
de doc sobre sondar edge — e chegou sem `versao.ts` e fora de `_shared/sonda-fingerprints.ts`.

O interessante não é a omissão. É que **nenhum gate de sonda reclamou**, e por desenho:

| gate | universo dele | o que fez com a edge ausente |
|---|---|---|
| `sonda:bump` | edges **instrumentadas** que a fatia tocou | não a viu — sem `versao.ts` ela não é instrumentada |
| `sonda:fingerprint` | edges **instrumentadas** | idem; mapa e lista nascem do mesmo `versao.ts` |
| `sonda:sql <edge>` | a leva que você **pediu** | recusou (exit 1, "Edge não sondável — sem sensor") |
| `pendencias:deploy` | o **mapa commitado** | tirou 39 do denominador — a 40ª não existia para ele |

Os quatro estão certos. O buraco é de classe: **universo derivado de artefato opt-in não acusa quem
nunca entrou nele — ele some.** `cobertura: 39/39` era `39/40`. É o gêmeo do #2089 (`2/39` saindo com o
mesmo exit 0 de `39/39`) um degrau acima: lá o numerador mentia, aqui o denominador.

## O custo medido (2026-08-28)

Provar que a edge estava no ar exigiu montar o caminho na hora: **N1** (`verify-edge.sh` — OPTIONS 200 +
controle negativo em 404) mais **N3 passivo** lendo `net._http_response`, onde o corpo trazia uma string
literal exclusiva do `index.ts`. Funcionou **por acaso** — a edge respondia 500 com mensagem distintiva.
É a §12 de `verificar-sonda-versao.md` com a pré-condição da §13.1 satisfeita por sorte: a forma só
discrimina se o diff **mudar a forma**, e uma fatia interna a esta edge (teto do lote, backoff, partição)
não mudaria campo nenhum.

## O que entra

- **`versao.ts`** (novo): `VERSAO`/`EFEITO`/`EDGE`/`FONTE` + `criarRespostaSonda`. A sonda responde logo
  **após** o `authorizeCronOrStaff` (que já aceita `x-cron-secret`, então sem gate próprio) e **antes**
  do `createClient`, do claim e de qualquer POST ao PostHog.
- **O ECO em toda resposta**, não só na da sonda — e aqui ele é mais barato que nos 5 steps do #2063: o
  cron `*/5` faz `net.http_post` **direto** nesta edge, sem orquestrador no meio, então o corpo já é o
  dela e a identidade não depende da `key` que um pai escolheu. ~72 amostras por janela de `pg_net.ttl`.
- **Mapa de fingerprints** regravado: 39 → 40 edges.
- **Contrato**: os 5 gates de eco deixaram de varrer `STEPS_CRON_DIARIO` e varrem `ECOAM_VERSAO`. A
  propriedade exigida nunca foi "ser step do `omie-cron-diario`" — é o corpo chegar a
  `net._http_response`. Lista extraída em vez de bloco novo de asserts: duas cópias do mesmo gate
  envelhecem separado, e a que não for mantida é a que deixa de valer.

## O custo de sondar aqui é COMPARATIVO

Um `{"probe":true}` num bundle pré-sensor roda `drenar()` — claim de 200, envio ao PostHog, marcação
(quarentena no 400/413). Parece caro até se notar que **o cron chama esse mesmo caminho, com os mesmos
defaults, a cada 5 minutos**: sondar às cegas **adianta um tick**, não cria efeito de classe nova. Esta
edge não entrou pelo critério do efeito — entrou pelo da 6ª leva: *barato de chamar* e *possível de
verificar* são propriedades diferentes, e só o marcador dá a segunda.

## Falsificação — 5 sabotagens, 5 vermelhos, cada um nomeando a edge

Gate verde numa edge recém-adicionada é indistinguível de gate que não a varre.

| sabotagem | quem ficou vermelho |
|---|---|
| eco sem `edge`/`fonte` | "o eco não carrega `edge: EDGE, fonte: FONTE` ao lado do `versao`" |
| `EDGE` ≠ nome do diretório | "EDGE declara …" |
| sonda classifica e **não responde** (`console.log` no lugar do `return` — o furo da §9) | "chama respostaSonda mas o corpo não alcança nenhum return" |
| `FONTE` transcrito à mão | "FONTE não é derivado de respostaSonda" |
| entrada removida do mapa | `sonda:fingerprint`: "instrumentada mas AUSENTE do mapa" |

Commitado **antes** de falsificar — o `restaurar()` é `git checkout --`.

## Evidência

```
bun run test:edges          ok | 937 passed | 0 failed (5s)      exit 0
bun run sonda:bump          toda edge alterada bumpou o VERSAO   exit 0
bun run sonda:fingerprint   ✓ 40 edge(s) — mapa bate com a fonte exit 0
bun run sonda:sql analytics-outbox-drain                          exit 0   (recusava com exit 1)
bun run edges:typecheck     ✅ 0 erros de classe-crash            exit 0
deno check <edge>/index.ts  0 erros                               exit 0
```

## Deploy — 3 arquivos, 1 NOVO (Passo 3 da `lovable-deploy-verify`)

Só a camada de **edge** (`classify.sh`: frontend=não · edge=SIM · migration=não). O `versao.ts` é
importado pelo `index.ts` — **um prompt que nomeie só o `index.ts` sobe uma função que não boota**, e
quem descobriria seria a sonda que existe para provar o deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
