### PR TITLE
feat(gate): `.claude/skills` entra no `docs:citacoes` — a pasta cuja única citação estava podre

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -47,7 +47,7 @@
 ## Editar uma skill: nenhum gate confere as citações dela
 
 `.claude/skills/` está **fora do `docs:citacoes`** — `ALVOS_VIVOS` é `CLAUDE.md` + `docs/agent`,
-`docs/visual-direction` e `docs/runbooks` (`scripts/docs-citacoes-gate-check.ts:113`<!--cita: ALVOS_VIVOS-->),
+`docs/visual-direction` e `docs/runbooks` (`scripts/docs-citacoes-gate-check.ts:130`<!--cita: ALVOS_VIVOS-->),
 e a skill não entra por nenhum dos dois lados: nem como doc varrido, nem pela âncora `<!--cita:-->` que
 resgata a citação do doc congelado. Medido em 2026-08-30 sabotando uma citação de
 `.claude/skills/lovable-deploy-verify/SKILL.md`: o gate passou com **exit 0 e sem mover o contador** —

--- a/docs/historico/gate-congelado-a-ancora-atravessa.md
+++ b/docs/historico/gate-congelado-a-ancora-atravessa.md
@@ -35,8 +35,8 @@ recusa.
 não se digita por acidente: é afirmação escrita à mão sobre o que está na linha HOJE. O corte por
 diretório protege o doc datado de ser *obrigado* a acompanhar a `main`; ele nunca teve razão para
 proteger quem se ofereceu. Regra nova: **toda citação ANCORADA é verificada, varrida a pasta ou
