### PR TITLE
docs(deploy): a via do 401 do #2104 valia só com gate INLINE — com `_shared/auth.ts` ela é CEGA e a ausência do marcador lê como "não deployou"

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -357,6 +357,24 @@ plataforma; sem esse par, "achei o campo" não discrimina.
 §anterior): em 2026-08-28 02:15Z, no MESMO tick, três steps trouxeram o marcador e `pedidos` veio
 com `versao` vazio. O 401 resolveu na hora — e mede AGORA, não no último tick.
 
+⚠️ **PRÉ-CONDIÇÃO que a via exige: o gate tem de ser INLINE na edge.** Medido no fecho de
+2026-08-29, e o modo de falha é o falso negativo caro. Nas 4 edges do #2063 o
+`authorizeCronOrStaff` é inline e a recusa passa pelo `jsonRes`, então o 401 carrega o marcador.
+Quando o gate vem de `_shared/auth.ts`, **não passa**: a edge faz `if (!auth.ok) return
+auth.response;` e a `Response` já vem pronta de lá (`function unauthorized(message =
+"Unauthorized")`), **por fora** do helper. O 401 dessa edge nunca carrega marcador — nem no bundle
+NOVO. Ler a ausência como "bundle velho" ⇒ pedir deploy de edge money-path **já no ar**.
+
+O caso: `analytics-outbox-drain` (#2094) respondeu `{"error":"Unauthorized"}` **sem** o campo, e o
+`jsonRes` dela na main anexa `versao`/`edge`/`fonte` — leitura que gritaria "não deployou". O eco
+PASSIVO desmentiu na mesma janela: o cron de 5 min (jobid 181) grava `versao:"v1.0-sensor-inicial"`
++ `edge:"analytics-outbox-drain"` em `net._http_response`, 4 ticks seguidos, status 200. **No ar.**
+
+⇒ **Antes de usar a via, confirme onde nasce o 401** (`grep -n 'Unauthorized' index.ts` — achou nada
+e o import é `_shared/auth.ts`? a via não discrimina AQUI). E o inverso do socorro vale: onde o 401
+é cego, quem enxerga é o eco passivo. As duas vias se cobrem em direções opostas — nenhuma sozinha
+cobre o parque.
+
 ## Quando o Lovable reverte um fix — detectar e restaurar
 
 O bot `gpt-engineer-app[bot]` commita direto na `main` SEM CI ("Changes"/"Deployed"/"Deployou edge") e às vezes reverte um PR (~16% dos commits; ≥4-5 reversões money-path recentes). Prevenção é inviável (o bot precisa de escrita direta) → o jogo é **detectar + restaurar rápido** (MTTR), não governança perfeita. Spec: `docs/superpowers/specs/2026-06-26-lovable-revert-mitigation-design.md`.


### PR DESCRIPTION
Follow-up imediato do #2104, mergeado horas atrás. A lacuna apareceu na **primeira aplicação da via a uma edge de terceiro**, durante a `/fecho` da mesma sessão que a documentou.

## A lacuna

O #2104 ensina a ler a versão pelo marcador que o `jsonRes` anexa ao 401. Faltou dizer **quando isso vale**.

Quando o gate é `_shared/auth.ts`, a edge faz `if (!auth.ok) return auth.response;` e a `Response` já vem pronta de lá (`function unauthorized(message = "Unauthorized")`) — **por fora** do `jsonRes`. O 401 nunca carrega o marcador, **nem no bundle NOVO**. Ler a ausência como "bundle velho" ⇒ pedir deploy de edge money-path **já no ar**: exatamente o falso negativo que a §Assinatura de GATE existe para evitar.

## Medido (eu quase cometi)

`analytics-outbox-drain` (#2094) respondeu `{"error":"Unauthorized"}` **sem** o campo — e o `jsonRes` dela na main anexa `versao`/`edge`/`fonte`. A leitura ingênua gritaria "não deployou".

O **eco passivo** desmentiu na mesma janela: o cron de 5 min (jobid 181) grava `versao:"v1.0-sensor-inicial"` + `edge:"analytics-outbox-drain"` em `net._http_response` — 4 ticks seguidos, status 200. **No ar.**

## A regra que entra

- Antes de usar a via, confirme **onde nasce o 401**: `grep -n 'Unauthorized' index.ts`. Achou nada + import de `_shared/auth.ts` ⇒ não discrimina aqui.
- E o inverso do socorro do #2104 vale: **onde o 401 é cego, quem enxerga é o eco passivo**. As duas se cobrem em direções **opostas** — nenhuma sozinha cobre o parque.

## Gates

`docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)