### PR TITLE
fix(db): a query de validação dava FALSO VERMELHO — e só o ramo negativo tinha sido testado

### DIFF
--- a/db/valida-reconciliar-pedidos-omie.sql
+++ b/db/valida-reconciliar-pedidos-omie.sql
@@ -1,0 +1,24 @@
+-- Validação pós-apply de 20260830190000_reconciliar_pedidos_omie.sql (read-only).
+-- ⚠️ Duas armadilhas já pagas nesta query, ambas da MESMA classe (só o ramo negativo tinha sido
+-- exercitado): (1) `pg_get_function_identity_arguments` inclui os NOMES dos parâmetros, então
+-- comparar com 'jsonb, text[], timestamptz' dava FALSO VERMELHO com a migration aplicada;
+-- (2) `::regprocedure` LANÇA quando a função não existe — a query erraria em vez de dizer ❌.
+-- `to_regprocedure` devolve NULL e deixa o CASE responder.
+SELECT
+  CASE WHEN (
+    SELECT p.oid IS NOT NULL
+       AND p.prosecdef = false
+       AND NOT has_function_privilege('anon', p.oid, 'EXECUTE')
+       AND NOT has_function_privilege('authenticated', p.oid, 'EXECUTE')
+       AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+      FROM pg_proc p
+     WHERE p.oid = to_regprocedure('public.reconciliar_pedidos_omie(jsonb, text[], timestamptz)')
+  )
+  AND to_regprocedure('public.reconciliar_pedidos_omie(jsonb, text[])') IS NULL
+  AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'sales_orders'
+       AND column_name = 'omie_reconciliado_em'
+  )
+  THEN '✅ RPC (jsonb,text[],timestamptz) INVOKER + só service_role + coluna omie_reconciliado_em + sem sobrecarga velha'
+  ELSE '❌ FALTANDO, grant errado, ou a sobrecarga de 2 args sobreviveu' END AS status;


### PR DESCRIPTION
A migration `20260830190000_reconciliar_pedidos_omie.sql` (#2134) foi aplicada em produção e a
query de validação que eu entreguei disse **`❌ FALTANDO`**. A migration estava certa; a **query**
estava errada — conferido depois no catálogo: função presente com a assinatura certa, `SECURITY
INVOKER`, `anon`/`authenticated` sem `EXECUTE`, `service_role` com, coluna `omie_reconciliado_em`
criada, sobrecarga de 2 argumentos ausente. Tudo como deveria.

## As duas causas, que são a mesma

1. **`pg_get_function_identity_arguments` inclui os NOMES dos parâmetros.** Ele devolve
   `p_pedidos jsonb, p_status_gerido_omie text[], p_lido_em timestamp with time zone`, e eu
   comparava com `'jsonb, text[], timestamp with time zone'`. Nunca ia bater.
2. **`::regprocedure` LANÇA quando a função não existe.** Isto é pior que o (1): no estado exato
   que a query existe para detectar — migration não aplicada —, ela **erraria** em vez de dizer
   `❌`. Uma sonda que explode no caso que ela vigia não é sonda.

## A causa-raiz das duas, que é a lição

**Eu pré-testei a query contra a produção e vi o `❌` — mas a função ainda não existia.** Só
exercitei o ramo **negativo**. Uma validação testada apenas no estado em que o objeto falta não
prova que ela sabe reconhecer o objeto **presente**, e foi por essa fresta que os dois defeitos
passaram juntos.

É o espelho exato do princípio que este repo já aplica — falsificar sabotando e **exigindo
vermelho** — com o sinal trocado: aqui faltou **exigir o verde**. O ritual cobre bem o lado
"o assert tem dente?" e não cobria "o assert reconhece o caso bom?".

O custo real: o founder colou a migration, rodou a validação, viu `❌` e reportou como falha de
apply. Diagnóstico de um defeito que não existia.

## O conserto

`to_regprocedure` (devolve `NULL`, não lança) e comparação que não depende do texto dos nomes.
**Exercitada nos DOIS ramos contra a prod:**

- positivo, estado real de agora → `✅ RPC (jsonb,text[],timestamptz) INVOKER + só service_role + coluna omie_reconciliado_em + sem sobrecarga velha`
- negativo, assinatura trocada para uma inexistente → `❌ FALTANDO, grant errado, ou a sobrecarga de 2 args sobreviveu` (e **não** um erro)

O arquivo entra em `db/` para não depender do corpo de um PR: quem for revalidar a RPC depois
tem a versão certa no repo, em vez da errada que ficou registrada no #2134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
