### PR TITLE
fix(deploy-verify): a condição (c) exigia `profiles` — e o próprio #2086 mediu `f` (falso negativo que descartaria prova de deploy válida)

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -584,9 +584,13 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        slug em `origin/main` acha **um** caller (o `index.ts` da própria edge). Sem isso prova-se o
        módulo `_shared/` compartilhado, não a versão daquela edge — mesma ressalva da mensagem única.
        **(c) nenhum 2º emissor** — o frontend chama a **EDGE**, não a RPC, e o harness roda em PG17
-       local. O que o `git grep` **não** fecha é a mão no 🟣 SQL Editor, então leia o **padrão**: 4
-       chamadas em 61 s do mesmo usuário real (staff, com `profiles`) é uso de app; rajada de
-       milissegundos ou `user_id` inventado é teste manual.
+       local. O que o `git grep` **não** fecha é a mão no 🟣 SQL Editor, então leia o **padrão**: as 4
+       do mesmo `user_id` vieram espaçadas em **segundos a dezenas de segundos** (22/27/12 s — tempo
+       de gravar áudio), e isso é uso de app; rajada de milissegundos ou `user_id` sem sessão é teste
+       manual. **Sem linha em `profiles` NÃO desqualifica**: aqui o `EXISTS` deu `f` e eram gravações
+       reais pelo microfone (cadastro em `/auth` é aberto; alias fiscal sem `profiles` é legítimo) —
+       quem fechou foi **perguntar ao founder**. Meça o vínculo com `EXISTS(...)`:
+       `coalesce(p.name,'…')` em LEFT JOIN lê igual para "não existe linha" e "coluna NULL".
     2. 🔴 **A direção é uma só: presença prova, ausência NÃO reprova.** Zero linhas pode ser "não
        deployou" **ou** "ninguém usou a feature", e edge de usuário não tem denominador que separe os
        dois. `ausente ≠ zero` de novo: sem chamada não houve medição, e "0 linhas" lê-se


### PR DESCRIPTION
## O que estava errado

A seção **N3 PASSIVO por ESCRITA DE APLICAÇÃO (#2086)**, condição **(c) nenhum 2º emissor**, ensinava a separar "uso pelo app" de "teste manual no 🟣 SQL Editor" assim:

> 4 chamadas em 61 s do mesmo usuário real (**staff, com `profiles`**) é uso de app; rajada de milissegundos ou `user_id` inventado é teste manual.

O parêntese está errado **sobre o próprio caso que gerou a regra**. Medido em prod agora (`psql-ro`, role `claude_ro`):

```
EXISTS(SELECT 1 FROM public.profiles p WHERE p.id = e.user_id), count(*), count(DISTINCT user_id)
  -> f | 4 | 1
```

As 4 linhas de `ia_uso_evento` vieram de **UM `user_id` SEM linha em `public.profiles`** — e o founder confirmou que foram **gravações reais pelo microfone no app**.

## Por que importa (o custo)

A condição (c) existe para **descartar teste manual da RPC**. Publicada como "com `profiles`", um agente futuro que aplicasse o critério à letra concluiria:

> sem `profiles` ⇒ `user_id` possivelmente inventado ⇒ teste manual ⇒ a prova não vale

…e **descartaria uma prova de deploy VÁLIDA**. É falso negativo, e o desfecho é escalar para o N3 ativo caro (que aqui custa o founder logado) ou pedir redeploy à toa — exatamente a classe de erro que esta seção existe para impedir.

E "sem `profiles`" é **compatível com uso legítimo** neste app, por dois motivos que o repo já conhece:
1. O próprio #2086 descreve o risco como "qualquer conta recém-criada — **inclusive customer com `is_approved=false`**" (o cadastro em `/auth` é aberto); conta nova pode não ter profile.
2. O `CLAUDE.md` já registra que users sem `profiles` **não são lixo** (aliases fiscais Colacor SC + Oben).

## O que entra no lugar

O discriminador que se sustenta é o **espaçamento**, não o vínculo com `profiles`. Deltas reais medidos entre as 4 chamadas:

```
22.506499 s · 26.792307 s · 11.931519 s     (span total 61 s, 00:32:26Z → 00:33:27Z)
```

Segundos a dezenas de segundos = tempo de **gravar áudio**. Contra isso, rajada de milissegundos ou `user_id` sem sessão é teste manual. Fica explícito que **`profiles` ausente NÃO desqualifica** (medido `f` no próprio #2086) e que a confirmação decisiva foi **perguntar ao founder**.

## Armadilha de MEDIÇÃO (1 linha, apareceu ao checar isto)

Ler o vínculo por `coalesce(p.name,'(sem profile)')` num LEFT JOIN **lê igual** para "não existe linha" e "coluna NULL" — é `ausente ≠ zero` na forma de JOIN. Foi assim que a primeira leitura saiu como `(sem profile)` sem que desse para justificar a causa; só o `EXISTS` responde a pergunta feita.

> Nuance medida e refletida no texto: **neste** caso a leitura por LEFT JOIN até acertava, porque `profiles.name` é `NOT NULL` (0 de 5.668 linhas com nome nulo) — mas isso exige uma **segunda consulta** para saber. `EXISTS(...)` dispensa o desvio. Por isso a linha diz "lê igual", não "dá a resposta errada".

## Controle de visibilidade (para o `f` não ser cegueira minha)

`EXISTS` e LEFT JOIN seriam **os dois** enganados se a role de leitura não enxergasse `profiles` por RLS. Conferido:

```
rolbypassrls(claude_ro) = t · profiles visíveis = 5668 · relrowsecurity = t · relforcerowsecurity = f
```

Logo o `f` é **fato**, não artefato de RLS.

## Gates

| Gate | Resultado |
|---|---|
| `bun run docs:links` | `exit 0` — 624 docs, todo link relativo resolve |
| `bun run claude:size` | `exit 0` (não toco o `CLAUDE.md`; rodado por sanidade) |
| `src/lib/__tests__/build-id-paridade.test.ts` | não afetado — lê `scripts/verify-frontend.sh` da skill, não o `SKILL.md` |

## Escopo

Só o bloco da condição (c) — **7 inserções, 3 remoções**, nada mais da skill. Arquivo QUENTE (4 toques em 28–29/08: #2086, #2088, #2090, #2091, #2102): conferido antes e imediatamente antes do PR — nenhum dos 3 PRs abertos (#2101, #2098, #2093) toca o arquivo, e o artefato não existe em `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)