### PR TITLE
docs(deploy-verify): auditei as 8 afirmações do #2127 — 6 de pé, e as 2 furadas eram os comandos que se copiam

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -154,12 +154,17 @@ estavam certos para a pergunta errada. Feche o closure, sempre:
 # imports locais de 1º nível — repita em cada arquivo alcançado até não achar mais
 grep -oE 'from "\.\.?/[^"]+"' supabase/functions/<edge>/index.ts | sort -u
 # algum deles é import NOVO nesta edge? (resposta POSITIVA no diff, nunca de memória)
-git show <sha-do-merge> -- supabase/functions/<edge>/index.ts | grep -E '^\+.*from "\.\.'
+# UM ponto só no padrão: `\.\.` perderia `from "./helper.ts"` — e 41 dos 96 diretórios de edge
+# importam assim, o mesmo ponto cego que este bloco existe para fechar (medido 2026-08-30)
+git show <sha-do-merge> -- supabase/functions/<edge>/index.ts | grep -E '^\+.*from "\.'
 ```
 
 ⚠️ E some ao closure o **mapa** `_shared/sonda-fingerprints.ts`: a `fecharGrafo()` do gerador o exclui
-de propósito (senão o hash se auto-referenciaria), então ele **nunca** aparece no closure — e ainda
-assim precisa ir no deploy, porque é ele que alimenta o campo `fonte`. **Fatia = closure ∪ {mapa}.**
+de propósito (senão o hash se auto-referenciaria) — e ainda assim precisa ir no deploy, porque é ele
+que alimenta o campo `fonte`. **Fatia = closure ∪ {mapa}.** ⚠️ Isso vale para quem derive a lista da
+`fecharGrafo()` ou do campo `fonte`; o `grep` acima, seguido até o fim, **alcança** o mapa por
+`versao.ts` → `_shared/sonda-versao.ts` → `./sonda-fingerprints.ts`. Achar o mapa ali é o esperado, não
+sinal de que você errou o procedimento (medido 2026-08-30, auditando este bloco).
 
 🔴 **E o closure sobre QUAL intervalo? O `<sha>` do PR nomeado é a pergunta ERRADA — a fatia tem
 eixo TEMPO (2026-08-30, #2123).** O `--name-status <sha>` responde *"o que aquele commit tocou"*; o


### PR DESCRIPTION
Sequência do #2130, que mediu: `.claude/skills/` está fora do `docs:citacoes`, então citação em skill **não é conferida por gate nenhum**. O #2127 acabara de acrescentar ao `Passo 3` um bloco com `arquivo:linha` e dois comandos prontos para copiar — exatamente o material que ninguém revalida. Auditei à mão.

## Resultado: 8 afirmações, 6 de pé

`ia-cota.ts` não sai no `--name-status` do #2101 · a string `+import { consumirCota, headersDeCota }` é exata · `ia-cota.ts` inalterado desde 2026-07-31 (`052646485`) · o `--name-status` devolve 3 arquivos · a `fecharGrafo()` exclui o mapa por ponto-fixo (`ARQ_MAPA`) · o mapa alimenta o campo `fonte`.

## As 2 furadas estão nos comandos

**1. O grep do diff é cego a `./`.** `grep -E ^\+.*from "\.\.` exige dois pontos, então perde `from "./helper.ts"`. **41 dos 96** diretórios de edge importam assim. É a mesma classe de cegueira que o bloco existe para fechar — um import novo que o método não enxerga. Corrigido para um ponto, com o motivo no comentário para ninguém "simplificar" de volta.

**2. "ele nunca aparece no closure" é falso para o procedimento prescrito.** Vale para a `fecharGrafo()` do gerador. Mas o `grep` manual do próprio bloco, seguido até o fim, **alcança** o mapa: `versao.ts` → `_shared/sonda-versao.ts` → `./sonda-fingerprints.ts`. Quem rodasse o comando e visse o mapa concluiria que errou o procedimento — o pior modo de falha num doc que ensina. A conclusão `closure ∪ {mapa}` continua certa; a justificativa é que não era.

## Verificação

Controle positivo e negativo em cada correção: o padrão novo captura `./` **e** `../`; o antigo perde o `./`. Alvos falsos de data e de string não casam.

⚠️ `docs:citacoes`/`docs:links`/`docs:indice` saem `exit 0`, mas **para este arquivo isso é ausência de dado** — é o achado do #2130. O que sustenta este PR é a verificação à mão acima, não o verde do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)