### PR TITLE
fix(money-path): `criar_pedido` não tinha guard de "já enviado" — linha pull ia ao IncluirPedido e o Omie criava PEDIDO DUPLICADO [achado Codex]

### DIFF
--- a/db/test-hash-omie-canonico.sh
+++ b/db/test-hash-omie-canonico.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA de migration money-path/auth com FALSIFICAÇÃO            ║
+# ║  Copie p/ db/test-<slug>.sh, preencha as ZONAS [[...]], rode:                  ║
+# ║      bash db/test-<slug>.sh > /tmp/t.log 2>&1; echo "exit=$?"                  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Lei de Ferro (skill prove-sql-money-path):                                    ║
+# ║   1. Aplica a migration REAL (psql -f), não um stub da lógica.                 ║
+# ║   2. Assert negativo captura a SQLSTATE esperada e RE-LANÇA o resto.           ║
+# ║   3. Falsificação obrigatória: sabota a migração → exija VERMELHO → restaura.  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (idêntico em todos os harnesses; contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"     # mude se rodar em paralelo com outro harness (40 worktrees)
+SLUG="hash-omie-canonico"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+# keg-only do brew: share/lib do postgresql@17 podem não estar linkados → initdb/server falham. Copia do Cellar (idempotente).
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }   # tuples-only, unaligned (pra capturar 1 valor)
+
+# ── base mínima do Supabase: roles, schema auth, auth.uid()/role() via GUC (impersonação de RLS) ──
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
+SQL
+
+# ── helpers de assert (pass/fail contados; exit 1 no fim se houve fail) ──
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# exige que um comando SQL FALHE (caminho negativo grosso). Pra checar a SQLSTATE exata, use o
+# padrão DO/EXCEPTION de references/assert-patterns.md (preferível — Lei #2).
+must_fail() { if P -q -c "$1" >/dev/null 2>&1; then bad "$2 — devia ter falhado e PASSOU"; else ok "$2 (rejeitado)"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Helper de SQLSTATE (Lei #2): devolve a SQLSTATE do comando, ou 00000 se passou.
+# Não engole nada — um erro DIFERENTE do esperado volta com o CÓDIGO DELE e o eq
+# reprova nomeando-o. A sentinela ('23514') não aparece no texto que o CHECK emite.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.tentar(cmd text) RETURNS text
+LANGUAGE plpgsql AS $f$
+BEGIN
+  EXECUTE cmd;
+  RETURN '00000';
+EXCEPTION WHEN OTHERS THEN
+  RETURN SQLSTATE;
+END $f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS. Stub de sales_orders com os tipos REAIS das 3 colunas que
+# o CHECK lê, conferidos no information_schema da PROD (2026-08-29):
+#   account bigint→NÃO: account text NOT NULL · hash_payload text NULL · omie_pedido_id bigint NULL
+# `account NOT NULL` é material, não cosmético: se fosse NULL-able, a concatenação viraria
+# NULL e o CHECK avaliaria NULL — e CHECK que avalia NULL PASSA (fresta fail-open silenciosa).
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TABLE public.sales_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text NOT NULL,
+  hash_payload text,
+  omie_pedido_id bigint,
+  status text NOT NULL DEFAULT 'rascunho'
+);
+-- espelha o índice parcial de identidade da PROD (uniq_sales_orders_omie_hash): é ele que
+-- transforma o hash corrompido em 23505 e faz o ON CONFLICT sumir com o pedido original.
+CREATE UNIQUE INDEX uniq_sales_orders_omie_hash
+  ON public.sales_orders (account, hash_payload) WHERE hash_payload LIKE 'omie\_%';
+SQL
+
+# ── ACERVO PRÉ-EXISTENTE: semeado ANTES da migration, para provar que ela ENTRA sem quebrar
+#    linha existente (é o que o pré-voo mediu na PROD: 31.086 pull, 0 violando).
+P -q <<'SQL'
+INSERT INTO public.sales_orders (account, hash_payload, omie_pedido_id, status) VALUES
+  ('oben',    'omie_oben_42',    42,   'faturado'),
+  ('colacor', 'omie_colacor_77', 77,   'importado'),
+  (E'oben',    NULL,              4242, 'enviado'),     -- push JA enviada (as 26 da PROD)
+  ('oben',    NULL,              NULL, 'rascunho'),     -- push virgem
+  ('oben',    'checkout_abc123', NULL, 'orcamento');    -- hash de OUTRA origem
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260829081556_sales_orders_hash_omie_canonico.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+echo
+
+# a própria aplicação sobre o acervo JÁ é um assert: se alguma das 5 linhas violasse,
+# o ADD CONSTRAINT teria abortado acima (set -e) e o harness morreria aqui.
+ok "migration ENTRA sobre acervo pré-existente (pull canônica + push + hash de outra origem)"
+eq "constraint existe e está VALIDADA" \
+   "$(Pq -c "SELECT convalidated FROM pg_constraint WHERE conname='sales_orders_hash_omie_canonico';")" "t"
+eq "re-aplicar a migration é idempotente (DO guardado)" \
+   "$(Pq -c "SELECT public.tentar('SET search_path=public');" >/dev/null; P -q -f "$MIG" >/dev/null 2>&1 && echo ok || echo falhou)" "ok"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+INS="INSERT INTO public.sales_orders (account, hash_payload, omie_pedido_id) VALUES"
+
+echo "── POSITIVOS: o que DEVE passar (precisão > recall — o CHECK não legisla fora do namespace omie_)"
+eq "P1 pull canônica nova (omie_oben_99 / pid 99)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_oben_99',99)\$q\$);")" "00000"
+eq "P2 push virgem (hash NULL, pid NULL)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben',NULL,NULL)\$q\$);")" "00000"
+eq "P3 push JÁ enviada (hash NULL, pid preenchido) — as 26 linhas da PROD" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('colacor',NULL,5555)\$q\$);")" "00000"
+eq "P4 hash de OUTRA origem (checkout_*) com pid NULL" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','checkout_zzz',NULL)\$q\$);")" "00000"
+eq "P5 hash que CONTÉM 'omie_' mas não COMEÇA com ele (LIKE ancorado)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','checkout_omie_oben_1',NULL)\$q\$);")" "00000"
+eq "P6 conta com underscore no nome (colacor_sc) é canônica" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('colacor_sc','omie_colacor_sc_7',7)\$q\$);")" "00000"
+
+echo
+echo "── NEGATIVOS: 23514 (check_violation). SQLSTATE exata — erro DIFERENTE volta com o código dele."
+eq "N1 [DEFEITO CENTRAL] write-back do reenvio grava pid NOVO sobre hash VELHO (omie_oben_42 → pid 43)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$UPDATE public.sales_orders SET omie_pedido_id=43 WHERE hash_payload='omie_oben_42'\$q\$);")" "23514"
+eq "N2 linha pull SEM pid (hash omie_* com omie_pedido_id NULL)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_oben_500',NULL)\$q\$);")" "23514"
+eq "N3 hash da conta ERRADA (omie_colacor_* gravado em account 'oben')" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_colacor_800',800)\$q\$);")" "23514"
+eq "N4 pid divergente do hash já no INSERT (omie_oben_900 / pid 901)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_oben_900',901)\$q\$);")" "23514"
+eq "N5 UPDATE que reescreve o HASH deixando o pid para trás" \
+   "$(Pq -c "SELECT public.tentar(\$q\$UPDATE public.sales_orders SET hash_payload='omie_oben_1' WHERE hash_payload='omie_colacor_77'\$q\$);")" "23514"
+
+echo
+echo "── A CADEIA QUE O CHECK CORTA: sem ele, o hash corrompido faz o pedido original SUMIR."
+# Prova o elo: se o hash pudesse mentir, o sync do pedido 42 bateria 23505 no índice de
+# identidade — e o ON CONFLICT DO NOTHING da RPC transformaria isso em no-op silencioso.
+eq "elo: re-inserir o hash omie_oben_42 bate 23505 no índice de identidade" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_oben_42',42)\$q\$);")" "23505"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — FALSIFICAÇÃO (Lei #3): sabota o CHECK, exige que o assert fique VERMELHO,
+# restaura. Sem isto, um assert que nunca poderia falhar passaria por prova.
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo "═══ FALSIFICAÇÃO ═══"
+DROP="ALTER TABLE public.sales_orders DROP CONSTRAINT sales_orders_hash_omie_canonico"
+restaurar() { P -q -c "$DROP" >/dev/null 2>&1 || true; P -q -f "$MIG" >/dev/null; }
+# assert-de-falsificação: o negativo tem de PARAR de morder (voltar a 00000).
+morde_menos() { if [ "$2" = "00000" ]; then ok "F$1 sabotagem soltou o assert (dente confirmado)"; else bad "F$1 SEM DENTE — sabotei e o assert seguiu [$2]: ele não estava provando isto"; fi; }
+
+echo "F1 — CHECK sem a cláusula de CANONICIDADE (só exige pid não-nulo)"
+P -q -c "$DROP" >/dev/null
+P -q -c "ALTER TABLE public.sales_orders ADD CONSTRAINT sales_orders_hash_omie_canonico CHECK (hash_payload IS NULL OR hash_payload NOT LIKE 'omie\_%' OR omie_pedido_id IS NOT NULL)" >/dev/null
+morde_menos 1a "$(Pq -c "SELECT public.tentar(\$q\$UPDATE public.sales_orders SET omie_pedido_id=43 WHERE hash_payload='omie_oben_42'\$q\$);")"
+morde_menos 1b "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_colacor_801',801)\$q\$);")"
+P -q -c "UPDATE public.sales_orders SET omie_pedido_id=42 WHERE hash_payload='omie_oben_42'" >/dev/null
+P -q -c "DELETE FROM public.sales_orders WHERE hash_payload='omie_colacor_801'" >/dev/null
+restaurar
+
+echo "F2 — CHECK sem a exigência de pid não-nulo"
+P -q -c "$DROP" >/dev/null
+P -q -c "ALTER TABLE public.sales_orders ADD CONSTRAINT sales_orders_hash_omie_canonico CHECK (hash_payload IS NULL OR hash_payload NOT LIKE 'omie\_%' OR hash_payload = 'omie_' || account || '_' || omie_pedido_id::text)" >/dev/null
+morde_menos 2 "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','omie_oben_501',NULL)\$q\$);")"
+P -q -c "DELETE FROM public.sales_orders WHERE hash_payload='omie_oben_501'" >/dev/null
+restaurar
+
+echo "F3 — LIKE DESANCORADO ('%omie\_%'): o CHECK passa a legislar sobre hash que não é dele"
+DESANC="CHECK (hash_payload IS NULL OR hash_payload NOT LIKE '%omie\_%' OR (omie_pedido_id IS NOT NULL AND hash_payload = 'omie_' || account || '_' || omie_pedido_id::text))"
+P -q -c "$DROP" >/dev/null
+# F3a — o desancorado nem ENTRA: o `checkout_omie_oben_1` do P5 (linha legítima) já o viola.
+# Efeito não previsto quando escrevi o F3; é a prova mais forte do que a âncora protege.
+eq "F3a desancorar nem APLICA sobre o acervo (linha checkout_* legítima viola)" \
+   "$(Pq -c "SELECT public.tentar(\$q\$ALTER TABLE public.sales_orders ADD CONSTRAINT sales_orders_hash_omie_canonico $DESANC\$q\$);")" "23514"
+# F3b — mesmo NOT VALID (que ignora o acervo), ele reprova a PRÓXIMA linha legítima.
+P -q -c "ALTER TABLE public.sales_orders ADD CONSTRAINT sales_orders_hash_omie_canonico $DESANC NOT VALID" >/dev/null
+FS3="$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','checkout_omie_oben_2',NULL)\$q\$);")"
+if [ "$FS3" = "23514" ]; then ok "F3b desancorar REPROVA linha legítima nova (P5 tem dente)"; else bad "F3b SEM DENTE — desancorei e o checkout_ passou [$FS3]"; fi
+restaurar
+
+echo "F4 — constraint presente porém NOT VALID: a POSTCONDIÇÃO da migration tem de RECUSAR"
+P -q -c "$DROP" >/dev/null
+P -q -c "ALTER TABLE public.sales_orders ADD CONSTRAINT sales_orders_hash_omie_canonico CHECK (hash_payload IS NULL OR hash_payload NOT LIKE 'omie\_%' OR (omie_pedido_id IS NOT NULL AND hash_payload = 'omie_' || account || '_' || omie_pedido_id::text)) NOT VALID" >/dev/null
+if P -q -f "$MIG" >/dev/null 2>&1; then bad "F4 SEM DENTE — a migration aceitou uma constraint NOT VALID como aplicada"; else ok "F4 postcondição recusa constraint NAO validada ('existe' != 'vale')"; fi
+restaurar
+
+echo
+echo "═══ VERDE DE VOLTA (migration verdadeira restaurada) ═══"
+eq "R1 negativo central volta a morder" \
+   "$(Pq -c "SELECT public.tentar(\$q\$UPDATE public.sales_orders SET omie_pedido_id=44 WHERE hash_payload='omie_oben_42'\$q\$);")" "23514"
+eq "R2 positivo segue passando" \
+   "$(Pq -c "SELECT public.tentar(\$q\$$INS ('oben','checkout_final',NULL)\$q\$);")" "00000"
+
+echo
+echo "═══ $PASS ok · $FAIL falhas ═══"
+[ "$FAIL" -eq 0 ]

