### PR TITLE
feat(fecho): chip de deploy de edge passa a exigir AUSÊNCIA DE PROVA, não commit na janela

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -149,8 +149,33 @@ git diff --name-only origin/main...HEAD -- supabase/functions/
 # ⚠️ E o que OUTRAS sessões mergearam na janela desta — MESMO argumento do passo 2, e ele vale
 # aqui palavra por palavra: edge de terceiro entra na main sem ninguém aqui saber, também NÃO
 # se auto-deploya (chat do Lovable, manual) e a falha é igualmente SILENCIOSA.
-git log origin/main --since="<hora de início da sessão>" --name-only --format="" -- supabase/functions/ | sort -u
+#
+# Este script enumera a janela INTEIRA (a desta sessão e a das outras) e já classifica quem
+# precisa de chip. Use-o em vez do `git log` cru — o cru é o gatilho velho, ver abaixo.
+bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início da sessão>"
+# exit 0 = nada pendente · 1 = abra chip para a lista · 2 = MECÂNICA não confiável (o script já
+# imprime tudo como pendente; trate assim) · 3 = uso inválido
 ```
+
+**O gatilho deste passo é "sem prova de estar no ar", não "tem commit na janela".** O `git log`
+cru era o gatilho antigo, e num repo com dezenas de worktrees ele é quase sempre verdadeiro: a
+MESMA edge virava chip em toda sessão que fechasse na mesma janela, e fila de chips iguais
+enterra o chip que importava. O script troca isso pela evidência que já existe de graça — o campo
+`fonte` que a sonda serve (SHA-256 do fecho transitivo dos imports) comparado com
+`sonda-fingerprints.ts` da main:
+
+| veredito | o que significa | chip? |
+|---|---|---|
+| `NO_AR` | `fonte` servido == main — o bundle no ar é este | **não** |
+| `DESATUALIZADA` | `fonte` servido ≠ main — bundle VELHO servindo | sim, e prioritário |
+| `SEM_PROVA` | fora do mapa de sondas, sem sonda na janela, ou mecânica quebrada | sim (fail-closed) |
+
+🔴 **A direção é uma só: presença PROVA, ausência NÃO reprova** (#2086/#2095). O script só sabe
+SUPRIMIR chip com evidência POSITIVA; ele é o lado que APAGA pendência, então na dúvida é chip.
+O mapa cobre ~40 das ~95 edges — as outras seguem virando chip como sempre, nada regride.
+Medido em 2026-08-28 numa janela real de 24h: 7 edges na janela, 3 provadas no ar, **4 chips em
+vez de 7**. E não é só corte: o `DESATUALIZADA` é sinal que o gatilho velho nunca teve — ele
+mostra bundle velho SERVINDO, que é a falha silenciosa que este passo existe para pegar.
 
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
@@ -165,8 +190,9 @@ alargou a consulta por conta própria — pela letra deste passo, ele teria olha
 `git log`, visto commit que não era dele, e seguido em frente.
 
 Destino de edge de terceiro **não é** "deployar por ela" nem "assumir que a outra sessão já
-pediu": é **chip** (a sessão dona pode ter fechado sem pedir o deploy), com o prompt mandando
-CONFIRMAR antes de pedir deploy redundante. E o prompt tem de nomear **todos** os arquivos,
+pediu": é **chip** (a sessão dona pode ter fechado sem pedir o deploy) — para as que o script
+marcar como pendentes, e só para elas —, com o prompt mandando CONFIRMAR antes de pedir deploy
+redundante. E o prompt tem de nomear **todos** os arquivos,
 `_shared` novo incluído — prompt que nomeia um só deixa a edge sem bootar (#2020).
 
 ### Passo 4 — Publish do frontend

--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -153,6 +153,7 @@ git diff --name-only origin/main...HEAD -- supabase/functions/
 # Este script enumera a janela INTEIRA (a desta sessão e a das outras) e já classifica quem
 # precisa de chip. Use-o em vez do `git log` cru — o cru é o gatilho velho, ver abaixo.
 bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início da sessão>"
+# aceita DATA ou REVISÃO — se você anotou o SHA de origin/main ao abrir a sessão, prefira o SHA
 # exit 0 = nada pendente · 1 = abra chip para a lista · 2 = MECÂNICA não confiável (o script já
 # imprime tudo como pendente; trate assim) · 3 = uso inválido
 ```

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -84,7 +84,9 @@ if [ "$1" = "--desde" ]; then
 
   # (b) pastas tocadas no git log: pega edge FORA do mapa, cega para _shared/
   git -C "$RAIZ" log "$base..origin/main" --name-only --format="" -- supabase/functions/ 2>/dev/null \
-    | sed -n 's#^supabase/functions/\([a-z0-9_-][a-z0-9_-]*\)/.*#\1#p' >> "$tmp/alvos"
+    | sed -n 's#^supabase/functions/\([a-z0-9][a-z0-9_-]*\)/.*#\1#p' >> "$tmp/alvos"
+  # o `[a-z0-9]` inicial exclui `_shared/` de propósito: não é edge, não se deploya sozinha,
+  # e o efeito dela nas edges que a importam já entra pela via (a), o diff dos fingerprints.
 
   sort -u -o "$tmp/alvos" "$tmp/alvos" 2>/dev/null || true
 else
@@ -127,7 +129,10 @@ esac
 if [ "$mecanica_ok" = 1 ]; then
   if [ ! -x "$PSQL" ]; then
     mecanica_ok=0; motivo="psql-ro ausente ou sem permissão de execução ($PSQL)"
-  elif [ "$("$PSQL" -Atc 'SELECT 1' 2>/dev/null | tr -d '[:space:]')" != "1" ]; then
+  elif ! "$PSQL" -Atc 'SELECT 1' 2>/dev/null | command grep -Fxq -- '1'; then
+    # LINHA exatamente "1", não a saída inteira: o wrapper emite os `SET` da sessão read-only
+    # antes do resultado (`docs/historico/evidencia-positiva-shell.md` §11 — o PREÂMBULO do wrapper
+    # vira "dado"). Exigir a FORMA, não a presença: vazio, só `SET`, ou erro não passam daqui.
     mecanica_ok=0; motivo="psql-ro não respondeu 1 ao SELECT 1 (presente porém mudo/quebrado)"
   fi
 fi

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -25,7 +25,7 @@
 #
 # Uso:
 #   edges-pendentes.sh <slug> [<slug> ...]      # classifica os slugs dados
