### PR TITLE
docs(authz): o md5 do contrato é o NORMALIZADO — faltava a régua no doc, não corrigir o valor

### DIFF
--- a/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
+++ b/docs/historico/rls-viva-fora-do-alcance-dos-audits.md
@@ -85,7 +85,10 @@ autorizar qualquer autenticado. Medindo quem cobriria isso: **nenhuma** das 4 fu
 predicados de RLS. Ninguém as vigiava.
 
 Daí o **terceiro eixo**: md5 do `prosrc` das funções-predicado, com `prosecdef` e `proconfig`
-junto. Elas são **descobertas por `pg_depend`** (`classid='pg_policy'` → `refclassid='pg_proc'`),
+junto — sob a **mesma normalização** de cima: `md5(regexp_replace(btrim(prosrc), '\s+', ' ', 'g'))`
+(`db/audit-rls-prod.ts`). **Todo md5 de corpo citado neste arquivo é o normalizado**, e
+`md5(prosrc)` cru devolve OUTRO valor — o trio de `5faf2a21…` mede `86052d07…` cru (aferido
+2026-08-29). Elas são **descobertas por `pg_depend`** (`classid='pg_policy'` → `refclassid='pg_proc'`),
 não por regex sobre o texto da policy: o §4 do `database.md` guarda duas varreduras textuais que
 produziram falso-positivo integral, e uma função chamada dentro de um `COALESCE` não aparece onde
 um grep espera. Função descoberta que não esteja declarada é `PREDICADO_NAO_DECLARADO` — erro,
@@ -761,7 +764,8 @@ verificação pediu **cinco** medições, e o valor da rodada está em ter exigi
 | `EXECUTE` de `anon` | negado (PUBLIC segue revogado) | `false` ✅ |
 
 O md5 bater com o que fora **previsto antes** do apply é o que transforma "rodei" em evidência: se
-viesse outro valor, o certo seria parar, não carimbar.
+viesse outro valor, o certo seria parar, não carimbar. (Os dois md5 desta tabela são **normalizados**,
+§3 — conferir com `md5(prosrc)` cru dá `86052d07…`/`4a2f49ed…` e faz a tabela parecer falsa.)
 
 #### A armadilha de leitura que apareceu no meio
 


### PR DESCRIPTION
## O relatório de erro caiu — e o que ele achou de verdade

A suspeita: o §11.2 de `rls-viva-fora-do-alcance-dos-audits.md` carimba `5faf2a21…` na coluna
**medido**, mas prod devolve `86052d07…` — logo seria previsão copiada para "medido" sem medir.

**Não é.** Medido em prod (2026-08-29, `psql-ro`), as duas réguas lado a lado:

| função | `md5(prosrc)` **cru** | `md5` **normalizado** |
|---|---|---|
| `cap_carteira_escrever` | `86052d07…` | **`5faf2a21…`** |
| `cap_compras_ler` | `86052d07…` | **`5faf2a21…`** |
| `cap_preco_escrever` | `86052d07…` | **`5faf2a21…`** |
| `cap_credito_escrever` | `86052d07…` | **`5faf2a21…`** |
| `cap_carteira_ler` | `4a2f49ed…` | **`836e8f46…`** |

Os **dois** valores do doc batem com a coluna normalizada — não um, os dois. Mesmo corpo, régua
outra. O contrato usa `md5(regexp_replace(btrim(prosrc), '\s+', ' ', 'g'))` (`db/audit-rls-prod.ts`),
e `bun run authz:rls:prod` fecha **exit 0** contra prod:

> ✅ audit-rls — 336 tabela(s) em public com RLS ligada (0 desligada); 21 curada(s), 54 policy(ies)
> e 13 funcao(oes)-predicado batem com o contrato

## Por que a correção pedida teria sido cara

A premissa "nenhum gate executável fixa esses md5" veio de um grep restrito a `db/` e `src/` com
`--include='*.ts'/'*.json'` — que exclui `.sh` e a pasta `scripts/`. Sem as restrições, `5faf2a21…`
é âncora de **dois gates**:

