### PR TITLE
fix(codex+recommend): o ritual retroativo rodou — 2 defeitos reais e uma lição registrada que estava errada

### DIFF
--- a/docs/historico/duplicata-por-objetivo.md
+++ b/docs/historico/duplicata-por-objetivo.md
@@ -171,6 +171,20 @@ Suíte: 31 → 33 asserções. `bun run test:hooks` verde; contrato roda no job 
 
 ## 4ª ocorrência: entrega por DESENHO DIFERENTE — quando o grep do ARTEFATO devolve 0 e mesmo assim é duplicata (2026-08-22, PR #928)
 
+> ⚠️ **ERRATA (2026-08-29, revisão independente):** esta seção ensina a lição errada. O objetivo
+> do #928 **não** foi entregue "sob outro desenho" — `uniq_sales_orders_omie_pedido_id`, nas
+> MESMAS colunas `(account, omie_pedido_id)`, existe desde 18/06 e está em produção. O detector
+> não era **cego**, era **estreito**: grepou o NOME do índice do #928. Grepar as COLUNAS acha na
+> hora —
+> ```bash
+> git grep -ln "account, omie_pedido_id" origin/main -- supabase/migrations/
+> # → …/20260618190000_b_cleanup_dups_oben.sql
+> ```
+> **A regra que sobrevive:** o grep do artefato busca o nome que VOCÊ escolheu; quem entregou
+> antes escolheu outro. Grepe a **assinatura** (colunas, tabela, constraint), não o identificador.
+> A ponte semântica descrita abaixo é real, mas não era necessária — e apostar nela escondeu o
+> índice direto por uma sessão inteira.
+
 As 3 ocorrências acima têm o mesmo formato: o símbolo que a sessão ia criar **já estava literalmente
 na `origin/main`**, então "procure o ARTEFATO" resolve. O PR #928 é o caso que **derrota a regra que
 fecha esta página** — e por isso vale mais do que os outros três juntos.
@@ -279,13 +293,54 @@ Zero. Somado a `pg_get_indexdef` da PROD (o predicado do índice é o esperado) 
 `(account, hash_payload)` **é** a unicidade `(account, omie_pedido_id)` entre linhas pull — para
 todas as linhas existentes, não por argumento.
 
-⚠️ **REVISÃO INDEPENDENTE PENDENTE** — a 2ª opinião do Codex (ritual money-path) não rodou: cota da
-janela de 7d esgotada (`codex-async.sh` exit 75 → Caminho B). O que está acima é validação adversária
-própria. O ponto mais frágil, se alguém quiser atacar: tudo aqui descreve o estado **atual** das
-linhas; um caminho de escrita FUTURO que insira linha pull fora da RPC atômica escaparia da forma
-canônica — mitigado hoje pelo `RAISE` da linha 56, que é o guard estrutural, mas é código, não
-constraint. Um `CHECK` de canonicidade do hash seria o hardening residual honesto — não foi feito
-aqui (nenhuma instância, e é escopo novo).
+> ### ⚠️ ERRATA (2026-08-29) — a revisão independente rodou e derrubou a premissa desta seção
+>
+> A 2ª opinião do Codex (`gpt-5.6-sol`, `xhigh`, `exit 0`) atacou a equivalência e achou o que
+> esta página inteira não tinha visto: **o índice DIRETO já existe, e está aplicado em produção.**
+>
+> ```
+> $ ~/.config/afiacao/psql-ro -c "\\d+ sales_orders"   (2026-08-29)
+> uniq_sales_orders_omie_hash       (account, hash_payload)   WHERE hash_payload ~~ 'omie\\_%'
+> uniq_sales_orders_omie_pedido_id  (account, omie_pedido_id) WHERE hash_payload IS NOT NULL
+>                                                               AND omie_pedido_id IS NOT NULL
+> ```
+>
+> `uniq_sales_orders_omie_pedido_id` está em
+> [`20260618190000_b_cleanup_dups_oben.sql`](../../supabase/migrations/20260618190000_b_cleanup_dups_oben.sql)
+> desde **18/06** — dois meses antes de o #928 ser fechado. **A ponte semântica nunca foi
+> load-bearing:** o objetivo do #928 foi entregue nas MESMAS COLUNAS que ele pedia, não "sob
+> outro desenho". A 4ª ocorrência acima continua sendo uma duplicata real, mas a lição que ela
+> registra está errada — ver a errata na própria seção.
+>
+> **A medição desta seção é NULL-blind e o parecer estava certo no método:** com
+> `omie_pedido_id` NULL, `hash <> ('omie_'||account||'_'||NULL)` é `NULL`, e a linha não entra
+> no `count`. Empiricamente o buraco está VAZIO — refiz na prod separando os casos:
+>
+> | `pull_total` | `pull_pid_null` | `pull_nao_canonico` | `nao_pull_com_hash` | total |
+> |---:|---:|---:|---:|---:|
+> | 31.086 | **0** | **0** | 0 | 31.114 |
+>
+> O resultado se sustenta; o método não. Quem repetir isto use `IS DISTINCT FROM` e conte o
+> `pid IS NULL` **em separado** — não dentro do mesmo predicado.
+>
+> **O risco que esta seção dava como FUTURO já tem caminho de escrita HOJE.** A action
+> `criar_pedido` não tem guard de "já enviado":
+> `atp_gate_pedido` reconhece o estado (`omie_pedido_id IS NOT NULL` →
+> `{ok:true, resultado:'ja_enviado'}`,
+> [`…atp_gate_pedido_fase2.sql:137`](../../supabase/migrations/20260807015000_atp_gate_pedido_fase2.sql:137))
+> mas `classificarRetornoAtpGate` mapeia **todo** `ok===true` para `acao:'seguir'`
+> ([`_shared/atp-gate.ts:45`](../../supabase/functions/_shared/atp-gate.ts:45)) — é gate de
+> RESERVA, não de idempotência. O `soRow` da action nem seleciona os campos
+> ([`omie-vendas-sync/index.ts:2750`](../../supabase/functions/omie-vendas-sync/index.ts:2750)),
+> e o write-back grava `omie_pedido_id` **sem tocar `hash_payload`**
+> ([`:2151`](../../supabase/functions/omie-vendas-sync/index.ts:2151)). Numa linha pull o hash
+> passaria a mentir, e o sync do pedido original bateria `23505` no índice de hash e viraria
+> **no-op — um pedido real sumindo em silêncio**. Nenhum chamador aponta para linha pull hoje;
+> o que segura é ausência de chamador, não guard. **Não consertado aqui: é money-path e mudança
+> de comportamento em edge quente — decisão do founder.**
+>
+> O `RAISE` da linha 56 exige PRESENÇA, não FORMA: `pid='42'` e `pid='0042'` geram hashes
+> distintos e ambos viram `bigint 42`. Quem barra é o índice direto, não o de hash.
 
 ## 5ª ocorrência: o objetivo foi **RECUSADO**, e um "não" não deixa artefato (2026-08-25)
 

