### PR TITLE
docs(deploy): a assinatura de GATE era inferência por 3 descartes — marcador explícito no 401 lê a versão direto, com custo zero

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -328,6 +328,35 @@ ao vivo**, sem credencial e sem ninguém avisar. A consequência prática, poré
 descreve o `v1.3` e não uma constante do sistema — levante a SUA assinatura com
 `git show <commit>:<arquivo>` a cada uso, nunca copie a tabela.
 
+**A PROMOÇÃO: com marcador EXPLÍCITO no corpo do erro, os três descartes caem (2026-08-28, #2063).**
+A tabela acima infere a versão de uma string **acidental** — daí exigir os três descartes e
+envelhecer a cada fatia. O #2063 fez o oposto por desenho: o helper `jsonRes` anexa `versao: VERSAO`
+a **TODA** resposta das suas 4 edges, o 401 do gate inclusive. A leitura vira direta, sem credencial:
+
+```console
+$ curl -s -X POST -d '{"probe":true}' .../functions/v1/omie-sync-pedidos-compra
+{"error":"Unauthorized","versao":"v1.0-eco-versao-passivo"}          # HTTP 401
+```
+
+O descarte (3) — "a versão velha não podia emitir isto" — se responde sozinho: o campo **nomeia** a
+versão em vez de deixá-la inferir, e não existia no bundle anterior (`versao.ts` é arquivo NOVO na
+fatia). O (1), do gateway, continua valendo e é barato: confira `verify_jwt = false` no
+`config.toml` ANTES, senão o 401 é do gateway e o corpo não é seu.
+
+**Custo ZERO de efeito — é o que a torna preferível à sonda `{"probe":true}` aqui.** O gate recusa
+antes de qualquer I/O (`if (!authHeader?.startsWith("Bearer ")) return false;`), então não há
+varredura no Omie nem escrita. Sondar um bundle PRÉ-sensor faria o oposto: sem roteamento por
+`action`, o corpo cai nos defaults e roda o sync inteiro (o aviso que cada `versao.ts` dos 4 traz).
+
+**Controle negativo de graça:** edge irmã SEM `versao.ts` (`omie-cron-diario`,
+`omie-sonda-recebimento`) responde `{"error":"Unauthorized"}` **sem** o campo — mesma linha de gate,
+mesma forma de corpo, mesmo 401. É o que prova que o marcador vem do nosso código, não da
+plataforma; sem esse par, "achei o campo" não discrimina.
+
+⚠️ **É o SOCORRO do eco passivo quando a linha do cron é INUTILIZÁVEL** (o `modo:"background"` da
+§anterior): em 2026-08-28 02:15Z, no MESMO tick, três steps trouxeram o marcador e `pedidos` veio
+com `versao` vazio. O 401 resolveu na hora — e mede AGORA, não no último tick.
+
 ## Quando o Lovable reverte um fix — detectar e restaurar
 
 O bot `gpt-engineer-app[bot]` commita direto na `main` SEM CI ("Changes"/"Deployed"/"Deployou edge") e às vezes reverte um PR (~16% dos commits; ≥4-5 reversões money-path recentes). Prevenção é inviável (o bot precisa de escrita direta) → o jogo é **detectar + restaurar rápido** (MTTR), não governança perfeita. Spec: `docs/superpowers/specs/2026-06-26-lovable-revert-mitigation-design.md`.


### PR DESCRIPTION
Resíduo durável da verificação de deploy do #2063 (edge de TERCEIRO — a sessão dona já tinha pedido o deploy; **as 4 estão no ar**, provado abaixo).

## O que aconteceu

Verificando os 4 steps do cron-diário que ganharam `versao.ts`, o **eco passivo** do #2070 devolveu exatamente a linha INUTILIZÁVEL que ele prevê: no tick de 02:15Z o `pedidos` veio `modo:"background"` com `versao` vazio, enquanto `ctes`/`sku_items`/`vendas` traziam o marcador. Julgar por ela reprovaria um deploy **CORRETO** e mandaria redeployar edge money-path à toa.

O socorro estava no desenho do próprio #2063 e não estava escrito em lugar nenhum: o helper `jsonRes` anexa `versao: VERSAO` a **TODA** resposta — **o 401 do gate inclusive**.

## Por que é PROMOÇÃO, não seção nova

A §"Assinatura de GATE" já ensina que um gate que recusa informa. Mas ela infere a versão de uma string **acidental**, e por isso exige os três descartes e envelhece a cada fatia (o próprio doc avisa: "levante a SUA assinatura a cada uso, nunca copie a tabela").

Com marcador **explícito** o descarte (3) se responde sozinho — o campo NOMEIA a versão em vez de deixá-la inferir, e não existia no bundle anterior (`versao.ts` é arquivo NOVO). O (1), do gateway, continua valendo: `verify_jwt = false` no `config.toml`.

## Medido, não presumido

| eixo | resultado |
|---|---|
| as 4 edges, 401 sem credencial | `{"error":"Unauthorized","versao":"v1.0-eco-versao-passivo"}` — 2 leituras (02:0xZ e 02:49Z) |
| **controle negativo** | `omie-cron-diario` · `omie-sonda-recebimento` · `omie-nfe-recebimento-sync` → `{"error":"Unauthorized"}` **sem** o campo |
| **controle temporal** | ticks 20:15/22:15/**00:15Z** (todos `respondido` + HTTP 200 = leitura positiva) → sem o campo ⇒ deploy entre 00:15Z e 02:02Z |
| custo zero | o gate recusa antes de qualquer I/O — nada de varredura no Omie, nada gravado |

O controle negativo é o que fecha: as edges-controle têm a **mesma linha de gate** (conferida literal, 1 ocorrência em cada) e o mesmo 401 — a única diferença é o marcador. Sem esse par, "achei o campo" não discrimina.

## O que deliberadamente NÃO entra

A armadilha do `modo:"background"` e o eco passivo já são do #2070 — **referencio, não repito**. O `fonte`/`_shared/` segue coberto só pela rota `{"probe":true}` (#2054), e o eco não o cobre.

## Gates

`docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` → **exit 0** (capturado direto, sem `| tail`). Ressalva honesta: o bloco não tem citação `arquivo:linha` nem link, então esses gates provam que **não quebrei nada**, não que o texto está certo — quem prova o texto são as medições acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)