### PR TITLE
fix(sonda): HTTP 401 é AMBÍGUO e saía como "BUNDLE VELHO" confiante — o bloco agora carrega o controle de credencial

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -458,6 +458,21 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
     a unicidade global se sustentava. Detalhe:
     [`docs/historico/escrita-de-aplicacao-como-sensor-de-deploy.md`](../../../docs/historico/escrita-de-aplicacao-como-sensor-de-deploy.md).
   - **5 edges já nascem com canária** (#1772): `fin-cashflow-engine`, `omie-cliente`, `omie-nfe-webhook`, `omie-sync-estoque`, `omie-sync-nfes-recebidas` respondem `{"probe":true}` com `{ok,probe:true,versao}` (contrato em `supabase/functions/_shared/sonda-versao.ts`). O eco `probe:true` é **obrigatório** na leitura: bundle ANTERIOR à sonda **ignora o parâmetro e executa o fluxo real** (sync Omie de verdade) — por isso **só sonde DEPOIS do deploy**, e resposta sem o eco já é o veredito "bundle velho, e ele rodou o efeito caro". Invocação sem terminal: bloco `net.http_post` no 🟣 SQL Editor + leitura de `net._http_response` (receita em `docs/agent/deploy.md` §Canárias).
+    🔴 **HTTP 401 na sonda NÃO é veredito — é ambiguidade, e o bloco agora a fecha sozinho
+    (2026-08-30).** Um 401 tem DUAS causas que o dado não separa: (a) bundle **pré-sonda**, que
+    ignorou o `{"probe":true}`, caiu no gate JWT e recusou; ou (b) **`CRON_SECRET` ausente/errado no
+    vault**, com `authorizeCronOrStaff` recusando o header. Nos dois o corpo vem sem `versao` e o
+    status é 401 — e ler (b) como (a) manda redeployar edge que **já está no ar** (`ausente ≠ zero`
+    na dimensão CREDENCIAL, irmão do guard temporal do #2079). O SQL gerado por `bun run sonda:sql`
+    passou a cruzar um **controle de credencial na MESMA consulta** (CTE `controle_credencial`:
+    ≥10 respostas 2xx e ZERO 401 recentes **fora da leva**, em `net._http_response`) e só então
+    emite veredito determinado; sem essa prova responde **INDETERMINADO**, nunca "bundle velho" —
+    fail-CLOSED, igual ao `CONTROLE_CRUZADO_NAO_OBSERVADO` do `verify-edge-escrita.sh`. Isto nasceu
+    de o desempate ter sido feito **à mão, fora da ferramenta**, ao verificar o deploy de
+    `generate-bundle-argument` (#2101): recado que depende de o operador lembrar é exatamente como
+    a armadilha da sentinela não-exclusiva passou. Guardado por `evals/sonda-veredito-401-eval.sh`,
+    o único eval que **EXECUTA** o SQL (Postgres efêmero) — casar string não observa ordem de `WHEN`
+    nem `NULL > 0`, que é onde este ramo erra.
   - ✅ **A exceção que torna a sonda ativa segura ANTES do deploy — e é a única ordem em que ela
     EVITA um deploy, em vez de só confirmá-lo (2026-08-30).** O "só sonde DEPOIS do deploy" acima
     vale enquanto o bundle em prod puder ser ANTERIOR à sonda — aí o probe vira efeito caro. Quando a

--- a/.claude/skills/lovable-deploy-verify/evals/run.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/run.sh
@@ -3,6 +3,8 @@
 #   (1) classify        — classificação de diff do Passo 1 (classify.sh vs classify-eval.json)
 #   (2) verify-frontend — enumeração + exit codes do Passo 4 (harness local determinístico)
 #   (3) verify-edge-eco  — guard TEMPORAL do N3 passivo (só ticks pré-merge ⇒ indeterminado)
+#   (4) verify-edge-escrita — N3 passivo por escrita de aplicação
+#   (5) sonda-veredito-401  — guard de CREDENCIAL do SQL de sondagem (401 é ambíguo; EXECUTA o SQL)
 # Exit 0 = tudo passou. Exit 1 = alguma divergência.
 # Falsificação (prova que os evals têm dente): --falsify sabota AMBOS e exige vermelho
 #   (classify sabota o gabarito UMA CHAVE POR VEZ e depois muta o classify.sh real; verify-frontend
@@ -144,6 +146,20 @@ if [ "$FALSIFY" = 1 ]; then
   bash verify-edge-escrita-eval.sh --falsify || rc=1
 else
   bash verify-edge-escrita-eval.sh || rc=1
+fi
+
+echo ""
+# (5) O ÚNICO eval que EXECUTA SQL: o veredito do Passo 2 da sonda de versão decide por semântica
+# de NULL e ordem de WHEN, que casamento de string não observa. Sobe um Postgres efêmero (initdb
+# local, zero rede — mesmo padrão dos db/test-*.sh) e lê a coluna `veredito` do banco.
+# Exit 2 do eval = via de prova não observável; propaga como FALHA de propósito: sem Postgres o
+# gate não passa em silêncio (ausência de dado nunca vira aprovação — é a regra que este próprio
+# eval guarda no SQL).
+echo "== (5) sonda-veredito-401 — 401 ambíguo: bundle velho × CRON_SECRET =="
+if [ "$FALSIFY" = 1 ]; then
+  bash sonda-veredito-401-eval.sh --falsify || rc=1
+else
+  bash sonda-veredito-401-eval.sh || rc=1
 fi
 
 echo ""

--- a/.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# sonda-veredito-401-eval.sh — EXECUTA o SQL gerado por `scripts/sonda-versao-sql.ts` num Postgres
+# efêmero e julga a coluna `veredito`, cenário a cenário.
+#
+# POR QUE EXECUTA em vez de casar string: o ramo em teste decide por SEMÂNTICA DE NULL e por ORDEM
+# de WHEN. `NULL > 0` não é falso, é NULL — o WHEN não dispara e a linha cai no vizinho, que pode
+# ser o ramo confiante. Um teste textual ("o SQL contém 'INDETERMINADO'") prova que a string está
+# no arquivo, não que o CASE a devolve: é a asserção que fica verde justamente quando a ordem dos
+# ramos está errada. Aqui o veredito é lido do banco, não do código-fonte.
+#
+# O QUE ESTE EVAL GUARDA: um HTTP 401 na sonda é AMBÍGUO por construção —
+#   (a) bundle PRÉ-SONDA, que ignorou {"probe":true}, caiu no gate JWT da edge e devolveu 401; ou
+#   (b) CRON_SECRET ausente/errado no vault, e `authorizeCronOrStaff` recusou o header.
+# Nos DOIS o corpo vem sem `versao` e o status é 401. Ler (b) como (a) manda o founder redeployar
+# uma edge que já está no ar — família `ausente ≠ zero`, na dimensão CREDENCIAL, e irmão exato do
+# guard temporal do #2079 (`verify-edge-eco.sh`), onde ler tick pré-merge como pendência produzia o
+# mesmo falso negativo confiante. Medido em 2026-08-30 verificando o deploy de
+# `generate-bundle-argument` (#2101): a ambiguidade é real e foi fechada À MÃO, fora da ferramenta,
+# com uma consulta que o bloco não fazia. Depender de o operador lembrar é o mesmo recado que
+# deixou a sentinela não-exclusiva passar (SKILL.md).
+#
+# Exit 0 = todos os cenários bateram. 1 = divergência. 2 = via de prova não observável (fail-CLOSED:
+# sem Postgres o eval NÃO passa em silêncio — ausência de dado nunca vira aprovação).
+#
+# --falsify: sabota o GERADOR (em CÓPIA no tmp; o versionado nunca é tocado) e exige que cada
+# sabotagem deixe ≥1 cenário VERMELHO. Sabotagem que ninguém pega = asserção sem dente.
+set -uo pipefail
+# `postmaster became multithreaded during startup` no macOS: o servidor recusa subir sob
+# locale herdado. Mesmo `export` do harness db/test-*.sh, pelo mesmo motivo.
+export LC_ALL=C LANG=C
+cd "$(dirname "$0")" || exit 2
+
+RAIZ_REPO=$(cd ../../../.. && pwd) || exit 2
+FALSIFY=0
+[ "${1:-}" = "--falsify" ] && FALSIFY=1
+
+TMP=$(mktemp -d) || exit 2
+PGDATA_DIR="$TMP/pgdata"
+PGSOCK="$TMP/sock"
+PORT=$(( 24000 + (RANDOM % 20000) ))
+
+# ── via de prova: bun (gera o SQL) e um Postgres (executa o veredito) ────────────────────────────
+# `command -v` NÃO basta — presente-porém-quebrada esvazia o guard igual. Cada via é confirmada por
+# resposta POSITIVA antes de qualquer cenário rodar.
+command -v bun >/dev/null 2>&1 || { echo "❌ VIA_NAO_OBSERVAVEL: bun ausente — o SQL não pode ser gerado."; exit 2; }
+
+achar_pgbin() {
+  local c
+  for c in /opt/homebrew/opt/postgresql@17/bin /opt/homebrew/opt/postgresql@16/bin \
+           /usr/lib/postgresql/17/bin /usr/lib/postgresql/16/bin /usr/lib/postgresql/15/bin; do
+    [ -x "$c/initdb" ] && [ -x "$c/pg_ctl" ] && { printf '%s' "$c"; return 0; }
+  done
+  if command -v initdb >/dev/null 2>&1 && command -v pg_ctl >/dev/null 2>&1; then
+    dirname "$(command -v initdb)"; return 0
+  fi
+  return 1
+}
+PGBIN=$(achar_pgbin) || {
+  echo "❌ VIA_NAO_OBSERVAVEL: nenhum Postgres local (initdb/pg_ctl)."
+  echo "   macOS: brew install postgresql@17 · Debian/Ubuntu: apt-get install -y postgresql"
+  echo "   O eval NÃO degrada para 'ok': o veredito 401 só se prova EXECUTANDO."
+  exit 2
+}
+
+# shellcheck disable=SC2329  # invocada indiretamente pelo `trap limpar EXIT` logo abaixo
+limpar() {
+  "$PGBIN/pg_ctl" -D "$PGDATA_DIR" stop -m immediate >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap limpar EXIT
+
+mkdir -p "$PGSOCK"
+"$PGBIN/initdb" -D "$PGDATA_DIR" -U postgres -E UTF8 --locale=C >"$TMP/initdb.log" 2>&1 || {
+  echo "❌ VIA_NAO_OBSERVAVEL: initdb falhou. $(tail -3 "$TMP/initdb.log")"; exit 2; }
+"$PGBIN/pg_ctl" -D "$PGDATA_DIR" -o "-p $PORT -k $PGSOCK -c listen_addresses=''" \
+  -l "$TMP/pg.log" -w start >/dev/null 2>&1 || {
+  echo "❌ VIA_NAO_OBSERVAVEL: o Postgres efêmero não subiu. $(tail -3 "$TMP/pg.log")"; exit 2; }
+
+P() { "$PGBIN/psql" -p "$PORT" -h "$PGSOCK" -U postgres -d postgres -v ON_ERROR_STOP=1 "$@"; }
+# Sonda POSITIVA da via: servidor no ar E respondendo o valor certo.
+[ "$(P -tAc 'SELECT 1' 2>/dev/null)" = "1" ] || {
+  echo "❌ VIA_NAO_OBSERVAVEL: Postgres subiu mas não respondeu 'SELECT 1'."; exit 2; }
+
+# ── stub de `net._http_response` (o que o pg_net materializa em prod) ────────────────────────────
+P -q <<'SQL' || exit 2
+CREATE SCHEMA net;
+CREATE TABLE net._http_response (
+  id           bigint PRIMARY KEY,
+  status_code  int,
+  content_type text,
+  headers      jsonb,
+  content      text,
+  timed_out    boolean,
+  error_msg    text,
+  created      timestamptz NOT NULL DEFAULT now()
+);
+SQL
+
+# ── repo-fixture: o gerador roda contra ele, não contra a árvore real ────────────────────────────
+# Mantém o eval determinístico (o mapa de fingerprints do repo muda a cada deploy) e preserva o
+# "cwd neutro" que o step do CI documenta: nada aqui lê `src/` nem o estado do repo de verdade.
+FIX="$TMP/repo"
+mkdir -p "$FIX/supabase/functions/edge-a" "$FIX/supabase/functions/_shared"
+printf 'project_id = "refdementira000000ab"\n' > "$FIX/supabase/config.toml"
+printf 'export const VERSAO = "v1.0-alfa";\n' > "$FIX/supabase/functions/edge-a/versao.ts"
+FP_A=$(printf 'edge-a' | shasum -a 256 2>/dev/null | cut -d' ' -f1) \
+  || FP_A=$(printf 'edge-a' | sha256sum | cut -d' ' -f1)
+printf 'export const FONTE_SHA256: Record<string, string> = {\n  "edge-a": "%s",\n};\n' \
+  "$FP_A" > "$FIX/supabase/functions/_shared/sonda-fingerprints.ts"
+
+ID_SONDA=1000
+
+# gera_sql <dir_do_gerador> — emite o BLOCO DE LEITURA (PASSO 2) com o JSON de ids já colado.
+gera_sql() {
+  local gdir="$1"
+  cat > "$gdir/runner.ts" <<RUNNER
+import { gerarSqlDaLeva } from './sonda-versao-sql';
+process.stdout.write(gerarSqlDaLeva({ raiz: process.argv[2], edges: ['edge-a'] }));
+RUNNER
+  bun "$gdir/runner.ts" "$FIX" 2>"$TMP/gen.err" \
+    | awk '/^-- PASSO 2 /{f=1} f' \
+    | sed "s/jsonb_each_text('{}'::jsonb)/jsonb_each_text('{\"edge-a\": $ID_SONDA}'::jsonb)/"
+}
+
+# Cópia do gerador — a sabotagem do --falsify muta ESTA, nunca a versionada.
+GER="$TMP/gerador"
+mkdir -p "$GER"
+cp "$RAIZ_REPO/scripts/sonda-versao-sql.ts" "$RAIZ_REPO/scripts/sonda-fingerprint.ts" "$GER/"
+
+# ── cenários: o estado de `net._http_response` no instante da leitura ────────────────────────────
+# `created` é sempre relativo a now(): janela fixa em timestamp literal envelheceria o eval.
+semear() {
+  local cen="$1"
+  P -q -c "TRUNCATE net._http_response;" || return 1
+  case "$cen" in
+    velho_com_controle)   # 401 na sonda + tráfego de fundo saudável: o secret ESTÁ sendo aceito
+      P -q <<SQL
+INSERT INTO net._http_response (id, status_code, content, created)
+  VALUES ($ID_SONDA, 401, '{"code":401,"message":"Missing authorization header"}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 40) g;
+SQL
+      ;;
+    sem_controle)         # 401 e NADA mais: o controle não pode ser observado
+      P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
+               VALUES ($ID_SONDA, 401, '{\"code\":401}', now());"
+      ;;
+    controle_com_401_alheio)  # há 2xx, mas TAMBÉM 401 fora da leva ⇒ o secret é suspeito
+      P -q <<SQL
+INSERT INTO net._http_response (id, status_code, content, created)
+  VALUES ($ID_SONDA, 401, '{"code":401}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 40) g;
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT 500 + g, 401, '{"code":401}', now() - (g || ' minutes')::interval FROM generate_series(1, 3) g;
+SQL
+      ;;
+    controle_velho)       # os 2xx existem, mas TODOS fora da janela ⇒ não provam o agora
+      P -q <<SQL
+INSERT INTO net._http_response (id, status_code, content, created)
+  VALUES ($ID_SONDA, 401, '{"code":401}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT g, 200, '{"ok":true}', now() - interval '30 hours' FROM generate_series(1, 40) g;
+SQL
+      ;;
+    controle_raso)        # tráfego recente ínfimo ⇒ população não informa; fail-closed
+      P -q <<SQL
+INSERT INTO net._http_response (id, status_code, content, created)
+  VALUES ($ID_SONDA, 401, '{"code":401}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 2) g;
+SQL
+      ;;
+    nao_401_segue_determinado)  # 404 não é ambíguo: a edge não está servida
+      P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
+               VALUES ($ID_SONDA, 404, '{\"code\":\"NOT_FOUND\"}', now());"
+      ;;
+    pre_sensor)           # 200 sem versao: ignorou o probe e RODOU o fluxo real
+      P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
+               VALUES ($ID_SONDA, 200, '{\"ok\":true}', now());"
+      ;;
+    confirmado)           # eco completo: versao + fonte + probe + edge
+      P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
+               VALUES ($ID_SONDA, 200,
+                 '{\"edge\":\"edge-a\",\"versao\":\"v1.0-alfa\",\"fonte\":\"$FP_A\",\"probe\":true}', now());"
+      ;;
+    *) echo "cenário desconhecido: $cen" >&2; return 1 ;;
+  esac
+}
+
+# veredito <cenario> <dir_gerador> — devolve a string do veredito da edge-a
+veredito() {
+  local cen="$1" gdir="$2"
+  semear "$cen" >/dev/null 2>&1 || { echo "SEED_FALHOU"; return; }
+  gera_sql "$gdir" > "$TMP/leitura.sql" 2>/dev/null
+  [ -s "$TMP/leitura.sql" ] || { echo "SQL_VAZIO"; return; }
+  P -tAF'|' -f "$TMP/leitura.sql" 2>"$TMP/psql.err" | awk -F'|' 'NF>1 {print $NF}' | head -1
+}
+
+rc=0
+uma_linha_por_edge() { # cenario — o CROSS JOIN do controle não pode multiplicar a leva
+  local cen="$1" n
+  semear "$cen" >/dev/null 2>&1 || { printf '  [XX ] %-26s seed falhou\n' "uma_linha_por_edge"; rc=1; return; }
+  gera_sql "$GER" > "$TMP/leitura.sql" 2>/dev/null
+  n=$(P -tAF'|' -f "$TMP/leitura.sql" 2>/dev/null | command grep -c . || true)
+  if [ "$n" != "1" ]; then
+    printf '  [XX ] %-26s a leva de 1 edge devolveu %s linha(s) — o controle multiplicou a projeção\n' \
+      "uma_linha_por_edge" "$n"; rc=1; return
+  fi
+  printf '  [ok ] %-26s 1 edge ⇒ 1 linha: o CROSS JOIN do controle não duplica o relatório\n' "uma_linha_por_edge"
+}
+
+caso() { # nome cenario marcador_esperado descricao [marcador_PROIBIDO]
+  local nome="$1" cen="$2" esp="$3" desc="$4" proibido="${5:-}" got
+  got=$(veredito "$cen" "$GER")
+  case "$got" in
+    *"$esp"*) ;;
+    *) printf '  [XX ] %-26s veredito=%s\n        esperava conter "%s" — %s\n' "$nome" "${got:-<vazio>}" "$esp" "$desc"
+       rc=1; return ;;
+  esac
+  if [ -n "$proibido" ]; then
+    case "$got" in
+      *"$proibido"*) printf '  [XX ] %-26s veredito trouxe a marca PROIBIDA "%s": %s\n' "$nome" "$proibido" "$got"
+                     rc=1; return ;;
+    esac
+  fi
+  printf '  [ok ] %-26s %s\n' "$nome" "$desc"
+}
+
+# ── os cenários ─────────────────────────────────────────────────────────────────────────────────
+# Marcadores em ASCII puro e caixa fixa: `grep`/`case` com acento dobrado por normalização Unicode
+# casa por acidente, e um marcador que casa sempre é asserção sem dente (#1483).
+executar_casos() {
+  rc=0
+  caso velho_com_controle       velho_com_controle       "BUNDLE VELHO (pre-sonda)" \
+    "401 com o secret PROVADO bom por tráfego de fundo ⇒ veredito determinado"
+  caso sem_controle             sem_controle             "INDETERMINADO" \
+    "401 sem controle observável ⇒ NUNCA 'bundle velho'" "BUNDLE VELHO (pre-sonda)"
+  caso controle_com_401_alheio  controle_com_401_alheio  "INDETERMINADO" \
+    "401 alheio na janela ⇒ o secret é suspeito, veredito se recusa" "BUNDLE VELHO (pre-sonda)"
+  caso controle_velho           controle_velho           "INDETERMINADO" \
+    "2xx todos fora da janela ⇒ não provam o AGORA" "BUNDLE VELHO (pre-sonda)"
+  caso controle_raso            controle_raso            "INDETERMINADO" \
+    "tráfego recente abaixo do piso ⇒ população não informa" "BUNDLE VELHO (pre-sonda)"
+  caso nao_401_segue_determinado nao_401_segue_determinado "NADA executou" \
+    "404 NÃO é ambíguo: segue determinado, o 401 não contaminou os outros 4xx"
+  caso pre_sensor               pre_sensor               "PRE-SENSOR" \
+    "200 sem versao continua no ramo do fluxo real"
+  caso confirmado               confirmado               "DEPLOY CONFIRMADO" \
+    "eco completo segue confirmando — o ramo novo não roubou o caminho feliz"
+  uma_linha_por_edge confirmado
+}
+
+if [ "$FALSIFY" = 0 ]; then
+  echo "== sonda-veredito-401 — 401 é ambíguo: bundle velho × CRON_SECRET inválido =="
+  executar_casos
+  [ "$rc" -eq 0 ] && echo "  tudo bateu: 8 vereditos + cardinalidade" || echo "  ❌ divergência(s) acima"
+  exit "$rc"
+fi
+
+# ── falsificação: cada sabotagem precisa deixar ≥1 cenário VERMELHO ──────────────────────────────
+echo "== sonda-veredito-401 --falsify — sabota o gerador e exige vermelho =="
+ORIG=$(cat "$GER/sonda-versao-sql.ts")
+cegas=0
+sabotar() { # nome de para
+  local nome="$1" de="$2" para="$3"
+  if ! printf '%s' "$ORIG" | command grep -qF "$de"; then
+    printf '  [XX ] sabotagem NO-OP (alvo sumiu do gerador): %s\n' "$nome"; cegas=$((cegas + 1)); return
+  fi
+  printf '%s' "$ORIG" | python3 -c '
+import sys
+de, para = sys.argv[1], sys.argv[2]
+sys.stdout.write(sys.stdin.read().replace(de, para))
+' "$de" "$para" > "$GER/sonda-versao-sql.ts"
+  executar_casos >"$TMP/falsify.out" 2>&1
+  if [ "$rc" -ne 0 ]; then
+    printf '  [ok ] pegada: %s\n' "$nome"
+  else
+    printf '  [XX ] sabotagem PASSOU DESPERCEBIDA: %s\n' "$nome"; cegas=$((cegas + 1))
+  fi
+  printf '%s' "$ORIG" > "$GER/sonda-versao-sql.ts"
+}
+
+sabotar "401 volta a cair no ramo generico >=400 (o falso 'bundle velho' que motivou tudo)" \
+        "l.status_code = 401" "false"
+sabotar "fail-closed vira fail-open: o fallback do 401 vira veredito confiante" \
+        "'INDETERMINADO — 401" "'BUNDLE VELHO (pre-sonda) — 401"
+sabotar "controle deixa de excluir a PROPRIA leva (a sonda avaliza a si mesma)" \
+        "AND NOT EXISTS (SELECT 1 FROM ids i2 WHERE i2.request_id = r.id)" ""
+sabotar "piso do controle zerado: uma unica resposta 2xx ja 'prova' o secret" \
+        "const PISO_CONTROLE_CREDENCIAL = 10;" "const PISO_CONTROLE_CREDENCIAL = 0;"
+sabotar "401 alheio na janela deixa de desqualificar o controle" \
+        "AND c.recusas_recentes = 0" ""
+sabotar "janela do controle esticada: 2xx de anteontem 'provam' o agora" \
+        "now() - interval '6 hours'" "now() - interval '100 years'"
+sabotar "controle nao chega na projecao (CROSS JOIN removido)" \
+        " CROSS JOIN controle_credencial c" ""
+
+echo "--falsify: $cegas cegueira(s) (esperado: 0)"
+[ "$cegas" -eq 0 ] || exit 1
+exit 0

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -208,6 +208,35 @@ manda olhar de novo. Testes: `scripts/sonda-versao-sql.test.ts` (as falsificaç�
 `WHERE`, o `LEFT JOIN` virado `JOIN`, o marcador/fingerprint hardcoded, o ramo `DEPLOY PARCIAL`
 neutralizado e o `AND fonte = fonte_esperada` dispensado do `DEPLOY CONFIRMADO`.
 
+⚠️ **HTTP 401 é o ÚNICO 4xx ambíguo — tem ramo próprio, e o veredito determinado exige um controle
+de CREDENCIAL cruzado na mesma consulta.** Um 404 diz "não há edge servida nessa URL"; um 401 tem
+DUAS causas que o dado **não separa**: (a) bundle **pré-sonda** que ignorou o `{"probe":true}`, caiu
+no gate JWT e recusou, ou (b) **`CRON_SECRET` ausente/errado no vault**, com `authorizeCronOrStaff`
+recusando o header. Nos dois casos `versao` vem NULL e o status é 401. O ramo antigo (`versao IS NULL
+AND status_code >= 400 → 'BUNDLE VELHO … NADA executou'`) lia os dois como (a): **falso negativo
+confiante**, cujo desfecho é redeployar edge que já está no ar — `ausente ≠ zero` na dimensão
+CREDENCIAL, irmão exato do guard temporal do #2079 (`verify-edge-eco.sh`), onde tick pré-merge lido
+como pendência produzia o mesmo erro. Agora o bloco carrega o CTE `controle_credencial`: conta, em
+`net._http_response` e **excluindo a própria leva** (`NOT EXISTS`, porque `NOT IN` seria NULL-blind
+com a trava fechada), as respostas recentes de 6h — **≥10 2xx e ZERO 401** provam que o secret do
+vault está sendo aceito AGORA, e só então o 401 vira `'BUNDLE VELHO (pre-sonda)'`. Sem essa prova o
+veredito é **`INDETERMINADO`**, nunca "bundle velho": fail-CLOSED, como o
+`CONTROLE_CRUZADO_NAO_OBSERVADO` do `verify-edge-escrita.sh`. O piso não é `> 0` por **denominador**:
+com 1–2 respostas, "nenhum 401" não distingue secret bom de ninguém-bateu-na-porta. Nasceu de o
+desempate ter sido feito **à mão, fora da ferramenta**, ao verificar `generate-bundle-argument`
+(#2101) — ferramenta que depende de o operador lembrar é a armadilha da sentinela não-exclusiva.
+Provado **EXECUTANDO** em `.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh`
+(Postgres efêmero, 8 cenários + 6 sabotagens): casar string ficaria verde justamente quando a ordem
+dos `WHEN` está errada, e `NULL > 0` não é falso — é NULL.
+
+⚠️ **O que esse controle NÃO fecha — e está escrito no próprio SQL:** ele é **populacional**, conclui
+"o secret está sendo aceito" a partir de tráfego que passou. Se o `CRON_SECRET` foi trocado **há
+poucos minutos** e **nenhum cron rodou desde a troca**, os 2xx da janela foram feitos com o secret
+ANTIGO e o controle avaliza indevidamente. O ramo **estreita** muito o erro (antes ele era
+incondicional), não o elimina; na próxima execução dos crons a recusa vira 401 e o controle se
+desqualifica sozinho. Regra prática: **se você acabou de mexer no vault, leia o veredito determinado
+como INDETERMINADO.**
+
 - ⚠️ **A trava do bloco perigoso tem de ser `CASE`, NÃO `WHERE`.** Quando parte da leva só pode ser sondada
   DEPOIS do deploy confirmado (bundle pré-sensor ignora o `probe` e dispara o run), a tentação é
   `... FROM alvos, guard WHERE guard.confirmei = 'sim'`. **Isso não protege**: o Postgres avalia a projeção

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -23,5 +23,17 @@ PEGA      | ramo DEPLOY PARCIAL neutralizado (nao dispara) | s/COALESCE\(l\.corp
 PEGA      | CONFIRMADO dispensa o fonte (falso POSITIVO)   | s/AND l\.corpo ->> 'fonte' = l\.fonte_esperada/AND true/
 PEGA      | fingerprint hardcoded em vez de lido do mapa   | s/lit\(e\.fonte\)/lit('0'.repeat(64))/
 PEGA      | edge fora do mapa degrada em vez de lancar     | s/if \(!\(edge in mapa\)\)/if (false)/
+# Os 6 abaixo guardam o ramo do 401 — o UNICO 4xx ambiguo (bundle pre-sonda que caiu no gate JWT
+# x CRON_SECRET invalido no vault). Sem eles a suite aceitava o veredito confiante 'BUNDLE VELHO'
+# para os dois casos, e o desfecho era redeployar edge que ja estava no ar: `ausente != zero` na
+# dimensao CREDENCIAL. A SEMANTICA (o CASE devolvendo mesmo o veredito) e provada EXECUTANDO, em
+# .claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh; aqui mede-se o dente da
+# suite textual, que e o que roda no gate de mutacao.
+PEGA      | 4xx generico perde a cobertura (404 cai no ELSE)       | s/l\.status_code >= 400/l.status_code = 401/
+PEGA      | fallback do 401 deixa de ser INDETERMINADO (fail-open)    | s/THEN 'INDETERMINADO/THEN 'BUNDLE VELHO (pre-sonda)/
+PEGA      | controle nao exclui a propria leva (a sonda se avaliza)   | s/AND NOT EXISTS \(SELECT 1 FROM ids i2 WHERE i2\.request_id = r\.id\)/AND true/
+PEGA      | piso do controle zerado (1 resposta 2xx ja 'prova')       | s/PISO_CONTROLE_CREDENCIAL = 10/PISO_CONTROLE_CREDENCIAL = 0/
+PEGA      | 401 alheio deixa de desqualificar o controle              | s/AND c\.recusas_recentes = 0/AND true/
+PEGA      | controle nao chega na projecao (CROSS JOIN removido)      | s/ CROSS JOIN controle_credencial c//
 SOBREVIVE | timeout 20s -> 30s (valor nao e pinado)    | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
 SOBREVIVE | ORDER BY por posicao (cosmetico)           | s/ORDER BY l\.edge;/ORDER BY 1;/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -231,7 +231,7 @@ describe('PASSO 1 — dispara a leva numa tacada', () => {
   });
 });
 
-describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', () => {
+describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os ramos', () => {
   const raiz = () => fixture({ 'edge-a': 'v1.0-alfa' });
 
   it('parte de `esperado` e LEFT JOIN nos ids — zero linhas não pode virar "nada a reportar"', () => {
@@ -265,7 +265,7 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', (
     expect(sql).toMatch(/COALESCE\(r\.content::jsonb -> 'data', r\.content::jsonb\)/);
   });
 
-  it('os 6 ramos de veredito estão nomeados', () => {
+  it('os 8 ramos de veredito estão nomeados', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
     for (const ramo of [
       'SEM ID',
@@ -274,6 +274,8 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', (
       'DEPLOY PARCIAL',
       'BUNDLE VELHO',
       'PRE-SENSOR',
+      'BUNDLE VELHO (pre-sonda)',
+      'INDETERMINADO',
     ]) {
       expect(sql, `ramo ausente: ${ramo}`).toContain(ramo);
     }
@@ -311,6 +313,49 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', (
     // O 400 recusou: nada executou → BUNDLE VELHO. Só o 200 sem versao rodou o fluxo real.
     expect(sql).toMatch(/status_code >= 400\s*\n?\s*THEN 'BUNDLE VELHO/);
     expect(sql).toMatch(/THEN 'PRE-SENSOR[^']*RODOU O FLUXO REAL/);
+  });
+
+  // ── 401: o único 4xx AMBÍGUO ────────────────────────────────────────────────────────────────
+  // Estes 5 guardam a ESTRUTURA (ordem dos WHEN, presença do controle). Quem prova a SEMÂNTICA —
+  // que o CASE devolve mesmo o veredito certo, incluindo `NULL > 0` não sendo falso — é
+  // `.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh`, que EXECUTA este SQL
+  // num Postgres efêmero. Casar string aqui não bastaria: a asserção textual fica verde
+  // exatamente quando a ordem dos ramos está errada.
+  it('401 tem ramo PRÓPRIO e vem ANTES do 4xx genérico — o ambíguo não herda o confiante', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/l\.status_code = 401/);
+    // Um WHEN só alcança o que o anterior não pegou: depois do `>= 400` o ramo do 401 seria
+    // inalcançável e o 401 voltaria a sair como 'BUNDLE VELHO' determinado.
+    expect(sql.indexOf('l.status_code = 401')).toBeLessThan(sql.indexOf('l.status_code >= 400'));
+  });
+
+  it('o fallback do 401 é INDETERMINADO — fail-CLOSED, nunca "bundle velho"', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const iIndeterminado = sql.indexOf("THEN 'INDETERMINADO");
+    expect(iIndeterminado).toBeGreaterThan(-1);
+    expect(iIndeterminado).toBeLessThan(sql.indexOf('l.status_code >= 400'));
+  });
+
+  it('o controle de credencial é cruzado na MESMA consulta — não é recado ao operador', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('controle_credencial AS (');
+    expect(sql).toMatch(/FROM lidas l CROSS JOIN controle_credencial c/);
+    expect(sql).toMatch(/count\(\*\) FILTER \(WHERE r\.status_code BETWEEN 200 AND 299\)/);
+    expect(sql).toMatch(/count\(\*\) FILTER \(WHERE r\.status_code = 401\)/);
+    expect(sql).toMatch(/r\.created > now\(\) - interval '6 hours'/);
+  });
+
+  it('o controle não conta a PRÓPRIA leva, e exclui por NOT EXISTS (NOT IN seria NULL-blind)', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/AND NOT EXISTS \(SELECT 1 FROM ids i2 WHERE i2\.request_id = r\.id\)/);
+    // A trava fechada do bloco caro devolve request_id NULL; `NOT IN` com NULL zeraria o
+    // controle inteiro em silêncio, e todo 401 viraria INDETERMINADO por acidente.
+    expect(sql).not.toMatch(/r\.id NOT IN \(/);
+  });
+
+  it('o veredito determinado do 401 exige PISO de 2xx E zero recusas — amostra rasa não prova', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/c\.ok_recentes >= 10 AND c\.recusas_recentes = 0/);
   });
 
   it('DEPLOY CONFIRMADO exige o eco probe:true E a edge que respondeu, não só a versao', () => {

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -198,6 +198,18 @@ function blocoDisparo(
 }
 
 /**
+ * Piso de respostas 2xx recentes (fora da leva) para o controle de credencial VALER.
+ *
+ * Não é `> 0` por um motivo de denominador: o controle é populacional — ele conclui "o CRON_SECRET
+ * está sendo aceito" a partir de tráfego que passou. Com 1 ou 2 respostas a ausência de 401 não
+ * distingue "secret bom" de "quase ninguém bateu na porta", e o veredito determinado sairia de uma
+ * amostra que não informa. Os ~52 crons que mandam `x-cron-secret` produzem centenas de respostas
+ * por janela de 6h (medido em 2026-08-30: 208 linhas, todas 200); abaixo de 10 o fundo está
+ * anormalmente quieto e a resposta honesta é INDETERMINADO.
+ */
+const PISO_CONTROLE_CREDENCIAL = 10;
+
+/**
  * Bloco de LEITURA e veredito.
  *
  * Parte da lista CANÔNICA (`FROM esperado LEFT JOIN ids`) e não dos ids: invertido, colar o JSON
@@ -209,6 +221,29 @@ function blocoDisparo(
  * ausente é a assinatura do bundle que subiu `index.ts` + `versao.ts` sem o mapa de fingerprints, e
  * ler isso como CONFIRMADO seria o falso POSITIVO que encerra a verificação. Confirmação exige os
  * DOIS campos; a dúvida cai sempre no lado que manda olhar de novo.
+ *
+ * POR QUE O 401 TEM RAMO PRÓPRIO: ele é AMBÍGUO por construção, e os outros 4xx não são. Um 404 diz
+ * "não há edge servida nessa URL"; um 401 pode ser (a) bundle PRÉ-SONDA que ignorou o
+ * `{"probe":true}`, caiu no gate JWT e recusou, ou (b) `CRON_SECRET` ausente/errado no vault, com
+ * `authorizeCronOrStaff` recusando o header. Nos DOIS casos `versao` vem NULL e o status é 401 — o
+ * dado não separa. Ler (b) como (a) manda redeployar uma edge que já está no ar: `ausente ≠ zero`
+ * na dimensão CREDENCIAL, irmão do guard temporal do #2079, onde tick pré-merge lido como pendência
+ * produzia o mesmo falso negativo confiante.
+ *
+ * Então o veredito determinado só sai quando o CONTROLE é observado na MESMA consulta (o CTE
+ * `controle_credencial`): tráfego de fundo recente que PASSOU (≥ piso de 2xx) e NENHUMA recusa 401
+ * fora desta leva provam que o secret do vault está sendo aceito AGORA — logo o 401 é da edge, não
+ * da credencial. Sem essa prova o veredito é INDETERMINADO, nunca "bundle velho": fail-CLOSED,
+ * igual ao `CONTROLE_CRUZADO_NAO_OBSERVADO` do `verify-edge-escrita.sh`. Antes disso a desambiguação
+ * dependia de o operador lembrar de rodar duas consultas à mão (feito assim em 2026-08-30, no
+ * #2101) — e recado que depende de alguém lembrar é exatamente como a armadilha da sentinela
+ * não-exclusiva passou.
+ *
+ * O QUE O CONTROLE NÃO PROVA: ele é populacional — conclui "o secret está sendo aceito" de
+ * tráfego que passou. Não fecha a janela em que o `CRON_SECRET` foi trocado há poucos minutos e
+ * NENHUM cron rodou desde a troca: ali os 2xx da janela foram feitos com o secret antigo e o
+ * controle avaliza indevidamente. O ramo ESTREITA muito o erro (antes ele era incondicional),
+ * não o elimina — e o SQL gerado diz isso ao operador, em vez de deixar a ressalva só no doc.
  */
 function blocoLeitura(leva: EdgeSondada[]): string {
   return (
@@ -217,6 +252,27 @@ function blocoLeitura(leva: EdgeSondada[]): string {
     `  -- ⬅️ COLE AQUI, no lugar do {}, a célula única devolvida pelo passo de disparo.\n` +
     `  SELECT chave AS edge, valor::bigint AS request_id\n` +
     `  FROM jsonb_each_text('{}'::jsonb) AS t(chave, valor)\n` +
+    `),\n` +
+    `controle_credencial AS (\n` +
+    `  -- Controle de CREDENCIAL: o 401 acima é ambíguo (bundle velho × CRON_SECRET inválido) e só\n` +
+    `  -- vira veredito determinado se ESTE bloco provar que o secret do vault está sendo ACEITO\n` +
+    `  -- agora. Lê a MESMA tabela do LEFT JOIN de cima de propósito: não acrescenta superfície de\n` +
+    `  -- permissão nova (se desse 'permission denied' o bloco inteiro já teria falhado), e um\n` +
+    `  -- controle que exige privilégio a mais viraria INDETERMINADO por acidente de ACL.\n` +
+    `  SELECT count(*) FILTER (WHERE r.status_code BETWEEN 200 AND 299) AS ok_recentes,\n` +
+    `         count(*) FILTER (WHERE r.status_code = 401)               AS recusas_recentes\n` +
+    `  FROM net._http_response r\n` +
+    `  WHERE r.created > now() - interval '6 hours'\n` +
+    `    -- A própria leva não pode se avalizar: sem isto, o 401 que estamos julgando entra na\n` +
+    `    -- contagem de recusas e o controle se auto-envenena (nenhum 401 seria explicável nunca).\n` +
+    `    -- NOT EXISTS, não NOT IN: a trava fechada do bloco caro devolve request_id NULL, e\n` +
+    `    -- \`NOT IN\` com NULL é NULL-blind — zeraria o controle inteiro em silêncio.\n` +
+    `    AND NOT EXISTS (SELECT 1 FROM ids i2 WHERE i2.request_id = r.id)\n` +
+    `    -- ⚠️ O que este controle NAO fecha: CRON_SECRET trocado ha poucos minutos E nenhum\n` +
+    `    --    cron rodado desde a troca — o trafego 2xx da janela usou o secret ANTIGO e\n` +
+    `    --    avalizaria indevidamente. Na proxima execucao dos crons isso vira 401 e o\n` +
+    `    --    controle se desqualifica sozinho. Se voce ACABOU de mexer no vault, trate o\n` +
+    `    --    veredito determinado abaixo como INDETERMINADO.\n` +
     `),\n` +
     `lidas AS (\n` +
     `  SELECT e.edge, e.versao_esperada, e.fonte_esperada, i.request_id, r.status_code,\n` +
@@ -237,6 +293,16 @@ function blocoLeitura(leva: EdgeSondada[]): string {
     `           THEN 'SEM ID — esta edge não saiu no JSON colado (bloco errado, ou trava fechada)'\n` +
     `         WHEN l.status_code IS NULL\n` +
     `           THEN 'AGUARDE — a resposta HTTP ainda não chegou (leva ~10s); rode este passo de novo'\n` +
+    `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code = 401\n` +
+    `              AND c.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL} AND c.recusas_recentes = 0\n` +
+    `           THEN 'BUNDLE VELHO (pre-sonda) — 401, e o CRON_SECRET esta PROVADO bom agora (' ||\n` +
+    `                c.ok_recentes || ' resposta(s) 2xx e ZERO 401 fora desta leva em 6h), ' ||\n` +
+    `                'logo a recusa e da EDGE: nada executou'\n` +
+    `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code = 401\n` +
+    `           THEN 'INDETERMINADO — 401 nao separa bundle velho de CRON_SECRET invalido, e o ' ||\n` +
+    `                'controle de credencial NAO foi observado (2xx fora da leva em 6h: ' ||\n` +
+    `                c.ok_recentes || ', recusas 401: ' || c.recusas_recentes || '). Confira o ' ||\n` +
+    `                'CRON_SECRET no vault ANTES de redeployar — nao ha prova de bundle velho aqui'\n` +
     `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code >= 400\n` +
     `           THEN 'BUNDLE VELHO — recusou o request (HTTP ' || l.status_code || '), NADA executou'\n` +
     `         WHEN l.corpo ->> 'versao' IS NULL\n` +
@@ -253,7 +319,7 @@ function blocoLeitura(leva: EdgeSondada[]): string {
     `              ', edge=' || COALESCE(l.corpo ->> 'edge', '?') ||\n` +
     `              ' (esperado ' || l.versao_esperada || ' / ' || l.fonte_esperada || ')'\n` +
     `       END AS veredito\n` +
-    `FROM lidas l\n` +
+    `FROM lidas l CROSS JOIN controle_credencial c\n` +
     `ORDER BY l.edge;\n`
   );
 }


### PR DESCRIPTION
## O problema

O SQL do PASSO 2 gerado por `scripts/sonda-versao-sql.ts` julgava todo 4xx pelo mesmo ramo:

```sql
WHEN l.corpo ->> 'versao' IS NULL AND l.status_code >= 400
  THEN 'BUNDLE VELHO — recusou o request (HTTP ' || l.status_code || '), NADA executou'
```

Um **401 é ambíguo por construção** e caía aí com veredito confiante:

- **(a)** bundle **PRÉ-SONDA** — ignorou `{"probe":true}`, caiu no gate JWT da edge e devolveu 401; ou
- **(b)** **`CRON_SECRET`** ausente/errado no vault — `authorizeCronOrStaff` recusou o header.

Nos dois casos `versao` é NULL e `status_code` é 401. Ler (b) como (a) manda redeployar uma edge
que **já está no ar** — família `ausente ≠ zero` na dimensão **CREDENCIAL**, irmão exato do guard
temporal do #2079 (`verify-edge-eco.sh`), onde ler tick pré-merge como pendência produzia o mesmo
falso negativo confiante.

Medido em 2026-08-30 verificando o deploy de `generate-bundle-argument` (#2101): a ambiguidade é
real e foi fechada **à mão, fora da ferramenta**, com consultas que o bloco não fazia. Recado que
depende de o operador lembrar é exatamente como a armadilha da sentinela não-exclusiva passou.

## O que muda

- **401 ganha ramo próprio, ANTES do 4xx genérico.** 404 continua determinado — ele não é ambíguo.
- **CTE `controle_credencial`** cruza a prova na MESMA consulta: em `net._http_response`, **≥10
  respostas 2xx e ZERO 401** nas últimas 6h, **excluindo a própria leva**.
- **Sem essa prova ⇒ `INDETERMINADO`**, nunca "bundle velho" — fail-CLOSED, como o
  `CONTROLE_CRUZADO_NAO_OBSERVADO` do `verify-edge-escrita.sh`.

Três decisões que não são cosméticas:

1. **`NOT EXISTS`, não `NOT IN`** — a trava fechada do bloco caro devolve `request_id` NULL, e
   `NOT IN` com NULL é NULL-blind: zeraria o controle inteiro em silêncio.
2. **A leva não se avaliza** — sem a exclusão, o próprio 401 sob julgamento entra na contagem de
   recusas e o controle se auto-envenena (nenhum 401 seria explicável, nunca).
3. **Piso ≥10, não `> 0`** — é questão de **denominador**: com 1–2 respostas, "nenhum 401" não
   distingue secret bom de ninguém-bateu-na-porta.

O controle lê a **mesma tabela** do `LEFT JOIN` que já existia: não acrescenta superfície de
permissão nova, então não vira INDETERMINADO por acidente de ACL.

## Provas — todas rodadas, nenhuma só descrita

| gate | resultado |
|---|---|
| `evals/sonda-veredito-401-eval.sh` | 8 vereditos + cardinalidade, `EXIT=0` |
| idem `--falsify` | 7 sabotagens, **0 cegueiras** |
| `evals/run.sh` (5 evals) | `EXIT=0` — normal **e** `--falsify` |
| propagação do exit no `run.sh` | **provada**: gerador sabotado ⇒ `run.sh` saiu **1** |
| `bun run typecheck` | `TYPECHECK_EXIT=0` |
| `shellcheck` (eval + run.sh) | `EXIT=0` |
| `mutcheck` | 22 mutações · 20 pegas · **0 inválidas** · 0 problemas |
| `docs:citacoes/indice/links`, `claude:size` | `EXIT=0` cada |

**RED antes do GREEN:** rodado contra o gerador sem o ramo, os 5 cenários de 401 devolviam
`BUNDLE VELHO — recusou o request (HTTP 401)` — o bug, reproduzido. Os 3 controles positivos (404,
pré-sensor, confirmado) já passavam, provando que o harness lia o veredito de verdade.

**O `--falsify` foi meta-falsificado:** injetei uma sabotagem inócua (`ORDER BY l.edge` →
`ORDER BY 1`) e o modo a acusou como cegueira (exit 1). Ele sabe reprovar.

### Por que o eval EXECUTA o SQL

É o único eval da skill que sobe um Postgres (initdb efêmero, **zero rede**, mesmo padrão dos
`db/test-*.sh`). Casar string provaria que `'INDETERMINADO'` está no arquivo, não que o `CASE` a
devolve — e a asserção textual fica verde **justamente quando a ordem dos `WHEN` está errada**.
`NULL > 0` não é falso, é NULL: o WHEN não dispara e a linha cai no vizinho confiante.

Sem Postgres o eval sai **exit 2** e o `run.sh` propaga como **falha** — ausência de via de prova
não vira aprovação silenciosa.

## Limitação conhecida (nomeada de propósito)

O controle prova que o secret **está sendo aceito**, por população. Ele **não** fecha a janela em
que o `CRON_SECRET` foi trocado há poucos minutos e **nenhum cron rodou desde a troca**: aí o
tráfego 2xx da janela foi feito com o secret antigo e o controle avalizaria indevidamente. O ramo
estreita muito o erro — não o elimina. Quando o secret é trocado, os crons passam a devolver 401 e
o controle desqualifica sozinho na próxima execução.

## Risco de CI

O eval depende de um Postgres local (`/opt/homebrew/opt/postgresql@{17,16}` ou
`/usr/lib/postgresql/{17,16,15}`). Por isso o PR nasce **draft**: o step dos evals vive no job
`validate`, o único check *required*, e eu quero **ver** o CI verde antes de liberar o auto-merge.
