### PR TITLE
feat(deploy-verify): o controle negativo da via de ESCRITA nunca materializou — `GROUP BY` não tem grupo vazio, e vira script com eval

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -590,10 +590,27 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        local. O que o `git grep` **não** fecha é a mão no 🟣 SQL Editor, então leia o **padrão**: as 4
        do mesmo `user_id` vieram espaçadas em **segundos a dezenas de segundos** (22/27/12 s — tempo
        de gravar áudio), e isso é uso de app; rajada de milissegundos ou `user_id` sem sessão é teste
-       manual. **Sem linha em `profiles` NÃO desqualifica**: aqui o `EXISTS` deu `f` e eram gravações
-       reais pelo microfone (cadastro em `/auth` é aberto; alias fiscal sem `profiles` é legítimo) —
-       quem fechou foi **perguntar ao founder**. Meça o vínculo com `EXISTS(...)`:
+       manual. **Sem linha em `profiles` NÃO desqualifica** — alias fiscal sem `profiles` é legítimo
+       (`database.md` §5) e o cadastro em `/auth` é aberto. Meça o vínculo com `EXISTS(...)`:
        `coalesce(p.name,'…')` em LEFT JOIN lê igual para "não existe linha" e "coluna NULL".
+       🔴 **Mas o `f` que o #2086/#2106 mediram NÃO era um desses casos — era a CHAVE ERRADA
+       (medido 2026-08-29).** `public.profiles` tem `id` **e** `user_id`, e a FK de `ia_uso_evento`
+       aponta para `auth.users(id)`, que casa com **`profiles.user_id`**. As duas leituras, lado a
+       lado, no mesmo `user_id` das 4 escritas:
+       ```
+        chave_id (a usada)  | chave_user_id |       nome
+       ---------------------+---------------+------------------
+        f                   | t             | Lucas Sardenberg     (role master, em user_roles)
+       ```
+       O usuário **tem** `profiles` — o `f` era artefato do join, não um vínculo ausente. A regra
+       acima continua valendo por si (aliases fiscais existem), mas **este caso não é exemplo dela**:
+       era um staff conhecido, e a pergunta ao founder respondeu o que a chave certa já respondia. É
+       a família `ausente ≠ zero` na dimensão **CHAVE**: um join que não casa devolve "não existe",
+       byte a byte igual a "existe e é nulo", e a explicação plausível fecha a investigação em cima
+       de uma medição defeituosa. **A role não vive em `profiles`** (é `public.user_roles`), e
+       `auth.users` é **inacessível** ao `claude_ro` (`permission denied for schema auth`) — logo a
+       identidade só se lê por `profiles`, e só pela chave certa. `scripts/verify-edge-escrita.sh`
+       já faz os dois joins.
     2. 🔴 **A direção é uma só: presença prova, ausência NÃO reprova.** Zero linhas pode ser "não
        deployou" **ou** "ninguém usou a feature", e edge de usuário não tem denominador que separe os
        dois. `ausente ≠ zero` de novo: sem chamada não houve medição, e "0 linhas" lê-se

--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -570,7 +570,10 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
     `net._http_response`, e ela morre no `pg_net.ttl = 6 h`. Edge chamada por **usuário** (transcrição,
     upload, copiloto) nunca aparece lá — a escada caía direto no N3 ativo, que aqui custa o founder
     logado. Mas quando a fatia nova **ESCREVE em tabela de aplicação**, essa escrita é assinatura do
-    bundle do mesmo jeito: **não expira**, não depende de cron e não invoca nada. O #2086 pôs gate de
+    bundle do mesmo jeito: **dura 7 dias** (não as 6 h do `pg_net`), não depende de cron e não
+    invoca nada. ⚠️ A 1ª versão desta seção dizia "**não expira**", e era **falso**: o cron
+    `ia-uso-evento-purga` (`23 4 * * *`, `active=t` medido em prod) apaga
+    `criado_em < now() - interval '7 days'`. Janela maior que a do `pg_net`, e finita. O #2086 pôs gate de
     cota na `elevenlabs-transcribe`; o gate chama a RPC `ia_consumir_cota`, que faz `INSERT INTO
     public.ia_uso_evento (user_id, funcao)`. O bundle velho **nem importava** `_shared/ia-cota.ts` —
     logo é **incapaz** de emitir a linha. Quatro linhas entre 00:32:26Z e 00:33:27Z contra o merge às
@@ -597,20 +600,52 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
        **INDETERMINADO**, nunca "deploy pendente". É a metade boa do guard temporal do #2079 — lá o
        risco era ler tick PRÉ-merge como pendência; aqui a evidência só pode existir **depois**, então
        o erro possível custa uma espera, não um redeploy à toa de edge money-path.