-não** — `scripts/docs-citacoes-gate-check.ts:236`<!--cita: export function apenasAncoradas-->,
-aplicada em `scripts/docs-citacoes-gate-check.ts:459`<!--cita: const ancoradas = apenasAncoradas-->.
+não** — `scripts/docs-citacoes-gate-check.ts:253`<!--cita: export function apenasAncoradas-->,
+aplicada em `scripts/docs-citacoes-gate-check.ts:476`<!--cita: const ancoradas = apenasAncoradas-->.
 Citação sem âncora em doc não varrido continua fora, e continua contada.
 
 Custo medido de ligar: **4 citações, todas já verdes. Zero conserto.** `docs/superpowers/` (453
@@ -50,7 +50,7 @@ Duas citações de `docs/historico/fase-sem-sinal.md` tinham âncora **correta**
 citação e âncora nunca via um `\n`. Em doc vivo isso vira o achado barulhento "não tem âncora"; em
 doc não varrido sumiria calado — e teria sumido calado **também sob a regra nova**, porque o filtro
 é `ancora !== null`. Consertar era pré-condição, não escopo extra:
-`scripts/docs-citacoes-gate-check.ts:199`<!--cita: const RE_ANCORA_SOLTA-->. A âncora só é adotada
+`scripts/docs-citacoes-gate-check.ts:216`<!--cita: const RE_ANCORA_SOLTA-->. A âncora só é adotada
 pela ÚLTIMA citação da linha e só se nada mais sobrar depois dela, senão seria atribuída a quem não
 é dona.
 

--- a/scripts/docs-citacoes-gate-check.ts
+++ b/scripts/docs-citacoes-gate-check.ts
@@ -109,8 +109,25 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import { removerCercas } from './lib/markdown-codigo';
 
-/** Docs VIVOS — os que precisam estar certos hoje. Congelados ficam fora (ver cabeçalho). */
-export const ALVOS_VIVOS = ['CLAUDE.md', 'docs/agent', 'docs/visual-direction', 'docs/runbooks'];
+/**
+ * Docs VIVOS — os que precisam estar certos hoje. Congelados ficam fora (ver cabeçalho).
+ *
+ * `.claude/skills` entrou em 2026-08-31, e é o alvo com a MELHOR razão custo/benefício da lista:
+ * ligar custou **zero** vermelho. A dívida que ele fecha foi medida no #2130 — citação em skill não
+ * era conferida por gate NENHUM, nem como doc varrido nem pela âncora que resgata o doc congelado —
+ * e a primeira varredura já cobrou o preço disso: a ÚNICA citação `arquivo:linha` que as 35 skills
+ * tinham apontava para linha VAZIA (`index.ts:74`, corrigida para :129 no #2137).
+ *
+ * Por que a régua do cabeçalho (que recusou `docs/historico/`) aprova esta pasta: lá o custo eram
+ * 131 vermelhos de FORMA para pegar 1 alvo sumido, sobre documento DATADO que não deve acompanhar a
+ * `main`. Skill é o oposto nos dois eixos — é instrução VIVA, que descreve o repo de hoje, e o que
+ * se copia dela é comando pronto. Citação podre ali não envelhece: ela mente na hora do uso.
+ *
+ * ⚠️ O que este gate NÃO cobre numa skill continua descoberto: ele lê `arquivo:linha`, não executa
+ * as cercas ```bash. Os dois defeitos do #2136 (um regex cego a `./` e uma afirmação de
+ * comportamento) passariam por aqui verdes.
+ */
+export const ALVOS_VIVOS = ['CLAUDE.md', 'docs/agent', 'docs/visual-direction', 'docs/runbooks', '.claude/skills'];
 
 /**
  * Artefatos DATADOS que moram dentro de pasta viva. Nominal e com motivo — a pasta é o default,


### PR DESCRIPTION
Fecha a dívida medida no [#2130](https://github.com/LucasSardenbergL/afiacao/pull/2130): citação em skill não era conferida por gate **nenhum** — nem como doc varrido, nem pela âncora que resgata o doc congelado.

**Custo de ligar, medido: zero vermelhos.** 30 citações verificadas, exit 0.

## Por que esta pasta passa na régua que recusou `docs/historico/`

O cabeçalho do gate registra que estender diretório congelado foi medido e recusado: 131 vermelhos de **forma** para pegar 1 alvo sumido, sobre documento **datado** que não deve acompanhar a `main`.

Skill é o oposto nos dois eixos — é instrução **viva**, que descreve o repo de hoje, e o que se copia dela é comando pronto. Citação podre numa skill não envelhece: **mente na hora do uso**. O [#2137](https://github.com/LucasSardenbergL/afiacao/pull/2137) provou com o único caso que existia (`index.ts:74` apontando para linha vazia).

## Falsificação nos dois sentidos

| cenário | resultado |
|---|---|
| escopo ligado + citação de skill sabotada | **exit 1**, nomeia arquivo, linha e conteúdo real |
| escopo revertido + **a mesma** sabotagem | **exit 0**, passa calada |

O segundo é o controle que importa: prova que o dente vem do escopo, não de outra coisa que eu tenha mexido junto.

## Custo colateral — e o gate o cobrou de mim na hora

O comentário que justifica a entrada tem 15 linhas e **deslocou 4 citações ancoradas** que apontam para este mesmo arquivo por número de linha (1 em `docs/agent/skills.md`, 3 em `docs/historico/gate-congelado-a-ancora-atravessa.md`). Atualizadas: 113→130, 236→253, 459→476, 199→216. Editar arquivo muito citado por linha tem esse preço, e quem o cobra é o próprio gate — que é o comportamento desejado.

## O que este gate NÃO cobre, escrito no código

Ele lê `arquivo:linha`; **não executa as cercas ```bash**. Os dois defeitos do [#2136](https://github.com/LucasSardenbergL/afiacao/pull/2136) — um regex cego a `./` e uma afirmação de comportamento — passariam por aqui verdes. Deixei isso explícito no comentário para ninguém ler este PR como "skills agora estão cobertas".

## Verificação

`docs:citacoes` exit 0 · 49 testes do gate · `typecheck` (app + scripts) · `lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)