- `scripts/authz-rls-esperado.ts` — 4× `srcMd5`
- `db/test-cap-carteira-escrever-master-only.sh:241` — `eq "A15b …" "$ESCMD5" "5faf2a21…"`

Trocar o valor no doc mandaria o próximo editor dessincronizar o contrato de prod — exatamente o
risco que o §11.1 já descreve ("mover o md5 … deixaria o gate do carimbo vermelho em todo PR").

## O que este PR muda

Só o que faltava de verdade: a **régua**. `scripts/authz-rls-esperado.ts:1111` já a documenta, e o
§3 do doc também — mas só para `pg_get_expr`. O eixo 3 (`prosrc`) a herdava implícita, e a tabela
do §11.2 não a mencionava. Duas anotações, nenhum valor tocado.

## Nota sobre "nada está vermelho no CI"

Nem `authz:rls:prod` nem o teste `.sh` rodam no CI — precisam de `psql-ro` ou PG17 local. **CI verde
nunca foi evidência sobre este md5**; a prova foi rodar o auditor à mão.

> **Lição:** hash registrado como evidência precisa registrar a **régua** junto. Sem ela a medição
> não é reproduzível, e uma reprodução com régua diferente faz registro correto **parecer** podre —
> desperdiçando a rodada, ou pior, "consertando" o que estava certo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 📌 Pendência registrada aqui por durabilidade (`/fecho` desta sessão)

O `/fecho` detectou uma pendência de **outra** sessão na janela e abriu o chip
**"Confirmar deploy da edge generate-bundle-argument"**. Chip vive só enquanto a sessão existir,
então o prompt fica registrado aqui (Passo 6 do ritual: destino perecível precisa de cópia durável).

**A pendência:** `.claude/skills/fecho/scripts/edges-pendentes.sh --desde "2026-08-29T02:00:00Z"`
devolveu `SEM_PROVA` para `generate-bundle-argument` (`analytics-outbox-drain` veio `NO_AR`,
fonte `b03bbf88…`). `SEM_PROVA` é **ausência de dado**, não deploy pendente provado — o chip nasce
por fail-closed. **Confirme antes de redeployar.**

**Por que tem prioridade:** o commit da janela é o #2101 — *"o gate de `generate-bundle-argument`
guardava só a SONDA — o caminho pago ia à Anthropic com JWT pelado"*. Enquanto o bundle velho
estiver no ar, o caminho pago segue aceitando JWT pelado.

**Já verificado (não refazer):**
- A migration pré-requisito `20260828224542_ia_uso_limite_generate_bundle_argument.sql` **está
  aplicada**: `SELECT count(*) FROM public.ia_uso_limite WHERE funcao='generate-bundle-argument'`
  → `1` (psql-ro, 2026-08-29). Importa porque `ia_consumir_cota` é fail-closed — sem o seed a edge
  responderia 503 assim que fosse deployada.
- O commit `ecf05231a "Lovable update"` **não** tocou `supabase/functions/` nem
  `supabase/migrations/` — o #2101 não foi atropelado pelo sync bidirecional.

**Como resolver:** skill `lovable-deploy-verify`. Meça primeiro
(`edges-pendentes.sh generate-bundle-argument`); se persistir `SEM_PROVA`, a sondagem ativa
(`bun run sonda:sql generate-bundle-argument`) precisa do SQL Editor do Lovable — ela lê
`vault.decrypted_secrets` e chama `net.http_post`, ambos negados ao `claude_ro`. Se o bundle
estiver velho, a fatia de deploy tem de nomear **todos** os arquivos (closure ∪ {mapa}, #2107):
`generate-bundle-argument/index.ts`, `generate-bundle-argument/versao.ts`,
`_shared/sonda-fingerprints.ts` — prompt que nomeia um só deixa a edge sem bootar (#2020).