-#   edges-pendentes.sh --desde "<git-since>"    # deriva os slugs da janela (UNIÃO de 2 fontes)
+#   edges-pendentes.sh --desde "<data-ou-SHA>"  # deriva os slugs da janela (UNIÃO de 2 fontes)
 #
 # `--desde` enumera pela UNIÃO, porque cada fonte sozinha tem furo (mesmo princípio do Passo 4 da
 # lovable-deploy-verify): (a) o DIFF do mapa de fingerprints entre o início da janela e a main —
@@ -62,10 +62,13 @@ if [ "$1" = "--desde" ]; then
   desde="${2:-}"
   [ -n "$desde" ] || { echo "uso: edges-pendentes.sh --desde \"<git-since>\""; exit 3; }
 
-  base="$(git -C "$RAIZ" rev-list -1 --before="$desde" origin/main 2>/dev/null)"
+  # aceita DATA ("3 hours ago", "2026-08-28 14:00") ou REVISÃO (o SHA do início da sessão, que é
+  # o dado mais preciso que o /fecho tem à mão). Revisão primeiro: um SHA nunca é data válida.
+  base="$(git -C "$RAIZ" rev-parse --verify --quiet "${desde}^{commit}" 2>/dev/null)"
+  [ -n "$base" ] || base="$(git -C "$RAIZ" rev-list -1 --before="$desde" origin/main 2>/dev/null)"
   if [ -z "$base" ]; then
     echo "⚠️ edges-pendentes: não achei o commit-base de origin/main antes de \"$desde\""
-    echo "   (git fetch feito? a data é parseável pelo git?) — MECÂNICA NÃO CONFIÁVEL, exit 2"
+    echo "   (git fetch feito? a data é parseável pelo git, ou o SHA existe?) — exit 2"
     exit 2
   fi
 
@@ -84,9 +87,27 @@ if [ "$1" = "--desde" ]; then
 
   # (b) pastas tocadas no git log: pega edge FORA do mapa, cega para _shared/
   git -C "$RAIZ" log "$base..origin/main" --name-only --format="" -- supabase/functions/ 2>/dev/null \
-    | sed -n 's#^supabase/functions/\([a-z0-9][a-z0-9_-]*\)/.*#\1#p' >> "$tmp/alvos"
+    | sort -u > "$tmp/paths"
+  sed -n 's#^supabase/functions/\([a-z0-9][a-z0-9_-]*\)/.*#\1#p' "$tmp/paths" >> "$tmp/alvos"
   # o `[a-z0-9]` inicial exclui `_shared/` de propósito: não é edge, não se deploya sozinha,
   # e o efeito dela nas edges que a importam já entra pela via (a), o diff dos fingerprints.