--- a/docs/historico/duplicata-por-objetivo.md
+++ b/docs/historico/duplicata-por-objetivo.md
@@ -336,8 +336,44 @@ todas as linhas existentes, não por argumento.
 > ([`:2151`](../../supabase/functions/omie-vendas-sync/index.ts:2151)). Numa linha pull o hash
 > passaria a mentir, e o sync do pedido original bateria `23505` no índice de hash e viraria
 > **no-op — um pedido real sumindo em silêncio**. Nenhum chamador aponta para linha pull hoje;
-> o que segura é ausência de chamador, não guard. **Não consertado aqui: é money-path e mudança
-> de comportamento em edge quente — decisão do founder.**
+> o que segura é ausência de chamador, não guard.
+>
+> **✅ FECHADO em 2026-08-29** (guard na fronteira + CHECK de canonicidade). O que a
+> implementação acrescentou ao parecer, e que vale como lição própria:
+>
+> 1. **A chave de dedup do Omie é `PV_<sales_order_id>` — determinística por linha LOCAL**
+>    ([`omie-vendas-sync/index.ts:2001`](../../supabase/functions/omie-vendas-sync/index.ts:2001)).
+>    É isto que separa os dois casos: retry de linha *push* bate duplicata no Omie e reconcilia
+>    via `ConsultarPedido` (inofensivo); linha *pull* **nunca usou essa chave**, então o Omie não
+>    tem como deduplicar e **cria pedido novo**. Sem esse elo, "falta um guard" parece severidade
+>    uniforme — não é.
+> 2. **Não existe retry legítimo com pid preenchido.** O write-back é o ÚNICO escritor do pid
+>    neste caminho e é um `UPDATE` único: falhou ⇒ pid NULL ⇒ o retry passa e reconcilia. O
+>    `"retry idempotente"` do comentário do gate ATP é escopo de **RESERVA** ("não re-reservar",
+>    não renovar TTL) — ler aquele comentário como permissão de reenvio teria travado o conserto.
+> 3. **O invariante já ERA o desenho, na camada errada.** 2 dos 3 chamadores o implementavam por
+>    conta própria (`pedido-programado-enviar:250`; `submitOrder` via `alreadySent`); o
+>    `SalesQuotes` não — dependia só do filtro `status='orcamento'`, e nenhuma das 31.086 linhas
+>    pull tem esse status. **Guard replicado no chamador é guard ausente na fronteira**: procure a
+>    réplica antes de concluir "isto nunca foi pensado".
+>
+> Entregue: decisão PURA em [`_shared/reenvio-pedido.ts`](../../supabase/functions/_shared/reenvio-pedido.ts)
+> (recusa por UNIÃO — `omie_pedido_id IS NOT NULL` **ou** `hash_payload LIKE 'omie\_%'`), chamada
+> ANTES do `criarPedidoVenda` e FORA do ramo `account === "oben"` (o gate ATP é oben-only, então
+> pedido colacor jamais passava por ele); `throw`, não `{success:false, blocked}` — caller antigo
+> lê `blocked` DESCONHECIDO como sucesso. Bônus fail-closed: o `.maybeSingle()` ignorava o
+> `error`, então linha ausente/ilegível seguia para o `IncluirPedido` e só quebrava no write-back,
+> **depois** de o pedido existir no Omie.
+>
+> **O CHECK proposto no parecer entrou, mas como SEGUNDA linha e com isso dito em voz alta**
+> ([`20260829081556_sales_orders_hash_omie_canonico.sql`](../../supabase/migrations/20260829081556_sales_orders_hash_omie_canonico.sql)):
+> um CHECK só reprova a escrita LOCAL, e quando ele disparasse o pedido duplicado **já existiria
+> no Omie**. Ele impede a corrupção se consolidar, não a duplicata acontecer. Duas medições que a
+> escrita do CHECK exigiu e o parecer não trazia: `account` é **NOT NULL** (se fosse nullable, a
+> concatenação viraria NULL e **CHECK que avalia NULL PASSA** — fresta fail-open silenciosa); e o
+> `LIKE` precisa ficar **ancorado**, porque desancorá-lo (`'%omie\_%'`) nem aplica sobre o acervo:
+> a linha legítima `checkout_omie_oben_1` já o viola. Prova em
+> [`db/test-hash-omie-canonico.sh`](../../db/test-hash-omie-canonico.sh) (23 asserts, 4 sabotagens).
 >
 > O `RAISE` da linha 56 exige PRESENÇA, não FORMA: `pid='42'` e `pid='0042'` geram hashes
 > distintos e ambos viram `bigint 42`. Quem barra é o índice direto, não o de hash.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **500** custom migrations totais
