### PR TITLE
docs(sonda): 5/5 pelo eco passivo — e "a via está esgotada" desmentida DUAS vezes

### DIFF
--- a/docs/historico/verificabilidade-do-conjunto-orquestrado.md
+++ b/docs/historico/verificabilidade-do-conjunto-orquestrado.md
@@ -366,3 +366,40 @@ pergunta estava errada.
 cada valor no pai (`git grep -c '<valor>' <sha>^ -- supabase/functions/` = 0), que é o análogo do
 guard `--pai`. Aqui os dois valores passaram: `v1.1-eco-identidade-fonte` e `v1.2-eco-identidade-fonte`
 têm 0 ocorrência em `069540905^`.
+
+## Adendo 2026-08-30 — 5/5 pelo eco passivo, e "a via está esgotada" desmentida DUAS vezes
+
+Desfecho da verificação do `069540905` (#2079): **os 5 steps ecoaram o marcador novo**, sem sonda ativa,
+sem SQL Editor, sem nenhuma ação do founder.
+
+| edge | marcador | ticks |
+|---|---|---|
+| `ctes-recebidos` · `sku-items` · `vendas-items` | `v1.1-eco-identidade-fonte` | 62431 (00:15Z) em diante |
+| `nfes-recebidas` | `v1.2-eco-identidade-fonte` | 63334 · 63400 · 63468 |
+| `pedidos-compra` | `v1.1-eco-identidade-fonte` | 63804 (10:15Z) · 63887 |
+
+O caro não foi a espera — foi **o que eu concluí durante ela**, duas vezes:
+
+1. Após **9 ticks** (18h) sem eco de `pedidos`/`nfes`, com os dois cravando `duracao_ms` 25.002 contra
+   os 10–12s do `ctes`, escrevi que "a via passiva está esgotada para esses dois steps" e recomendei
+   **sonda ativa** — que custa bloco `net.http_post` colado pelo founder. Seis horas depois o `nfes`
+   respondeu, e respondeu em **três ticks seguidos**.
+2. Corrigido isso, o watcher de `pedidos` fechou 6h com `exit 3` ("sem `respondido`"). Enunciei de novo
+   o fim da linha. `pedidos` respondeu **35 minutos** depois de o watcher expirar.
+
+A duração cravada no teto **descreve** o step (ele realmente estoura os 25s quase sempre); ela **não**
+prevê o tick em que a carga do Omie cede. Ler "0/9" como propriedade do sistema é a mesma falácia que
+esta sessão passou o dia evitando na leitura do `modo` — `background` é ausência de dado — só que
+cometida uma camada acima, **na conclusão sobre o sensor** em vez de na leitura dele. O sinal raro não
+avisa que vai chegar; o custo de esperar mais um tick é zero e o de comprar a resposta é o SQL Editor
+do founder.
+
+**Regra:** enquanto a espera não bloquear decisão nenhuma, "não veio ainda" **nunca** se promove a "não
+vem" — e um `exit 3` de watcher é o fim da *janela dele*, não o fim da via. O gatilho para pagar sonda
+ativa continua sendo o que a §"O gatilho para reconsiderar" já dizia: atraso que provoque ciclo
+incorreto, reparo de dados ou resposta a incidente. Nenhum dos dois casos aqui chegou perto disso.
+
+Nota de mecânica que caiu junto: o watcher deste ciclo nasceu com **controle positivo** — a mesma query
+com a janela recuada tinha de achar o tick já conhecido antes de armar. Foi o que garantiu que os
+`background` fossem lidos como ausência de dado e não como sonda cega; sem ele, os dois enganos acima
+teriam sido indistinguíveis de um bug de query.


### PR DESCRIPTION
Fecha a verificação de deploy do `069540905` (#2079). **Os 5 steps ecoaram o marcador novo** — sem sonda ativa, sem SQL Editor, sem ação do founder.

| edge | marcador | ticks |
|---|---|---|
| `ctes-recebidos` · `sku-items` · `vendas-items` | `v1.1-eco-identidade-fonte` | 62431 → 63096 |
| `nfes-recebidas` | **`v1.2`**`-eco-identidade-fonte` | 63334 · 63400 · 63468 |
| `pedidos-compra` | `v1.1-eco-identidade-fonte` | 63804 · 63887 |

## A lição: declarei a via esgotada duas vezes, e o dado desmentiu as duas

1. Após **9 ticks** (18h) sem eco, com `pedidos`/`nfes` cravando `duracao_ms` 25.002 contra os 10–12s do `ctes`, escrevi que a via passiva estava "esgotada" e recomendei **sonda ativa** — que custa um bloco `net.http_post` colado pelo founder. 6h depois o `nfes` respondeu, **três ticks seguidos**.
2. O watcher de `pedidos` fechou 6h com `exit 3`. Enunciei de novo o fim da linha. `pedidos` respondeu **35 min** depois de ele expirar.

A duração cravada no teto **descreve** o step; não **prevê** o tick em que a carga do Omie cede. Ler `0/9` como propriedade do sistema é a falácia de `ausente ≠ zero` cometida uma camada acima — na conclusão sobre o sensor, não na leitura dele.

**Regra:** enquanto a espera não bloquear decisão nenhuma, "não veio ainda" não vira "não vem"; `exit 3` de watcher é o fim da *janela dele*, não da via. O gatilho para pagar sonda ativa segue o já documentado (atraso que provoque ciclo incorreto, reparo de dados ou incidente) — nenhum dos dois casos chegou perto.

Complementa o #2088 (o marcador esperado é POR EDGE), que pagou neste mesmo ciclo: os três `respondido` do `nfes` viriam com `v1.2`, e procurar o `v1.1` do "bump do lote" os leria como *"não subiu"*.

## Gates

`docs:indice` · `docs:citacoes` · `docs:links` · `claude:size` — encadeados com `&&`, exit propagado 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Cópia durável do chip aberto no `/fecho` (passo 6 — chip é destino perecível)

Chip: **"Confirmar deploy de 7 edges da janela 29-30/08"**. Se ele não for clicado antes do arquivamento da sessão, o prompt abaixo é o destino durável.

<details>
<summary>Prompt auto-contido</summary>

Na janela 2026-08-29 00:00Z → 2026-08-30 15:00Z, sete edges mudaram e nenhuma tem prova de estar no ar. O `edges-pendentes.sh` classificou as sete como `SEM_PROVA` (nenhuma sonda nas últimas 6h = INDETERMINADO, chip por fail-closed) — **não** é prova de que estão pendentes.

⚠️ Antes de pedir qualquer deploy, confirmar que a sessão dona não pediu: re-rodar `edges-pendentes.sh --desde "2026-08-29 00:00"`, ler o eco passivo em `net._http_response` (TTL 6h) e achar o PR dono com `git log origin/main --oneline -- supabase/functions/<edge>/`.

**Com arquivo próprio modificado:** `fin-valor-cockpit` (index.ts + versao.ts) · `omie-analytics-sync` (index.ts + versao.ts) · `carteira-positivacao-snapshot` (versao.ts)

**Sem arquivo próprio — entraram pelo `_shared/` que empacotam:** `omie-vendas-sync` · `scoring-recalc-batch` · `sync-reprocess` · `visit-score-recalc-batch`

**`_shared/` alterado na janela** (entra no bundle de cada edge que o importa): `itens-com-pedido.ts` (**A = NOVO**) · `mapas-paginados.ts` (M) · `sonda-fingerprints.ts` (M — alimenta o campo `fonte`; sem ele a sonda responde `nao-mapeada` e a prova nasce cega).

O prompt de deploy tem de nomear **todos** os arquivos da edge — prompt que nomeia só o `index.ts` sobe função que não boota (#2020). `Active` prova existência, não versão. N2 (Management API) é indisponível — não pedir PAT.

**Não refazer:** o `069540905` (#2079) já está verificado 5/5 no ar.

</details>
