### PR TITLE
docs(deploy-verify): a única citação `arquivo:linha` das skills apontava para linha VAZIA — 74 virou 129

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -465,7 +465,7 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
     (2026-08-29, #2035).** Antes de instrumentar sonda, **leia o corpo do erro que o cron já gravou**:
     se a mensagem for única no repo (`git grep` prova), ela identifica o BUNDLE. Na
     `analytics-outbox-drain`, `{"erro":"POSTHOG_INGEST_KEY nao configurado"}` (id 62407) existia em UM
-    arquivo — `index.ts:74`, criado pelo PR — logo só aquele bundle podia emiti-la: prova de VERSÃO sem
+    arquivo — `supabase/functions/analytics-outbox-drain/index.ts:129`<!--cita: POSTHOG_INGEST_KEY nao configurado-->, criado pelo PR — logo só aquele bundle podia emiti-la: prova de VERSÃO sem
     PAT, sem canária, sem invocar nada. Bônus de graça: o 500 vem DEPOIS do `authorizeCronOrStaff`,
     então a mesma linha prova que o `x-cron-secret` do Vault está correto (errado pararia em 401).
     ⛔ Não vale para mensagem genérica (`{"error":"internal"}`) nem para string que também existe em


### PR DESCRIPTION
Você pediu para corrigir o `index.ts:74` que a medição de custo apontou. Ao escrever o caminho completo, o defeito era maior do que o rótulo do gate sugeria.

## Não era forma, era apodrecimento

A linha 74 de `supabase/functions/analytics-outbox-drain/index.ts` está **vazia**. A mensagem `POSTHOG_INGEST_KEY nao configurado` — que é o próprio sensor de deploy que o bloco ensina a usar — mora hoje na linha **129**. O arquivo cresceu desde o #2035 e ninguém revalidou, porque `.claude/skills/` está fora do gate ([#2130](https://github.com/LucasSardenbergL/afiacao/pull/2130)).

**Corrijo aqui uma classificação minha:** ao reportar a medição eu chamei esse vermelho de "forma, não apodrecimento", seguindo o rótulo do gate (basename ambíguo). Estava errado — e o erro invertia a conclusão: das skills, a **única** citação com `:linha` que existe estava podre. Taxa de podridão medida: 1/1.

## Correção

Caminho completo + linha 129 + âncora `<!--cita:-->`. Verificado nos dois sentidos: a linha 129 contém a mensagem, a 74 não. A mensagem segue **única no repo** (1 arquivo), que é o que sustenta seu uso como prova de VERSÃO — sem isso ela provaria o módulo, não o bundle.

## O custo de ligar o escopo caiu para ZERO

Remedindo com `.claude/skills` no `ALVOS_VIVOS`:

| | antes | depois desta correção |
|---|---|---|
| verificadas | 29 + **1 quebrada** | **30**, zero quebradas |
| exit | 1 | **0** |

Falsificado com o gate ligado: sabotei a âncora e ele reprovou nomeando arquivo, linha e conteúdo real.

Isso não reabre sozinho a decisão de ligar o escopo — meu argumento de que ele não pegaria os defeitos do #2127 (regex e afirmação de comportamento) continua de pé. Mas o outro lado da balança mudou: agora ligar não custa nada, e o único caso existente provou que a classe de erro é real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)