+
+  # 🔴 O furo que a UNIÃO ainda deixaria: `_shared/` tocado é a ÚNICA classe cujas edges afetadas
+  # NENHUMA das duas vias enxerga sem o mapa — a (b) não conhece o grafo de imports e a (a) precisa
+  # do arquivo. Sem essa trava, mudança só em `_shared/` sairia como "nenhuma edge na janela": chip
+  # suprimido por AUSÊNCIA DE DADO, que é o modo de falha caro de um script que APAGA pendência.
+  if command grep -q '^supabase/functions/_shared/' "$tmp/paths" 2>/dev/null; then
+    if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then
+      echo "⚠️ edges-pendentes: \`_shared/\` mudou na janela e o mapa de fingerprints não pôde ser"
+      echo "   lido nas duas pontas — não sei QUAIS edges isso afetou. MECÂNICA NÃO CONFIÁVEL, exit 2."
+      exit 2
+    fi
+    if [ ! -s "$tmp/alvos" ]; then
+      echo "⚠️ \`_shared/\` mudou na janela e NENHUM fingerprint mudou. Ou a mudança não entra em"
+      echo "   bundle nenhum, ou o mapa não foi regenerado no merge (\`bun run sonda:fingerprint\`)."
+      echo "   Confira antes de concluir que não há deploy pendente."
+    fi
+  fi
 
   sort -u -o "$tmp/alvos" "$tmp/alvos" 2>/dev/null || true
 else

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# edges-pendentes.sh — Passo 3 do /fecho: das edges que mergearam na janela, quais AINDA
+# precisam de chip?
+#
+# O QUE ELE RESOLVE. O gatilho do Passo 3 era `git log ... -- supabase/functions/` puro: commit na
+# janela ⇒ chip. Num repo com dezenas de worktrees e ~4–11 merges de edge por dia, esse gatilho é
+# quase sempre verdadeiro, e a MESMA edge vira chip em toda sessão que fecha na mesma janela. Chip
+# redundante não é grátis: o founder é quem clica, e uma fila de chips iguais some com o chip que
+# importava. Este script troca "commit no git" por "o que está NO AR", usando a única evidência
+# que já existe de graça: o campo `fonte` que `criarRespostaSonda` serve (SHA-256 do fecho
+# transitivo dos imports locais) comparado com `_shared/sonda-fingerprints.ts` da main.
+#
+# 🔴 A DIREÇÃO É UMA SÓ: presença PROVA, ausência NÃO reprova (a lição do #2086/#2095). Este
+# script só sabe SUPRIMIR chip com evidência POSITIVA — `fonte` servido == `fonte` da main. Tudo
+# o mais (sem linha na janela, edge fora do mapa, `nao-mapeada`, banco mudo) sai como pendência.
+# Ele é o lado que APAGA a pendência, então é fail-CLOSED por desenho: na dúvida, chip.
+#
+# Por que a comparação é imune ao guard temporal do #2079: o `fonte` é função do CONTEÚDO, não do
+# relógio. Uma resposta gravada ANTES do merge carrega o fingerprint do bundle velho e não casa com
+# a main. Não há "tick pré-merge lido como prova" aqui — o que o `versao` não veria (mesma string
+# nas duas pontas), o `fonte` vê (foi assim que o `omie-vendas-sync` foi pego com bundle velho).
+#
+# COBERTURA, dita em voz alta: o mapa cobre ~40 das ~95 edges. As outras ~55 saem SEM_PROVA e
+# viram chip como hoje — o gate não regride nada, só corta o redundante onde há prova.
+#
+# Uso:
+#   edges-pendentes.sh <slug> [<slug> ...]      # classifica os slugs dados
+#   edges-pendentes.sh --desde "<git-since>"    # deriva os slugs da janela (UNIÃO de 2 fontes)
+#
+# `--desde` enumera pela UNIÃO, porque cada fonte sozinha tem furo (mesmo princípio do Passo 4 da
+# lovable-deploy-verify): (a) o DIFF do mapa de fingerprints entre o início da janela e a main —
+# única via que enxerga mudança em `_shared/`, que muda o bundle de N edges sem tocar na pasta de
+# nenhuma; (b) o `git log --name-only` das pastas — única via que enxerga edge FORA do mapa.
+#
+# Exit: 0 = nada pendente (todas provadas no ar) · 1 = há pendência → abra chip para a lista
+#       2 = a MECÂNICA não é confiável (sem banco, mapa ilegível, janela inválida) → trate TUDO
+#           como pendente; o script já imprime todos os alvos como SEM_PROVA
+#       3 = uso inválido
+#
+# Env: AFIACAO_PSQL (default ~/.config/afiacao/psql-ro) · FECHO_JANELA_TTL (default '6 hours',
+#      = pg_net.ttl) · FECHO_MAPA_FONTE (arquivo de mapa alternativo; default = o da origin/main).
+# Testes: scripts/test-fecho-edges-pendentes.sh (com --falsificar).
+set -uo pipefail
+
+JANELA="${FECHO_JANELA_TTL:-6 hours}"
+PSQL="${AFIACAO_PSQL:-$HOME/.config/afiacao/psql-ro}"
+MAPA_REL="supabase/functions/_shared/sonda-fingerprints.ts"
+RAIZ="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../../../.." 2>/dev/null && pwd)}"
+
+tmp="$(mktemp -d)" || { echo "edges-pendentes: mktemp falhou"; exit 2; }
+trap 'rm -rf "$tmp"' EXIT
+
+# --------------------------------------------------------------------- uso ---
+[ "$#" -ge 1 ] || {
+  echo "uso: edges-pendentes.sh <slug> [slug...]   |   edges-pendentes.sh --desde \"<git-since>\""
+  exit 3
+}
+
+# ------------------------------------------------------- alvos (quem medir) ---
+# Modo --desde: a UNIÃO das duas fontes. Sem ela o gate herda o furo da fonte escolhida.
+if [ "$1" = "--desde" ]; then
+  desde="${2:-}"
+  [ -n "$desde" ] || { echo "uso: edges-pendentes.sh --desde \"<git-since>\""; exit 3; }
+
+  base="$(git -C "$RAIZ" rev-list -1 --before="$desde" origin/main 2>/dev/null)"
+  if [ -z "$base" ]; then
+    echo "⚠️ edges-pendentes: não achei o commit-base de origin/main antes de \"$desde\""
+    echo "   (git fetch feito? a data é parseável pelo git?) — MECÂNICA NÃO CONFIÁVEL, exit 2"
+    exit 2
+  fi
+
+  # (a) diff do mapa de fingerprints: pega mudança vinda de _shared/, cega para edge fora do mapa
+  git -C "$RAIZ" show "$base:$MAPA_REL" 2>/dev/null \
+    | sed -nE 's/.*"([a-z0-9_-]+)": *"([0-9a-f]{64})".*/\1 \2/p' > "$tmp/mapa_base" || true
+  git -C "$RAIZ" show "origin/main:$MAPA_REL" 2>/dev/null \
+    | sed -nE 's/.*"([a-z0-9_-]+)": *"([0-9a-f]{64})".*/\1 \2/p' > "$tmp/mapa_agora" || true
+  # slug cujo par (slug sha) existe no mapa de agora e NÃO existe igual no mapa base ⇒ fonte mudou
+  # (inclui edge NOVA, que não tem linha no base).
+  if [ -s "$tmp/mapa_agora" ]; then
+    while read -r slug sha; do
+      command grep -Fxq -- "$slug $sha" "$tmp/mapa_base" 2>/dev/null || printf '%s\n' "$slug"
+    done < "$tmp/mapa_agora" >> "$tmp/alvos"
+  fi
+
+  # (b) pastas tocadas no git log: pega edge FORA do mapa, cega para _shared/
+  git -C "$RAIZ" log "$base..origin/main" --name-only --format="" -- supabase/functions/ 2>/dev/null \
+    | sed -n 's#^supabase/functions/\([a-z0-9_-][a-z0-9_-]*\)/.*#\1#p' >> "$tmp/alvos"
+
+  sort -u -o "$tmp/alvos" "$tmp/alvos" 2>/dev/null || true
+else
+  printf '%s\n' "$@" | sort -u > "$tmp/alvos"
+fi
+
+if [ ! -s "$tmp/alvos" ]; then
+  echo "✅ nenhuma edge na janela — nada a deployar, nenhum chip."
+  exit 0
+fi
+
+# --------------------------------------------------- mapa de fingerprints ---
+# Da origin/main de propósito: a pergunta é "o ar bate com o que ESTÁ MERGEADO?", não com o
+# worktree local (que pode ter fatia ainda não mergeada, e aí o "desatualizada" seria mentira).
+if [ -n "${FECHO_MAPA_FONTE:-}" ]; then
+  cat "$FECHO_MAPA_FONTE" 2>/dev/null > "$tmp/mapa_bruto"
+else
+  git -C "$RAIZ" show "origin/main:$MAPA_REL" 2>/dev/null > "$tmp/mapa_bruto"
+fi
+sed -nE 's/.*"([a-z0-9_-]+)": *"([0-9a-f]{64})".*/\1 \2/p' "$tmp/mapa_bruto" \
+  2>/dev/null > "$tmp/mapa" || true
+
+mecanica_ok=1
+motivo=""
+if [ ! -s "$tmp/mapa" ]; then
+  mecanica_ok=0
+  motivo="mapa de fingerprints ilegível ou vazio ($MAPA_REL na origin/main)"
+fi
+
+# ------------------------------------------------------- sonda do BANCO ---
+# `command -v` NÃO basta: wrapper presente-porém-quebrado esvaziaria o gate igual, e este é o
+# script que APAGA pendência. Exige-se RESPOSTA POSITIVA ('1') antes de confiar em qualquer
+# ausência lida do banco.
+# shellcheck disable=SC2016  # aspas simples sao TEXTO aqui; a string externa e dupla
+case "$JANELA" in
+  [0-9]*' hours' | [0-9]*' hour' | [0-9]*' minutes' | [0-9]*' days') ;;
+  *) mecanica_ok=0; motivo="${motivo:-janela inválida: '$JANELA' (use '6 hours')}" ;;
+esac
+
+if [ "$mecanica_ok" = 1 ]; then
+  if [ ! -x "$PSQL" ]; then
+    mecanica_ok=0; motivo="psql-ro ausente ou sem permissão de execução ($PSQL)"
+  elif [ "$("$PSQL" -Atc 'SELECT 1' 2>/dev/null | tr -d '[:space:]')" != "1" ]; then
+    mecanica_ok=0; motivo="psql-ro não respondeu 1 ao SELECT 1 (presente porém mudo/quebrado)"
+  fi
+fi
+
+if [ "$mecanica_ok" = 1 ]; then
+  # DISTINCT ON pega a resposta MAIS RECENTE por edge: dentro da janela cabe o deploy no meio dela
+  # (bundle velho às 21:48, novo às 22:04) e "alguma resposta bateu" leria o velho como prova.
+  # O `OFFSET 0` é barreira de otimização: sem ela o planner pode empurrar o `content::jsonb` para
+  # antes do filtro de forma e estourar em linha que não é JSON.
+  sql="WITH bruto AS (
+         SELECT created, content FROM net._http_response
+         WHERE status_code = 200 AND content IS NOT NULL
+           AND left(ltrim(content), 1) = '{'
+           AND created > now() - interval '$JANELA'
+         OFFSET 0
+       ), sondas AS (
+         SELECT created,
+                (content::jsonb) ->> 'edge'  AS edge,
+                (content::jsonb) ->> 'fonte' AS fonte
+         FROM bruto WHERE (content::jsonb) ? 'fonte'
+       )
+       SELECT DISTINCT ON (edge) edge || ' ' || fonte
+       FROM sondas WHERE edge IS NOT NULL AND fonte IS NOT NULL
+       ORDER BY edge, created DESC;"
+  if ! "$PSQL" -Atc "$sql" > "$tmp/ar" 2>"$tmp/erro"; then
+    mecanica_ok=0
+    motivo="a consulta a net._http_response falhou: $(head -c 160 "$tmp/erro" | tr '\n' ' ')"
+  fi
+fi
+
+# ------------------------------------------------------------ veredito ---
+: > "$tmp/chips"
+echo "== edges da janela: precisa de chip? =="
+if [ "$mecanica_ok" = 0 ]; then
+  echo "⚠️ MECÂNICA NÃO CONFIÁVEL — $motivo"
+  echo "   Fail-closed: sem evidência POSITIVA, toda edge da janela segue pendente."
+fi
+
+while read -r slug; do
+  [ -n "$slug" ] || continue
+  esperado=""; servido=""
+  if [ "$mecanica_ok" = 1 ]; then
+    esperado="$(command grep -m1 -- "^$slug " "$tmp/mapa"  2>/dev/null | cut -d' ' -f2)"
+    servido="$( command grep -m1 -- "^$slug " "$tmp/ar"    2>/dev/null | cut -d' ' -f2)"
+  fi
+
+  if [ "$mecanica_ok" = 1 ] && [ -n "$esperado" ] && [ "$servido" = "$esperado" ]; then
+    printf '  NO_AR          %-34s fonte %s… bate com a main\n' "$slug" "${servido:0:8}"
+    continue
+  fi
+
+  printf '%s\n' "$slug" >> "$tmp/chips"
+  if [ "$mecanica_ok" = 0 ]; then
+    printf '  SEM_PROVA      %-34s mecânica não confiável (ver acima)\n' "$slug"
+  elif [ -z "$esperado" ]; then
+    printf '  SEM_PROVA      %-34s fora do mapa de sondas — não há prova passiva possível\n' "$slug"
+  elif [ -z "$servido" ]; then
+    printf '  SEM_PROVA      %-34s nenhuma sonda em %s (ausência ≠ pendência: INDETERMINADO)\n' "$slug" "$JANELA"
+  elif [ "$servido" = "nao-mapeada" ]; then
+    # shellcheck disable=SC2016  # as crases sao TEXTO: `nao-mapeada` e o valor servido
+    printf '  SEM_PROVA      %-34s a sonda respondeu `nao-mapeada` — a prova nasceu cega\n' "$slug"
+  else
+    printf '  DESATUALIZADA  %-34s no ar %s… ≠ main %s… — BUNDLE VELHO SERVINDO\n' \
+      "$slug" "${servido:0:8}" "${esperado:0:8}"
+  fi
+done < "$tmp/alvos"
+
+n_chips="$(wc -l < "$tmp/chips" | tr -d "[:space:]")"
+echo
+if [ "$n_chips" -eq 0 ]; then
+  echo "✅ todas provadas no ar pelo \`fonte\` — nenhum chip de deploy por estas edges."
+  exit 0
+fi
+echo "🎫 abra chip para: $(tr '\n' ' ' < "$tmp/chips")"
+echo "   (DESATUALIZADA = deploy pendente PROVADO · SEM_PROVA = indeterminado, chip por fail-closed)"
+[ "$mecanica_ok" = 1 ] && exit 1
+exit 2

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pipestatus-guard-sinal pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
-    "test:falsificacao": "for t in orfaos-custosos read-contexto-nudge; do bash scripts/test-$t.sh --falsificar || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pipestatus-guard-sinal pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query fecho-edges-pendentes; do bash scripts/test-$t.sh || exit 1; done",
+    "test:falsificacao": "for t in orfaos-custosos read-contexto-nudge fecho-edges-pendentes; do bash scripts/test-$t.sh --falsificar || exit 1; done",
     "evals:deploy-verify": "bash .claude/skills/lovable-deploy-verify/evals/run.sh",
     "evals:deploy-verify:falsificacao": "bash .claude/skills/lovable-deploy-verify/evals/run.sh --falsify",
     "heavy:install": "bash scripts/heavy-install.sh"

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -48,7 +48,11 @@ cat > "$tmp/psql-stub" <<'STUB'
 sql="${!#}"
 case "${STUB_MODO:-ok}" in
   mudo) exit 0 ;;                       # presente-porém-QUEBRADO: responde vazio ao SELECT 1