--- a/docs/historico/paginacao-offset-janela.md
+++ b/docs/historico/paginacao-offset-janela.md
@@ -123,7 +123,7 @@ Isso vale para QUALQUER cap, sem `count:'exact'` e sem mexer nos 21 call-sites. 
 requisição a mais por leitura, a que volta vazia. O fim da tabela deixa de ser uma inferência a
 partir de um número que o servidor escolhe, e passa a ser um fato observado.
 
-## ⚠️ REVISÃO INDEPENDENTE PENDENTE
+## O Caminho B que cobriu o intervalo (a revisão independente RODOU depois — ver o fim deste doc)
 
 O ritual `/codex` desta entrega **não rodou**: a cota do ChatGPT Plus (janela rolante de 7
 dias) esgotou em 2026-08-21 — `codex-async.sh` saiu com `COTA_ESGOTADA` (exit 75) antes de
@@ -232,3 +232,59 @@ Gate: RED verificado antes do fix (`esperava lançar KEYSET_PAGINA_SOBREPOSTA, m
 vermelhos por **código errado**, provando que o teste casa a classificação e não "lançou algo")
 · tirar `KEYSET_PAGINA_SOBREPOSTA` da allowlist (`veio desconhecido`, provando que a entrada é
 carga e não enfeite).
+
+## A revisão independente RODOU (2026-08-29) — `DONE_WITH_CONCERNS`
+
+A cota voltou antes de 20/09. O ritual rodou com o prompt **gerado** por
+`scripts/codex-prompt-paginacao.sh` (não o guardado, que este doc já declarava defasado):
+`gpt-5.6-sol`, `reasoning=xhigh`, `exit 0`, 9.388 bytes. **O marcador de pendência sai — mas a
+revisão não voltou limpa, e o parecer pediu explicitamente para não fechar como "sem achados".**
+
+### O que ela derrubou DESTE doc
+
+- **Os pares PR↔SHA do prompt estavam errados**, e o parecer não conseguiu usá-los. Não era
+  erro de redação: `sha_de()` do gerador resolvia o número com `git log --grep "(#N)" -1`, e o
+  `--grep` varre a mensagem INTEIRA — um PR posterior que cita "(#N)" em prosa no CORPO roubava
+  o SHA. `(#1856)` resolvia para `4dd2a0271` (o citador) em vez de `4b592b506`; `(#1889)` para
+  `0ed5a9b31` em vez de `b559e8bdd`. **A ironia é a lição:** este gerador nasceu para o prompt
+  não envelhecer em silêncio, e errava em silêncio de outro jeito — entregando SHA plausível.
+  Consertado ancorando no ASSUNTO (a convenção de squash-merge fecha o assunto com `(#N)`), com
+  `scripts/test-codex-prompt-paginacao.sh` + `--falsificar`, ambos no CI.
+- **"21 call-sites" não reproduz.** O parecer contou 62 expressões `fetchAll` no HEAD; a
+  contagem literal em código de edge não-teste dá **119** de `fetchAll` mais 9 de
+  `fetchAllKeyset`. Seja qual for a definição que produziu 21, **este doc não a registra** — e
+  número sem receita de contagem é exatamente o que a doutrina do repo condena. Não repita o 21.
+- **`omie_products` não foi escolhido por DELETE** — o histórico local registra zero deletes; o
+  mecanismo era mutação do filtro `ativo`.
+
+### O que ela confirmou
+
+Nenhum **P0**. A sonda de versão (#1877/#1882) está limpa: `req.json()` uma vez → `corpoBruto`
+→ `classificarSonda` → auth → reuso; sem bypass de `action` por cron secret, sem vazamento de
+versão com `Bearer x`, sem efeito colateral antes dos gates.
+
+### Segue aberto (nomeado para não passar por consertado)
+
+- **Keyset não é snapshot, e offset desloca** — natureza da paginação sem transação, não
+  defeito introduzido por #1856/#1889. Mas a suíte de keyset **aceita** insert atrás do cursor:
+  ela exige "sem duplicata", não exige que o insert apareça. O teste não mede o que o nome sugere.
+- **P1 money-path novos, não tratados aqui:** `fin-valor-cockpit/index.ts:477` (`order_items`,
+  com INSERT e hard DELETE vivos em `sync-reprocess/index.ts:314`) e `:483` (`sales_orders`,
+  hard DELETE em `omie-vendas-sync/index.ts:3370`) — o cockpit **cruza as duas listas** em
+  `:486`, então migrar só uma não fecha nada. Mais dois: `_shared/mapas-paginados.ts:71`
+  (snapshot mensal persistente) e `omie-analytics-sync/index.ts:2227` (universo Apriori,
+  publicado globalmente). Correção de fato para o cockpit é **uma consulta só** (join +
+  agregação sob o mesmo snapshot), não dois keysets separados.
+- **`fetchAllKeyset` não tem orçamento** de páginas/linhas/deadline: escrita sustentada pode
+  mantê-lo vivo até o timeout externo.
+- **P2:** desde #1882 o JSON é parseado antes de qualquer auth — body inválido anônimo virou
+  400 (era 401) e body grande é materializado pré-auth. Não fabrica dado; amplia superfície.
+
+### O que a revisão NÃO prova
+
+`n_tup_ins/del/upd` acumulado não prova taxa nem sobreposição temporal (`stats_reset`
+desconhecido). **Igualdade de contagem não prova igualdade de identidade** — a simulação do
+parecer terminou 2.299 × 2.299 com a identidade trocada e uma linha viva de R$ 1.000.000
+omitida, sem exceção. Os guards só validam linhas DEVOLVIDAS: não detectam o que o `.gt()`
+suprimiu. E os testes usam doubles estáticos — não provam gateway, RLS, réplica nem snapshot
+entre requests.

--- a/docs/historico/recommend-teto-linhas-cluster.md
+++ b/docs/historico/recommend-teto-linhas-cluster.md
@@ -141,7 +141,7 @@ O que esperar quando alguém usar a tela: `cluster_based` sumindo de `critico` (
 DOMINAR o mix contra `cross_sell`, é consequência esperada de destampar sinal real — e é o gatilho
 para a decisão de produto sobre os cortes, que segue aberta abaixo.
 
-## ⚠️ REVISÃO INDEPENDENTE PENDENTE — e o diagnóstico ANTERIOR estava errado
+## O diagnóstico ANTERIOR estava errado (a revisão independente rodou — ver o fim deste doc)
 
 **Correção do que este doc afirmava em 2026-08-22.** Estava escrito aqui que "a conta recusa
 **todos** os modelos com HTTP 400" e que o eixo era acesso de conta, não nome de modelo. **Falso**,
@@ -251,3 +251,61 @@ Medido aqui: `aprovaReal=SIM · pegaSabotagem1=SIM · pegaSabotagem2=SIM`, com o
   implementação;
 - o caminho de degradação sob `truncado` **nunca executa hoje** (779 « 5.000): é disjuntor, e sua
   primeira execução real será a primeira vez que alguém o vê funcionar.
+
+## A revisão independente RODOU (2026-08-29) — e achou um crash latente no alvo (c)
+
+`gpt-5.6-sol`, `reasoning=xhigh`, `exit 0`, 9.584 bytes. Os dois alvos que este doc nomeava
+como "sem nenhuma execução real" foram atacados. **O marcador de pendência sai.**
+
+⚠️ **Nota de transporte:** este doc registrava `gpt-5.6-sol` como MORTO (HTTP 400) e mandava
+usar `terra`/`luna`. Isso está **superado** — o cabeçalho de `scripts/codex-async.sh` registra a
+remedição de 23/08: o 400 vinha de `plan_type` congelado no token, e `codex login` devolveu o
+`sol` na hora. "Outro modelo responder NÃO inocenta o login." O default `sol` é deliberado.
+
+### Alvo (c) — defeito REAL, consertado
+
+`sim_score` volta `null` sob `truncado` de propósito, mas `useRecommendationEngine.ts`
+declarava `_admin.sim_score: number` e o card chamava `.toFixed(3)` direto: o breakdown de
+admin morreria com `TypeError: Cannot read properties of null (reading 'toFixed')` **na
+primeira vez que o disjuntor mordesse** — exatamente o risco que este doc nomeou. Consertado
+(tipo honesto + `fmt3()` rendendo `—`, nunca `0.000`), com teste vermelho pelo TypeError e
+falsificação que discrimina o ramo: reintroduzir o `.toFixed` cru deixa vermelhas as 2
+asserções do caminho null e a do caminho **medido segue verde**.
+
+### Alvo (c) — o que segue aberto
+
+- **A renormalização NÃO preserva escala comparável**, só a soma algébrica dos pesos. Como
+  `minMaxNorm` redefine min/max por execução, e penalidades + exploração (`epsilon`, até 0,3)
+  ficam fora dela, a justificativa escrita no código ("o `score_final` sairia numa escala
+  diferente… ele é gravado em `recommendation_log` e comparado entre execuções") **não se
+  sustenta**. O parecer exibiu dois vetores com transformações incompatíveis entre os regimes.
+  Isso não torna a renormalização pior que `sim=0`; torna a JUSTIFICATIVA errada.
+- **O regime truncado muda o TOP-N**, e a redistribuição de peso não compensa: os cortes em
+  `sim` CRU (0,10 / 0,15 / 0,20) simplesmente não disparam, então ninguém ganha `ctx += .3` nem
+  vira `cluster_based`. O parecer exibiu uma inversão completa de ordem (`S > A > R` → `R > A > S`).
+- **`cfg` não é validado.** `recommendation_config` é `numeric NOT NULL` sem `CHECK`, e a UI só
+  rejeita `NaN`. Com `T = wA+wP+wC`: `T=0` por cancelamento (`1 + (-1)`) torna falso o comentário
+  "todo peso em sim"; `0<T≪1` explode (`wA=1, wP=-0.999999, wS=0.2` → fator ≈ 200.001);
+  `wS=-T` zera tudo; `wS<-T` **inverte o sinal**; e `T<0` nem passa pelo guard.
+- **`meta.weights` do retorno vazio mente** (manda a config, não os pesos efetivos, e `mode`
+  fixo em `"profit"`). Inofensivo HOJE — não há consumidor local — mas é contrato falso.
+
+### Alvo (b) — histórico sem recorte temporal
+
+- **O disjuntor mede o eixo errado.** Ele conta CLIENTES (`n > 5.000`), mas o custo é o número
+  de linhas de `order_items` após o join. O próprio arquivo registra 749 linhas em `critico`
+  contra 16.738 em `estavel` para ~mesmo `n` — **22,3×** de diferença. Um cluster de 100
+  clientes concentrando o histórico usaria 2% do teto e processaria centenas de milhares de
+  linhas. Aumentar o teto não corrige; o eixo é que está errado.
+- **O short-circuit provavelmente funciona, mas o teste não prova.** `pop` tende a virar
+  `InitPlan` e o predicado pseudoconstante a virar `One-Time Filter` (filhos `never executed`),
+  mas quem protege é o `One-Time Filter`, não o `InitPlan`, e SQL não garante ordem textual de
+  `AND`. `db/test-recommend-cluster-agregado.sh:208` só verifica flag/NULL: **trocar a guarda
+  por `AND true` deixaria os asserts verdes** enquanto o trabalho pesado roda. Falta
+  `EXPLAIN (ANALYZE, BUFFERS)` asseverando `Actual Loops = 0` nos scans.
+- **Sem recorte temporal, `sim` é penetração LIFETIME, não propensão atual** — um par de 2020
+  pesa igual a uma compra deste mês, e o sinal só cresce, favorecendo SKU antigo. Menor
+  conserto proposto: predicado sobre `COALESCE(so.order_date_kpi, (so.created_at AT TIME ZONE
+  'America/Sao_Paulo')::date)` numa janela a calibrar. **Calibrar a janela é decisão de
+  produto** — não feito aqui. Se lifetime for intencional, a copy tem de dizer "já compraram",
+  não "compram".

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pipestatus-guard-sinal pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query fecho-edges-pendentes; do bash scripts/test-$t.sh || exit 1; done",
-    "test:falsificacao": "for t in orfaos-custosos read-contexto-nudge fecho-edges-pendentes; do bash scripts/test-$t.sh --falsificar || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pipestatus-guard-sinal pr-watch codex-prompt-paginacao preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query fecho-edges-pendentes; do bash scripts/test-$t.sh || exit 1; done",
+    "test:falsificacao": "for t in orfaos-custosos read-contexto-nudge fecho-edges-pendentes codex-prompt-paginacao; do bash scripts/test-$t.sh --falsificar || exit 1; done",
     "evals:deploy-verify": "bash .claude/skills/lovable-deploy-verify/evals/run.sh",
     "evals:deploy-verify:falsificacao": "bash .claude/skills/lovable-deploy-verify/evals/run.sh --falsify",
     "heavy:install": "bash scripts/heavy-install.sh"

--- a/scripts/codex-prompt-paginacao.sh
+++ b/scripts/codex-prompt-paginacao.sh
@@ -40,7 +40,18 @@ recortar() {
   printf '%s\n' "$saida"
 }
 
-sha_de() { git log origin/main --format=%h --grep "(#$1)" -1 -- 2>/dev/null || true; }
+# Resolve o número do PR para o SHA do commit que o ENTREGOU.
+# ⚠️ `--grep` varre a mensagem INTEIRA (assunto + corpo) e `-1` fica com o commit MAIS
+# RECENTE: um PR posterior que cite "(#N)" em prosa no corpo ROUBAVA o SHA do PR real —
+# o prompt saía com SHA plausível e ERRADO (medido 2026-08-29: `(#1856)` resolvia para o
+# citador 4dd2a0271 em vez de 4b592b506; `(#1889)` para 0ed5a9b31 em vez de b559e8bdd).
+# A âncora é a convenção de squash-merge do repo: o marcador `(#N)` FECHA o ASSUNTO.
+# Preso por scripts/test-codex-prompt-paginacao.sh (com --falsificar).
+sha_de() {
+  git log origin/main --format='%h%x09%s' --grep "(#$1)" -- 2>/dev/null \
+  | awk -F'\t' -v suf="(#$1)" \
+      'substr($2, length($2) - length(suf) + 1) == suf { print $1; exit }'
+}
 
 # Extração ANTES do heredoc, cada uma com a sua morte explícita. Se qualquer recorte falhar, o
 # script morre aqui e nenhum prompt é emitido — em vez de emitir um prompt mutilado.

--- a/scripts/test-codex-prompt-paginacao.sh
+++ b/scripts/test-codex-prompt-paginacao.sh
@@ -47,6 +47,8 @@ esac
 if [ "$falsificar" = 1 ]; then
   # SABOTAGEM: reintroduz o defeito exato. O teste TEM de ficar vermelho — se ficar verde,
   # ele não estava medindo nada.
+  # shellcheck disable=SC2016  # o $1 NÃO pode expandir aqui: a string é o corpo da
+  # função, expandido só no `eval` abaixo (é a sabotagem, tem de ser literal).
   defn='sha_de() { git log origin/main --format=%h --grep "(#$1)" -1 -- 2>/dev/null || true; }'
   echo "-- modo falsificação: sha_de sabotado para a versão --grep/-1 --"
 fi

--- a/scripts/test-codex-prompt-paginacao.sh
+++ b/scripts/test-codex-prompt-paginacao.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test-codex-prompt-paginacao.sh — TDD do resolvedor PR→SHA de scripts/codex-prompt-paginacao.sh.
+#
+# O DEFEITO que este teste prende (achado pela 2ª opinião do Codex, 2026-08-29): `sha_de`
+# resolvia o número do PR com `git log --grep "(#N)" -1`. O `--grep` varre a mensagem INTEIRA
+# (assunto + corpo) e `-1` fica com o commit MAIS RECENTE — então um PR posterior que cite
+# "(#N)" em prosa no corpo ROUBA o SHA do PR real. Medido na main: `(#1856)` casava
+# 4dd2a0271 (o citador) em vez de 4b592b506 (o PR), e `(#1889)` casava 0ed5a9b31 em vez de
+# b559e8bdd. O prompt saía com SHA plausível e ERRADO — falha SILENCIOSA num gerador que
+# nasceu exatamente para o prompt não envelhecer em silêncio.
+#
+# A âncora certa é a convenção de squash-merge do repo: o marcador `(#N)` FECHA o ASSUNTO.
+#
+# Uso: bash scripts/test-codex-prompt-paginacao.sh [--falsificar]   (exit 0 = verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+GERADOR="$here/codex-prompt-paginacao.sh"
+falsificar=0
+[ "${1:-}" = "--falsificar" ] && falsificar=1
+
+falhas=0
+ok()   { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; falhas=$((falhas + 1)); }
+
+[ -f "$GERADOR" ] || { echo "ABORT: $GERADOR não existe"; exit 69; }
+
+# ── Extrai a função `sha_de` do script real, por balanço de chaves.
+#    Fail-CLOSED: se o símbolo sumir (renome/refactor), o teste ABORTA em vez de virar no-op
+#    verde — sonda ausente não é sonda satisfeita.
+defn="$(awk '
+  /^sha_de\(\)/ { dentro = 1 }
+  dentro {
+    print
+    n = gsub(/\{/, "{"); abertas += n
+    n = gsub(/\}/, "}"); abertas -= n
+    if (abertas <= 0) exit
+  }
+' "$GERADOR")"
+
+case "$defn" in
+  *"git log"*) : ;;
+  *) echo "ABORT: não achei a definição de sha_de() com 'git log' em $GERADOR"
+     echo "       (símbolo renomeado? conserte o extrator, não contorne)"; exit 65 ;;
+esac
+
+if [ "$falsificar" = 1 ]; then
+  # SABOTAGEM: reintroduz o defeito exato. O teste TEM de ficar vermelho — se ficar verde,
+  # ele não estava medindo nada.
+  defn='sha_de() { git log origin/main --format=%h --grep "(#$1)" -1 -- 2>/dev/null || true; }'
+  echo "-- modo falsificação: sha_de sabotado para a versão --grep/-1 --"
+fi
+
+# ── Fixture: repositório com a MESMA forma que enganou o gerador na main.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+repo="$tmp/repo"
+mkdir -p "$repo"
+cd "$repo" || exit 70
+git init -q .
+git config user.email t@t.local
+git config user.name teste
+git config commit.gpgsign false
+
+: > a.txt; git add a.txt
+# (1) O PR REAL: o marcador FECHA o assunto.
+git commit -q -m "fix(paginação): o offset desloca sob escrita concorrente — keyset (#1856)"
+sha_real_1856="$(git rev-parse --short HEAD)"
+
+: > b.txt; git add b.txt
+# (2) PR POSTERIOR que CITA o anterior em prosa no CORPO. É este que o `-1` escolhia.
+git commit -q -m "fix(edges): fetchAll lança FalhaLeituraCritica (#1858)" \
+  -m "O helper nasceu (#1856) repetindo o mesmo vazamento; o #1856 mergeou em voo."
+sha_citador="$(git rev-parse --short HEAD)"
+
+: > c.txt; git add c.txt
+git commit -q -m "fix(paginação): página curta não é fim de tabela (#1889)"
+sha_real_1889="$(git rev-parse --short HEAD)"
+
+: > d.txt; git add d.txt
+git commit -q -m "feat(sonda): a monthly-report escapava do grep (#1946)" \
+  -m "Mesma família do (#1889), que trocou o critério de parada."
+git update-ref refs/remotes/origin/main HEAD
+
+eval "$defn"
+
+echo "== resolvedor PR→SHA =="
+
+got="$(sha_de 1856)"
+if [ "$got" = "$sha_real_1856" ]; then
+  ok "#1856 → o PR real ($sha_real_1856), não o citador ($sha_citador)"
+else
+  fail "#1856 → esperado '$sha_real_1856' (assunto fecha com o marcador), veio '$got'"
+fi
+
+got="$(sha_de 1889)"
+if [ "$got" = "$sha_real_1889" ]; then
+  ok "#1889 → o PR real ($sha_real_1889), não o citador posterior"
+else
+  fail "#1889 → esperado '$sha_real_1889', veio '$got'"
+fi
+
+# Um número que ninguém entregou não pode devolver o SHA de quem só o citou.
+got="$(sha_de 9999)"
+if [ -z "$got" ]; then
+  ok "PR inexistente → vazio (não inventa SHA)"
+else
+  fail "PR inexistente → esperado vazio, veio '$got'"
+fi
+
+# Prefixo não pode casar: (#185) é outro PR que não (#1856).
+got="$(sha_de 185)"
+if [ -z "$got" ]; then
+  ok "#185 não casa com (#1856)/(#1858) — marcador é o número INTEIRO"
+else
+  fail "#185 casou indevidamente com '$got'"
+fi
+
+echo
+if [ "$falhas" -eq 0 ]; then
+  if [ "$falsificar" = 1 ]; then
+    echo "FALSIFICAÇÃO FALHOU: o defeito foi reintroduzido e o teste passou — teste cego."
+    exit 1
+  fi
+  echo "verde: $0"
+  exit 0
+fi
+if [ "$falsificar" = 1 ]; then
+  echo "falsificação OK: $falhas asserção(ões) ficaram vermelhas com o defeito reintroduzido."
+  exit 0
+fi
+echo "VERMELHO: $falhas falha(s)."
+exit 1

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -9,6 +9,9 @@ import type { RecommendationItem } from '@/hooks/useRecommendationEngine';
 
 const fmt = (v: number | null | undefined) => v == null ? '—' : v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 const fmtPct = (v: number) => `${(v * 100).toFixed(0)}%`;
+// 3 casas do breakdown de admin. `null` é "não medi" (cluster truncado), NUNCA 0,000 —
+// a mesma degradação honesta que `fmt` já faz com dinheiro ausente.
+const fmt3 = (v: number | null | undefined) => v == null ? '—' : v.toFixed(3);
 
 const EXPLANATION_ICONS: Record<string, typeof Sparkles> = {
   association: Package,
@@ -107,7 +110,7 @@ export const RecommendationCard = React.memo(function RecommendationCard({
               </div>
               <div className="bg-muted rounded px-1.5 py-1 text-center">
                 <span className="text-muted-foreground block">Sim</span>
-                <span className="font-mono font-semibold">{item._admin.sim_score.toFixed(3)}</span>
+                <span className="font-mono font-semibold">{fmt3(item._admin.sim_score)}</span>
               </div>
               <div className="bg-muted rounded px-1.5 py-1 text-center">
                 <span className="text-muted-foreground block">Ctx</span>

--- a/src/components/__tests__/recommendation-card-sim-indisponivel.test.tsx
+++ b/src/components/__tests__/recommendation-card-sim-indisponivel.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * O disjuntor do cluster (`truncado`) faz a edge `recommend` devolver `sim_score: null` —
+ * é a distinção inteira daquela entrega: NULL é "não medi", 0 seria "medi e ninguém comprou"
+ * (supabase/functions/recommend/index.ts:272 e :330).
+ *
+ * Mas o breakdown de admin chamava `item._admin.sim_score.toFixed(3)` sobre um tipo declarado
+ * `number`, que MENTE: a edge manda `number | null`. Como o teto é 5.000 clientes e o maior
+ * cluster medido tem 779, esse caminho NUNCA executou — o defeito só apareceria na primeira
+ * vez que o disjuntor mordesse, derrubando o card com TypeError em vez de degradar.
+ *
+ * Achado pela 2ª opinião do Codex sobre docs/historico/recommend-teto-linhas-cluster.md
+ * (2026-08-29), que nomeava justamente "a primeira execução real será a primeira vez que
+ * alguém o vê funcionar".
+ *
+ * Os IRMÃOS do bloco (`assoc`, `ctx`, `pen`) seguem `number` de verdade e continuam exigidos
+ * com número — se um deles virar null um dia, este teste NÃO cobre, de propósito: o contrato
+ * que a edge quebra é só o de `sim_score`.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { RecommendationCard } from '@/components/RecommendationCard';
+import type { RecommendationItem } from '@/hooks/useRecommendationEngine';
+
+/** O card usa `Tooltip`, que exige o provider — envolver é harness, não parte da asserção. */
+function renderCard(item: RecommendationItem) {
+  return render(<TooltipProvider><RecommendationCard item={item} showAdminBreakdown /></TooltipProvider>);
+}
+
+function itemComSim(sim: number | null): RecommendationItem {
+  return {
+    product_id: 'p1',
+    codigo: 'SKU-1',
+    descricao: 'Verniz PU 900',
+    price: 100,
+    margin: 30,
+    probability: 0.4,
+    eip: 12,
+    recommendation_type: 'cross_sell',
+    explanation_text: 'porque sim',
+    explanation_key: 'association',
+    estoque: 5,
+    _admin: {
+      score_final: 0.5,
+      cost_final: 70,
+      estimated_cost_for_ranking: 70,
+      cost_source: 'cmc',
+      cost_confidence: 1,
+      assoc_score: 0.25,
+      // O campo sob teste: a edge manda NULL quando o cluster foi truncado.
+      sim_score: sim as unknown as number,
+      ctx_score: 0.125,
+      penalties: 0,
+      familia: 'PU',
+      eiltv: null,
+    },
+  };
+}
+
+describe('RecommendationCard — breakdown admin com similaridade INDISPONÍVEL', () => {
+  it('renderiza "—" para sim_score null, sem derrubar o card', () => {
+    renderCard(itemComSim(null));
+
+    // O rótulo do campo continua na tela: o breakdown não some, ele degrada.
+    expect(screen.getByText('Sim')).toBeInTheDocument();
+
+    // O valor é o travessão de "não medi" — NUNCA "0.000", que seria o zero fabricado.
+    const bloco = screen.getByText('Sim').parentElement;
+    expect(bloco?.textContent).toContain('—');
+    expect(bloco?.textContent).not.toContain('0.000');
+  });
+
+  it('com similaridade MEDIDA segue mostrando o número com 3 casas', () => {
+    renderCard(itemComSim(0.4212));
+
+    const bloco = screen.getByText('Sim').parentElement;
+    expect(bloco?.textContent).toContain('0.421');
+  });
+
+  it('os irmãos do bloco seguem exigidos como número', () => {
+    renderCard(itemComSim(null));
+
+    expect(screen.getByText('Assoc').parentElement?.textContent).toContain('0.250');
+    expect(screen.getByText('Ctx').parentElement?.textContent).toContain('0.125');
+  });
+});

--- a/src/hooks/useRecommendationEngine.ts
+++ b/src/hooks/useRecommendationEngine.ts
@@ -26,7 +26,10 @@ export interface RecommendationItem {
     cost_source: string;
     cost_confidence: number;
     assoc_score: number;
-    sim_score: number;
+    // `null` quando o disjuntor do cluster mordeu (`truncado`): a edge degrada para
+    // INDISPONÍVEL em vez de fabricar 0 — ver recommend/index.ts:272. Declarar `number`
+    // aqui era MENTIRA de contrato, e o breakdown quebrava com `.toFixed` de null.
+    sim_score: number | null;
     ctx_score: number;
     penalties: number;
     familia: string | null;

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -290,6 +290,7 @@ export const MODULOS: ModuloApp[] = [
     ],
     testes: [
       "src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx",
+      "src/components/__tests__/recommendation-card-sim-indisponivel.test.tsx",
       "src/hooks/__tests__/bundle-argumento-gravacao-calada.test.tsx",
       "src/hooks/__tests__/bundle-custo-fora-do-browser.test.tsx",
       "src/hooks/__tests__/bundle-conta-unica.test.tsx",


### PR DESCRIPTION
Ritual `/codex` retroativo (tarefa agendada de 23/08, quando a cota estava esgotada até 20/09).
**A cota voltou.** 3 pareceres, `gpt-5.6-sol` / `reasoning=xhigh`, todos `exit 0`.

## Defeitos REAIS consertados (2)

### 1. O gerador de prompt entregava SHA plausível e ERRADO
`sha_de()` de `scripts/codex-prompt-paginacao.sh` resolvia o PR com `git log --grep "(#N)" -1`.
O `--grep` varre a mensagem INTEIRA — um PR posterior que cita "(#N)" **em prosa no corpo**
roubava o SHA:

```
(#1856) → 4dd2a0271 (citador)   em vez de  4b592b506 (o PR real)
(#1889) → 0ed5a9b31 (citador)   em vez de  b559e8bdd (o PR real)
```

Foi o próprio parecer que tropeçou nisso: ele não conseguiu usar os pares PR/SHA do prompt.
A ironia é a lição — este gerador nasceu para o prompt não envelhecer em silêncio, e errava
em silêncio de outro jeito. Âncora certa: a convenção de squash-merge fecha o **ASSUNTO** com
`(#N)`.

### 2. O breakdown de admin do `recommend` quebrava com `sim_score` null
Sob `truncado`, a edge manda `sim_score: null` de propósito (NULL = "não medi"; 0 seria "medi e
ninguém comprou"). Mas o tipo declarava `number` e o card chamava `.toFixed(3)` direto. Com teto
de 5.000 e maior cluster em 779, **esse caminho nunca executou** — o defeito só apareceria na
primeira vez que o disjuntor mordesse, derrubando o card com TypeError em vez de degradar.
É exatamente o risco que o doc nomeava: "a primeira execução real será a primeira vez que
alguém o vê funcionar."

Ambos com TDD: vermelho antes (pelo `TypeError` / pelo SHA do citador) e falsificação que
**discrimina o ramo** — no card, reintroduzir o `.toFixed` cru deixa vermelhas as 2 asserções
do caminho null e a do caminho medido **segue verde**.

## A lição registrada que estava errada

`docs/historico/duplicata-por-objetivo.md` ensinava, na 4ª ocorrência, que o objetivo do #928
foi entregue "sob outro desenho" e que por isso o grep do artefato é cego. **Falso.**
`uniq_sales_orders_omie_pedido_id` sobre `(account, omie_pedido_id)` — as MESMAS colunas do
#928 — existe desde 18/06 e está **aplicado em produção** (confirmado via `psql-ro`).

O detector não era cego, era **estreito**: grepou o NOME do índice. Grepar as COLUNAS acha na
hora. Regra que sobrevive: **grepe a assinatura, não o identificador que VOCÊ escolheu.**

Também corrigido ali: a medição de canonicidade era NULL-blind. Refeita separando os casos —
31.086 pull, **0** com pid NULL, **0** não-canônico. O resultado se sustenta; o método não.

## Registrado como ABERTO, não consertado (money-path — decisão do founder)

- **`criar_pedido` sem guard de "já enviado".** `atp_gate_pedido` reconhece o estado
  (`ja_enviado`) mas `classificarRetornoAtpGate` mapeia todo `ok:true` para `'seguir'` — é gate
  de RESERVA, não de idempotência. O `soRow` nem seleciona `omie_pedido_id`/`hash_payload`, e o
  write-back grava o pid **sem tocar o hash**. Numa linha pull o hash passaria a mentir e o
  sync do pedido original viraria no-op — **um pedido real sumindo em silêncio**. O que segura
  hoje é ausência de chamador, não guard.
- **4 call-sites P1 de offset** em `fin-valor-cockpit` (`order_items` **e** `sales_orders`, que
  o cockpit cruza — migrar só um não fecha nada), `_shared/mapas-paginados.ts` e
  `omie-analytics-sync`.
- **O disjuntor do cluster mede o eixo errado**: conta clientes, mas o custo é linhas de
  `order_items` (22,3× de variação medida para o mesmo `n`). Aumentar o teto não corrige.
- **`sim` sem recorte temporal é penetração lifetime, não propensão atual.** Calibrar a janela
  é decisão de produto.

## Outras correções de fato nos docs

- "21 call-sites" **não reproduz** (119 ocorrências de `fetchAll` em código de edge não-teste).
- `omie_products` não foi escolhido por DELETE (zero deletes; era mutação do filtro `ativo`).
- **`gpt-5.6-sol` NÃO está morto.** O 400 vinha de `plan_type` congelado no token, remedido em
  23/08 — `terra`/`luna` respondiam por serem o tier de baixo. Trocar de modelo escondia a causa.

## Evidência

- `heavy bun run test` → **exit 0**, 750 arquivos, 7503 testes (pós-rebase).
- `bun run typecheck` → exit 0 · `bun run lint` → 0 erros · `shellcheck` → exit 0.
- `test:falsificacao` completo → exit 0.
- Gate `scripts/falsificacao-cobertura.test.ts` reprovou a 1ª forma (`--falsificar` pendurado ao
  lado do laço em vez de dentro): "modo que só roda à mão é ausência de dado". Corrigido.
- Índices conferidos na PROD via `psql-ro`.

Marcador `REVISÃO INDEPENDENTE PENDENTE` removido dos 3 docs **com registro** do que cada
revisão disse — marcador removido sem registro é pior que marcador não removido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
