### PR TITLE
feat(deploy-verify): secret novo de edge não era NENHUMA das 3 camadas — `classify.sh` ganha a 4ª linha e o checklist ganha 🔑 ANTES da edge

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -4,13 +4,16 @@ description: >-
   Ritual de "está REALMENTE no ar?" para QUALQUER entrega neste repo (Afiação/Colacor),
   que roda em Lovable Cloud. Use SEMPRE que terminar de mergear um PR e precisar saber o que falta pra
   a mudança ir a produção, ou quando o usuário perguntar "já está no ar?", "deu pra ver no app?",
-  "publiquei?", "preciso dar Publish?", "tem que deployar a edge?". Vale mesmo quando o usuário não
+  "publiquei?", "preciso dar Publish?", "tem que deployar a edge?", "falta configurar algum secret?".
+  Vale mesmo quando o usuário não
   diz "deploy" e só assume que mergear basta ("terminei, era só isso?", "pode testar agora?"). Por quê:
   o Lovable NÃO auto-deploya NADA a partir de push no GitHub — mergear na main deixa o código na main,
   mas o app continua servindo o build anterior. TRÊS coisas são manuais e independentes: (1) FRONTEND
   (Publish no editor do Lovable), (2) EDGE FUNCTIONS (chat do Lovable, ler do repo, verbatim), (3)
-  MIGRATIONS (SQL Editor — coberto pela skill lovable-db-operator). A skill empacota: detectar quais
-  das 3 se aplicam ao diff, montar o checklist de pendências do founder, montar o prompt de deploy de
+  MIGRATIONS (SQL Editor — coberto pela skill lovable-db-operator). E uma QUARTA que não é camada de
+  código e mesmo assim trava tudo: (4) SECRET novo de edge (Edge Functions → Secrets) — sem ele a edge
+  sobe Active, o cron fica verde e a função morre no 1º Deno.env.get. A skill empacota: detectar quais
+  das 4 se aplicam ao diff, montar o checklist de pendências do founder, montar o prompt de deploy de
   edge, e VERIFICAR o deploy do frontend pelos bytes do bundle (hash do index + grep da string-alvo em
   TODOS os chunks). NÃO use para: a mudança de banco em si (use lovable-db-operator), escrever a feature,
   ou debugar erro de runtime no app (use /investigate).
@@ -48,16 +51,16 @@ As **três** coisas são deploy manual e **independente**, e NENHUMA acontece so
 ## A Lei de Ferro (guardrail inegociável)
 
 1. **Você nunca diz "está no ar" sem prova.** Mergear na main **não publica nada**. Frontend: os **bytes do bundle** confirmam (string-alvo nos chunks — Passo 4). Edge **não serve seu código**, logo não há prova por bytes — a prova é a **escada** existência (`verify-edge.sh`) → versão (Management API/painel) → comportamento (probe); `Active` sozinho prova existência, **não** que a versão nova subiu. Até lá: "mergeado na main; **falta Publish/deploy** pra ir ao ar".