+  so-set) echo SET; echo SET; exit 0 ;; # abre a sessao e nao devolve resultado nenhum
 esac
+# o wrapper REAL emite os `SET` da sessao read-only ANTES do resultado (medido em prod 2026-08-28):
+# quem exigir a saida inteira == "1" reprova o wrapper BOM e o gate nasce sempre em fail-closed.
+echo SET; echo SET
 if [ "$sql" = "SELECT 1" ]; then echo 1; exit 0; fi
 printf '%s' "$sql" > "${STUB_SQL_ECO:-/dev/null}"
 [ "${STUB_MODO:-ok}" = "erro-query" ] && { echo "ERROR: relation net._http_response" >&2; exit 1; }
@@ -116,6 +120,13 @@ suite() {
   if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ] && ! tem 'NO_AR' "$out"
   then ok "psql presente-porem-MUDO -> fail-closed: SEM_PROVA, exit 2"
   else bad "psql mudo devia manter a pendencia com exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 6b. o wrapper que responde `SET SET 1` e o BOM: exigir a saida inteira == "1" reprovaria ele e
+  #     o gate nasceria travado em exit 2 (medido contra o banco real antes de entregar).
+  run so-set "$tmp/psql-stub" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ]
+  then ok "psql que so abre sessao (SET SET, sem resultado) -> fail-closed, exit 2"
+  else bad "psql sem resultado devia dar exit 2 (rc=$rc): ${out:0:90}"; fi
 
   # 7. a consulta estourou -> mecanica nao confiavel, tudo pendente
   run erro-query "$tmp/psql-stub" edge-no-ar