+- **501** custom migrations totais
 - **1723** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 522
@@ -4195,6 +4195,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.data_health_watchdog` | — |
 | `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260829081556_sales_orders_hash_omie_canonico.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 500
+-- Total de custom migrations: 501
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -541,7 +541,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260828213000', 'cap_carteira_escrever_master_only', '20260828213000_cap_carteira_escrever_master_only.sql'),
   ('20260828224542', 'ia_uso_limite_generate_bundle_argument', '20260828224542_ia_uso_limite_generate_bundle_argument.sql'),
   ('20260829012000', 'analytics_outbox_perda_visivel', '20260829012000_analytics_outbox_perda_visivel.sql'),
-  ('20260829041500', 'analytics_outbox_trigger_sensor', '20260829041500_analytics_outbox_trigger_sensor.sql')
+  ('20260829041500', 'analytics_outbox_trigger_sensor', '20260829041500_analytics_outbox_trigger_sensor.sql'),
+  ('20260829081556', 'sales_orders_hash_omie_canonico', '20260829081556_sales_orders_hash_omie_canonico.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -399,12 +399,78 @@ describe('guardrail money-path: criar_pedido não confia no espelho legado omie_
   });
 
   it('deriva do PEDIDO LOCAL (customer_user_id + customer_document), não confia no payload', () => {
-    // checkout_id entrou no select na fase 2 do ATP (o gate ATP ancora a reserva
-    // nele); o pin segue EXATO na forma nova — perder qualquer campo fica vermelho.
+    // checkout_id entrou no select na fase 2 do ATP (o gate ATP ancora a reserva nele);
+    // omie_pedido_id + hash_payload entraram no guard de reenvio (Codex 2026-08-29) — sem
+    // eles o guard classifica linha ENVIADA como virgem e volta a duplicar no Omie.
+    // O pin segue EXATO na forma nova — perder qualquer campo fica vermelho.
     expect(
       src,
       'o edge deixou de ler customer_user_id/customer_document do pedido local — voltaria a confiar no payload',
-    ).toMatch(/select\("account, customer_user_id, customer_document, created_by, checkout_id"\)/);
+    ).toMatch(
+      /select\("account, customer_user_id, customer_document, created_by, checkout_id, omie_pedido_id, hash_payload"\)/,
+    );
+  });
+});
+
+// ── Guard de REENVIO da fronteira criar_pedido (achado Codex 2026-08-29, /codex do #2117) ──
+// A decisão é PURA e testada em Deno (_shared/reenvio-pedido_test.ts). Este bloco vigia o
+// WIRING no edge — que o Lovable pode reverter e commitar na main como "Changes".
+describe('guardrail money-path: criar_pedido recusa reenvio ANTES do IncluirPedido', () => {
+  const src = read(VENDAS);
+  const criar = blocoCriarPedido(src);
+  // Assert NEGATIVO sobre a fonte → limpar comentário primeiro (a prosa do guard cita
+  // criarPedidoVenda/IncluirPedido de propósito, ao explicar a ordem).
+  const criarLimpo = removerComentarios(criar);
+
+  it('sentinela: extraiu o bloco REAL do case criar_pedido (e o stripper não o esvaziou)', () => {
+    expect(criar).toContain('criarPedidoVenda(');
+    expect(criarLimpo).toContain('criarPedidoVenda(');
+    expect(criarLimpo.length, 'stripper comeu o miolo do bloco').toBeGreaterThan(500);
+  });
+
+  it('o edge USA a decisão pura (import + chamada), não uma cópia inline', () => {
+    expect(src, 'sumiu o import de reenvio-pedido.ts').toMatch(
+      /import \{[^}]*classificarEnvioPedido[^}]*\} from "\.\.\/_shared\/reenvio-pedido\.ts"/,
+    );
+    expect(criarLimpo, 'REGRESSÃO: o case criar_pedido parou de chamar o guard de reenvio')
+      .toMatch(/classificarEnvioPedido\(\s*soRow\s*\)/);
+  });
+
+  it('lê os campos que o guard precisa (sem eles, linha ENVIADA parece virgem)', () => {
+    expect(criarLimpo, 'omie_pedido_id saiu do select — o guard ficaria cego').toContain('omie_pedido_id');
+    expect(criarLimpo, 'hash_payload saiu do select — linha pull ficaria indistinguível').toContain('hash_payload');
+  });
+
+  it('a recusa é um throw (fail-closed), não um blocked que caller antigo lê como sucesso', () => {
+    expect(criarLimpo).toMatch(/if \(!vereditoEnvio\.permitido\) \{[\s\S]{0,400}?throw new Error\(/);
+    expect(
+      criarLimpo,
+      'a recusa de reenvio virou blocked — caller antigo trata blocked desconhecido como sucesso',
+    ).not.toMatch(/blocked:\s*["'](ja_enviado|reenvio)["']/);
+  });
+
+  it('ORDEM: o guard roda ANTES de criarPedidoVenda (um CHECK no banco seria tarde demais)', () => {
+    const iGuard = criarLimpo.indexOf('classificarEnvioPedido(');
+    const iEnvio = criarLimpo.indexOf('criarPedidoVenda(');
+    expect(iGuard, 'guard de reenvio não encontrado no bloco').toBeGreaterThan(-1);
+    expect(iEnvio, 'criarPedidoVenda não encontrado no bloco').toBeGreaterThan(-1);
+    expect(iGuard, 'o guard passou a rodar DEPOIS do IncluirPedido — o pedido já existiria no Omie')
+      .toBeLessThan(iEnvio);
+  });
+
+  it('o guard NÃO está atrás do if (account === "oben") do gate ATP (vale para toda conta)', () => {
+    const iGuard = criarLimpo.indexOf('classificarEnvioPedido(');
+    const iOben = criarLimpo.indexOf('account === "oben"');
+    expect(iOben, 'gate ATP oben-only não encontrado — bloco mudou de forma').toBeGreaterThan(-1);
+    expect(iGuard, 'o guard caiu dentro do ramo oben — pedido colacor voltaria a duplicar')
+      .toBeLessThan(iOben);
+  });
+
+  it('a decisão pura NÃO foi duplicada dentro do edge (fonte única)', () => {
+    expect(
+      removerComentarios(src),
+      'o edge redefiniu classificarEnvioPedido — cópia divergiria do módulo testado em Deno',
+    ).not.toMatch(/function classificarEnvioPedido/);
   });
 });
 

--- a/supabase/functions/_shared/reenvio-pedido.ts
+++ b/supabase/functions/_shared/reenvio-pedido.ts
@@ -1,0 +1,90 @@
+// Guard de REENVIO da fronteira `criar_pedido` (omie-vendas-sync). PURO (zero Deno/DB):
+// provado por `deno test --no-remote supabase/functions/_shared/reenvio-pedido_test.ts`.
+//
+// Achado Codex 2026-08-29 (ritual /codex retroativo do PR #2117). A action `criar_pedido`
+// não tinha guard de "já enviado". A cadeia:
+//   1. atp_gate_pedido RECONHECE o estado (`omie_pedido_id IS NOT NULL` → 'ja_enviado'),
+//      mas classificarRetornoAtpGate mapeia todo `ok===true` para acao:'seguir' — é gate
+//      de RESERVA (TTL), não de idempotência de ENVIO. E só roda para account 'oben'.
+//   2. O `soRow` da action nem lia omie_pedido_id/hash_payload.
+//   3. O write-back grava omie_pedido_id SEM tocar hash_payload.
+//
+// Por que a linha *pull* é o caso caro: a chave de dedup do Omie é `PV_<sales_order_id>`,
+// DETERMINÍSTICA POR LINHA LOCAL. Retry de linha *push* bate duplicata no Omie e reconcilia
+// (inofensivo). Linha pull nasceu do sync — nunca usou essa chave ⇒ o Omie NÃO deduplica e
+// cria um pedido novo; o write-back grava o pid novo sobre o hash velho (`omie_oben_42` com
+// pid 43); o próximo sync do pedido 42 remonta `omie_oben_42`, bate 23505 no índice parcial
+// uniq_sales_orders_omie_hash e o ON CONFLICT da RPC criar_pedidos_com_itens trata como
+// no-op → UM PEDIDO REAL SOME EM SILÊNCIO (positivação/OTE/comissão perdidas).
+//
+// O que segurava até aqui era AUSÊNCIA DE CHAMADOR apontando para linha pull, não um guard:
+// nenhuma das 31.086 linhas pull da PROD tem status 'orcamento' (o filtro do SalesQuotes).
+// Ausência de gatilho não é invariante.
+//
+// ⚠️ O guard tem de rodar ANTES do IncluirPedido: um CHECK no banco seria TARDIO — falharia
+// depois de o pedido já existir no Omie. O CHECK de canonicidade
+// (20260829120000_sales_orders_hash_canonico.sql) é defesa em profundidade, não substituto.
+
+export interface LinhaPedidoParaEnvio {
+  omie_pedido_id?: number | null;
+  hash_payload?: string | null;
+}
+
+/** Ramos de recusa. São a MARCA testável de cada decisão (a prosa do detalhe é humana). */
+export type MotivoRecusaEnvio = "linha_ausente" | "ja_enviado" | "linha_do_sync";
+
+export interface VereditoEnvioPedido {
+  permitido: boolean;
+  motivo: MotivoRecusaEnvio | null;
+  /** mensagem curta para o erro do edge; null quando permitido (nunca recusa opaca) */
+  detalhe: string | null;
+}
+
+/** Prefixo do hash das linhas nascidas no sync do Omie (`omie_<account>_<pid>`). ANCORADO no
+ *  início: um hash que só CONTÉM 'omie_' (ex.: `checkout_omie_oben_1`) não é linha pull. */
+export function nascidaNoSync(hash: string | null | undefined): boolean {
+  return typeof hash === "string" && hash.startsWith("omie_");
+}
+
+/**
+ * Decide se a linha local pode virar um `IncluirPedido` no Omie.
+ *
+ * Fail-closed: linha ausente/ilegível recusa (o edge lê com `.maybeSingle()`, então "não achou"
+ * e "erro de DB" chegam iguais — como `null`). Recusar deixa o pedido local INTACTO para retry;
+ * seguir criaria o PV no Omie e só quebraria no write-back, deixando linha órfã.
+ *
+ * "Já enviado" usa o MESMO predicado do índice uniq_sales_orders_omie_pedido_id e do CHECK de
+ * canonicidade — `omie_pedido_id IS NOT NULL`. Uma noção própria de "pid válido" abriria fresta
+ * entre duas definições de enviado.
+ *
+ * Não existe retry legítimo com pid preenchido: o write-back é o ÚNICO escritor do pid neste
+ * caminho e é um UPDATE único — falhou ⇒ pid NULL ⇒ o retry passa aqui e reconcilia via
+ * `PV_<id>`. O "retry idempotente" do comentário do gate ATP é escopo de RESERVA ("não
+ * re-reservar", não renovar TTL), não permissão de reenvio.
+ */
+export function classificarEnvioPedido(
+  linha: LinhaPedidoParaEnvio | null | undefined,
+): VereditoEnvioPedido {
+  if (typeof linha !== "object" || linha === null || Array.isArray(linha)) {
+    return {
+      permitido: false,
+      motivo: "linha_ausente",
+      detalhe: "pedido local não encontrado (ou ilegível) — envio recusado antes do Omie",
+    };
+  }
+  if (linha.omie_pedido_id !== null && linha.omie_pedido_id !== undefined) {
+    return {
+      permitido: false,
+      motivo: "ja_enviado",
+      detalhe: `pedido já enviado ao Omie (omie_pedido_id=${linha.omie_pedido_id}) — reenvio criaria duplicata`,
+    };
+  }
+  if (nascidaNoSync(linha.hash_payload)) {
+    return {
+      permitido: false,
+      motivo: "linha_do_sync",
+      detalhe: "linha nasceu no sync do Omie (hash_payload omie_*) — nunca vira IncluirPedido",
+    };
+  }
+  return { permitido: true, motivo: null, detalhe: null };
+}

--- a/supabase/functions/_shared/reenvio-pedido.ts
+++ b/supabase/functions/_shared/reenvio-pedido.ts
@@ -30,8 +30,11 @@ export interface LinhaPedidoParaEnvio {
   hash_payload?: string | null;
 }
 
-/** Ramos de recusa. São a MARCA testável de cada decisão (a prosa do detalhe é humana). */
-export type MotivoRecusaEnvio = "linha_ausente" | "ja_enviado" | "linha_do_sync";
+/** Ramos de recusa. São a MARCA testável de cada decisão (a prosa do detalhe é humana).
+ *  NÃO exportado de propósito: ninguém importa o tipo (o teste casa a STRING do ramo, que é o
+ *  ponto — assert por literal sobrevive a renomear o tipo), e export sem consumidor reprova no
+ *  gate de dead code (`bunx knip`). Segue público via `VereditoEnvioPedido.motivo`. */
+type MotivoRecusaEnvio = "linha_ausente" | "ja_enviado" | "linha_do_sync";
 
 export interface VereditoEnvioPedido {
   permitido: boolean;

--- a/supabase/functions/_shared/reenvio-pedido_test.ts
+++ b/supabase/functions/_shared/reenvio-pedido_test.ts
@@ -19,41 +19,49 @@ function assertEquals(a: unknown, b: unknown, msg?: string) {
   }
 }
 
+// Compara o PAR (permitido, motivo) num assert SÓ. Asserir `permitido` numa linha e `motivo`
+// na seguinte parece equivalente e não é: sabotar um ramo faz o teste morrer em
+// `true !== false` ANTES de chegar no motivo, e o vermelho deixa de nomear QUAL ramo caiu.
+// Medido na falsificação S2 desta entrega — o teste estava fraco, não o guard.
+function assertVeredito(
+  v: { permitido: boolean; motivo: string | null },
+  permitido: boolean,
+  motivo: string | null,
+  msg?: string,
+) {
+  assertEquals({ permitido: v.permitido, motivo: v.motivo }, { permitido, motivo }, msg);
+}
+
 // ── permitido: a linha local nasceu aqui e ainda não foi ao Omie ──
 
 Deno.test("linha push virgem (pid NULL, hash NULL) → permitido", () => {
   const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: null });
-  assertEquals(v.permitido, true);
-  assertEquals(v.motivo, null);
+  assertVeredito(v, true, null);
 });
 
 Deno.test("campos ausentes no objeto (undefined) contam como virgem → permitido", () => {
   // O select do edge devolve as colunas; undefined só apareceria em objeto parcial.
   // Virgem é o estado que DEVE passar — não pode virar recusa por forma.
   const v = classificarEnvioPedido({});
-  assertEquals(v.permitido, true);
-  assertEquals(v.motivo, null);
+  assertVeredito(v, true, null);
 });
 
 Deno.test("hash não-Omie (orçamento/checkout com hash próprio) → permitido", () => {
   const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "checkout_abc123" });
