### PR TITLE
chore(authz): contrato acompanha cap_carteira_escrever master-only — medido pós-apply [money-path]

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-08-28T23:49:46.372Z",
-  "sourceHead": "6cc3041bbd8a9a5d8e7c3670d9329b40382aaca6",
+  "medidoEm": "2026-08-29T01:13:52.575Z",
+  "sourceHead": "81c9d9e9fdfd2a15571ebfefb3a88949f0b9d703",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -50,7 +50,7 @@
       "exit": 0,
       "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 21 tabela(s) curada(s), 54 policy(ies) e 13 funcao(oes)-predicado batem com o contrato (fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao); 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 7 ",
       "denominador": null,
-      "contratoFingerprint": "8f09f8737e150c53a13d24d49ece9a1144f2657a7d7f97203841467e09300e14",
+      "contratoFingerprint": "983189279bc797985d2ff78f0ee10434d7c6ab7e582d223ff02d0bddd84841b0",
       "auditorFingerprint": "f24bdcecdcf841257b1c817fbeecddf0b47b91ae42c8784d68e110b86a126986",
       "achados": []
     }

--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -746,3 +746,37 @@ Mas a preocupação tinha fundo, e verificá-la achou um buraco de verdade:
 ninguém aplicou": **existência fazendo as vezes de estado**. Fica registrado como pendência com o
 formato da correção já claro — para objeto recriado, o inventário precisa guardar o md5 do corpo
 ESPERADO, não só o nome.
+
+### 11.2 Aplicada — e a medição pós-apply que quase não aconteceu
+
+`20260828213000_cap_carteira_escrever_master_only.sql` foi colada no SQL Editor em 2026-08-29. A
+verificação pediu **cinco** medições, e o valor da rodada está em ter exigido as cinco:
+
+| o que | esperado | medido |
+|---|---|---|
+| `srcMd5` de `cap_carteira_escrever` | `5faf2a21…` (previsto ANTES do apply) | `5faf2a21…` ✅ |
+| `prosecdef` / `proconfig` | `true` / `search_path=public` | idem ✅ |
+| `srcMd5` de `cap_carteira_ler` | `836e8f46…` (intacta) | idem ✅ |
+| `EXECUTE` de `authenticated` | preservado | `true` ✅ |
+| `EXECUTE` de `anon` | negado (PUBLIC segue revogado) | `false` ✅ |
+
+O md5 bater com o que fora **previsto antes** do apply é o que transforma "rodei" em evidência: se
+viesse outro valor, o certo seria parar, não carimbar.
+
+#### A armadilha de leitura que apareceu no meio
+
+As duas últimas linhas **não voltaram** na primeira medição. A saída trouxe três resultados e um
+`ERROR: permission denied for schema private` no fim — e um `grep` pelas linhas que interessavam
+teria mostrado três ✅ e **nenhum sinal do que faltou**.
+
+A causa: `has_function_privilege('anon', 'private.cap_carteira_escrever(uuid)', 'EXECUTE')` resolve
+a função **pela assinatura em texto**, e isso exige `USAGE` no schema — que o `claude_ro` não tem.
+Ler `pg_proc` direto funciona (catálogo é legível); **resolver o nome, não**. A forma por **OID**
+(`has_function_privilege(rol, p.oid, 'EXECUTE')`, com `p` vindo de um join em `pg_proc`) não passa
+por resolução de nome e devolve o dado.
+
+> **Lição:** *a mesma função do Postgres tem sobrecargas com requisitos de permissão diferentes.*
+> Sob um papel read-only deliberadamente estreito, prefira sempre a forma por **OID** — e trate
+> linha que não voltou como **ausência de dado**, nunca como o valor que você esperava. Aqui o
+> `psql` sinalizou com um ERROR; num caso com `LEFT JOIN` ou agregação, o mesmo buraco sairia como
+> `NULL` silencioso.