@@ -194,8 +205,11 @@ if [ "${1:-}" = "--falsificar" ]; then
   }
 
   # (a) a sonda positiva vira `command -v` de mentira: presente passa a valer por respondendo
-  sabota "aceitar psql mudo (sem exigir resposta positiva)" \
-    's%!= "1"%!= "IMPOSSIVEL"%'
+  sabota "presenca do wrapper basta (sem exigir resposta positiva)" \
+    "s%! \"\$PSQL\" -Atc 'SELECT 1' 2>/dev/null | command grep -Fxq -- '1'%false%"
+  # (a2) a sonda volta a exigir a saida INTEIRA == "1": reprova o wrapper bom (o defeito de prod)
+  sabota "sonda exigindo saida inteira == 1 (ignora os SET do wrapper)" \
+    "s%| command grep -Fxq -- '1'%| tr -d '[:space:]' | command grep -Fxq -- '1'%"
   # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "classificar como NO_AR mesmo com mecanica quebrada" \

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# test-fecho-edges-pendentes.sh — suíte do gate do Passo 3 do /fecho.
+#
+# O alvo é `.claude/skills/fecho/scripts/edges-pendentes.sh`, o script que decide se uma edge da
+# janela AINDA precisa de chip. Ele é o lado que APAGA pendência, então a asserção que mais importa
+# aqui não é "sabe dizer NO_AR" — é **sabe continuar dizendo pendente quando a mecânica falha**
+# (`docs/historico/sonda-ausente-em-script-que-apaga.md`: `command -v` não basta, exige-se resposta
+# POSITIVA; sonda quebrada que esvazia o guard é o modo de falha caro).
+#
+# O banco entra por STUB: a suíte prova o SCRIPT, não o PostgREST. O que não dá para provar sem
+# banco (a query pegar a resposta MAIS RECENTE por edge) vira guardrail de FORMA sobre o SQL.
+#
+#   bash scripts/test-fecho-edges-pendentes.sh              # suíte
+#   bash scripts/test-fecho-edges-pendentes.sh --falsificar # sabota o alvo e EXIGE vermelho
+#
+# Roda nos DOIS locales de propósito (#1483): falsificar em UM ambiente não prova a asserção.
+set -uo pipefail
+
+RAIZ="$(cd "$(dirname "$0")/.." && pwd)"
+ALVO="$RAIZ/.claude/skills/fecho/scripts/edges-pendentes.sh"
+[ -f "$ALVO" ] || { echo "VERMELHO — alvo não encontrado: $ALVO"; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+# ------------------------------------------------------------------ fixtures ---
+SHA_NOVO="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SHA_VELHO="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+cat > "$tmp/mapa.ts" <<MAPA
+export const FONTE_SHA256: Record<string, string> = {
+  "edge-no-ar": "$SHA_NOVO",
+  "edge-velha": "$SHA_NOVO",
+  "edge-muda": "$SHA_NOVO",
+  "edge-cega": "$SHA_NOVO",
+};
+MAPA
+
+# o que o "banco" devolve: a resposta mais recente por edge, formato `<edge> <fonte>`
+cat > "$tmp/pares.txt" <<PARES
+edge-no-ar $SHA_NOVO
+edge-velha $SHA_VELHO
+edge-cega nao-mapeada
+PARES
+
+# stub do psql-ro. MODO controla a avaria: ok | mudo | erro-query
+cat > "$tmp/psql-stub" <<'STUB'
+#!/usr/bin/env bash
+sql="${!#}"
+case "${STUB_MODO:-ok}" in
+  mudo) exit 0 ;;                       # presente-porém-QUEBRADO: responde vazio ao SELECT 1
+esac
+if [ "$sql" = "SELECT 1" ]; then echo 1; exit 0; fi
+printf '%s' "$sql" > "${STUB_SQL_ECO:-/dev/null}"
+[ "${STUB_MODO:-ok}" = "erro-query" ] && { echo "ERROR: relation net._http_response" >&2; exit 1; }
+cat "${STUB_PARES:-/dev/null}" 2>/dev/null
+exit 0
+STUB
+chmod +x "$tmp/psql-stub"
+
+export FECHO_MAPA_FONTE="$tmp/mapa.ts" STUB_PARES="$tmp/pares.txt" STUB_SQL_ECO="$tmp/sql.txt"
+
+# roda o alvo: `run <modo-do-stub> <psql> <args...>` publica a saida em $out e o codigo em $rc.
+# NAO devolve a saida por stdout de proposito: `run ...` executaria a funcao num SUBSHELL
+# e o `rc` morreria com ele — o veredito voltaria 0 SEMPRE, que e a fabricacao de exit code do
+# CLAUDE.md em forma de harness de teste (foi exatamente o que a 1a versao desta suite fez).
+rc=0
+out=""
+run() {
+  local modo="$1" psql="$2"; shift 2
+  out="$(STUB_MODO="$modo" AFIACAO_PSQL="$psql" bash "$ALVO" "$@" 2>&1)"; rc=$?
+}
+
+fail=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+# marcador ASCII, caixa fixa, sem -i, via `command grep` (o grep do shell é shim p/ ugrep)
+tem() { printf '%s' "$2" | command grep -q -- "$1"; }
+
+# --------------------------------------------------------------------- suíte ---
+suite() {
+  printf '== edges-pendentes (locale=%s) ==\n' "${LC_ALL:-?}"
+
+  # 1. prova POSITIVA: fonte servida == main -> some o chip
+  run ok "$tmp/psql-stub" edge-no-ar
+  if tem 'NO_AR' "$out" && [ "$rc" -eq 0 ] && ! tem 'abra chip' "$out"
+  then ok "fonte bate com a main -> NO_AR, exit 0, sem chip"
+  else bad "fonte batendo devia dar NO_AR/exit 0 (rc=$rc): ${out:0:90}"; fi
+
+  # 2. bundle velho servindo -> chip PROVADO
+  run ok "$tmp/psql-stub" edge-velha
+  if tem 'DESATUALIZADA' "$out" && [ "$rc" -eq 1 ]
+  then ok "fonte diferente -> DESATUALIZADA, exit 1"
+  else bad "fonte divergente devia dar DESATUALIZADA/exit 1 (rc=$rc): ${out:0:90}"; fi
+
+  # 3. ausencia NAO reprova, mas tambem nao absolve: INDETERMINADO -> chip
+  run ok "$tmp/psql-stub" edge-muda
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 1 ]
+  then ok "sem sonda na janela -> SEM_PROVA, exit 1"
+  else bad "edge sem sonda devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
+
+  # 4. as ~55 edges fora do mapa continuam virando chip como hoje (sem regressao)
+  run ok "$tmp/psql-stub" edge-fora-do-mapa
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 1 ]
+  then ok "edge fora do mapa -> SEM_PROVA, exit 1"
+  else bad "edge fora do mapa devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
+
+  # 5. sonda respondeu `nao-mapeada`: a prova nasceu cega, nao e prova
+  run ok "$tmp/psql-stub" edge-cega
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 1 ]
+  then ok "sonda nao-mapeada -> SEM_PROVA, exit 1"
+  else bad "nao-mapeada devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
+
+  # 6. O TESTE-SENTINELA: wrapper PRESENTE porem MUDO. A mesma edge que no caso 1 era NO_AR tem de
+  #    voltar a ser pendencia — `command -v` acharia o arquivo e esvaziaria o guard.
+  run mudo "$tmp/psql-stub" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ] && ! tem 'NO_AR' "$out"
+  then ok "psql presente-porem-MUDO -> fail-closed: SEM_PROVA, exit 2"
+  else bad "psql mudo devia manter a pendencia com exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 7. a consulta estourou -> mecanica nao confiavel, tudo pendente
+  run erro-query "$tmp/psql-stub" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ]
+  then ok "consulta com erro -> fail-closed, exit 2"
+  else bad "erro na consulta devia dar exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 8. wrapper AUSENTE
+  run ok "$tmp/nao-existe" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ]
+  then ok "psql ausente -> fail-closed, exit 2"
+  else bad "psql ausente devia dar exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 9. mapa ilegivel: sem regua nao ha como absolver ninguem
+  FECHO_MAPA_FONTE="$tmp/mapa-que-nao-existe.ts" run ok "$tmp/psql-stub" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ]
+  then ok "mapa ilegivel -> fail-closed, exit 2"
+  else bad "mapa ilegivel devia dar exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 10. janela vem de env -> nao pode entrar crua no SQL
+  FECHO_JANELA_TTL="6 hours'; DROP TABLE x --" run ok "$tmp/psql-stub" edge-no-ar
+  if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 2 ]
+  then ok "janela invalida (injecao) -> recusa, exit 2"
+  else bad "janela invalida devia dar exit 2 (rc=$rc): ${out:0:90}"; fi
+
+  # 11. uso invalido
+  run ok "$tmp/psql-stub"
+  if [ "$rc" -eq 3 ]
+  then ok "sem argumentos -> exit 3"
+  else bad "sem argumentos devia dar exit 3 (rc=$rc)"; fi
+
+  # 12. guardrail de FORMA do SQL: o stub nao executa SQL, entao o que da para provar aqui e que a
+  #     consulta pede a resposta MAIS RECENTE por edge. Sem isso, um deploy no meio da janela deixa
+  #     o bundle velho no resultado e ele seria lido como prova (o caso do omie-vendas-sync).
+  : > "$tmp/sql.txt"; run ok "$tmp/psql-stub" edge-no-ar > /dev/null
+  if tem 'DISTINCT ON (edge)' "$(cat "$tmp/sql.txt")" && tem 'created DESC' "$(cat "$tmp/sql.txt")"
+  then ok "SQL pede a resposta mais recente por edge (DISTINCT ON + created DESC)"
+  else bad "SQL sem DISTINCT ON (edge)/created DESC — deploy no meio da janela viraria prova falsa"; fi
+}
+
+# ---------------------------------------------------------------- falsificação ---
+if [ "${1:-}" = "--falsificar" ]; then
+  falhou=0
+  printf '== falsificacao (sabota o alvo e EXIGE vermelho) ==\n'
+
+  utf8=""
+  for cand in pt_BR.UTF-8 pt_BR.utf8 en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+    if [ "$(LC_ALL="$cand" locale charmap 2>/dev/null)" = "UTF-8" ]; then utf8="$cand"; break; fi
+  done
+  [ -n "$utf8" ] || { printf '  \033[31mFALHA\033[0m nenhum locale UTF-8 — metade da cobertura fingindo ser inteira\n'; exit 1; }
+
+  ALVO_REAL="$ALVO"
+  sabota() { # <descricao> <expressao-sed>
+    local desc="$1" expr="$2" copia="$tmp/sabotado.sh" erro
+    erro="$(sed "$expr" "$ALVO_REAL" 2>&1 >"$copia")"
+    if [ -n "$erro" ]; then
+      printf '  \033[31mFALHA\033[0m "%s": sed invalido (%s) — falsificacao vazia\n' "$desc" "${erro:0:50}"; falhou=1; return
+    fi
+    if cmp -s "$ALVO_REAL" "$copia"; then
+      printf '  \033[31mFALHA\033[0m "%s": padrao nao casou, alvo intacto — falsificacao vazia\n' "$desc"; falhou=1; return
+    fi
+    chmod +x "$copia"
+    local viu_vermelho=0 loc
+    for loc in C "$utf8"; do
+      # subshell de proposito: a sabotagem e o locale morrem com ela, e o ALVO global fica intacto
+      # shellcheck disable=SC2030,SC2031
+      if ! ( export LC_ALL="$loc"; ALVO="$copia"; fail=0; suite >/dev/null 2>&1; [ "$fail" -eq 0 ] ); then
+        viu_vermelho=$((viu_vermelho + 1))
+      fi
+    done
+    if [ "$viu_vermelho" -eq 2 ]; then
+      printf '  \033[32mok\033[0m   "%s" -> suite vermelha nos 2 locales\n' "$desc"
+    else
+      printf '  \033[31mFALHA\033[0m "%s": suite ficou VERDE (%d/2 vermelhos) — assercao frouxa\n' "$desc" "$viu_vermelho"; falhou=1
+    fi
+  }
+
+  # (a) a sonda positiva vira `command -v` de mentira: presente passa a valer por respondendo
+  sabota "aceitar psql mudo (sem exigir resposta positiva)" \
+    's%!= "1"%!= "IMPOSSIVEL"%'
+  # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "classificar como NO_AR mesmo com mecanica quebrada" \
+    's%if \[ "$mecanica_ok" = 1 \] && \[ -n "$esperado" \] && \[ "$servido" = "$esperado" \]; then%if [ -n "$esperado" ]; then%'
+  # (c) presenca vira prova: qualquer fonte servida absolveria, inclusive a velha
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "aceitar qualquer fonte servida como prova" \
+    's%\[ "$servido" = "$esperado" \]%[ -n "$servido" ]%'
+  # (d) a query perde o "mais recente por edge"
+  sabota "SQL sem DISTINCT ON (edge)" \
+    's%SELECT DISTINCT ON (edge) edge%SELECT edge%'
+
+  [ "$falhou" -eq 0 ] && { printf '\n== falsificacao: todas as sabotagens ficaram vermelhas ==\n'; exit 0; }
+  printf '\n== falsificacao REPROVOU ==\n'; exit 1
+fi
+
+# ------------------------------------------------------------------- execução ---
+utf8=""
+for cand in pt_BR.UTF-8 pt_BR.utf8 en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+  if [ "$(LC_ALL="$cand" locale charmap 2>/dev/null)" = "UTF-8" ]; then utf8="$cand"; break; fi
+done
+[ -n "$utf8" ] || { echo "FALHA: nenhum locale UTF-8 disponivel"; exit 1; }
+
+total=0
+for loc in C "$utf8"; do
+  # shellcheck disable=SC2031
+  export LC_ALL="$loc"
+  fail=0
+  suite
+  total=$((total + fail))
+done
+[ "$total" -eq 0 ] || { printf '\n\033[31m== REPROVOU ==\033[0m\n'; exit 1; }
+printf '\n\033[32m== verde nos 2 locales ==\033[0m\n'

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -158,6 +158,55 @@ suite() {
   then ok "sem argumentos -> exit 3"
   else bad "sem argumentos devia dar exit 3 (rc=$rc)"; fi
 
+  # 13. modo --desde: a UNIAO das duas vias, num repo git de verdade. O que se prova aqui e a
+  #     ENUMERACAO (quem entra na lista), nao a classificacao — e o furo caro e o `_shared/`:
+  #     nenhuma das duas vias enxerga as edges afetadas por ele sem o mapa de fingerprints.
+  # um repo POR PASSADA: o 2o caso deste bloco mutila o repo (remove o mapa), e reusar o mesmo
+  # diretorio no 2o locale faria o 1o caso rodar contra um repo ja quebrado — vermelho falso.
+  local repo="$tmp/repo-${LC_ALL:-x}"
+  if [ ! -d "$repo" ]; then
+    mkdir -p "$repo/supabase/functions/_shared" "$repo/supabase/functions/edge-do-shared"
+    git -C "$repo" init -q -b main 2>/dev/null
+    git -C "$repo" config user.email t@t; git -C "$repo" config user.name t
+    printf 'x\n' > "$repo/supabase/functions/_shared/lib.ts"
+    printf 'import "../_shared/lib.ts"\n' > "$repo/supabase/functions/edge-do-shared/index.ts"
+    cat > "$repo/supabase/functions/_shared/sonda-fingerprints.ts" <<MAPA0
+export const FONTE_SHA256: Record<string, string> = {
+  "edge-do-shared": "$SHA_VELHO",
+};
+MAPA0
+    git -C "$repo" add -A >/dev/null; git -C "$repo" commit -qm base
+    base_sha="$(git -C "$repo" rev-parse HEAD)"
+    # 2o commit: mexe SO em _shared/ e o CI regenera o mapa -> o fingerprint da edge muda
+    printf 'y\n' > "$repo/supabase/functions/_shared/lib.ts"
+    cat > "$repo/supabase/functions/_shared/sonda-fingerprints.ts" <<MAPA1
+export const FONTE_SHA256: Record<string, string> = {
+  "edge-do-shared": "$SHA_NOVO",
+};
+MAPA1
+    git -C "$repo" add -A >/dev/null; git -C "$repo" commit -qm shared
+    git -C "$repo" update-ref refs/remotes/origin/main HEAD
+    printf '%s' "$base_sha" > "$tmp/base_sha"
+  fi
+
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+         FECHO_MAPA_FONTE="" bash "$ALVO" --desde "$(cat "$tmp/base_sha")" 2>&1)"; rc=$?
+  # a edge afetada SO por _shared/ tem de aparecer: a via (b) nao a ve, a via (a) sim
+  if tem 'edge-do-shared' "$out" && ! tem '_shared ' "$out"
+  then ok "--desde: _shared/ puxa a edge afetada e _shared NAO entra como edge"
+  else bad "--desde devia listar edge-do-shared e nunca _shared (rc=$rc): ${out:0:120}"; fi
+
+  # mapa ilegivel + _shared/ tocado = nao sei quais edges foram afetadas -> exit 2, nunca "nada"
+  git -C "$repo" rm -q --cached supabase/functions/_shared/sonda-fingerprints.ts >/dev/null 2>&1
+  rm -f "$repo/supabase/functions/_shared/sonda-fingerprints.ts"
+  git -C "$repo" commit -qm "sem mapa" >/dev/null 2>&1
+  git -C "$repo" update-ref refs/remotes/origin/main HEAD
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+         bash "$ALVO" --desde "$(cat "$tmp/base_sha")" 2>&1)"; rc=$?
+  if [ "$rc" -eq 2 ] && ! tem 'nenhuma edge na janela' "$out"
+  then ok "--desde: _shared/ sem mapa legivel -> exit 2, nunca 'nenhuma edge'"
+  else bad "_shared sem mapa devia dar exit 2 e nao absolver (rc=$rc): ${out:0:120}"; fi
+
   # 12. guardrail de FORMA do SQL: o stub nao executa SQL, entao o que da para provar aqui e que a
   #     consulta pede a resposta MAIS RECENTE por edge. Sem isso, um deploy no meio da janela deixa
   #     o bundle velho no resultado e ele seria lido como prova (o caso do omie-vendas-sync).