-  assertEquals(v.permitido, true);
-  assertEquals(v.motivo, null);
+  assertVeredito(v, true, null);
 });
 
 // ── recusa 1: já enviado (o pid é prova de que o Omie JÁ criou o PV) ──
 
 Deno.test("pid preenchido em linha push → recusa ja_enviado", () => {
   const v = classificarEnvioPedido({ omie_pedido_id: 4242, hash_payload: null });
-  assertEquals(v.permitido, false);
-  assertEquals(v.motivo, "ja_enviado");
+  assertVeredito(v, false, "ja_enviado");
 });
 
 Deno.test("DEFEITO CENTRAL: linha pull com pid → recusa (ja_enviado vence pull)", () => {
   // omie_oben_42 com pid 42: era isto que ia ao IncluirPedido e duplicava no Omie.
   const v = classificarEnvioPedido({ omie_pedido_id: 42, hash_payload: "omie_oben_42" });
-  assertEquals(v.permitido, false);
-  assertEquals(v.motivo, "ja_enviado");
+  assertVeredito(v, false, "ja_enviado");
 });
 
 Deno.test("pid 0 conta como enviado: o guard usa o MESMO predicado do índice (IS NOT NULL)", () => {
@@ -62,8 +70,7 @@ Deno.test("pid 0 conta como enviado: o guard usa o MESMO predicado do índice (I
   // de "pid válido" (>0) faria o guard divergir do índice — e é dessa fresta entre
   // duas definições de "enviado" que o furo nasce.
   const v = classificarEnvioPedido({ omie_pedido_id: 0, hash_payload: null });
-  assertEquals(v.permitido, false);
-  assertEquals(v.motivo, "ja_enviado");
+  assertVeredito(v, false, "ja_enviado");
 });
 
 // ── recusa 2: linha nascida no sync nunca vira IncluirPedido ──
@@ -72,8 +79,7 @@ Deno.test("linha pull SEM pid → recusa linha_do_sync (invariante estrutural)",
   // 0 linhas assim na PROD hoje (medido 2026-08-29), mas o dia que o sync falhar
   // no meio do write-back esta é a porta aberta.
   const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "omie_colacor_sc_99" });