-    3. ✅ **O controle negativo vem de graça, e com dado real.** O mesmo `GROUP BY` sobre a tabela
-       devolve **zero** para as outras funções que têm limite configurado (`identify-tool`,
-       `copilot-analyze`, `analyze-services`): a query **sabe dizer "não"** sem sabotar nada — se ela
-       desse verde para tudo, elas sairiam na mesma leitura. Por isso o `GROUP BY` **sem** filtro de
-       função abaixo é de propósito: filtrar pela sua edge joga fora justamente o controle.
+    3. 🔴 **O controle negativo prescrito aqui NÃO MATERIALIZAVA — corrigido 2026-08-29.** A 1ª
+       versão mandava ler `GROUP BY funcao` sobre `ia_uso_evento` e afirmava que as vizinhas com
+       limite configurado "saem em zero na mesma leitura". **Não saem:** `GROUP BY` só produz
+       grupos que **têm** linhas. Rodado em prod, devolveu **uma** linha (a própria edge) e as três
+       vizinhas não apareceram — nem como zero. Quem seguisse a receita ao pé da letra registrava
+       "controle negativo passou" **sem ter observado nada** — e a própria seção se contradizia, já
+       que o comentário do bloco dizia `linha única`. Para o controle EXISTIR, o universo tem de vir
+       da tabela de **LIMITES** unida ao alvo (só os limites esconderia o alvo se a config dele fosse
+       removida). Isto e os guards abaixo são hoje do **script**, não da sua memória:
+
+       ```bash
+       .claude/skills/lovable-deploy-verify/scripts/verify-edge-escrita.sh \
+         --desde '<timestamp do merge, UTC>' --funcao '<slug da edge>'
+       # 0 = BUNDLE_NOVO_OBSERVADO_EM_T · 2 = INDETERMINADO · 3 = RECUSA
+       # 🔴 NENHUM exit significa "bundle velho": a via é unidirecional por construção.
+       ```
+
+       Ele materializa o controle (`CONTROLE_CRUZADO_OK`), **diz quando não pôde observá-lo**
+       (`CONTROLE_CRUZADO_NAO_OBSERVADO`, universo só com o alvo — nunca "passou"), e **recusa**
+       quando a query não discrimina (`CORRELACAO_SUSPEITA`: toda vizinha com o mesmo total é a
+       assinatura do filtro solto contando a tabela inteira). Rede: `evals/verify-edge-escrita-eval.sh`
+       — 17 casos + 4 sabotagens, no gate `evals/run.sh`.
+    3b. 🔴 **A presença prova PASSADO, não estado ATUAL (2ª opinião, Codex).** Uma linha pós-merge
+       prova que o bundle novo atendeu ≥1 chamada **naquele instante** — não que ele siga no ar: um
+       redeploy ou revert posterior deixa o rastro **intacto**. Por isso o exit 0 se chama
+       `BUNDLE_NOVO_OBSERVADO_EM_T` e a saída repete que não é "versão atual confirmada". Para
+       afirmar "está no ar AGORA" continua sendo preciso sonda viva ou marcador observado **depois
+       do último deploy possível**.
+    3c. ⚠️ **O join de proveniência é `profiles.user_id`, NUNCA `profiles.id`.** A tabela tem as
+       **duas** colunas e a FK de `ia_uso_evento` aponta para `auth.users(id)`, que casa com
+       `profiles.user_id`. Com `p.id` o join devolve "sem profile" para usuário legítimo — falso
+       sinal de "`user_id` inventado" bem no teste da condição (c), que foi onde mordeu. A **role**
+       (`master`/`employee`) vive em `public.user_roles`, não em `profiles`; e `auth.users` é
+       **inacessível** ao `claude_ro` (`permission denied for schema auth`), então a identidade só se
+       lê por `profiles`. O script já faz os dois joins certos.
     4. **Leia onde o INSERT mora no código ANTES de ler a linha.** Em `ia_consumir_cota` ele fica
        **depois** de todos os `RETURN` de bloqueio, então a linha prova chamada **PERMITIDA** — e de
        quebra que a migration do limite entrou **antes** do deploy (bloqueada teria voltado 503
        `sem_limite` sem gravar nada). INSERT incondicional provaria só a chamada: a diferença é o que
        você pode afirmar depois.
     ```bash
-    # ⌨️ seu terminal — o timestamp NASCE inválido de propósito (Lei de Ferro #5): troque pelo
-    # do SEU merge, em UTC. No #2086 deu `elevenlabs-transcribe | 4 | 4 | 00:33:27Z`, linha única.
-    ~/.config/afiacao/psql-ro -c "SELECT funcao, count(*) AS total, count(*) FILTER (WHERE criado_em > 'COLE_O_TIMESTAMP_DO_MERGE_UTC') AS pos_merge, max(criado_em) AS ultimo FROM public.ia_uso_evento GROUP BY funcao ORDER BY total DESC;"
+    # ⌨️ seu terminal — só se precisar ler à mão o que o script já lê. O timestamp NASCE inválido
+    # de propósito (Lei de Ferro #5): troque pelo do SEU merge, em UTC.
+    # ⚠️ O universo parte de `ia_uso_limite` UNIDO ao alvo — NÃO de um `GROUP BY` sobre
+    #    `ia_uso_evento`, que não materializa as vizinhas em zero e mata o controle negativo.
+    ~/.config/afiacao/psql-ro -c "WITH universo AS (SELECT funcao AS f FROM public.ia_uso_limite UNION SELECT 'COLE_O_SLUG_DA_EDGE') SELECT u.f, (SELECT count(*) FROM public.ia_uso_evento e WHERE e.funcao = u.f) AS total, (SELECT count(*) FROM public.ia_uso_evento e WHERE e.funcao = u.f AND e.criado_em > 'COLE_O_TIMESTAMP_DO_MERGE_UTC') AS pos_merge FROM universo u ORDER BY 2 DESC, 1;"
     ```
 
 ### Passo 4b — QA visual pós-Publish (Claude-in-Chrome na sessão logada do founder)
