### PR TITLE
docs(escolha-de-modelo): a reversão herda a latência que o Achado 2 mediu — data efetiva ≠ mergedAt

### DIFF
--- a/docs/historico/escolha-de-modelo.md
+++ b/docs/historico/escolha-de-modelo.md
@@ -396,3 +396,14 @@ mesmo achado do #1654 com o sinal invertido.
 >
 > Corolário do "ausente ≠ zero": aqui o zero era **real**, e um zero real num eixo que a
 > intervenção não queria zerar é regressão — mesmo quando a métrica-alvo melhorou.
+
+## Quando a reversão passa a valer (simétrico do Achado 2)
+
+O revert é o mesmo tipo de mudança que o #1654: **versionada**. Logo herda a mesma latência —
+vale só onde o branch contém o commit (mergeado em 2026-08-29T03:55Z, `40272793`). No instante
+do merge, o diretório principal e as ~80 worktrees vivas ainda tinham `"model": "opus"`.
+
+Pela rotação medida em 08-06 (23% → 86,7% de cobertura por tráfego em 48h), a propagação se
+resolve sozinha em dias. **Mas a data efetiva do revert NÃO é a data do merge** — quem for
+medir o efeito desta reversão tem que recortar por quando a cobertura convergiu, não por
+`mergedAt`, sob pena de repetir exatamente o erro da verificação de 08-04.


### PR DESCRIPTION
Follow-up de uma frase do #2113.

O revert do `"model": "opus"` é **versionado**, igual ao #1654 — logo herda a mesma latência que o **Achado 2** já mediu: vale só onde o branch contém o commit. No instante do merge (2026-08-29T03:55Z, `40272793`) o diretório principal e as ~80 worktrees vivas **ainda tinham a linha**.

Pela rotação medida em 08-06 (23% → 86,7% de cobertura por tráfego em 48h) isso se resolve sozinho. O que precisa ficar escrito é a consequência para quem for medir o efeito desta reversão: **a data efetiva não é `mergedAt`** — é quando a cobertura convergiu. Recortar por `mergedAt` é exatamente o erro que a verificação de 2026-08-04 cometeu (mediu 6 minutos depois do merge e leu o baseline como resultado).

Gate: `bun run claude:size` → **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)