### PR TITLE
docs(skills): citação em `.claude/skills/` não é conferida por gate nenhum — sabotei e passou com exit 0

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -44,6 +44,18 @@
 - ⚠️ **Colisão de nome:** `/review` (gstack, **canônico**) vs `review` (oficial code-review) — invocar via gstack.
 - **Memória entre sessões:** **`claude-mem`** (plugin global ATIVO — **funcionando desde 2026-07-07**; 0 → 214 observações na 1ª hora). Conserto em 2 camadas: (1) o generator não achava o binário `claude` do app desktop — fix: shim `~/.claude-mem/claude-shim.sh` + `CLAUDE_CODE_PATH` em `~/.claude-mem/settings.json`; (2) o CLI headless não herda o login do app — resolvido com `/login` no CLI (se `Not logged in` voltar: terminal → `~/.claude-mem/claude-shim.sh` → `/login`). Limitação conhecida: memória fragmentada por worktree (cada um é um `project` distinto). Auto-memory nativo segue **desligado de propósito** (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` no settings global) — não ligar os dois (duplicaria).
 
+## Editar uma skill: nenhum gate confere as citações dela
+
+`.claude/skills/` está **fora do `docs:citacoes`** — `ALVOS_VIVOS` é `CLAUDE.md` + `docs/agent`,
+`docs/visual-direction` e `docs/runbooks` (`scripts/docs-citacoes-gate-check.ts:113`<!--cita: ALVOS_VIVOS-->),
+e a skill não entra por nenhum dos dois lados: nem como doc varrido, nem pela âncora `<!--cita:-->` que
+resgata a citação do doc congelado. Medido em 2026-08-30 sabotando uma citação de
+`.claude/skills/lovable-deploy-verify/SKILL.md`: o gate passou com **exit 0 e sem mover o contador** —
+28 citações / 7 ancoradas antes e depois. ⇒ **Ao citar `arquivo:linha` numa skill, confira à mão**; verde
+ali é ausência de dado, não aprovação. Mesma família de `docs/historico/gates-textuais-cegos.md`, por
+ESCOPO DE VARREDURA em vez de stripper — e o custo é maior do que parece, porque a skill é justamente
+onde o próximo agente vai buscar o comando pronto para copiar.
+
 ## Skills stack-specific
 
 Instaladas via `git clone` dos repos oficiais em `~/.claude/skills/` (sem auto-update — re-clonar pra atualizar): Supabase oficial · Vercel Eng (react/composition/web-design) · TanStack Query · Sentry (`sentry-react-sdk` só via router `sentry-sdk-setup`) · Trail of Bits (semgrep/codeql/sarif/supply-chain) · RBAC.


### PR DESCRIPTION
Vim registrar na `lovable-deploy-verify` a lição de que a fatia de deploy é o closure de imports, não o diff. **Essa parte foi entregue pelo #2127 enquanto eu trabalhava** — mesmo exemplo (`ia-cota.ts` na `generate-bundle-argument`), e mais preciso que o meu rascunho. Descartei o duplicado e reduzi ao diferencial.

## O diferencial

Ao registrar, rodei `docs:citacoes`, vi verde e quase parei aí. **O verde era ausência de dado.**

`.claude/skills/` está fora do `ALVOS_VIVOS` (`CLAUDE.md` + `docs/{agent,visual-direction,runbooks}`) — e fora dos **dois** lados: nem como doc varrido, nem pela âncora `<!--cita:-->` que resgata a citação do doc congelado. Tentei ancorar 3 citações na SKILL.md e o contador não se moveu; foi ele, não o exit code, que revelou.

## Falsificação — o contraste é o achado

| Mesma sabotagem em | Resultado |
|---|---|
| `.claude/skills/lovable-deploy-verify/SKILL.md` | **exit 0**, contador imóvel (28 citações / 7 ancoradas antes e depois) |
| `docs/agent/skills.md` (este PR) | **exit 1**, nomeando arquivo, linha e o trecho esperado |

Machuca mais na skill do que num doc: skill é onde o próximo agente copia comando pronto, com `arquivo:linha` que ninguém revalida. É a família de `gates-textuais-cegos.md`, por **escopo de varredura** em vez de stripper.

## Onde ficou, e por quê

Em `docs/agent/skills.md`, que **é** varrido — a citação do próprio `ALVOS_VIVOS` entrou no gate (contador 28 → 29) e foi falsificada exigindo vermelho. Dogfooding: a regra vive num lugar onde ela mesma é cobrada.

## O que deliberadamente NÃO fiz

Estender o escopo do gate para `.claude/skills/`. O cabeçalho de `scripts/docs-citacoes-gate-check.ts` registra que ligar diretório congelado foi medido e recusado por churn (131 vermelhos para pegar 1 alvo real). Isso é decisão de produto, não efeito colateral de um registro — fica como opção sua.

## Verificação

- `docs:citacoes` · `docs:links` · `docs:indice` — os três `exit 0`, capturados
- Falsificação exigida em vermelho (acima), restaurada, working tree limpo
- Colisão re-conferida imediatamente antes deste PR: ninguém tocou `docs/agent/skills.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)