@@ -766,10 +801,30 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
 - [x] **N3 PASSIVO por ESCRITA DE APLICAÇÃO (2026-08-29, #2086 `elevenlabs-transcribe`):** as duas vias
   passivas anteriores nascem do cron e morrem no `pg_net.ttl = 6 h` — edge chamada por **usuário** não
   passa por nenhuma delas, e a escada caía no N3 ativo (que custa o founder logado). Quando a fatia nova
-  escreve em tabela de aplicação, a escrita é assinatura do bundle **sem TTL**: o gate de cota insere em
+  escreve em tabela de aplicação, a escrita é assinatura do bundle com janela de **7 dias**: o gate de cota insere em
   `ia_uso_evento(user_id, funcao)` e o bundle velho, que nem importava `_shared/ia-cota.ts`, é **incapaz**
   de produzir a linha — 4 delas 15 min após o merge provaram o deploy sem PAT, sem canária, sem invocar
   nada. Vale só na direção **presença**: ausência é "ninguém usou", não "não subiu". Controle negativo de
   graça (as vizinhas com limite configurado saem em zero na mesma query), desde que o `GROUP BY` não seja
   filtrado pela edge. Detalhe no Passo 4.
+- [x] **A via da ESCRITA virou SCRIPT, e a receita em prosa tinha 4 furos (2026-08-29):** ela
+  nasceu no #2086 e apodreceu em 3 dias — verificando as 3 edges do chip de 01:50Z, todos apareceram.
+  **(1)** O controle negativo prescrito (`GROUP BY funcao` sobre `ia_uso_evento`) **não
+  materializava**: `GROUP BY` não produz grupo vazio, então as vizinhas nunca saíam "em zero" e o
+  operador registrava "controle passou" sem observar nada — a seção se contradizia sozinha, com
+  `linha única` escrito no próprio comentário. **(2)** O join de proveniência usava `profiles.id`
+  quando a chave é `profiles.user_id` (a tabela tem as duas), devolvendo "sem profile" para usuário
+  legítimo — falso sinal de "`user_id` inventado" bem na condição (c). **(3)** A 2ª opinião (Codex,
+  `gpt-5.6-sol` xhigh) achou o furo maior: a escrita prova **passado**, não estado atual — redeploy
+  ou revert posterior deixa o rastro intacto, então o exit 0 é `BUNDLE_NOVO_OBSERVADO_EM_T` e nunca
+  "versão atual". **(4)** E o "**não expira**" era literalmente falso: o cron `ia-uso-evento-purga`
+  (`23 4 * * *`, `active=t` em prod) apaga acima de **7 dias**. Virou
+  `scripts/verify-edge-escrita.sh` (universo = limites ∪ alvo; `CONTROLE_CRUZADO_OK` /
+  `_NAO_OBSERVADO` / `CORRELACAO_SUSPEITA`; fail-closed na via; **nenhum** exit significa "bundle
+  velho"), com `evals/verify-edge-escrita-eval.sh` — 17 casos + 4 sabotagens — no gate. A
+  falsificação pagou de novo: a sabotagem do ping saiu **inócua** contra a via totalmente muda
+  (o guard do universo vazio recusa sozinho), e só mordeu no cenário `psql_mudo_parcial` — via que
+  cala no ping mas ainda devolve linhas, onde sem o ping o script leria via quebrada como "ninguém
+  usou a feature". Mesma lição que o eval do `verify-edge-eco` já tinha registrado, redescoberta
+  medindo.
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/evals/run.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/run.sh
@@ -139,5 +139,13 @@ else
 fi
 
 echo ""
+echo "== (4) verify-edge-escrita — N3 passivo por escrita de aplicação =="
+if [ "$FALSIFY" = 1 ]; then
+  bash verify-edge-escrita-eval.sh --falsify || rc=1
+else
+  bash verify-edge-escrita-eval.sh || rc=1
+fi
+
+echo ""
 if [ "$rc" -eq 0 ]; then echo "✅ evals lovable-deploy-verify: OK"; else echo "❌ evals lovable-deploy-verify: FALHOU"; fi
 exit "$rc"

--- a/.claude/skills/lovable-deploy-verify/evals/verify-edge-escrita-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-edge-escrita-eval.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# verify-edge-escrita-eval.sh — rede de regressão do N3 PASSIVO por ESCRITA DE APLICAÇÃO
+# (scripts/verify-edge-escrita.sh).
+#
+# Determinístico e offline: um `psql` FALSO devolve fixtures por cenário, discriminando as queries
+# pelos marcadores de comentário SQL que o script emite (-- ESCRITA_PING / _ROWS / _QUEM / _PURGA).
+#
+# O caso que dá nome ao arquivo é o `controle_nao_materializa`: a receita em prosa mandava ler
+# `GROUP BY funcao` sobre a tabela de eventos e AFIRMAVA que as vizinhas "saem em zero na mesma
+# leitura". `GROUP BY` só produz grupos que TÊM linhas — em prod a query devolveu UMA linha e as
+# três vizinhas não apareceram nem como zero. O controle prometido nunca existiu, e o operador
+# registrava "passou" sem ter observado nada. Aqui o universo é `limites UNION alvo`, e o caso
+# `so_o_alvo` prova que o script DIZ quando o controle não pôde ser observado, em vez de calar.
+set -uo pipefail
+cd "$(dirname "$0")" || exit 2
+SCRIPT="../scripts/verify-edge-escrita.sh"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# ── psql falso ──────────────────────────────────────────────────────────────────────────────────
+cat > "$TMP/psql-fake" <<'FAKE'
+#!/usr/bin/env bash
+# Varre TODOS os args atrás do marcador: o script usa tanto `-At -c` quanto `-Atc` (flag
+# combinada), e um fake que só olhasse o argumento após `-c` ficaria cego para o segundo —
+# devolvendo vazio para toda query e fazendo TODO cenário recusar. Foi o que aconteceu na
+# primeira rodada deste eval: 16 casos, 16 exit 3, e as 4 sabotagens "verdes" por cegueira.
+q=""
+for a in "$@"; do case "$a" in *ESCRITA_*) q="$a" ;; esac; done
+case "${CENARIO:-}" in
+  psql_morto) exit 1 ;;
+esac
+if [[ "$q" == *ESCRITA_PING* ]]; then
+  # psql_mudo: presente-porém-QUEBRADO — sai 0 e não imprime nada. É o caso que dá dente ao ping:
+  # com a via totalmente MORTA o guard do universo vazio já recusa sozinho, então a sabotagem do
+  # ping sairia inócua ali (mesma lição medida no eval do verify-edge-eco).
+  case "${CENARIO:-}" in psql_mudo|psql_mudo_parcial) exit 0 ;; esac
+  echo "1"; exit 0
+fi
+if [[ "$q" == *ESCRITA_PURGA* ]]; then
+  case "$CENARIO" in
+    corte_antigo) echo "1" ;;
+    *)            echo "0" ;;
+  esac
+  exit 0
+fi
+if [[ "$q" == *ESCRITA_ROWS* ]]; then
+  case "$CENARIO" in
+    psql_mudo) : ;;                       # vazio, sem erro
+    psql_mudo_parcial)
+      # A via cala no ping mas AINDA devolve linhas — e o alvo vem zerado. É aqui que o ping é o
+      # ÚNICO guard: sem ele o script leria uma via quebrada como "ninguém usou a feature"
+      # (exit 2, INDETERMINADO honesto) em vez de RECUSA. Ausência de dado se passando por
+      # medição — a mesma família que a skill inteira existe para impedir. Com a via TOTALMENTE
+      # muda a sabotagem sai inócua, porque o guard do universo vazio recusa sozinho (medido).
+      echo "elevenlabs-transcribe|0|0"
+      echo "analyze-services|0|0" ;;
+    observado|corte_antigo)
+      echo "elevenlabs-transcribe|4|4"
+      echo "analyze-services|0|0"
+      echo "copilot-analyze|0|0" ;;
+    ninguem_usou)
+      echo "elevenlabs-transcribe|0|0"
+      echo "analyze-services|0|0" ;;
+    so_pre_merge)                          # tem escrita, mas TODA anterior ao corte
+      echo "elevenlabs-transcribe|9|0"
+      echo "analyze-services|0|0" ;;
+    so_o_alvo)                             # universo sem vizinha: controle não observável
+      echo "elevenlabs-transcribe|4|4" ;;
+    correlacao_quebrada)                   # filtro solto: TODA função com o mesmo total
+      echo "elevenlabs-transcribe|4|4"
+      echo "analyze-services|4|0"
+      echo "copilot-analyge|4|0" ;;
+    controle_fraco)                        # nenhuma zera, mas os totais divergem
+      echo "elevenlabs-transcribe|4|4"
+      echo "analyze-services|7|0"
+      echo "copilot-analyze|2|0" ;;
+    alvo_sumiu)                            # leitura devolveu linhas, mas nenhuma é o alvo
+      echo "analyze-services|0|0" ;;
+  esac
+  exit 0
+fi
+if [[ "$q" == *ESCRITA_QUEM* ]]; then
+  echo "2026-08-29 00:32:26|Lucas Sardenberg|master"
+  exit 0
+fi
+exit 0
+FAKE
+chmod +x "$TMP/psql-fake"
+
+rc=0
+caso() { # nome cenario exit_esperado descricao [marcador_de_saida]
+  local nome="$1" cen="$2" esp="$3" desc="$4" marc="${5:-}" got
+  CENARIO="$cen" PSQL_RO="$TMP/psql-fake" bash "$SCRIPT" --desde '2026-08-29 00:17:10+00' \
+    --funcao elevenlabs-transcribe >"$TMP/out" 2>&1; got=$?
+  if [ "$got" -ne "$esp" ]; then
+    printf '  [XX ] %-24s exit %s (esperado %s) — %s\n' "$nome" "$got" "$esp" "$desc"; rc=1; return
+  fi
+  if [ -n "$marc" ] && ! command grep -q "$marc" "$TMP/out"; then
+    printf '  [XX ] %-24s exit %s ok, mas a marca "%s" não saiu — %s\n' "$nome" "$got" "$marc" "$desc"; rc=1; return
+  fi
+  printf '  [ok ] %-24s exit %s — %s\n' "$nome" "$got" "$desc"
+}
+
+echo "== verify-edge-escrita — N3 passivo por escrita de aplicação =="
+caso observado            observado            0 "escrita pós-corte + vizinhas zeradas ⇒ observado em T" "BUNDLE_NOVO_OBSERVADO_EM_T"
+caso rebaixa_veredito     observado            0 "o exit 0 DIZ que não prova estado atual (redeploy/revert)" "NÃO prova que ele"
+caso controle_materializa observado            0 "o controle que a prosa prometia agora SAI na leitura" "CONTROLE_CRUZADO_OK"
+caso ninguem_usou         ninguem_usou         2 "zero escritas ⇒ INDETERMINADO, nunca 'deploy pendente'" "INDETERMINADO"
+caso so_pre_merge         so_pre_merge         2 "tem escrita, mas toda PRÉ-corte ⇒ INDETERMINADO"
+caso nunca_diz_velho      ninguem_usou         2 "ausência não vira exit 1: a via é unidirecional"
+caso so_o_alvo            so_o_alvo            0 "universo sem vizinha: DIZ que o controle não foi observado" "CONTROLE_CRUZADO_NAO_OBSERVADO"
+caso controle_fraco       controle_fraco       0 "nenhuma zera mas os totais divergem ⇒ correlação viva, e dito" "CONTROLE_CRUZADO_FRACO"
+caso correlacao_quebrada  correlacao_quebrada  3 "todas as vizinhas com o MESMO total ⇒ RECUSA (não discrimina)" "CORRELACAO_SUSPEITA"
+caso corte_antigo         corte_antigo         0 "corte além dos 7 dias ⇒ avisa que a purga pode ter comido" "CORTE_ALEM_DA_PURGA"
+caso alvo_sumiu           alvo_sumiu           3 "alvo ausente da leitura ⇒ RECUSA, não 'zero escritas'"
+caso psql_morto           psql_morto           3 "via de leitura morta ⇒ RECUSA fail-closed"
+caso psql_mudo            psql_mudo            3 "via presente-porém-QUEBRADA (vazio sem erro) ⇒ RECUSA"
+caso psql_mudo_parcial    psql_mudo_parcial    3 "via muda que ainda devolve linhas ⇒ RECUSA, não 'ninguém usou'"
+
+# ── uso inválido (não chega a tocar a via) ──────────────────────────────────────────────────────
+uso_invalido() { # nome descricao args...
+  local nome="$1" desc="$2"; shift 2; local got
+  PSQL_RO="$TMP/psql-fake" bash "$SCRIPT" "$@" >/dev/null 2>&1; got=$?
+  if [ "$got" -eq 3 ]; then printf '  [ok ] %-24s exit 3 — %s\n' "$nome" "$desc"
+  else printf '  [XX ] %-24s exit %s (esperado 3) — %s\n' "$nome" "$got" "$desc"; rc=1; fi
+}
+uso_invalido falta_desde  "sem --desde não há corte a guardar"  --funcao x
+uso_invalido falta_funcao "sem --funcao não há edge a nomear"   --desde '2026-08-29 00:17:10+00'
+uso_invalido arg_estranho "argumento desconhecido ⇒ RECUSA"     --desde '2026-08-29 00:17:10+00' --funcao x --wat
+
+# ── falsificação: sabota o guard EM CÓPIA e exige vermelho ──────────────────────────────────────
+# O `exit_normal` é MEDIDO no script real antes de comparar — nunca o declarado. (Furo achado no
+# harness irmão: sabotagem escrita antes da feature ficava verde sem sabotar nada.)
+if [ "${1:-}" = "--falsify" ]; then
+  echo ""
+  echo "== falsificação (sabota o guard, exige vermelho) =="
+  fals=0; total=0
+
+  sabota() { # nome cenario sed_expr marca_de_aplicacao descricao
+    local nome="$1" cen="$2" expr="$3" marca="$4" desc="$5" normal sabrc
+    total=$((total+1))
+    CENARIO="$cen" PSQL_RO="$TMP/psql-fake" bash "$SCRIPT" --desde '2026-08-29 00:17:10+00' \
+      --funcao elevenlabs-transcribe >/dev/null 2>&1; normal=$?
+    sed "$expr" "$SCRIPT" > "$TMP/sab.sh"
+    if ! command grep -q "$marca" "$TMP/sab.sh"; then
+      printf '  [XX ] %-26s sabotagem NÃO aplicou — o eval não testaria nada\n' "$nome"; rc=1; return
+    fi
+    CENARIO="$cen" PSQL_RO="$TMP/psql-fake" bash "$TMP/sab.sh" --desde '2026-08-29 00:17:10+00' \
+      --funcao elevenlabs-transcribe >/dev/null 2>&1; sabrc=$?
+    if [ "$sabrc" -ne "$normal" ]; then
+      printf '  [ok ] %-26s %s (exit %s -> %s)\n' "$nome" "$desc" "$normal" "$sabrc"; fals=$((fals+1))
+    else
+      printf '  [XX ] %-26s sabotado e o caso seguiu VERDE (exit %s) — eval CEGO\n' "$nome" "$sabrc"; rc=1
+    fi
+  }
+
+  # (1) a via unidirecional quebrada: ausência passaria a significar "bundle velho"
+  sabota ausencia_vira_velho ninguem_usou 's/^  exit 2$/  exit 1/' '^  exit 1$' \
+    "ausência virando exit 1 -> VIRA vermelho"
+  # (2) fail-closed do ping removido: via muda deixaria de recusar
+  # shellcheck disable=SC2016  # literal do script-alvo, não deve expandir aqui
+  sabota ping_sem_dente psql_mudo_parcial 's/\[ "${PING:-0}" -ge 1 \] || recusa/[ 1 -ge 0 ] || recusa/' \
+    '\[ 1 -ge 0 \]' "ping desarmado -> VIRA vermelho (vira 'ninguém usou')"
+  # (3) guard da correlação arrancado: query que não discrimina passaria batido
+  sabota correlacao_sem_guard correlacao_quebrada 's/^    recusa "CORRELACAO_SUSPEITA/    : "CORRELACAO_SUSPEITA/' \
+    '^    : "CORRELACAO_SUSPEITA' "guard de correlação arrancado -> VIRA vermelho"
+  # shellcheck disable=SC2016  # literal do script-alvo, não deve expandir aqui
+  # (4) guard do alvo ausente removido: leitura sem o alvo viraria "zero escritas"
+  sabota alvo_sem_guard alvo_sumiu 's/^\[ -n "${ALVO_TOTAL:-}" \] || recusa/[ -z "${ALVO_TOTAL:-}" ] || recusa/' \
+    '\[ -z "${ALVO_TOTAL:-}" \]' "guard do alvo invertido -> VIRA vermelho"
+
+  echo "  falsificações efetivas: $fals/$total"
+  [ "$fals" -eq "$total" ] || rc=1
+fi
+
+[ "$rc" -eq 0 ] && echo "OK — verify-edge-escrita" || echo "FALHOU — verify-edge-escrita"
+exit "$rc"

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-edge-escrita.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-edge-escrita.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# verify-edge-escrita.sh — lê o N3 PASSIVO por ESCRITA DE APLICAÇÃO (#2086) com os guards que a
+# receita em prosa não tinha.
+#
+# POR QUE ESTE SCRIPT EXISTE (2026-08-29, verificando as 3 edges do chip de 01:50Z)
+# --------------------------------------------------------------------------------
+# A via nasceu em prosa no Passo 4 da skill e apodreceu em 3 dias, em dois pontos:
+#
+#   1. O CONTROLE NEGATIVO PRESCRITO NÃO MATERIALIZAVA. A receita mandava ler
+#      `SELECT funcao, count(*) ... FROM ia_uso_evento GROUP BY funcao` e afirmava que as
+#      vizinhas com limite configurado "saem em zero na mesma leitura". Não saem: `GROUP BY`
+#      só produz grupos que TÊM linhas. Rodado em prod devolveu UMA linha (a própria edge), e
+#      as três vizinhas simplesmente não apareceram — nem como zero. Quem seguisse a receita
+#      ao pé da letra registrava "controle negativo passou" sem ter observado nada. A própria
+#      skill se contradizia: o comentário do bloco já dizia `linha única`.
+#   2. O JOIN DE PROVENIÊNCIA ERRAVA A CHAVE. `public.profiles` tem `id` E `user_id`; a FK de
+#      `ia_uso_evento` aponta para `auth.users(id)`, que casa com `profiles.user_id`. Com
+#      `p.id` o join devolve "sem profile" para usuário legítimo — falso sinal de "user_id
+#      inventado" bem no teste da condição (c). E `auth.users` é inacessível ao `claude_ro`
+#      (`permission denied for schema auth`), então a identidade SÓ se lê por `profiles`.
+#
+# E a 2ª opinião (Codex, gpt-5.6-sol xhigh) achou o furo MAIOR, que nenhum dos dois cobria:
+#
+#   3. A ESCRITA PROVA PASSADO, NÃO ESTADO ATUAL. Uma linha pós-merge prova que o bundle novo
+#      atendeu ≥1 chamada NAQUELE INSTANTE. Não prova que ele continua no ar: um redeploy ou
+#      revert posterior deixa o rastro intacto. Por isso o exit 0 aqui se chama
+#      BUNDLE_NOVO_OBSERVADO_EM_T e NUNCA "versão atual confirmada".
+#   4. E o "não expira" da skill é literalmente FALSO: o cron `ia-uso-evento-purga`
+#      (`23 4 * * *`, `active=t` em prod) apaga `criado_em < now() - interval '7 days'`. A via
+#      tem janela de 7 DIAS — muito maior que as 6 h do `pg_net`, mas finita.
+#
+# EXIT CODES (mesma gramática dos irmãos verify-frontend.sh / verify-edge-eco.sh)
+#   0 = BUNDLE_NOVO_OBSERVADO_EM_T — ≥1 escrita pós-corte, proveniência lida, controle mecânico
+#       observado. NUNCA leia como "a versão atual é esta".
+#   2 = INDETERMINADO — zero escritas pós-corte (ninguém usou a feature), ou corte além da
+#       purga. NUNCA leia como "deploy pendente".
+#   3 = RECUSA — uso inválido, via de leitura não provada, alvo fora do universo, ou a query
+#       não demonstrou discriminar (correlação suspeita).
+#
+# 🔴 NENHUM exit significa "bundle velho". A via é unidirecional por construção: presença
+#    prova, ausência é indeterminada. Edge de usuário não tem denominador que separe "não
+#    subiu" de "ninguém usou".
+set -uo pipefail
+
+PSQL_RO="${PSQL_RO:-$HOME/.config/afiacao/psql-ro}"
+DESDE=""; FUNCAO=""
+TABELA="${TABELA:-public.ia_uso_evento}"
+UNIVERSO="${UNIVERSO:-public.ia_uso_limite}"
+COL_FUNCAO="${COL_FUNCAO:-funcao}"
+COL_TS="${COL_TS:-criado_em}"
+PURGA_DIAS="${PURGA_DIAS:-7}"
+
+recusa() { printf '❌ RECUSA: %s\n' "$1" >&2; exit 3; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --desde)   [ $# -ge 2 ] && [ -n "${2:-}" ] || recusa "--desde exige um timestamp"; DESDE="$2"; shift 2 ;;
+    --funcao)  [ $# -ge 2 ] && [ -n "${2:-}" ] || recusa "--funcao exige o slug da edge"; FUNCAO="$2"; shift 2 ;;
+    *) recusa "argumento desconhecido '$1'" ;;
+  esac
+done
+
+[ -n "$DESDE" ]  || recusa "falta --desde '<timestamp do merge, UTC>' — sem corte temporal não há o que guardar"
+[ -n "$FUNCAO" ] || recusa "falta --funcao '<slug da edge>' — é ele que nomeia a EDGE na escrita"
+
+# ── Fail-CLOSED na via de leitura ───────────────────────────────────────────────────────────────
+# `command -v` não basta: presente-porém-QUEBRADA esvazia o guard igual, e aí "0 escritas" se leria
+# como INDETERMINADO honesto em vez de RECUSA. Exija resposta POSITIVA.
+PING=$("$PSQL_RO" -Atc "SELECT 1; -- ESCRITA_PING" 2>/dev/null | command grep -cE '^1$')
+[ "${PING:-0}" -ge 1 ] || recusa "a via de leitura não respondeu POSITIVAMENTE ($PSQL_RO). Sem ela, 'não achei escrita' seria ausência de dado se passando por veredito."
+
+# ── O UNIVERSO é `limites UNION alvo` ───────────────────────────────────────────────────────────
+# Partir só da tabela de LIMITES materializa os zeros que o GROUP BY escondia — mas esconde o ALVO
+# se a configuração dele for removida/renomeada. O alvo entra explicitamente, sempre.
+LINHAS=$("$PSQL_RO" -At -F '|' -c "
+  WITH universo AS (
+    SELECT $COL_FUNCAO AS f FROM $UNIVERSO
+    UNION SELECT '$FUNCAO'
+  )
+  SELECT u.f,
+         (SELECT count(*) FROM $TABELA e WHERE e.$COL_FUNCAO = u.f),
+         (SELECT count(*) FROM $TABELA e WHERE e.$COL_FUNCAO = u.f AND e.$COL_TS > '$DESDE'::timestamptz)
+    FROM universo u ORDER BY 2 DESC, 1; -- ESCRITA_ROWS" 2>/dev/null | command grep -v '^SET$')
+
+[ -n "${LINHAS:-}" ] || recusa "a leitura do universo não devolveu linha alguma — inutilizável, e um vazio aqui se leria como 'ninguém escreveu'."
+
+ALVO_TOTAL=""; ALVO_POS=""; VIZ_ZERO=0; VIZ_N=0; TOTAIS=""
+while IFS='|' read -r f total pos; do
+  [ -z "${f:-}" ] && continue
+  if [ "$f" = "$FUNCAO" ]; then
+    ALVO_TOTAL="$total"; ALVO_POS="$pos"
+    printf '  🎯 %-26s total=%-5s pós-corte=%s\n' "$f" "$total" "$pos"
+  else
+    VIZ_N=$((VIZ_N+1)); TOTAIS="$TOTAIS $total"
+    [ "$total" -eq 0 ] && VIZ_ZERO=$((VIZ_ZERO+1))
+    printf '     %-26s total=%-5s pós-corte=%s\n' "$f" "$total" "$pos"
+  fi
+done <<< "$LINHAS"
+
+[ -n "${ALVO_TOTAL:-}" ] || recusa "'$FUNCAO' não apareceu no universo lido — sem o alvo na leitura não há veredito a dar."
+
+# ── CONTROLE MECÂNICO: a query sabe dizer "não"? ────────────────────────────────────────────────
+# O modo de falha que isto pega: a correlação quebra e a query passa a devolver o MESMO número
+# para toda função (filtro solto contando a tabela inteira). Aí ela dá "verde para tudo", e o
+# alvo positivo não vale nada.
+if [ "$VIZ_N" -eq 0 ]; then
+  printf '\n  ⚠️  CONTROLE_CRUZADO_NAO_OBSERVADO — o universo tem só o alvo (nenhuma vizinha em %s).\n' "$UNIVERSO"
+  printf '      A query representou o alvo, mas NÃO demonstrou saber dizer "não". Não escreva\n'
+  printf '      "controle negativo passou": ele não foi observado.\n'
+elif [ "$VIZ_ZERO" -eq 0 ]; then
+  UNICOS=$(printf '%s' "$TOTAIS" | tr ' ' '\n' | command grep -E '^[0-9]+$' | sort -u | wc -l | tr -d ' ')
+  if [ "$UNICOS" -eq 1 ]; then
+    recusa "CORRELACAO_SUSPEITA — as $VIZ_N vizinhas têm TODAS o mesmo total ($TOTAIS ) e nenhuma zera. Isso é a assinatura do filtro solto contando a tabela inteira: a query não discrimina, logo o positivo do alvo não prova nada."
+  fi
+  printf '\n  ⚠️  CONTROLE_CRUZADO_FRACO — nenhuma vizinha zerou, mas os totais divergem entre si,\n'
+  printf '      então a correlação está viva. Controle mais fraco que o de zeros, e dito.\n'
+else
+  printf '\n  ✓ CONTROLE_CRUZADO_OK — %s de %s vizinha(s) em zero: a query SABE dizer "não".\n' "$VIZ_ZERO" "$VIZ_N"
+fi
+
+# ── O guard da PURGA — o irmão do TTL de 6 h do pg_net ──────────────────────────────────────────
+FORA=$("$PSQL_RO" -Atc "SELECT CASE WHEN '$DESDE'::timestamptz < now() - interval '$PURGA_DIAS days' THEN 1 ELSE 0 END; -- ESCRITA_PURGA" 2>/dev/null | command grep -E '^[01]$' | head -1)
+if [ "${FORA:-0}" = "1" ]; then
+  # shellcheck disable=SC2016  # crases são texto citado, não expansão
+  printf '\n  ⚠️  CORTE_ALEM_DA_PURGA — --desde é mais antigo que %s dias, e o cron `ia-uso-evento-purga`\n' "$PURGA_DIAS"
+  printf '      (23 4 * * *, active=t) apaga o que passa disso. Escrita da época pode ter sumido:\n'
+  printf '      um zero aqui é a purga falando, não o deploy. O "não expira" da receita é FALSO.\n'
+fi
+
+# ── Veredito ────────────────────────────────────────────────────────────────────────────────────
+if [ "${ALVO_POS:-0}" -eq 0 ]; then
+  # shellcheck disable=SC2016  # crases são texto citado, não expansão
+  printf '\n⏳ INDETERMINADO — nenhuma escrita de `%s` posterior a %s.\n' "$FUNCAO" "$DESDE"
+  printf '   Isto NÃO é "deploy pendente": pode ser que ninguém tenha usado a feature. Edge de\n'
+  printf '   usuário não tem denominador que separe "não subiu" de "não foi chamada". Sem chamada\n'
+  printf '   não houve medição.\n'
+  exit 2
+fi
+
+# Proveniência: `profiles.user_id` (NÃO `profiles.id`) + a role, que vive em `user_roles`.
+printf '\n  quem escreveu (proveniência — condição (c)):\n'
+"$PSQL_RO" -At -F '|' -c "
+  SELECT to_char(e.$COL_TS,'YYYY-MM-DD HH24:MI:SS'), coalesce(p.name,'(sem profile)'), coalesce(r.role::text,'-')
+    FROM $TABELA e
+    LEFT JOIN public.profiles   p ON p.user_id = e.user_id
+    LEFT JOIN public.user_roles r ON r.user_id = e.user_id
+   WHERE e.$COL_FUNCAO = '$FUNCAO' AND e.$COL_TS > '$DESDE'::timestamptz
+   ORDER BY e.$COL_TS; -- ESCRITA_QUEM" 2>/dev/null | command grep -v '^SET$' \
+  | while IFS='|' read -r ts nome role; do
+      [ -z "${ts:-}" ] && continue
+      printf '     %s  %s (role: %s)\n' "$ts" "$nome" "$role"
+    done
+
+# shellcheck disable=SC2016  # crases são texto citado, não expansão
+printf '\n✅ BUNDLE_NOVO_OBSERVADO_EM_T — %s escrita(s) de `%s` após %s.\n' "$ALVO_POS" "$FUNCAO" "$DESDE"
+printf '   ⚠️  Isto prova que o bundle novo atendeu ≥1 chamada NAQUELE INSTANTE. NÃO prova que ele\n'
+printf '   continua no ar: um redeploy ou revert posterior deixaria este rastro intacto. Para\n'
+printf '   afirmar "está no ar AGORA", é preciso sonda viva ou marcador observado depois do\n'
+printf '   último deploy possível.\n'
+exit 0


### PR DESCRIPTION
Saiu de confirmar as 3 edges cuja presença no ar a sonda passiva não tinha confirmado (chip de 01:50Z). **As 3 estavam no ar** — nenhum deploy foi pedido. O que sobrou foi a receita que usei para provar isso, e ela tinha 4 furos.

## Os furos

**1. O controle negativo prescrito NÃO materializava.** A receita mandava `GROUP BY funcao` sobre `ia_uso_evento` e afirmava que as vizinhas com limite configurado "saem em zero na mesma leitura". **Não saem:** `GROUP BY` só produz grupos que *têm* linhas. Em prod devolveu **uma** linha e as três vizinhas não apareceram nem como zero — o operador registrava "controle negativo passou" sem ter observado nada. A seção se contradizia sozinha: `linha única` estava escrito no próprio comentário.

**2. O join de proveniência errava a chave** — `profiles.id`, sendo `profiles.user_id`.

**3. A escrita prova PASSADO, não estado atual** (2ª opinião: Codex `gpt-5.6-sol` xhigh). Um redeploy ou revert posterior deixa o rastro intacto. O exit 0 passa a se chamar `BUNDLE_NOVO_OBSERVADO_EM_T`, nunca "versão atual confirmada".

**4. O "não expira" era literalmente falso.** O cron `ia-uso-evento-purga` (`23 4 * * *`, `active=t` medido em prod) apaga acima de **7 dias**.

## O que entra

`scripts/verify-edge-escrita.sh` — universo = **limites ∪ alvo** (só os limites esconderia o alvo se a config dele sumisse), `CONTROLE_CRUZADO_OK` / `_NAO_OBSERVADO` / `CORRELACAO_SUSPEITA`, fail-closed na via de leitura, e **nenhum** exit significando "bundle velho" (a via é unidirecional por construção: presença prova, ausência é indeterminada).

`evals/verify-edge-escrita-eval.sh` — 17 casos + 4 sabotagens, registrado no gate `evals/run.sh`.

## O 2º commit: o `f` que o #2106 explicou era a chave errada

O #2106 mergeou enquanto isto era escrito, sobre o mesmo sintoma. Ele leu o `EXISTS` dar `f` e concluiu "sem linha em `profiles` não desqualifica — eram gravações reais, alias fiscal é legítimo, quem fechou foi perguntar ao founder". A regra geral é verdadeira e **fica**; o que muda é que aquele caso não é exemplo dela. Medido em prod, no mesmo `user_id`:

```
 chave_id (a usada)  | chave_user_id |       nome
---------------------+---------------+------------------
 f                   | t             | Lucas Sardenberg
```

O usuário **tem** `profiles` (staff, role `master` — que vive em `user_roles`). É `ausente ≠ zero` na dimensão **chave**: um join que não casa devolve "não existe", byte a byte igual a "existe e é nulo", e a explicação plausível encerra a investigação em cima de uma medição defeituosa.

## Evidência

```
$ scripts/verify-edge-escrita.sh --desde '2026-08-29 00:17:10Z' --funcao elevenlabs-transcribe
  🎯 elevenlabs-transcribe      total=4     pós-corte=4
  ✓ CONTROLE_CRUZADO_OK — 3 de 3 vizinha(s) em zero: a query SABE dizer "não".
✅ BUNDLE_NOVO_OBSERVADO_EM_T — 4 escrita(s) após 2026-08-29 00:17:10Z.        # exit 0

$ bash evals/run.sh --falsify
  falsificações efetivas: 4/4
✅ evals lovable-deploy-verify: OK                                             # exit 0

$ shellcheck scripts/verify-edge-escrita.sh evals/verify-edge-escrita-eval.sh  # exit 0
```

A falsificação pagou de novo: a sabotagem do ping saiu **inócua** contra a via totalmente muda (o guard do universo vazio recusa sozinho) e só mordeu no cenário `psql_mudo_parcial` — via que cala no ping mas ainda devolve linhas, onde sem o ping o script leria via quebrada como "ninguém usou a feature". Mesma lição que o eval do `verify-edge-eco` já registrara, redescoberta medindo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)