@@ -210,6 +259,9 @@ if [ "${1:-}" = "--falsificar" ]; then
   # (a2) a sonda volta a exigir a saida INTEIRA == "1": reprova o wrapper bom (o defeito de prod)
   sabota "sonda exigindo saida inteira == 1 (ignora os SET do wrapper)" \
     "s%| command grep -Fxq -- '1'%| tr -d '[:space:]' | command grep -Fxq -- '1'%"
+  # (a3) o fail-closed do `_shared/` sem mapa vira aviso: enumeracao voltaria a absolver por ausencia
+  sabota "_shared sem mapa deixando de ser exit 2" \
+    's%      exit 2$%      :%'
   # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "classificar como NO_AR mesmo com mecanica quebrada" \


### PR DESCRIPTION
## O problema

O Passo 3 do `/fecho` disparava chip de deploy de edge por **commit na janela**:

```bash
git log origin/main --since="<início da sessão>" --name-only --format="" -- supabase/functions/
```

Num repo com 85 worktrees / dezenas de sessões vivas e **4–11 merges de edge por dia**, esse
gatilho é quase sempre verdadeiro — e como cada sessão varre a própria janela, a **mesma edge**
vira chip em N sessões. O chip é por-sessão, não há fila global, e a própria skill já assumia a
duplicidade ("CONFIRMAR antes de pedir deploy redundante"). Fila de chips iguais enterra o chip
que importava.