-2. **As 3 camadas são independentes — sempre diga QUAIS se aplicam.** Um diff só-frontend não precisa de deploy de edge; um diff de edge precisa de deploy via chat *e* (se mexeu em UI) Publish. Liste só o que o diff realmente toca.
+2. **As camadas de deploy são independentes — sempre diga QUAIS se aplicam.** Um diff só-frontend não precisa de deploy de edge; um diff de edge precisa de deploy via chat *e* (se mexeu em UI) Publish — e, se a edge lê um `Deno.env.get` que nenhuma outra lê, o **secret** antes do deploy. Liste só o que o diff realmente toca.
 3. **Edge deploy SÓ DEPOIS do merge, e VERBATIM.** Deployar "da main" antes do merge faz o Lovable ler a main **velha** (já mordeu em #383/#252 — a action nova não existia no binário → `400 "Ação desconhecida"`). E o Lovable tende a "melhorar" o código — o prompt deve mandar **não modificar/reinterpretar**, ler de `supabase/functions/<nome>/index.ts` e deployar idêntico.
 4. **Verificar frontend varre TODOS os chunks, e enumerá-los é a UNIÃO de duas fontes.** Nenhuma sozinha é completa (validado em prod 2026-06-18 + Codex): (a) o **fechamento transitivo** do grafo lazy do Vite — o entry lista só o 1º nível via `__vite__mapDeps(["assets/x.js"])` (sem barra, aspas), e um lazy-dentro-de-página guarda o mapDeps no chunk DELE (entry=260, closure=274); (b) o **precache do Workbox** (`/sw.js`), que omite chunks grandes (globIgnores/maxFileSize — faltavam 6). Use a UNIÃO. Grep de literais `/assets/...` dá 0 (o bug original). Contagem 0/1 = enumeração quebrada — conserte antes de concluir.
-5. **Todo artefato pro founder tem o DESTINO rotulado na 1ª linha** — `🟣 SQL Editor` / `💬 chat do Lovable` / `🖱️ Publish (editor do Lovable)` / `⌨️ seu terminal` — e **zero placeholders** (`<VALOR>` não substituído já foi colado em produção) — e **valor de EXEMPLO plausível CONTA como placeholder, com falha PIOR, porque é CALADA**: o `<VALOR>` quebra ruidoso (404, erro de sintaxe), o número plausível devolve uma linha real de OUTRO emissor. Em 2026-08-24 um `WHERE id = 58967` inventado leu o tick do watchdog e reprovou um deploy money-path CORRETO. Campo que o founder substitui nasce sintaticamente **inválido** (`COLE_AQUI_O_REQUEST_ID`), nunca preenchido de exemplo → `deploy.md` §Canárias. JS/bash NUNCA vai pro SQL Editor (já foi colado lá 4×); o rótulo responde de antemão o "isso eu colo onde?".
+5. **Todo artefato pro founder tem o DESTINO rotulado na 1ª linha** — `🟣 SQL Editor` / `💬 chat do Lovable` / `🖱️ Publish (editor do Lovable)` / `🔑 Secrets (Lovable → Edge Functions → Secrets)` / `⌨️ seu terminal` — e **zero placeholders** (`<VALOR>` não substituído já foi colado em produção) — e **valor de EXEMPLO plausível CONTA como placeholder, com falha PIOR, porque é CALADA**: o `<VALOR>` quebra ruidoso (404, erro de sintaxe), o número plausível devolve uma linha real de OUTRO emissor. Em 2026-08-24 um `WHERE id = 58967` inventado leu o tick do watchdog e reprovou um deploy money-path CORRETO. Campo que o founder substitui nasce sintaticamente **inválido** (`COLE_AQUI_O_REQUEST_ID`), nunca preenchido de exemplo → `deploy.md` §Canárias. JS/bash NUNCA vai pro SQL Editor (já foi colado lá 4×); o rótulo responde de antemão o "isso eu colo onde?".
 
 ## O ritual — 5 passos
 
 Crie estes todos (TodoWrite) ao fechar uma entrega que pode precisar de deploy:
 
-1. **Classificar o diff** — quais das 3 camadas o PR toca (frontend / edge / migration)?
+1. **Classificar o diff** — o que o PR exige de manual (frontend / edge / migration / **secret**)?
 2. **Pendências do founder** — montar o checklist do que ele precisa fazer manualmente
 3. **Prompt de edge** (se houver edge) — montar o handoff "ler do repo, verbatim, não melhorar"
 4. **Verificar o deploy** — frontend pelos bytes; edge pela escada existência→versão→comportamento
@@ -67,24 +70,53 @@ Crie estes todos (TodoWrite) ao fechar uma entrega que pode precisar de deploy:
 
 ### Passo 1 — Classificar o diff
 
-Quais das 3 camadas o PR toca? A lógica canônica — ampliada para pegar **arquivos de build na raiz**
-(`vite.config`, `package.json`, …), não só `src/` — vive em [`evals/classify.sh`](evals/classify.sh) e é
-coberta por [`evals/run.sh`](evals/run.sh) (8 casos + mutation-check):
+O que o PR exige de manual? A lógica canônica — ampliada para pegar **arquivos de build na raiz**
+(`vite.config`, `package.json`, …), não só `src/`, e para acusar **secret novo de edge** — vive em
+[`evals/classify.sh`](evals/classify.sh) e é coberta por [`evals/run.sh`](evals/run.sh) (16 casos +
+mutation-check). **Rode da raiz do repo** (a 4ª linha lê o conteúdo das edges, não só os nomes):
 
 ```bash
 git diff --name-only origin/main...HEAD \
   | .claude/skills/lovable-deploy-verify/evals/classify.sh
-# -> frontend=SIM|não · edge=SIM|não · migration=SIM|não
+# -> frontend=SIM|não · edge=SIM|não · migration=SIM|não · secrets=não|NOME,…|?dinamico
 ```
 
-### Passo 2 — Checklist de pendências do founder (ORDEM TRAVADA: merge → SQL → edge → Publish)
+**A 4ª linha é a camada que as três não cobrem.** Um secret novo não é frontend, não é edge e não é
+migration — e mesmo assim é dependência manual do founder, com o pior modo de falha que existe aqui:
+edge **Active**, cron **verde**, `cron.job_run_details = succeeded`, e a função morrendo no 1º
+`Deno.env.get` com 500 sem fazer nada. Descoberto no #2035 — `analytics-outbox-drain` lê
+`POSTHOG_INGEST_KEY`, que nenhuma outra edge lê; naquele deploy o secret já estava configurado, o que
+foi **sorte**: nenhum dos 3 passos tinha como acusar antes de rodar.
+
+Como ler a saída:
+
+| `secrets=` | Significa | O que fazer |
+|---|---|---|
+| `não` | nenhuma edge tocada lê env que as outras já não leiam | nada |
+| `NOME1,NOME2` | **candidatos a secret novo** | linha 🔑 no Passo 2, **antes** do deploy da edge |
+| `?dinamico` | a edge lê env por nome **computado** (`` Deno.env.get(`OMIE_${empresa}_APP_KEY`) ``) | conferir **à mão** quais nomes aquilo resolve |
+
+⚠️ **`?dinamico` não é "não tem secret" — é "não sei".** O script resolve nome literal; nome montado em
+runtime ele não resolve, e tratar isso como silêncio seria ler ausência de dado como aprovação. E a
+lista é de **candidatos**: a verdade sobre o que existe é o painel de Secrets, não o repo — o script
+compara o diff com as *outras* edges do repo, então secret que só este PR usa aparece mesmo que já
+esteja configurado. Errar para mais custa uma linha de checklist; errar para menos custa uma edge morta.
+
+### Passo 2 — Checklist de pendências do founder (ORDEM TRAVADA: merge → SQL → secret → edge → Publish)
 
 **Nada de deploy antes do MERGE** (Lei de Ferro #3 — o Lovable lê da main). Entregar SÓ as linhas que se aplicam (do passo 1), NESTA ordem, cada uma com o destino rotulado:
 
 > ⚠️ **Pra ir ao ar, falta (manual no Lovable) — nesta ordem, APÓS o merge do PR:**
 > - [ ] 🟣 **SQL Editor**: migration Z *(se tocou `supabase/migrations/` — bloco da `lovable-db-operator`; banco ANTES do código que o consome)*
+> - [ ] 🔑 **Secrets (Lovable → Edge Functions → Secrets)**: confirmar que `NOME_DO_SECRET` existe *(se o passo 1 deu `secrets=` com nome ou `?dinamico`)*
 > - [ ] 💬 **chat do Lovable**: deploy das edges X, Y — verbatim da main *(se tocou `supabase/functions/`)*
 > - [ ] 🖱️ **Publish** do frontend no editor do Lovable *(se o passo 1 deu frontend=SIM; por último — o build novo nasce contra banco/edge já atualizados)*
+
+**O secret vem ANTES do deploy da edge, e a ordem não é estética.** Deployar primeiro sobe uma função
+que responde 500 no primeiro request — e como ela fica `Active` e o cron acusa `succeeded`, a verificação
+do Passo 4 pode carimbar "no ar" uma edge que não faz nada. Secret primeiro, edge depois, e o probe do
+Passo 4 vira prova de verdade. **Nunca escreva o VALOR do secret no chat nem no PR** (a transcrição
+persiste em disco): a linha pede ao founder para *conferir/criar* pelo nome, e o valor só existe no painel.
 
 ### Passo 3 — Prompt de deploy de edge (se aplicável)
 

--- a/.claude/skills/lovable-deploy-verify/evals/classify-eval.json
+++ b/.claude/skills/lovable-deploy-verify/evals/classify-eval.json
@@ -1,25 +1,235 @@
 [
-  { "name": "só-frontend (página lazy)", "files": ["src/pages/Sales.tsx"],
-    "expect": { "frontend": "SIM", "edge": "não", "migration": "não" } },
-
-  { "name": "só-edge", "files": ["supabase/functions/omie-sync/index.ts"],
-    "expect": { "frontend": "não", "edge": "SIM", "migration": "não" } },
-
-  { "name": "só-migration", "files": ["supabase/migrations/20260618120000_add_col.sql"],
-    "expect": { "frontend": "não", "edge": "não", "migration": "SIM" } },
-
-  { "name": "misto (3 camadas)", "files": ["src/App.tsx", "supabase/functions/x/index.ts", "supabase/migrations/y.sql"],
-    "expect": { "frontend": "SIM", "edge": "SIM", "migration": "SIM" } },
-
-  { "name": "só-doc (NÃO precisa deploy)", "files": ["docs/historico/x.md", "CLAUDE.md", ".claude/skills/y/SKILL.md"],
-    "expect": { "frontend": "não", "edge": "não", "migration": "não" } },
-
-  { "name": "build na raiz (regressão: vite.config muda o bundle)", "files": ["vite.config.ts"],
-    "expect": { "frontend": "SIM", "edge": "não", "migration": "não" } },
-
-  { "name": "dep nova (package.json muda o bundle)", "files": ["package.json", "bun.lockb"],
-    "expect": { "frontend": "SIM", "edge": "não", "migration": "não" } },
-
-  { "name": "frontend + edge", "files": ["src/hooks/useX.ts", "supabase/functions/y/index.ts"],
-    "expect": { "frontend": "SIM", "edge": "SIM", "migration": "não" } }
+  {
+    "name": "só-frontend (página lazy)",
+    "files": [
+      "src/pages/Sales.tsx"
+    ],
+    "expect": {
+      "frontend": "SIM",
+      "edge": "não",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "só-edge",
+    "files": [
+      "supabase/functions/omie-sync/index.ts"
+    ],
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "só-migration",
+    "files": [
+      "supabase/migrations/20260618120000_add_col.sql"
+    ],
+    "expect": {
+      "frontend": "não",
+      "edge": "não",
+      "migration": "SIM",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "misto (3 camadas)",
+    "files": [
+      "src/App.tsx",
+      "supabase/functions/x/index.ts",
+      "supabase/migrations/y.sql"
+    ],
+    "expect": {
+      "frontend": "SIM",
+      "edge": "SIM",
+      "migration": "SIM",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "só-doc (NÃO precisa deploy)",
+    "files": [
+      "docs/historico/x.md",
+      "CLAUDE.md",
+      ".claude/skills/y/SKILL.md"
+    ],
+    "expect": {
+      "frontend": "não",
+      "edge": "não",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "build na raiz (regressão: vite.config muda o bundle)",
+    "files": [
+      "vite.config.ts"
+    ],
+    "expect": {
+      "frontend": "SIM",
+      "edge": "não",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "dep nova (package.json muda o bundle)",
+    "files": [
+      "package.json",
+      "bun.lockb"
+    ],
+    "expect": {
+      "frontend": "SIM",
+      "edge": "não",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "frontend + edge",
+    "files": [
+      "src/hooks/useX.ts",
+      "supabase/functions/y/index.ts"
+    ],
+    "expect": {
+      "frontend": "SIM",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "#2035 — secret NOVO em edge nova (POSTHOG_INGEST_KEY)",
+    "files": [
+      "supabase/functions/analytics-outbox-drain/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/analytics-outbox-drain/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst key = Deno.env.get(\"POSTHOG_INGEST_KEY\");\nif (!key) return json({ erro: \"POSTHOG_INGEST_KEY nao configurado\" }, 500);\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "POSTHOG_INGEST_KEY"
+    }
+  },
+  {
+    "name": "secret que OUTRA edge já usa não é novo (senão o detector grita sempre)",
+    "files": [
+      "supabase/functions/nova/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/nova/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "edge MODIFICADA ganha secret novo — não pode se comparar consigo mesma",
+    "files": [
+      "supabase/functions/existente/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/existente/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst t = Deno.env.get(\"BROWSERLESS_TOKEN\");\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "BROWSERLESS_TOKEN"
+    }
+  },
+  {
+    "name": "nome COMPUTADO ⇒ ?dinamico (ausência de literal não é ausência de secret)",
+    "files": [
+      "supabase/functions/omie-cliente/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/omie-cliente/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst k = Deno.env.get(`OMIE_${empresa}_APP_KEY`);\nconst s = Deno.env.get(conta.envSecret);\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "?dinamico"
+    }
+  },
+  {
+    "name": "secret novo + nome computado convivem na mesma saída",
+    "files": [
+      "supabase/functions/mista/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/mista/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst a = Deno.env.get(\"D360_API_KEY\");\nconst b = Deno.env.get(`OMIE_${e}_APP_KEY`);\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "D360_API_KEY,?dinamico"
+    }
+  },
+  {
+    "name": "_test.ts tocado não pede secret (não vai pro bundle)",
+    "files": [
+      "supabase/functions/nova/index_test.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/nova/index_test.ts": "const fake = Deno.env.get(\"SECRET_DE_TESTE\");\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "não"
+    }
+  },
+  {
+    "name": "secret citado só em _test.ts do universo NÃO vira conhecido",
+    "files": [
+      "supabase/functions/nova/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/nova/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst v = Deno.env.get(\"VAPID_PRIVATE_KEY\");\n",
+      "supabase/functions/outra/index_test.ts": "Deno.env.get(\"VAPID_PRIVATE_KEY\");\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "VAPID_PRIVATE_KEY"
+    }
+  },
+  {
+    "name": "duas edges novas com o MESMO secret novo ⇒ uma entrada só",
+    "files": [
+      "supabase/functions/a/index.ts",
+      "supabase/functions/b/index.ts"
+    ],
+    "fixtures": {
+      "supabase/functions/a/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst x = Deno.env.get('DEEPGRAM_API_KEY');\n",
+      "supabase/functions/b/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\nconst y = Deno.env.get(\"DEEPGRAM_API_KEY\");\n",
+      "supabase/functions/omie-sync/index.ts": "const url = Deno.env.get(\"SUPABASE_URL\")!;\nconst cron = Deno.env.get(\"CRON_SECRET\");\n"
+    },
+    "expect": {
+      "frontend": "não",
+      "edge": "SIM",
+      "migration": "não",
+      "secrets": "DEEPGRAM_API_KEY"
+    }
+  }
 ]

--- a/.claude/skills/lovable-deploy-verify/evals/classify.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/classify.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 # classify.sh — FONTE ÚNICA da classificação do Passo 1 da skill lovable-deploy-verify.
-# Lê nomes de arquivo (1 por linha) do stdin e diz quais das 3 camadas de deploy
-# Lovable (frontend/edge/migration) o conjunto toca. O Passo 1 do SKILL.md usa este
-# script; o evals/run.sh testa este script. Uma fonte = sem divergência.
+# Lê nomes de arquivo (1 por linha) do stdin e diz quais camadas de deploy manual do
+# Lovable o conjunto toca. O Passo 1 do SKILL.md usa este script; o evals/run.sh testa
+# este script. Uma fonte = sem divergência.
 #
 # Uso:  git diff --name-only origin/main...HEAD | ./classify.sh
-# Saída (3 linhas):  frontend=SIM|não / edge=SIM|não / migration=SIM|não
+# Saída (4 linhas):  frontend=SIM|não / edge=SIM|não / migration=SIM|não / secrets=…
+#
+# As 3 primeiras camadas são função PURA dos nomes. A 4ª (secrets) precisa do CONTEÚDO
+# dos arquivos e do resto do repo, e por isso lê o disco a partir de $CLASSIFY_RAIZ
+# (default: $PWD — o Passo 1 roda da raiz do repo; o eval aponta para fixtures).
 set -euo pipefail
-awk '
+
+RAIZ="${CLASSIFY_RAIZ:-$PWD}"
+entrada="$(cat)"
+
+printf '%s\n' "$entrada" | awk '
   # FRONTEND = precisa de Publish. Não é só src/: qualquer arquivo que altere o
   # bundle servido conta (senão dá falso-negativo "não precisa Publish" quando
   # precisa — ex.: mexer no vite.config ou subir uma dependência).
@@ -28,3 +36,85 @@ awk '
     printf "edge=%s\n",      (ef?"SIM":"não")
     printf "migration=%s\n", (mg?"SIM":"não")
   }'
+
+# ---------------------------------------------------------------------------
+# 4ª camada — SECRETS (Lovable → Edge Functions → Secrets).
+#
+# Por que existe: um secret novo NÃO é nenhuma das 3 camadas acima e mesmo assim é
+# dependência manual do founder. A edge sobe Active, o cron fica verde,
+# `cron.job_run_details` diz `succeeded` — e a função morre no 1º `Deno.env.get`
+# devolvendo 500 sem fazer nada. Descoberto no #2035 (`analytics-outbox-drain` lê
+# POSTHOG_INGEST_KEY, usado por essa edge e por nenhuma outra): naquele deploy o
+# secret já estava configurado, o que foi SORTE — não havia como saber antes de rodar.
+#
+# Heurística: nome lido por uma edge TOCADA pelo diff que não aparece em nenhuma edge
+# NÃO tocada = provavelmente novo. Os tocados saem do universo de propósito — sem isso
+# um arquivo se compara consigo mesmo e todo secret novo parece conhecido.
+#
+# Ausência de literal NÃO é ausência de secret: este repo lê env por nome computado
+# (`Deno.env.get(`OMIE_${empresa}_APP_KEY`)`, `Deno.env.get(conta.envKey)`). Nome que
+# o script não consegue resolver vira `?dinamico` — pendência de conferência à mão,
+# nunca silêncio (silêncio aqui seria ausência de dado lida como aprovação).
+#
+# Limite honesto: o repo não é a verdade sobre o painel. A saída é lista de CANDIDATOS
+# — quem decide é o painel de Secrets do Lovable. Errar para mais custa uma linha de
+# checklist; errar para menos custa uma edge morta em produção.
+# ---------------------------------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/env.awk" <<'AWK'
+# Lê uma lista de paths (1 por linha) e, para cada Deno.env.get() encontrado, emite
+# "L <NOME>" (literal resolvido) ou "D <arquivo>" (nome dinâmico/irresolvível).
+function varrer(linha, arq,   p, resto, aspa, corpo, q, nome) {
+  while ((p = index(linha, "Deno.env.get(")) > 0) {
+    resto = substr(linha, p + 13)
+    linha = resto                       # continua após esta ocorrência (várias por linha)
+    sub(/^[ \t]*/, "", resto)
+    aspa = substr(resto, 1, 1)
+    if (aspa == "\"" || aspa == "\047") {
+      corpo = substr(resto, 2)
+      q = index(corpo, aspa)
+      if (q > 1) {
+        nome = substr(corpo, 1, q - 1)
+        if (nome ~ /^[A-Za-z_][A-Za-z0-9_]*$/) { print "L " nome; continue }
+      }
+    }
+    print "D " arq                      # crase, variável, string vazia, multi-linha
+  }
+}
+{
+  arq = $0
+  while ((getline l < arq) > 0) varrer(l, arq)
+  close(arq)                            # arquivo inexistente (deletado no diff): getline < 0, silencioso
+}
+AWK
+
+# Tocados: só código de edge. `_test.ts` fora — não vai pro bundle (mesmo filtro do Passo 3).
+printf '%s\n' "$entrada" \
+  | awk '/^supabase\/functions\/.*\.ts$/ && !/_test\.ts$/' \
+  | sort -u > "$tmp/tocados"
+
+if [ ! -s "$tmp/tocados" ]; then
+  echo "secrets=não"
+  exit 0
+fi
+
+( cd "$RAIZ" 2>/dev/null && awk -f "$tmp/env.awk" "$tmp/tocados" ) > "$tmp/uso" || true
+awk '$1=="L"{print $2}' "$tmp/uso" | sort -u > "$tmp/usados"
+dinamico="$(awk '$1=="D"{c=1} END{print c?1:0}' "$tmp/uso")"
+
+# Universo = edges já existentes NÃO tocadas pelo diff. `_test.ts` também fora daqui:
+# secret citado só em teste não prova que existe no painel (incluí-lo daria falso negativo).
+( cd "$RAIZ" 2>/dev/null && find supabase/functions -type f -name '*.ts' 2>/dev/null ) \
+  | awk '!/_test\.ts$/' | sort -u > "$tmp/todos" || true
+comm -23 "$tmp/todos" "$tmp/tocados" > "$tmp/universo"
+( cd "$RAIZ" 2>/dev/null && awk -f "$tmp/env.awk" "$tmp/universo" ) > "$tmp/uso_universo" || true
+awk '$1=="L"{print $2}' "$tmp/uso_universo" | sort -u > "$tmp/conhecidos"
+
+comm -23 "$tmp/usados" "$tmp/conhecidos" > "$tmp/novos"
+lista="$(awk 'BEGIN{ORS=""} NR>1{print ","} {print}' "$tmp/novos")"
+if [ "$dinamico" = 1 ]; then
+  lista="${lista:+$lista,}?dinamico"
+fi
+printf 'secrets=%s\n' "${lista:-não}"

--- a/.claude/skills/lovable-deploy-verify/evals/run.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/run.sh
@@ -5,8 +5,9 @@
 #   (3) verify-edge-eco  — guard TEMPORAL do N3 passivo (só ticks pré-merge ⇒ indeterminado)
 # Exit 0 = tudo passou. Exit 1 = alguma divergência.
 # Falsificação (prova que os evals têm dente): --falsify sabota AMBOS e exige vermelho
-#   (classify inverte os esperados; verify-frontend sabota a enumeração; verify-edge-eco arranca
-#   o guard temporal, o fail-closed do ping e o filtro do tick mais recente). Exit 0 só se pegou tudo.
+#   (classify sabota o gabarito UMA CHAVE POR VEZ e depois muta o classify.sh real; verify-frontend
+#   sabota a enumeração; verify-edge-eco arranca o guard temporal, o fail-closed do ping e o filtro
+#   do tick mais recente). Exit 0 só se pegou tudo.
 set -uo pipefail
 cd "$(dirname "$0")" || exit 2
 
@@ -16,29 +17,108 @@ rc=0
 
 echo "== (1) classify — Passo 1 =="
 if python3 - "$@" <<'PY'
-import json, subprocess, sys
+import json, os, subprocess, sys, tempfile
+
 falsify = "--falsify" in sys.argv
 cases = json.load(open("classify-eval.json"))
-diverg = 0
-for c in cases:
-    out = subprocess.run(["bash", "classify.sh"],
-                         input="\n".join(c["files"]) + "\n",
-                         capture_output=True, text=True).stdout
-    got = dict(l.split("=") for l in out.strip().splitlines())
-    exp = dict(c["expect"])
-    if falsify:  # sabota o gabarito: agora got==exp seria o ERRO
-        exp = {k: ("SIM" if v == "não" else "não") for k, v in exp.items()}
-    ok = (got == exp)
-    if not ok:
-        diverg += 1
-    print(f"  [{'ok ' if ok else 'XX '}] {c['name']}")
-n = len(cases)
-if falsify:
-    # esperamos que TODOS divirjam; se algum 'passou', o eval é cego
-    print(f"--falsify: {diverg}/{n} divergiram (esperado: {n}/{n})")
-    sys.exit(0 if diverg == n else 1)
-print(f"{n - diverg}/{n} passaram")
-sys.exit(1 if diverg else 0)
+
+def roda(caso, script="classify.sh"):
+    """Cada caso roda num tmpdir PRÓPRIO: as 3 primeiras camadas são função pura dos nomes,
+    mas a 4ª (secrets) lê o disco. Sem sandbox o eval passaria a depender do estado do repo
+    real — caso sem `fixtures` roda contra árvore vazia e por isso dá secrets=não."""
+    with tempfile.TemporaryDirectory() as raiz:
+        for p, conteudo in caso.get("fixtures", {}).items():
+            alvo = os.path.join(raiz, p)
+            os.makedirs(os.path.dirname(alvo), exist_ok=True)
+            with open(alvo, "w") as fh:
+                fh.write(conteudo)
+        r = subprocess.run(["bash", script],
+                           input="\n".join(caso["files"]) + "\n",
+                           capture_output=True, text=True,
+                           env=dict(os.environ, CLASSIFY_RAIZ=raiz))
+    return dict(l.split("=", 1) for l in r.stdout.strip().splitlines())
+
+def sabota(valor, chave):
+    # `secrets` não é booleano: inverter SIM/não não o tocaria. Sem regra própria, a sabotagem
+    # das OUTRAS chaves já bastaria para divergir e a 4ª camada ficaria sem dente.
+    if chave == "secrets":
+        return "não" if valor != "não" else "POSTHOG_INGEST_KEY"
+    return "SIM" if valor == "não" else "não"
+
+# Mutações do classify.sh REAL (cópia em tmp; o versionado nunca é mutado). Cada uma arranca
+# uma decisão da 4ª camada e precisa deixar ≥1 caso VERMELHO — se não deixar, o gabarito é cego
+# naquele eixo e o eval está passando por acidente.
+MUTACOES = [
+    ("universo inclui os próprios arquivos tocados (edge se compara consigo mesma)",
+     'comm -23 "$tmp/todos" "$tmp/tocados" > "$tmp/universo"',
+     'cp "$tmp/todos" "$tmp/universo"'),
+    ("nome dinâmico vira silêncio em vez de ?dinamico",
+     'if [ "$dinamico" = 1 ]; then',
+     'if [ "$dinamico" = 9 ]; then'),
+    ("_test.ts tocado conta como código de edge",
+     "/^supabase\\/functions\\/.*\\.ts$/ && !/_test\\.ts$/",
+     "/^supabase\\/functions\\/.*\\.ts$/"),
+    ("não subtrai o universo: todo secret lido vira 'novo'",
+     'comm -23 "$tmp/usados" "$tmp/conhecidos" > "$tmp/novos"',
+     'cp "$tmp/usados" "$tmp/novos"'),
+    ("_test.ts entra no universo e faz secret novo parecer conhecido",
+     "| awk '!/_test\\.ts$/' | sort -u > \"$tmp/todos\"",
+     '| sort -u > "$tmp/todos"'),
+]
+
+falha = 0
+if not falsify:
+    diverg = 0
+    for c in cases:
+        got, exp = roda(c), dict(c["expect"])
+        ok = (got == exp)
+        if not ok:
+            diverg += 1
+            print(f"  [XX ] {c['name']}\n        esperado {exp}\n        obtido   {got}")
+        else:
+            print(f"  [ok ] {c['name']}")
+    print(f"{len(cases) - diverg}/{len(cases)} passaram")
+    falha = 1 if diverg else 0
+else:
+    # (a) gabarito sabotado UMA CHAVE POR VEZ — prova que cada chave participa da comparação.
+    #     Sabotar todas de uma vez deixaria a 4ª camada carona nas outras três.
+    cegas = []
+    for c in cases:
+        got = roda(c)
+        if set(got) != set(c["expect"]):
+            cegas.append(f"{c['name']}: saída {sorted(got)} ≠ gabarito {sorted(c['expect'])}")
+            continue
+        for chave, valor in c["expect"].items():
+            exp = dict(c["expect"], **{chave: sabota(valor, chave)})
+            if got == exp:
+                cegas.append(f"{c['name']}: chave '{chave}' sem dente")
+    n = len(cases) * 4
+    print(f"  gabarito por chave: {n - len(cegas)}/{n} sabotagens pegas")
+    for c in cegas:
+        print(f"    [XX ] {c}")
+
+    # (b) mutação do classify.sh real — o gabarito acima não cobre isto: ele prova que o eval
+    #     compara, não que a lógica tem dente. Aqui a lógica é arrancada e exigimos vermelho.
+    fonte = open("classify.sh").read()
+    with tempfile.TemporaryDirectory() as td:
+        mutante = os.path.join(td, "classify.sh")
+        for nome, de, para in MUTACOES:
+            if de not in fonte:
+                cegas.append(f"mutação NO-OP (alvo sumiu do classify.sh): {nome}")
+                print(f"    [XX ] mutação NO-OP: {nome}")
+                continue
+            with open(mutante, "w") as fh:
+                fh.write(fonte.replace(de, para, 1))
+            pegou = [c["name"] for c in cases if roda(c, mutante) != c["expect"]]
+            if pegou:
+                print(f"  [ok ] mutação pega ({len(pegou)} caso(s)): {nome}")
+            else:
+                cegas.append(f"mutação NÃO pega por nenhum caso: {nome}")
+                print(f"  [XX ] mutação passou despercebida: {nome}")
+    falha = 1 if cegas else 0
+    print(f"--falsify: {len(cegas)} cegueira(s) (esperado: 0)")
+
+sys.exit(falha)
 PY
 then :; else rc=1; fi
 

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -1,4 +1,4 @@
-# Deploy no Lovable — 3 camadas manuais (referência operacional)
+# Deploy no Lovable — 3 camadas manuais + o secret (referência operacional)
 
 > O que NÃO acontece sozinho no merge. Lição durável carregada sob demanda. Runbook passo-a-passo completo: `docs/runbooks/lovable-supabase.md`. Banco/migration: `docs/agent/database.md`. Verificação: skill `lovable-deploy-verify`.
 
@@ -29,16 +29,19 @@ O job `validate` do `.github/workflows/ci.yml` tem **muito mais que os 5 gates �
 1. **`manifesto.gate.test.ts`** (dentro do `bun run test`) — todo arquivo de `src/` precisa de **1 dono declarado** em `src/lib/modulos/manifesto.ts` (`codigo`/`testes` do módulo). Arquivo novo sem entrada sai como `[orfao]`. Sobreposição de globs entre módulos e glob que não casa nada também são erro. `NAO_CLASSIFICADOS` é dívida datada e está VAZIO — não seja o primeiro a sujá-lo.
 2. **`bunx knip`** — export sem consumidor. Núcleo de domínio novo, ainda sem UI, tende a bater aqui: os testes tornam as *funções* alcançáveis (o `vitest.config.ts` é entry no `knip.json`), mas **tipo/interface exportado que só o próprio arquivo usa fica órfão**. Correção certa é tirar o `export` do que é interno — reexportar quando a fase seguinte lhe der consumidor —, não engordar o `ignore` do `knip.json`.
 
-## Merge na `main` ≠ produção — 3 deploys MANUAIS e independentes
+## Merge na `main` ≠ produção — 3 deploys MANUAIS e independentes (+ a 4ª dependência)
 
 1. **Migration** → colar o SQL no **SQL Editor do Lovable** → Run → validar com query de contagem. O Lovable **NÃO** aplica migration de nome custom sozinho (falha SILENCIOSA: a feature compila e quebra em runtime). Detalhe + ritual + skill `lovable-db-operator`: `docs/agent/database.md`.
 2. **Frontend** → **Publish** manual no editor do Lovable. `steu.lovable.app` serve o **build velho** até o Publish (lição 2026-05-31: mergear e achar que foi pro ar é o erro recorrente).
 3. **Edge functions** → criadas/editadas pelo **chat do Lovable** (ele lê `supabase/functions/<nome>/index.ts` do repo e deploya **verbatim**), **NÃO** pela UI Cloud (que só mostra logs).
+4. **SECRET novo de edge** → **Edge Functions → Secrets**, e **antes** do deploy da edge. Não é camada de código — nenhuma das 3 acima o acusa — e falha do jeito mais caro: a edge fica **Active**, o cron fica **verde**, `cron.job_run_details` diz `succeeded`, e a função morre no 1º `Deno.env.get` devolvendo 500 sem fazer nada. Deployar antes do secret **arma** exatamente esse estado, e a verificação por sonda pode carimbar "no ar" uma edge que não faz nada. #2035 (`analytics-outbox-drain` ↔ `POSTHOG_INGEST_KEY`, lido por essa edge e por nenhuma outra) só não quebrou porque o secret já estava lá — **sorte, não processo**.
 
 **Achar UMA camada pendente é SINTOMA — audite as TRÊS do MESMO PR.** As camadas deployam separado, mas o PR que as tocou é um só: migration não-aplicada é evidência de **PR não-deployado**, não de migration esquecida. E o caminho de detecção enviesa — um `/fecho` que varre migrations acha migrations; frontend e edge nem entram no campo de visão. Ao detectar qualquer pendência, classifique o diff por camada antes de fechar o caso:
 
 ```bash
 git show --name-only --format="" <sha> | awk '/^supabase\/migrations/{m++} /^supabase\/functions/{e++} /^src\//{f++} END{print "mig="m+0" edge="e+0" front="f+0}'
+# as 4 de uma vez (secret inclusive), da RAIZ do repo — fonte única do Passo 1 da lovable-deploy-verify:
+git show --name-only --format="" <sha> | .claude/skills/lovable-deploy-verify/evals/classify.sh
 ```
 
 Mordido 2026-08-14 (#1520 `9f7e8962`, FU4-F fase 3): o `/fecho` pegou `…130000_fecha_product_costs.sql` mergeada e não aplicada, aplicou, verificou — caso encerrado. O mesmo PR trazia **5 migrations + frontend (já publicado) + 2 edges nunca confirmadas**, e edge velha ali é money-path concreto, porque o front novo é que mudou o contrato: `generate-bundle-argument` imprime `p.margin.toFixed(2)`/`bundle.lieBundle.toFixed(2)` num payload que o hook publicado **parou de mandar** (→ **TypeError**, argumento de venda não gera); `generate-tactical-plan` ordena as recomendações por `lie_bundle DESC`, hoje NULL em toda linha, e DESC implica NULLS FIRST → **topBundle arbitrário, plano tático sobre ranking fabricado**. ⚠️ O risco é assimétrico: com as duas metades faltando elas se cancelam, então **aplicar só a camada que apareceu pode ser o que ARMA a quebra** — é a armadilha do `carteira-rebuild` (abaixo) vista pelo lado do PR, não da edge.


### PR DESCRIPTION
## O buraco

O Passo 1 da `lovable-deploy-verify` classificava todo diff em **3 camadas manuais** (frontend / edge / migration). Um **secret novo de edge** não é nenhuma delas — e mesmo assim trava tudo, com o pior modo de falha que existe aqui:

> edge **Active** · cron **verde** · `cron.job_run_details = succeeded` · e a função morrendo no 1º `Deno.env.get` com 500, sem fazer nada.

Descoberto no deploy do #2035: `supabase/functions/analytics-outbox-drain/index.ts:71` lê `POSTHOG_INGEST_KEY`, usado por essa edge e por **nenhuma outra**. Nada quebrou porque o secret já estava configurado — **sorte, não processo**: nenhum dos 3 passos tinha como acusar antes de rodar.

## O que muda

**`evals/classify.sh` — 4ª linha `secrets=`.** As 3 primeiras seguem função **pura dos nomes**; a 4ª precisa do **conteúdo** e lê o disco a partir de `$CLASSIFY_RAIZ` (default `$PWD` — daí o "rode da raiz do repo"; o eval aponta para fixtures).

| `secrets=` | Significa |
|---|---|
| `não` | nenhuma edge tocada lê env que as outras já não leiam |
| `NOME1,NOME2` | candidatos a secret novo → linha 🔑 **antes** do deploy da edge |
| `?dinamico` | a edge lê env por nome **computado** — conferir à mão |

Três decisões que o caso concreto forçou:

1. **Os arquivos tocados saem do universo.** Sem isso a edge se compara consigo mesma e todo secret novo parece conhecido — é o eixo que a mutação nº 1 do `--falsify` arranca.
2. **`?dinamico` em vez de silêncio.** O repo lê env por nome montado de verdade (`` Deno.env.get(`OMIE_${empresa}_APP_KEY`) ``, `Deno.env.get(conta.envKey)` — 9 ocorrências medidas). Um detector só-literal seria **cego**, e tratar isso como silêncio seria ler ausência de dado como aprovação.
3. **`_test.ts` fora dos DOIS lados, por motivos opostos:** fora dos *tocados* porque não vai pro bundle; fora do *universo* porque secret citado só em teste não prova que existe no painel — incluí-lo daria falso **negativo**.

**Passo 2 — ordem travada vira `merge → SQL → secret → edge → Publish`.** Não é estética: deployar antes do secret **arma** exatamente o estado em que o Passo 4 pode carimbar "no ar" uma edge que não faz nada.

## Prova (os dois modos, exit colado)

```
bun run evals:deploy-verify              → 16/16 passaram · EXIT=0   (8 originais + 8 novos)
bun run evals:deploy-verify:falsificacao → EXIT=0
    gabarito por chave: 64/64 sabotagens pegas
    [ok] mutação pega (5 casos): universo inclui os próprios arquivos tocados
    [ok] mutação pega (2 casos): nome dinâmico vira silêncio
    [ok] mutação pega (1 caso ): _test.ts tocado conta como código de edge
    [ok] mutação pega (7 casos): não subtrai o universo
    [ok] mutação pega (1 caso ): _test.ts entra no universo
```

O gabarito agora sabota **uma chave por vez**. Inverter todas de uma vez (o que o eval fazia) deixaria `secrets` pegando **carona** nas outras três: a 4ª camada nasceria sem dente e o `--falsify` ficaria verde de qualquer jeito.

**Falsificada a falsificação** (em cópia, `classify.sh` versionado nunca mutado):

| sabotagem do próprio gate | resultado |
|---|---|
| mutação cujo alvo sumiu do script | `EXIT=1` — `mutação NO-OP` |
| gabarito sem os 8 casos de secret | `EXIT=1` — 5× `mutação passou despercebida` |

**Contra o repo real:** `analytics-outbox-drain` → `secrets=POSTHOG_HOST,POSTHOG_INGEST_KEY` · `omie-sync` → `secrets=não` · `omie-cliente` → `secrets=?dinamico`.

`shellcheck` dos 2 scripts → exit 0 · gates textuais que leem `docs/` → 287 testes, exit 0.

## CLAUDE.md fica intacto — medido, não suposto

A menção cabia na §Armadilhas por **2 palavras**; `bun run claude:size` **reprovou** (`❌ seção estourou o teto`) e eu revertí. A política do próprio arquivo manda `docs/` nesse caso — a lição foi para `docs/agent/deploy.md` como item 4. E o mecanismo não depende de o agente lembrar: o Passo 1 emite a linha sozinho.

## Multi-sessão

`#2099` toca o mesmo `SKILL.md` (hunk da linha ~392, Passo 4/N3). Núcleos disjuntos e integração **provada**, não suposta: `git merge-tree` dos dois → **0 conflitos**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 📌 Pendência aberta no `/fecho` desta sessão (destino durável do chip)

> Chip criado: **"Corrigir md5 registrado de cap_carteira_escrever"**. Copiado para cá porque chip é destino perecível — morre com a sessão.

`docs/historico/rls-viva-fora-do-alcance-dos-audits.md:757` afirma, na coluna **"medido"**, que o `srcMd5` de `private.cap_carteira_escrever` é `5faf2a21…`. Medido em prod agora (2026-08-29 ~02:25 UTC, via `psql-ro`):

```sql
SELECT p.proname, md5(p.prosrc), p.prosrc ~* 'commercial_role'
  FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
 WHERE n.nspname='private'
   AND p.proname IN ('cap_carteira_escrever','cap_compras_ler','cap_preco_escrever','cap_credito_escrever');
-- os QUATRO → 86052d07b87adb60ea0f1b568b28f5f3 · commercial_role = f
```

**A invariante do #2092 está cumprida** (os quatro byte-a-byte iguais, sem `commercial_role`) — o que diverge é só o **valor registrado**. Nenhum gate fixa esses md5 (`grep -rn '86052d07\|5faf2a21' db/ src/` → zero), então nada está vermelho: é erro de registro puro. Importa porque a coluna se chama "medido" e o commit que a acompanha (#2096) se chama "medido pós-apply" — previsão copiada para a coluna "medido" é a classe de defeito que este repo persegue.

Corrigir o texto em `rls-viva-fora-do-alcance-dos-audits.md` (e a menção no comentário de cabeçalho da migration `20260828213000_…sql:17`, sem tocar no SQL executável), depois de checar nos PRs #2087/#2092/#2096 se `5faf2a21…` chegou a ser o md5 do trio em algum momento — isso decide se é "instantâneo antigo, basta datar" ou "previsão que virou medição".