--- a/scripts/authz-rls-esperado.ts
+++ b/scripts/authz-rls-esperado.ts
@@ -1134,9 +1134,11 @@ export interface PredicadoEsperado {
  * policy em `public`; 11 estão congeladas aqui. ⇒ **Convergência medida sobre uma amostra
  * escolhida por semelhança não é convergência — é o método se ouvindo falar.**
  *
- * ⚠️ `cap_compras_ler`, `cap_credito_escrever` e `cap_preco_escrever` têm o MESMO `srcMd5`
- * (`5faf2a21…`): três capabilities distintas cujo corpo hoje é o mesmo `has_role(master)`. Não é
- * duplicação a limpar — é o estado a congelar, e o dia em que uma divergir é o sinal que se quer.
+ * ⚠️ `cap_compras_ler`, `cap_credito_escrever`, `cap_preco_escrever` e — desde 2026-08-29 —
+ * `cap_carteira_escrever` têm o MESMO `srcMd5` (`5faf2a21…`): QUATRO capabilities distintas cujo
+ * corpo hoje é o mesmo `has_role(master)`. Não é duplicação a limpar — é o estado a congelar, e o
+ * dia em que uma divergir é o sinal que se quer. A quarta entrou por escolha explícita: o corpo
+ * dela foi copiado byte-a-byte do `cap_compras_ler` para NÃO criar um 5º md5 para a mesma regra.
  */
 export const AUTHZ_RLS_PREDICADOS: Record<string, PredicadoEsperado> = {
   'private.cap_carteira_ler': {
@@ -1147,19 +1149,24 @@ export const AUTHZ_RLS_PREDICADOS: Record<string, PredicadoEsperado> = {
       '`master` OU (`employee` E `commercial_roles` em gerencial/estrategico/super_admin) — corpo ' +
       'lido de prod. O predicado de carteira de MAIOR alcance: 22 tabelas (medido por pg_depend), ' +
       'das quais o contrato cura UMA. Congelar o corpo cobre as 22 no eixo 3 sem curar o conteúdo ' +
-      'das outras 21 — o mesmo retorno que `cap_compras_ler` deu na 3ª rodada. ⚠️ Corpo IDÊNTICO ' +
-      'ao de `cap_carteira_escrever`: hoje LER e ESCREVER carteira são a mesma autorização.',
+      'das outras 21 — o mesmo retorno que `cap_compras_ler` deu na 3ª rodada. Até 2026-08-29 o ' +
+      'corpo era IDÊNTICO ao de `cap_carteira_escrever` (LER e ESCREVER eram a mesma autorização); ' +
+      'a migration `20260828213000` estreitou a ESCRITA para `master`-only e deixou ESTA intacta. ' +
+      'Os dois md5 divergem de propósito desde então, e reconvergir é achado.',
   },
   'private.cap_carteira_escrever': {
     secdef: true,
     cfg: 'search_path=public',
-    srcMd5: '836e8f46f863eefd75b3b46a49eba81a',
+    srcMd5: '5faf2a21a46209aaf0ffa75041af6b4b',
     motivo:
-      'Gate de ESCRITA da carteira em 15 tabelas (medido). O `srcMd5` é o MESMO de ' +
-      '`cap_carteira_ler` — não é duplicação a limpar, é o estado a congelar: quem hoje LÊ a ' +
-      'carteira também a ESCREVE, e o dia em que os dois divergirem (ou em que afrouxar a leitura ' +
-      'arrastar a escrita junto) é exatamente o sinal que se quer ver. Perder o SECDEF aqui quebra ' +
-      'a autorização por BAIXO: a policy fica idêntica e passa a negar para todo mundo.',
+      'Gate de ESCRITA da carteira em 15 tabelas (medido). `master`-only desde ' +
+      '`20260828213000_cap_carteira_escrever_master_only` (aplicada 2026-08-29, md5 conferido em ' +
+      'prod). Até então o corpo era o MESMO de `cap_carteira_ler` — quem lia a carteira escrevia —, ' +
+      'e foi o congelamento da 4ª rodada que tornou isso visível. O corpo novo é cópia byte-a-byte ' +
+      'de `cap_compras_ler`, o que faz este md5 ser o do QUARTETO abaixo, de propósito: um texto ' +
+      'equivalente-porém-diferente criaria um md5 distinto para a mesma regra, que é ruído puro ' +
+      'neste eixo. Voltar a coincidir com `cap_carteira_ler` (`836e8f46…`) é o alarme. Perder o ' +
+      'SECDEF aqui quebra a autorização por BAIXO: a policy fica idêntica e passa a negar para todos.',
   },
   'private.carteira_visivel_para': {
     secdef: true,
@@ -1181,9 +1188,10 @@ export const AUTHZ_RLS_PREDICADOS: Record<string, PredicadoEsperado> = {
       'alcance que este contrato passa a congelar depois de `has_role`: 18 policies em 14 tabelas ' +
       '(medido por pg_depend), das quais o contrato cura UMA (`pedido_compra_item`). Congelar o corpo ' +
       'cobre as 14 no eixo 3 mesmo sem curar o conteúdo das outras 13 — é o melhor retorno por entrada ' +
-      'do arquivo inteiro. ⚠️ Corpo IDÊNTICO ao de `cap_preco_escrever`/`cap_credito_escrever`, logo o ' +
-      'mesmo md5 nas três: são capabilities distintas com a mesma regra hoje, e o dia em que uma ' +
-      'divergir é exatamente o que se quer ver.',
+      'do arquivo inteiro. ⚠️ Corpo IDÊNTICO ao de `cap_preco_escrever`/`cap_credito_escrever` e, ' +
+      'desde 2026-08-29, ao de `cap_carteira_escrever` — logo o mesmo md5 nas QUATRO: são ' +
+      'capabilities distintas com a mesma regra hoje, e o dia em que uma divergir é exatamente o ' +
+      'que se quer ver.',
   },
   'private.cap_credito_escrever': {
     secdef: true,


### PR DESCRIPTION
## Fecha o ciclo do [#2092](https://github.com/LucasSardenbergL/afiacao/pull/2092) — **aplicada e medida**

A migration `20260828213000_cap_carteira_escrever_master_only.sql` foi colada no SQL Editor em
2026-08-29. Este PR move o contrato de RLS para o estado **medido**, não para o estado desejado —
é a ordem que o #2087/#2092 separaram de propósito, para não deixar o gate do carimbo vermelho na
janela merge→apply (ele roda no CI de **todo** PR do repo, não só no da mudança).

## As cinco medições

| o que | esperado | medido |
|---|---|---|
| `srcMd5` de `cap_carteira_escrever` | `5faf2a21…` — **previsto ANTES do apply** | `5faf2a21…` ✅ |
| `prosecdef` / `proconfig` | `true` / `search_path=public` | idem ✅ |
| `srcMd5` de `cap_carteira_ler` | `836e8f46…` (intacta) | idem ✅ |
| `EXECUTE` de `authenticated` | preservado pelo `CREATE OR REPLACE` | `true` ✅ |
| `EXECUTE` de `anon` | negado (PUBLIC segue revogado) | `false` ✅ |

O md5 bater com o que fora **previsto antes** do apply é o que transforma "rodei" em evidência.
Se viesse outro valor, o certo seria parar, não carimbar.

## Não só o md5: três prosas que afirmavam a igualdade

O `srcMd5` sozinho não fecha a mudança. Reescritos **também**:

1. o motivo do predicado da **escrita** (dizia "o `srcMd5` é o MESMO de `cap_carteira_ler`");
2. o motivo do predicado da **leitura** (dizia "⚠️ Corpo IDÊNTICO ao de `cap_carteira_escrever`");
3. o cabeçalho do bloco e o motivo de `cap_compras_ler` — o **trio** `5faf2a21…` virou **quarteto**,
   e os dois textos diziam "as três".

Deixar qualquer uma seria plantar de novo exatamente a classe que este arquivo documenta.

## 🔴 Uma armadilha de leitura que apareceu na verificação

Duas das cinco medições **não voltaram** na primeira tentativa: a saída trouxe três resultados e um
`ERROR: permission denied for schema private` no fim. Um `grep` pelas linhas esperadas teria
mostrado **três ✅ e nenhum sinal do que faltou**.

Causa: `has_function_privilege('anon', 'private.cap_carteira_escrever(uuid)', 'EXECUTE')` resolve a
função **pela assinatura em texto**, e isso exige `USAGE` no schema — que o `claude_ro` não tem.
Ler `pg_proc` direto funciona (catálogo é legível); **resolver o nome, não**. A forma por **OID**
devolve o dado.

> **Lição (§11.2):** a mesma função do Postgres tem sobrecargas com requisitos de permissão
> diferentes. Sob um papel read-only estreito, prefira a forma por **OID** — e trate linha que não
> voltou como **ausência de dado**. Aqui o `psql` gritou com um `ERROR`; num `LEFT JOIN` ou numa
> agregação, o mesmo buraco sairia como `NULL` silencioso.

## Falsificação

Devolvi o `srcMd5` antigo (`836e8f46…`) e exigi vermelho contra prod:

```
[PREDICADO_ALTERADO] private.cap_carteira_escrever (referenciada DIRETAMENTE por uma policy
curada): corpo md5 5faf2a21… (contrato: 836e8f46…).
```

Restaurado → exit 0. Sem isso, o novo md5 seria só um número que ninguém confere.

## Evidência

`authz:rls:prod` **exit 0** (21 tabelas · 54 policies · 13 predicados) · harness
**24 ok / 0 fail** nos dois locales · `bun run test` **7453 passed** · carimbo regravado e gate
verde (re-conferido **depois** do rebase, porque a `main` andou).

Registro: `docs/historico/rls-viva-fora-do-alcance-dos-audits.md` §11.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