## O que muda

O gatilho passa a ser **"sem prova de estar no ar"**, medido pela evidência que já existia de
graça: o campo `fonte` que `criarRespostaSonda` serve (SHA-256 do fecho transitivo dos imports)
comparado com `_shared/sonda-fingerprints.ts` da main.

| veredito | significa | chip? |
|---|---|---|
| `NO_AR` | `fonte` servido == main | **não** |
| `DESATUALIZADA` | `fonte` servido ≠ main — bundle VELHO servindo | sim, prioritário |
| `SEM_PROVA` | fora do mapa, sem sonda na janela, ou mecânica quebrada | sim (fail-closed) |

🔴 **Presença PROVA, ausência NÃO reprova** (#2086/#2095). O script só SUPRIME chip com evidência
positiva — ele é o lado que APAGA pendência, então é fail-CLOSED em todo o resto.

Não é só corte de ruído: `DESATUALIZADA` é sinal que o gatilho velho **nunca teve** — bundle velho
SERVINDO, que é a falha silenciosa que o passo existe para pegar.

## Enumeração: UNIÃO de duas fontes

Nenhuma sozinha fecha (mesmo princípio do Passo 4 da `lovable-deploy-verify`):

- **(a) diff do mapa de fingerprints** entre o início da janela e a main — única via que enxerga
  mudança em `_shared/`, que muda o bundle de N edges sem tocar a pasta de nenhuma;
- **(b) `git log --name-only`** das pastas — única via que enxerga edge **fora** do mapa.

E uma trava para o furo que a união ainda deixava: `_shared/` tocado **sem** mapa legível nas duas
pontas ⇒ exit 2, nunca "nenhuma edge na janela" (chip suprimido por ausência de dado seria o modo
de falha caro deste script).

## Evidência

- Suíte hermética (banco por stub) **verde nos 2 locales** (C e pt_BR.UTF-8), 15 casos.
- **Falsificação verde**: 6 sabotagens, cada uma deixando a suíte vermelha nos 2 locales. A trava
  do `sabota()` pegou uma sabotagem obsoleta durante o desenvolvimento e reprovou em vez de passar.
- **Contra o banco real** (janela de 24 h, 2026-08-28): 7 edges na janela → 3 provadas no ar →
  **4 chips em vez de 7**.

## Dois defeitos que só produção revelou

1. O `psql-ro` emite `SET\nSET` **antes** do resultado; exigir a saída inteira == `1` reprovava o
   wrapper BOM e o gate nasceria travado em exit 2. Corrigido para exigir a **FORMA** (linha
   exatamente `1`) — a mesma classe que o #2100 documentou em `evidencia-positiva-shell.md` §11,
   mergeado enquanto este PR era escrito.
2. `_shared` entrava na lista como se fosse edge deployável.

## Cobertura no CI

`scripts/test-fecho-edges-pendentes.sh` registrado nos dois laços (`test:hooks` e
`test:falsificacao`) — `scripts/hooks-guard-cobertura.test.ts` verde, que é quem cobra isso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