-  assertEquals(v.permitido, false);
-  assertEquals(v.motivo, "linha_do_sync");
+  assertVeredito(v, false, "linha_do_sync");
 });
 
 Deno.test("o prefixo é ancorado no INÍCIO (hash que só CONTÉM 'omie_' não é pull)", () => {
@@ -88,8 +94,7 @@ Deno.test("linha ausente (null) → recusa linha_ausente, NUNCA permitido", () =
   // IncluirPedido e só falhava no write-back — DEPOIS de o pedido existir no Omie
   // (linha órfã). Ausente ≠ zero: recusar deixa o pedido local intacto p/ retry.
   const v = classificarEnvioPedido(null);
-  assertEquals(v.permitido, false);
-  assertEquals(v.motivo, "linha_ausente");
+  assertVeredito(v, false, "linha_ausente");
 });
 
 Deno.test("linha undefined → recusa linha_ausente", () => {
@@ -99,8 +104,7 @@ Deno.test("linha undefined → recusa linha_ausente", () => {
 Deno.test("shape fora do contrato (array/string/número) → recusa linha_ausente", () => {
   for (const lixo of [[] as unknown, "x" as unknown, 7 as unknown]) {
     const v = classificarEnvioPedido(lixo as never);
-    assertEquals(v.permitido, false, `shape ${JSON.stringify(lixo)} passou`);
-    assertEquals(v.motivo, "linha_ausente");
+    assertVeredito(v, false, "linha_ausente", `shape ${JSON.stringify(lixo)}`);
   }
 });
 

--- a/supabase/functions/_shared/reenvio-pedido_test.ts
+++ b/supabase/functions/_shared/reenvio-pedido_test.ts
@@ -1,0 +1,134 @@
+// Testa o CÓDIGO REAL de reenvio-pedido.ts (guard "já enviado" da fronteira do
+// criar_pedido) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/reenvio-pedido_test.ts
+//
+// Por que este guard existe (achado Codex 2026-08-29, ritual /codex do PR #2117):
+// a chave de dedup do Omie é `PV_<sales_order_id>` — DETERMINÍSTICA POR LINHA LOCAL.
+// Linha *push* reenviada bate duplicata no Omie e reconcilia (inofensivo). Linha
+// *pull* (nascida do sync, hash `omie_<account>_<pid>`) NUNCA usou essa chave ⇒ o
+// Omie não tem como deduplicar e CRIA UM PEDIDO NOVO. Pior: o write-back grava o
+// pid novo sem tocar o hash, e o próximo sync do pedido original bate 23505 no
+// índice parcial uniq_sales_orders_omie_hash → ON CONFLICT no-op → UM PEDIDO REAL
+// SOME EM SILÊNCIO (positivação/OTE/comissão perdidas).
+
+import { classificarEnvioPedido, nascidaNoSync } from "./reenvio-pedido.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${msg ?? "assertEquals"}: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// ── permitido: a linha local nasceu aqui e ainda não foi ao Omie ──
+
+Deno.test("linha push virgem (pid NULL, hash NULL) → permitido", () => {
+  const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: null });
+  assertEquals(v.permitido, true);
+  assertEquals(v.motivo, null);
+});
+
+Deno.test("campos ausentes no objeto (undefined) contam como virgem → permitido", () => {
+  // O select do edge devolve as colunas; undefined só apareceria em objeto parcial.
+  // Virgem é o estado que DEVE passar — não pode virar recusa por forma.
+  const v = classificarEnvioPedido({});
+  assertEquals(v.permitido, true);
+  assertEquals(v.motivo, null);
+});
+
+Deno.test("hash não-Omie (orçamento/checkout com hash próprio) → permitido", () => {
+  const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "checkout_abc123" });
+  assertEquals(v.permitido, true);
+  assertEquals(v.motivo, null);
+});
+
+// ── recusa 1: já enviado (o pid é prova de que o Omie JÁ criou o PV) ──
+
+Deno.test("pid preenchido em linha push → recusa ja_enviado", () => {
+  const v = classificarEnvioPedido({ omie_pedido_id: 4242, hash_payload: null });
+  assertEquals(v.permitido, false);
+  assertEquals(v.motivo, "ja_enviado");
+});
+
+Deno.test("DEFEITO CENTRAL: linha pull com pid → recusa (ja_enviado vence pull)", () => {
+  // omie_oben_42 com pid 42: era isto que ia ao IncluirPedido e duplicava no Omie.
+  const v = classificarEnvioPedido({ omie_pedido_id: 42, hash_payload: "omie_oben_42" });
+  assertEquals(v.permitido, false);
+  assertEquals(v.motivo, "ja_enviado");
+});
+
+Deno.test("pid 0 conta como enviado: o guard usa o MESMO predicado do índice (IS NOT NULL)", () => {
+  // Deliberado: "enviado" aqui é `omie_pedido_id IS NOT NULL`, idêntico ao predicado
+  // de uniq_sales_orders_omie_pedido_id e ao CHECK de canonicidade. Uma noção PRÓPRIA
+  // de "pid válido" (>0) faria o guard divergir do índice — e é dessa fresta entre
+  // duas definições de "enviado" que o furo nasce.
+  const v = classificarEnvioPedido({ omie_pedido_id: 0, hash_payload: null });
+  assertEquals(v.permitido, false);
+  assertEquals(v.motivo, "ja_enviado");
+});
+
+// ── recusa 2: linha nascida no sync nunca vira IncluirPedido ──
+
+Deno.test("linha pull SEM pid → recusa linha_do_sync (invariante estrutural)", () => {
+  // 0 linhas assim na PROD hoje (medido 2026-08-29), mas o dia que o sync falhar
+  // no meio do write-back esta é a porta aberta.
+  const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "omie_colacor_sc_99" });
+  assertEquals(v.permitido, false);
+  assertEquals(v.motivo, "linha_do_sync");
+});
+
+Deno.test("o prefixo é ancorado no INÍCIO (hash que só CONTÉM 'omie_' não é pull)", () => {
+  const v = classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "checkout_omie_oben_1" });
+  assertEquals(v.permitido, true, "prefixo desancorado recusaria linha legítima");
+});
+
+// ── recusa 3: fail-closed em linha ausente/ilegível ──
+
+Deno.test("linha ausente (null) → recusa linha_ausente, NUNCA permitido", () => {
+  // Hoje o edge lê com .maybeSingle() e ignora o error: linha ausente seguia para o
+  // IncluirPedido e só falhava no write-back — DEPOIS de o pedido existir no Omie
+  // (linha órfã). Ausente ≠ zero: recusar deixa o pedido local intacto p/ retry.
+  const v = classificarEnvioPedido(null);
+  assertEquals(v.permitido, false);
+  assertEquals(v.motivo, "linha_ausente");
+});
+
+Deno.test("linha undefined → recusa linha_ausente", () => {
+  assertEquals(classificarEnvioPedido(undefined).motivo, "linha_ausente");
+});
+
+Deno.test("shape fora do contrato (array/string/número) → recusa linha_ausente", () => {
+  for (const lixo of [[] as unknown, "x" as unknown, 7 as unknown]) {
+    const v = classificarEnvioPedido(lixo as never);
+    assertEquals(v.permitido, false, `shape ${JSON.stringify(lixo)} passou`);
+    assertEquals(v.motivo, "linha_ausente");
+  }
+});
+
+// ── detalhe: mensagem existe em TODA recusa (nunca recusa opaca) ──
+
+Deno.test("toda recusa carrega detalhe não-vazio; permitido carrega detalhe null", () => {
+  const recusas = [
+    classificarEnvioPedido(null),
+    classificarEnvioPedido({ omie_pedido_id: 1, hash_payload: null }),
+    classificarEnvioPedido({ omie_pedido_id: null, hash_payload: "omie_oben_1" }),
+  ];
+  for (const r of recusas) {
+    assertEquals(r.permitido, false);
+    if (typeof r.detalhe !== "string" || r.detalhe.length === 0) {
+      throw new Error(`recusa ${r.motivo} sem detalhe — recusa opaca`);
+    }
+  }
+  assertEquals(classificarEnvioPedido({}).detalhe, null);
+});
+
+// ── predicado exportado (usado pelo CHECK de canonicidade como espelho conceitual) ──
+
+Deno.test("nascidaNoSync: só prefixo 'omie_' no início, e só string", () => {
+  assertEquals(nascidaNoSync("omie_oben_42"), true);
+  assertEquals(nascidaNoSync("omie_colacor_sc_7"), true);
+  assertEquals(nascidaNoSync("checkout_1"), false);
+  assertEquals(nascidaNoSync("x_omie_1"), false);
+  assertEquals(nascidaNoSync(null), false);
+  assertEquals(nascidaNoSync(undefined), false);
+  assertEquals(nascidaNoSync(""), false);
+});

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -43,7 +43,7 @@ export const FONTE_SHA256: Record<string, string> = {
   "omie-sync-sku-items": "b19805d273783fc16ac01d33272b84d775482fe76195b94fa950cbb6bb1da7c3",
   "omie-sync-status-produtos": "2767f1dfa0f1caadf823e7a8f6cca8364b4359ba97938c3cf40b4d0bed8124a3",
   "omie-sync-vendas-items": "56a22cc97bdb12e9b60e374c18f8c4443e2dbe9159ca36067f1de9cf7adbce22",
-  "omie-vendas-sync": "86a106bb6ef57c10907faca90abd05a2b027a7fe70d342be4c32d990dc58e805",
+  "omie-vendas-sync": "5931e78e34bdb4126950955e6d7fc91be45868135997234c179cf1dd83442294",
   "pedido-programado-enviar": "c4e2a9ed647e5fc0096b55ddcce3e20668d0f88363eeda82e1909962d3b178a0",
   "process-nfe": "e00a9048f96b00d79b8270460ccc47cef00a3b35ab3218988324df355b35f80f",
   "recommend": "d557f77ac5ad8d56f6f1a71afacb365c9a0736c51219c77d8362a4c7b5bbafa3",

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -43,7 +43,7 @@ export const FONTE_SHA256: Record<string, string> = {
   "omie-sync-sku-items": "b19805d273783fc16ac01d33272b84d775482fe76195b94fa950cbb6bb1da7c3",
   "omie-sync-status-produtos": "2767f1dfa0f1caadf823e7a8f6cca8364b4359ba97938c3cf40b4d0bed8124a3",
   "omie-sync-vendas-items": "56a22cc97bdb12e9b60e374c18f8c4443e2dbe9159ca36067f1de9cf7adbce22",
-  "omie-vendas-sync": "5931e78e34bdb4126950955e6d7fc91be45868135997234c179cf1dd83442294",
+  "omie-vendas-sync": "849608175b68901a65955168d91b2d86a9d3d8637212a2002511b7d362009613",
   "pedido-programado-enviar": "c4e2a9ed647e5fc0096b55ddcce3e20668d0f88363eeda82e1909962d3b178a0",
   "process-nfe": "e00a9048f96b00d79b8270460ccc47cef00a3b35ab3218988324df355b35f80f",
   "recommend": "d557f77ac5ad8d56f6f1a71afacb365c9a0736c51219c77d8362a4c7b5bbafa3",

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -4,6 +4,7 @@ import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } fro
 import { omieDateToIso, classifyOmieTransient, classifyPedidosPage, gerarJanelasMensais } from "./pagination.ts";
 import { carregarProductMap } from "../_shared/mapas-paginados.ts";
 import { classificarErroAtpGate, classificarRetornoAtpGate } from "../_shared/atp-gate.ts";
+import { classificarEnvioPedido } from "../_shared/reenvio-pedido.ts";
 import { deltaEdicaoOben } from "../_shared/atp-edicao.ts";
 import { avaliarAssinaturaA2, CONTRATO_A2 } from "./assinatura-a2.ts";
 import type { BancoPostgrest } from "../_shared/paginate.ts";
@@ -2745,11 +2746,24 @@ Deno.serve(async (req) => {
         await assertOmieItemsAtivos(supabaseAdmin, items, account);
         // Anti-downgrade de conta (veredito Codex): account desconhecido normaliza
         // silenciosamente pra 'oben' — o pedido local é a âncora server-side.
-        const { data: soRow } = await supabaseAdmin
+        const { data: soRow, error: soErr } = await supabaseAdmin
           .from("sales_orders")
-          .select("account, customer_user_id, customer_document, created_by, checkout_id")
+          .select("account, customer_user_id, customer_document, created_by, checkout_id, omie_pedido_id, hash_payload")
           .eq("id", sales_order_id)
           .maybeSingle();
+        // Guard de REENVIO (achado Codex 2026-08-29) — ANTES do IncluirPedido, porque um CHECK
+        // no banco seria TARDIO: falharia depois de o pedido já existir no Omie. Vale para TODA
+        // conta (o gate ATP abaixo é só 'oben', e seu 'ja_enviado' significa "não re-reservar",
+        // não "pode reenviar"). Decisão pura+testada em _shared/reenvio-pedido.ts.
+        const vereditoEnvio = classificarEnvioPedido(soRow);
+        if (!vereditoEnvio.permitido) {
+          // throw (não `{success:false, blocked}`): os 3 chamadores já tratam erro como falha,
+          // e caller antigo lê `blocked` DESCONHECIDO como sucesso (mordido no submitOrder).
+          throw new Error(
+            `Envio recusado [${vereditoEnvio.motivo}] para o pedido ${sales_order_id}: ${vereditoEnvio.detalhe}` +
+              (soErr ? ` (leitura do pedido local falhou: ${soErr.message})` : ""),
+          );
+        }
         if (soRow?.account && soRow.account !== account) {
           throw new Error(
             `Conta do payload (${account}) diverge do pedido local (${soRow.account}) — pedido não enviado`,

--- a/supabase/functions/omie-vendas-sync/versao.ts
+++ b/supabase/functions/omie-vendas-sync/versao.ts
@@ -46,13 +46,17 @@ export const respostaSonda = criarRespostaSonda("omie-vendas-sync");
 /**
  * Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho.
  *
- * `v1.0-sensor-inicial` é HONESTO aqui: o sensor de VERSÃO nasce nesta fatia. A canária
- * pré-existente não muda isso — ela é sensor de COMPORTAMENTO, e a regra 1 de `deploy.md`
- * ("`v1.0-sensor-inicial` só é honesto quando o sensor NASCE ali") fala do marcador que está
- * nascendo, não de haver outro sensor na edge. Mesmo precedente da `omie-analytics-sync` e da
- * `carteira-rebuild`, que também tinham canária quando ganharam a sonda.
+ * `v1.0-sensor-inicial` foi HONESTO na fatia de 2026-08-25, em que o sensor de VERSÃO nasceu:
+ * a canária pré-existente não muda isso — ela é sensor de COMPORTAMENTO, e a regra 1 de
+ * `deploy.md` ("`v1.0-sensor-inicial` só é honesto quando o sensor NASCE ali") fala do marcador
+ * que está nascendo, não de haver outro sensor na edge. Mesmo precedente da `omie-analytics-sync`
+ * e da `carteira-rebuild`, que também tinham canária quando ganharam a sonda.
+ *
+ * `v1.1-guard-reenvio-criar-pedido` (2026-08-29): o `criar_pedido` passou a RECUSAR reenvio na
+ * fronteira (linha já com `omie_pedido_id`, ou nascida no sync). Fatia EDGE-LOCAL ⇒ a canária
+ * já ecoa este `versao`, e uma chamada basta para provar o bundle.
  */
-export const VERSAO = "v1.0-sensor-inicial";
+export const VERSAO = "v1.1-guard-reenvio-criar-pedido";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =

--- a/supabase/migrations/20260829081556_sales_orders_hash_omie_canonico.sql
+++ b/supabase/migrations/20260829081556_sales_orders_hash_omie_canonico.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- sales_orders: CHECK de CANONICIDADE do hash_payload das linhas nascidas no sync do Omie.
+--
+-- Defesa em PROFUNDIDADE do guard de reenvio da action `criar_pedido`
+-- (supabase/functions/_shared/reenvio-pedido.ts). Achado Codex 2026-08-29, ritual /codex
+-- retroativo do PR #2117.
+--
+-- ⚠️ ESTE CHECK É TARDIO PARA O DEFEITO PRINCIPAL — e isso é DELIBERADO, não um descuido.
+--    O `criar_pedido` chamava `IncluirPedido` no Omie e SÓ DEPOIS gravava o write-back. Um
+--    CHECK só pode reprovar a ESCRITA LOCAL — quando ele disparasse, o pedido duplicado JÁ
+--    EXISTIRIA no Omie, fora do nosso banco e sem desfazer. Por isso o guard REAL é o da
+--    fronteira, ANTES da mutação. Este CHECK é a segunda linha: ele impede que a CORRUPÇÃO
+--    DO HASH se consolide (e com ela o sumiço silencioso do pedido original, abaixo).
+--
+-- O QUE ELE IMPEDE, concretamente:
+--   linha pull `omie_oben_42` (pid 42) reenviada → Omie cria o pedido 43 → o write-back
+--   gravaria pid=43 SEM tocar o hash. A linha ficaria com o hash MENTINDO. Aí o próximo sync
+--   do pedido 42 remonta `omie_oben_42`, bate 23505 no índice parcial
+--   uniq_sales_orders_omie_hash, e o ON CONFLICT da RPC `criar_pedidos_com_itens` trata como
+--   no-op → UM PEDIDO REAL SOME EM SILÊNCIO (positivação/OTE/comissão perdidas).
+--   Com o CHECK, esse write-back falha (23514) e o estado incoerente NUNCA se consolida.
+--
+-- PRÉ-VOO NA PROD (2026-08-29, via psql-ro — entra sem quebrar linha existente):
+--   • 31.086 linhas com hash `omie\_%`; 0 com omie_pedido_id NULL; 0 fora da forma canônica.
+--   • `account` é NOT NULL ⇒ a concatenação nunca vira NULL (um CHECK que avalia NULL PASSA:
+--     seria fresta fail-open silenciosa). Confirmado no information_schema, não presumido.
+--   • Writer único do par (hash_payload, omie_pedido_id) em sales_orders: a RPC
+--     `criar_pedidos_com_itens`, que insere os dois do MESMO payload, montado como
+--     `omie_${account}_${codigo_pedido}` (omie-vendas-sync:1283, sync-reprocess:242).
+--     `sync-reprocess` só ESCREVE hash em `order_items`; em sales_orders ele apenas LÊ o pai
+--     pelo hash. Nenhum trigger de sales_orders toca a coluna.
+--   • Linha *push* (checkout/orçamento) tem hash NULL ⇒ isenta pela 1ª cláusula. As 26 linhas
+--     push já enviadas (hash NULL, pid NOT NULL) não são afetadas.
+--
+-- ESCOPO: só o namespace `omie_`. Hash de outra origem (ex.: `checkout_…`) passa intacto —
+-- este CHECK não legisla sobre forma de hash que ele não conhece (precisão > recall).
+--
+-- Idempotente: o DO só adiciona se ainda não existir. Re-colar é seguro.
+-- ============================================================
+
+DO $add$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.sales_orders'::regclass
+      AND conname = 'sales_orders_hash_omie_canonico'
+  ) THEN
+    ALTER TABLE public.sales_orders
+      ADD CONSTRAINT sales_orders_hash_omie_canonico CHECK (
+        hash_payload IS NULL
+        OR hash_payload NOT LIKE 'omie\_%'
+        OR (
+          omie_pedido_id IS NOT NULL
+          AND hash_payload = 'omie_' || account || '_' || omie_pedido_id::text
+        )
+      );
+  END IF;
+END
+$add$;
+
+-- [post] postcondição: a constraint existe E está VALIDADA (uma constraint NOT VALID aceitaria
+-- linha nova mas não provaria nada sobre o acervo — "existe" não é "vale").
+DO $post$
+DECLARE v_existe boolean; v_validada boolean;
+BEGIN
+  SELECT true, convalidated INTO v_existe, v_validada
+  FROM pg_constraint
+  WHERE conrelid = 'public.sales_orders'::regclass
+    AND conname = 'sales_orders_hash_omie_canonico';
+
+  IF NOT coalesce(v_existe, false) THEN
+    RAISE EXCEPTION 'postcondicao: sales_orders_hash_omie_canonico NAO foi criada';
+  END IF;
+  IF NOT coalesce(v_validada, false) THEN
+    RAISE EXCEPTION 'postcondicao: sales_orders_hash_omie_canonico existe mas NAO esta validada';
+  END IF;
+END
+$post$;
+
+COMMENT ON CONSTRAINT sales_orders_hash_omie_canonico ON public.sales_orders IS
+  'Linha nascida no sync do Omie (hash_payload omie_*) tem de ter omie_pedido_id e hash '
+  'canonico omie_<account>_<pid>. Defesa em profundidade do guard de reenvio de criar_pedido '
+  '(_shared/reenvio-pedido.ts): impede que um write-back grave pid novo sobre hash velho e o '
+  'pedido original suma no proximo sync via ON CONFLICT no-op. Codex 2026-08-29.';


### PR DESCRIPTION
Achado pela 2ª opinião do **Codex** (gpt-5.6-sol/xhigh) no ritual `/codex` retroativo do #2117, registrado como **ABERTO** em `docs/historico/duplicata-por-objetivo.md`. Não foi consertado lá porque é money-path e muda comportamento de edge quente — decisão do founder, tomada nesta sessão.

## O defeito

A action `criar_pedido` de `omie-vendas-sync` **não tinha guard de "já enviado"**:

1. `atp_gate_pedido` **RECONHECE** o estado (`omie_pedido_id IS NOT NULL` → `{ok:true, resultado:'ja_enviado'}`, com o comentário "PV já criado no Omie: NUNCA re-reservar");
2. mas `classificarRetornoAtpGate` mapeia **todo** `ok===true` para `acao:'seguir'` — é gate de **RESERVA (TTL)**, não de idempotência de envio. E só roda para `account === "oben"`;
3. o `soRow` da action nem selecionava `omie_pedido_id`/`hash_payload`;
4. o write-back grava `omie_pedido_id` **sem tocar** `hash_payload`.

**Gate que RECONHECE um estado não é gate que AGE sobre ele** — o classificador entre a RPC e a decisão achatou o reconhecimento.

## O que a investigação acrescentou ao parecer

**1. A chave de dedup do Omie é `PV_<sales_order_id>` — determinística por linha LOCAL** (`index.ts:2001`). É este elo que separa os dois casos:

| | dedup do Omie | efeito de reenviar |
|---|---|---|
| linha **push** (checkout/orçamento) | `PV_<id>` já foi usada | bate duplicata → `ConsultarPedido` reconcilia → **inofensivo** |
| linha **pull** (nascida do sync) | `PV_<id>` **nunca** foi usada | Omie **não deduplica → CRIA PEDIDO NOVO** |

Sem esse elo, "falta um guard" parece severidade uniforme. Não é.

**2. Consequência em cascata na linha pull:** o write-back grava o pid novo sobre o hash velho (`omie_oben_42` com pid 43) → o próximo sync do pedido 42 remonta `omie_oben_42` → `23505` no índice parcial `uniq_sales_orders_omie_hash` → o `ON CONFLICT` da RPC `criar_pedidos_com_itens` trata como no-op → **um pedido real some em silêncio** (positivação/OTE/comissão perdidas).

**3. Não existe retry legítimo com pid preenchido.** O write-back é o **único** escritor do pid neste caminho e é um `UPDATE` único: falhou ⇒ pid NULL ⇒ o retry passa e reconcilia. O `"retry idempotente"` do comentário do gate ATP é escopo de **reserva** ("não re-reservar", não renovar TTL) — lê-lo como permissão de reenvio teria travado o conserto.

**4. O invariante já ERA o desenho, na camada errada.** 2 dos 3 chamadores o implementam por conta própria (`pedido-programado-enviar:250`; `submitOrder` via `alreadySent`); o `SalesQuotes` **não** — depende só do filtro `status='orcamento'`. Medido na PROD: **nenhuma** das 31.086 linhas pull tem esse status. **O que segurava era ausência de chamador, não um guard.**

## A entrega

**Guard na fronteira** — decisão PURA em `_shared/reenvio-pedido.ts`, chamada **ANTES** do `criarPedidoVenda` e **FORA** do ramo `account === "oben"` (o gate ATP é oben-only ⇒ pedido colacor jamais passava por ele):

- recusa por **UNIÃO**: `omie_pedido_id IS NOT NULL` **ou** `hash_payload LIKE 'omie\_%'`;
- **`throw`**, não `{success:false, blocked}` — os 3 chamadores já tratam erro como falha, e o repo já foi mordido por caller antigo lendo `blocked` **desconhecido** como sucesso;
- **bônus fail-closed:** o `.maybeSingle()` ignorava o `error`, então linha ausente/ilegível seguia para o `IncluirPedido` e só quebrava no write-back — **depois** de o pedido existir no Omie (linha órfã). Agora recusa antes, pedido local intacto para retry.

**CHECK de canonicidade** — defesa em profundidade, com a limitação dita em voz alta: um CHECK só reprova a escrita **local**; quando ele disparasse, o pedido duplicado **já existiria no Omie**. Ele impede a corrupção do hash se **consolidar**, não a duplicata acontecer.

## Prova

| gate | resultado |
|---|---|
| `deno test _shared/reenvio-pedido_test.ts` | 13 asserts |
| `db/test-hash-omie-canonico.sh` (PG17 local) | **23 ok · 0 falhas** |
| vitest (wiring da edge) | 7 asserts novos |
| suíte completa | 751 arquivos · 7.518 testes |

**Falsificação — 12 sabotagens, todas vermelhas casando a MARCA DO RAMO** (não "lançou algo"):

- 3 na decisão pura (remover cada ramo) · 5 no wiring (remover a chamada; movê-la para dentro do ramo `oben`; movê-la para depois do `IncluirPedido`; tirar `omie_pedido_id` do select; trocar `throw` por `blocked`) · 4 no CHECK.
- **A falsificação S2 corrigiu o meu próprio teste:** ele asseria `permitido` numa linha e `motivo` na seguinte, então sabotar um ramo o matava em `true !== false` **antes** de nomear qual ramo caiu. Virou assert do **par** — commit separado.
- **F3 revelou efeito não previsto:** desancorar o `LIKE` (`'%omie\_%'`) **nem aplica** sobre o acervo, porque a linha legítima `checkout_omie_oben_1` já o viola. É a prova mais forte do que a âncora protege.

## Pré-voo na PROD (`psql-ro`, 2026-08-29) — o CHECK entra sem quebrar linha existente

- 31.086 linhas `omie\_%` · **0** com pid NULL · **0** fora da forma canônica;
- **`account` é NOT NULL** — conferido no `information_schema`, não presumido: se fosse nullable, a concatenação viraria NULL, e **CHECK que avalia NULL PASSA** (fresta fail-open silenciosa);
- writer único do par: a RPC `criar_pedidos_com_itens`, que insere hash e pid do **mesmo** payload; `sync-reprocess` só escreve hash em `order_items`; nenhum trigger de `sales_orders` toca a coluna;
- linha push (hash NULL) isenta pela 1ª cláusula — as 26 já enviadas ficam intactas.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260829081556_sales_orders_hash_omie_canonico.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa ser colado no SQL Editor do Lovable e rodado.

Também precisa de **deploy da edge** `omie-vendas-sync` (o `versao.ts` foi bumpado para `v1.1-guard-reenvio-criar-pedido`, então a sonda distingue o bundle novo do velho).
