### PR TITLE
docs(deploy-verify): `--name-status` é cego ao import NOVO de arquivo pré-existente — a fatia de deploy é o CLOSURE, não o diff

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -142,6 +142,25 @@ git show --name-status --format='' <sha-do-merge> -- supabase/functions/ | grep 
 # A = arquivo NOVO (é o que o prompt de 1 arquivo esquece) · M = modificado
 ```
 
+🔴 **O `--name-status` é ESTRUTURALMENTE CEGO ao import NOVO de arquivo PRÉ-EXISTENTE — a fatia de
+deploy é o CLOSURE DE IMPORTS, não o diff (2026-08-30, #2101).** O comando acima lista o que o commit
+TOCOU; o bundle carrega o que o `index.ts` ALCANÇA. Arquivo que já existia e passou a ser importado não
+sai em nenhum dos dois lados (`A` nem `M`) — e é exatamente o que impede a função de bootar. No #2101 a
+`generate-bundle-argument` ganhou `+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts"`
+com o `ia-cota.ts` **inalterado desde 2026-07-31**: o `--name-status` devolvia três arquivos, e os três
+estavam certos para a pergunta errada. Feche o closure, sempre:
+
+```bash
+# imports locais de 1º nível — repita em cada arquivo alcançado até não achar mais
+grep -oE 'from "\.\.?/[^"]+"' supabase/functions/<edge>/index.ts | sort -u
+# algum deles é import NOVO nesta edge? (resposta POSITIVA no diff, nunca de memória)
+git show <sha-do-merge> -- supabase/functions/<edge>/index.ts | grep -E '^\+.*from "\.\.'
+```
+
+⚠️ E some ao closure o **mapa** `_shared/sonda-fingerprints.ts`: a `fecharGrafo()` do gerador o exclui
+de propósito (senão o hash se auto-referenciaria), então ele **nunca** aparece no closure — e ainda
+assim precisa ir no deploy, porque é ele que alimenta o campo `fonte`. **Fatia = closure ∪ {mapa}.**
+
 E nomeie cada um, marcando o novo (teste e doc ficam de fora — não vão pro bundle):
 
 > Edit the edge function `<nome>` and update it from the `main` branch using the current contents of


### PR DESCRIPTION
Follow-up do #2126, no mesmo arquivo. Achado ao montar o pedido de deploy das edges da janela 28-29/08.

## O furo

O Passo 3 prescreve `git show --name-status` para derivar os arquivos do prompt de deploy. Ele lista o que o commit **tocou**; o bundle carrega o que o `index.ts` **alcança**. Arquivo que já existia e passou a ser importado não sai em nenhum dos dois lados (`A` nem `M`) — e é justamente o que impede a função de bootar (#2020).

Medido no #2101: a `generate-bundle-argument` ganhou

```
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
```

com o `ia-cota.ts` **inalterado desde 2026-07-31** (`052646485`). O `--name-status` devolvia três arquivos, e os três estavam certos para a pergunta errada. Foi por fechar o closure de imports que o pedido daquela edge saiu com **quatro** — o quarto sendo exatamente o que faria a função não bootar.

Some ao closure o **mapa** `_shared/sonda-fingerprints.ts`: a `fecharGrafo()` do gerador o exclui de propósito (senão o hash se auto-referenciaria), então ele **nunca** aparece no closure e ainda assim precisa ir no deploy — é ele que alimenta o campo `fonte`. **Fatia = closure ∪ {mapa}.**

## Verificação

Os dois comandos documentados foram **executados contra o repo real** antes de entrar, não escritos de memória:

```
$ grep -oE 'from "\.\.?/[^"]+"' supabase/functions/generate-bundle-argument/index.ts | sort -u
from "../_shared/anthropic.ts"
from "../_shared/auth.ts"
from "../_shared/ia-cota.ts"        ← o que o --name-status não vê

$ git show 0b5662801 -- supabase/functions/generate-bundle-argument/index.ts | grep -E '^\+.*from "\.\.'
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
```

## Convergência

A sessão `trusting-tu-dcd280-44` mediu o mesmo furo por outro caminho (verificando a mesma edge) e cedeu a correção para cá, para não conflitar com o #2126 que já estava em voo neste arquivo — coordenação multi-sessão funcionando como o CLAUDE.md pede.

## Gates

`docs:indice` · `docs:citacoes` · `docs:links` · `claude:size` · `evals/run.sh` da skill — encadeados com `&&`, exit propagado 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
