### PR TITLE
fix(pendencias-deploy): a query só via a sonda ATIVA — o eco passivo, que é a via maior, era 100% invisível

### DIFF
--- a/db/test-pendencias-deploy-eco-passivo.sh
+++ b/db/test-pendencias-deploy-eco-passivo.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test-pendencias-deploy-eco-passivo.sh — prova, EXECUTANDO, que a query de `pendencias:deploy`
+# enxerga as DUAS vias pelas quais prod diz qual bundle está no ar: a sonda ATIVA (`probe:true`) e
+# o ECO PASSIVO (`edge`+`versao` presentes, `probe` ausente).
+#
+# POR QUE EXISTE: o filtro só aceitava `probe:true`. A `analytics-outbox-drain` respondia 72 vezes
+# por janela, com `fonte` idêntico ao mapa commitado, e saía classificada como "⚪ sem sonda na
+# janela (ausência de dado)" — cobertura 7/40, abaixo do piso, e um chip inteiro de verificação de
+# deploy sobre uma edge que já estava provada no ar. O #2103 nomeou o ponto cego em DOCS; o script
+# não acompanhou. Doc não filtra linha: só teste que RODA a query prova que ela filtra.
+#
+# O SQL não é copiado — é IMPORTADO de `scripts/pendencias-deploy.ts`. Uma cópia aqui viraria uma
+# segunda verdade, e a que não tem teste é a que decide errado.
+#
+# Uso:
+#   bash db/test-pendencias-deploy-eco-passivo.sh              # verde = as 2 vias contam
+#   bash db/test-pendencias-deploy-eco-passivo.sh --falsificar # sabota o SQL e EXIGE vermelho
+set -uo pipefail
+
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17; PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"; PORT=5439
+export LC_ALL=C LANG=C  # sem isto o postmaster morre com "became multithreaded during startup"
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pgtest-pend.XXXXXX")"
+DATA="$TMP/data"; SOCK="$TMP"
+# shellcheck disable=SC2329  # invocada pelo `trap` abaixo
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# ------------------------------------------------------- o SQL REAL, não uma cópia ---
+SQL_REAL="$TMP/real.sql"
+if ! (cd "$RAIZ" && bun -e 'import("./scripts/pendencias-deploy.ts").then((m)=>process.stdout.write(m.SQL))') > "$SQL_REAL" 2>"$TMP/import.err"; then
+  echo "VERMELHO — não importei o SQL de scripts/pendencias-deploy.ts:"; cut -c1-300 "$TMP/import.err"; exit 1
+fi
+# Sonda POSITIVA: import vazio/silencioso viraria suíte verde sobre query nenhuma.
+grep -q 'net._http_response' "$SQL_REAL" || { echo "VERMELHO — SQL importado não menciona net._http_response (export sumiu?)"; exit 1; }
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null 2>&1
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k $SOCK -c listen_addresses=" -l "$TMP/pg.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h "$SOCK" -U postgres pend_verify
+P() { "$PGBIN/psql" -p "$PORT" -h "$SOCK" -U postgres -d pend_verify "$@"; }
+
+SHA_OK="b03bbf880f09d2f08d3320def1f7d617506869d063ca0023af65292511c9fded"
+
+# ------------------------------------------------------------------- fixtures ---
+# Só o que a query toca: `net._http_response` com status_code/content/created. O schema real do
+# pg_net tem mais colunas, e nenhuma delas entra no predicado — arrastá-las aqui seria cenário
+# maior sem asserção maior.
+P -v ON_ERROR_STOP=1 -q <<SQL
+CREATE SCHEMA net;
+CREATE TABLE net._http_response (
+  id bigserial PRIMARY KEY, status_code int, content text, created timestamptz NOT NULL
+);
+INSERT INTO net._http_response (status_code, content, created) VALUES
+  -- (1) ECO PASSIVO: o caso que a query era cega. Sem 'probe', com edge+versao+fonte.
+  (200, '{"ok":true,"drenados":3,"versao":"v1.1-guard","edge":"eco-passivo","fonte":"$SHA_OK"}', '2026-09-04 10:00:00+00'),
+  -- (2) o MESMO eco, mais recente: 'julgar' pega a última, o SQL só precisa devolver as duas.
+  (200, '{"ok":true,"drenados":0,"versao":"v1.1-guard","edge":"eco-passivo","fonte":"$SHA_OK"}', '2026-09-04 10:05:00+00'),
+  -- (3) SONDA ATIVA: não pode regredir ao aceitar o eco.
+  (200, '{"ok":true,"probe":true,"versao":"v1.1-cota","edge":"sonda-ativa","fonte":"$SHA_OK"}', '2026-09-04 09:00:00+00'),
+  -- (4) eco SEM fonte: tem de CONTAR como observada e sair 'sem-campo' (vira DIVERGE na lib),
+  --     nunca sumir — versao certo com fonte ausente é o deploy incompleto da ARMADILHA 2.
+  (200, '{"ok":true,"versao":"v1.0","edge":"eco-sem-fonte"}', '2026-09-04 09:30:00+00'),
+  -- (5) JSON TRUNCADO que começa com '{': o guard textual tem de barrá-lo ANTES do cast. Sem
+  --     isso a query INTEIRA aborta e o cron devolve exit 2 por causa de uma linha alheia.
+  (200, '{"edge":"truncada","versao":"v9","fonte":"aaa', '2026-09-04 09:40:00+00'),
+  -- (6) não-200: resposta de erro não prova bundle no ar.
+  (500, '{"erro":"boom","versao":"v1.0","edge":"caiu","fonte":"$SHA_OK"}', '2026-09-04 09:50:00+00'),
+  -- (7) sem 'edge': 'versao' não identifica quem respondeu (o empate de 2026-08-18).
+  (200, '{"ok":true,"versao":"v1.0","fonte":"$SHA_OK"}', '2026-09-04 09:55:00+00'),
+  -- (8) 'probe' presente com valor que NÃO é true: shape que não emitimos → fica de fora.
+  (200, '{"probe":"talvez","versao":"v1.0","edge":"ambigua","fonte":"$SHA_OK"}', '2026-09-04 09:56:00+00'),
+  -- (9) corpo que nem começa com '{': o guard mais antigo, preservado.
+  (200, 'texto solto com "edge" e "versao" dentro', '2026-09-04 09:57:00+00');
+SQL
+
+# Sonda POSITIVA de mecânica, ANTES de qualquer asserção: servidor morto, schema ausente ou
+# fixture não semeada devolvem erro em TODA query — inclusive nas sabotadas. Sem este corte, a
+# falsificação veria vermelho em tudo e se declararia OK sem ter provado nada: o vermelho seria
+# do banco, não da sabotagem. Exige o NÚMERO, não "rodou sem erro" (ausência de dado != prova).
+SEMEADAS="$(P -tA -c 'SELECT count(*) FROM net._http_response' 2>/dev/null)"
+if [ "$SEMEADAS" != "9" ]; then
+  printf 'VERMELHO — MECANICA: esperava 9 fixtures em net._http_response, li "%s".\n' "${SEMEADAS:-<nada>}"
+  echo "  Isto nao e veredito sobre a query: e o banco de teste nao estar de pe."
+  cut -c1-200 "$TMP/pg.log" 2>/dev/null | tail -5
+  exit 2
+fi
+
+fail=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+
+# ---------------------------------------------------------------------- suíte ---
+# Roda o SQL em $ALVO no MESMO formato do script (`-A -F'|' -t`), então o que se assere é a saída
+# que `parsearObservacoes` vai receber de verdade.
+suite() {
+  local saida rc
+  # Mecânica de novo, agora POR RODADA: a suíte roda uma vez por sabotagem × locale, e um banco
+  # que caísse no meio transformaria "sabotagem detectada" em "psql não conectou" — a falsificação
+  # veria vermelho em tudo e se declararia OK sem ter provado nada.
+  if [ "$(P -tA -c 'SELECT 1' 2>/dev/null)" != "1" ]; then
+    printf 'MECANICA: psql nao respondeu SELECT 1 — abortando em vez de fabricar veredito\n' >&2
+    exit 2
+  fi
+
+  saida="$(P -v ON_ERROR_STOP=1 -A -F'|' -t -f "$ALVO" 2>&1)"; rc=$?
+
+  # (5) o guard: query que aborta não tem veredito nenhum, e é o modo de falha CARO.
+  if [ "$rc" -ne 0 ]; then
+    bad "a query ABORTOU (exit $rc) — corpo não-JSON derrubou a varredura inteira: $(printf '%s' "$saida" | head -1 | cut -c1-90)"
+    return
+  fi
+  ok "a query sobreviveu ao corpo truncado que começa com '{' (guard textual antes do cast)"
+
+  # A ASSERÇÃO CENTRAL. Sem ela o resto é decoração.
+  if printf '%s' "$saida" | grep -Fq 'eco-passivo|v1.1-guard|'"$SHA_OK"; then
+    ok "ECO PASSIVO conta como observada (edge+versao, 'probe' AUSENTE)"
+  else
+    bad "eco passivo NÃO voltou — é o bug do #2103: 72 respostas em prod lidas como 'ausência de dado'"
+  fi
+
+  if [ "$(printf '%s' "$saida" | grep -Fc 'eco-passivo|')" = "2" ]; then
+    ok "as DUAS respostas do mesmo eco voltam (julgar escolhe a mais recente)"
+  else
+    bad "esperava 2 linhas de eco-passivo, veio $(printf '%s' "$saida" | grep -Fc 'eco-passivo|')"
+  fi
+
+  if printf '%s' "$saida" | grep -Fq 'sonda-ativa|v1.1-cota|'"$SHA_OK"
+  then ok "SONDA ATIVA continua contando (aceitar o eco não regrediu a via antiga)"
+  else bad "sonda ativa sumiu — o fix quebrou a via que já funcionava"; fi
+
+  # O veredito julga o FONTE, não o versao: eco sem fingerprint precisa CHEGAR na lib marcado.
+  if printf '%s' "$saida" | grep -Fq 'eco-sem-fonte|v1.0|sem-campo'
+  then ok "eco sem 'fonte' volta como 'sem-campo' (vira DIVERGE, não some do relatório)"
+  else bad "eco sem 'fonte' não voltou como 'sem-campo' — deploy incompleto sairia invisível"; fi
+
+  # Contrato do parse: 4 campos não-vazios, senão `parsearObservacoes` conta como linha ignorada.
+  if [ -z "$(printf '%s' "$saida" | grep -v '^$' | awk -F'|' 'NF!=4 || $1=="" || $2=="" || $3=="" || $4==""')" ]; then
+    ok "toda linha tem os 4 campos não-vazios que parsearObservacoes exige"
+  else
+    bad "alguma linha não casa o contrato de 4 campos"
+  fi
+
+  local negativos=0
+  for proibido in 'caiu|' 'ambigua|' 'truncada|'; do
+    if printf '%s' "$saida" | grep -Fq "$proibido"; then
+      bad "voltou o que NÃO devia: $proibido"; negativos=1
+    fi
+  done
+  if [ "$negativos" -eq 0 ]; then ok "não-200, 'probe' ambíguo e corpo truncado ficam de fora"; fi
+}
+
+# ------------------------------------------------------------------- execução ---
+if [ "${1:-}" != "--falsificar" ]; then
+  printf '== pendencias:deploy — as 2 vias (sonda ativa + eco passivo) ==\n'
+  ALVO="$SQL_REAL"; suite
+  if [ "$fail" -eq 0 ]; then printf '\nECO PASSIVO OK\n'; exit 0; fi
+  printf '\nVERMELHO\n'; exit 1
+fi
+
+# ---------------------------------------------------------------- falsificação ---
+# Verde só vale se o vermelho for alcançável: cada sabotagem reintroduz um defeito REAL e exige
+# que a suíte reprove. Sabotagem que não casa o padrão deixa o alvo intacto e a suíte verde —
+# falsificação VAZIA, que é o teatro que este bloco existe para pegar; por isso o `cmp`.
+printf '== falsificacao (sabota o SQL e EXIGE vermelho) ==\n'
+falhou=0
+utf8=""
+for cand in pt_BR.UTF-8 pt_BR.utf8 en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+  if [ "$(LC_ALL="$cand" locale charmap 2>/dev/null)" = "UTF-8" ]; then utf8="$cand"; break; fi
+done
+[ -n "$utf8" ] || { printf '  \033[31mFALHA\033[0m nenhum locale UTF-8 — metade da cobertura fingindo ser inteira\n'; exit 1; }
+
+sabota() { # <descricao> <expressao-sed>
+  local desc="$1" expr="$2" copia="$TMP/sabotado.sql" erro
+  erro="$(sed -E "$expr" "$SQL_REAL" 2>&1 >"$copia")"
+  if [ -n "$erro" ]; then
+    printf '  \033[31mFALHA\033[0m "%s": sed invalido (%s) — falsificacao vazia\n' "$desc" "${erro:0:60}"; falhou=1; return
+  fi
+  if cmp -s "$SQL_REAL" "$copia"; then
+    printf '  \033[31mFALHA\033[0m "%s": padrao nao casou, SQL intacto — falsificacao vazia\n' "$desc"; falhou=1; return
+  fi
+  local viu_vermelho=0 loc
+  for loc in C "$utf8"; do
+    if ! ( export LC_ALL="$loc"; ALVO="$copia"; fail=0; suite >/dev/null 2>&1; [ "$fail" -eq 0 ] ); then
+      viu_vermelho=$((viu_vermelho + 1))
+    fi
+  done
+  if [ "$viu_vermelho" -eq 2 ]; then
+    printf '  \033[32mok\033[0m   "%s" -> suite vermelha nos 2 locales\n' "$desc"
+  else
+    printf '  \033[31mFALHA\033[0m "%s": suite ficou VERDE (%d/2 vermelhos) — assercao frouxa\n' "$desc" "$viu_vermelho"; falhou=1
+  fi
+}
+
+# (a) O BUG ORIGINAL, de volta: só a sonda ativa conta. É a sabotagem que dá sentido ao arquivo.
+sabota "o filtro volta a exigir probe:true (o bug do #2103)" \
+  "s/AND \(\(r\.c ->> 'probe'\) = 'true' OR NOT \(r\.c \? 'probe'\)\)/AND (r.c ->> 'probe') = 'true'/"
+# (b) A troca NULL-blind: `<> 'true'` parece equivalente e volta a perder a chave AUSENTE.
+sabota "eco aceito por <> 'true' (NULL-blind: chave ausente devolve NULL, nao TRUE)" \
+  "s/NOT \(r\.c \? 'probe'\)/(r.c ->> 'probe') <> 'true'/"
+# (c) O guard que EU adicionei precisa ser carga, não enfeite: sem ele o corpo truncado da linha
+#     (5) chega ao cast e derruba a query inteira — o modo de falha que o comentário promete evitar.
+sabota "sem o IS JSON OBJECT (corpo truncado chega ao cast)" \
+  "/AND content IS JSON OBJECT/d"
+# (d) O veredito tem de julgar o FONTE: sem o coalesce, eco sem fingerprint vira campo vazio e
+#     `parsearObservacoes` o descarta como linha ignorada — deploy incompleto sai invisível.
+sabota "sem o coalesce do fonte (eco sem fingerprint some do relatorio)" \
+  "s/coalesce\(r\.c ->> 'fonte', 'sem-campo'\)/r.c ->> 'fonte'/"
+
+if [ "$falhou" -eq 0 ]; then printf '\nFALSIFICACAO OK — todo verde tem vermelho alcancavel\n'; exit 0; fi
+printf '\nVERMELHO\n'; exit 1

--- a/docs/historico/fix-em-doc-nao-alcanca-a-ferramenta.md
+++ b/docs/historico/fix-em-doc-nao-alcanca-a-ferramenta.md
@@ -7,6 +7,13 @@
 
 ## O desfecho, primeiro
 
+> **Fechado em 2026-09-04:** o predicado mudou. `scripts/pendencias-deploy.ts` passou a aceitar as
+> DUAS vias (sonda ativa **ou** eco passivo), com prova que EXECUTA o SQL num PG17 local e
+> falsifica (`db/test-pendencias-deploy-eco-passivo.sh`). Na mesma janela de 6h a cobertura foi de
+> 2 para 3 edges e a `analytics-outbox-drain` virou `✅ confere`. Medições e o que a via nova
+> admite de novo: `sonda-eco-passivo-sem-colagem.md` §10.
+
+
 Chip pedia verificar se duas edges mergeadas entre 2026-08-29T01:00Z e 05:00Z chegaram a ser
 deployadas. **As duas estavam no ar, verbatim.** Nenhum deploy foi pedido ao founder.
 

--- a/docs/historico/sonda-eco-passivo-sem-colagem.md
+++ b/docs/historico/sonda-eco-passivo-sem-colagem.md
@@ -137,3 +137,55 @@ Esta é a variante em que a falsificação roda **concorrente** ao commit, e ela
   `git diff HEAD --stat` **vazio** — e reconfira `git status --porcelain` DEPOIS de cada suíte, para
   provar que nada mutou a árvore durante a corrida. Suíte verde sobre um working tree que diverge do
   commit é medição do artefato errado: a família "evidência positiva do objeto ERRADO".
+
+## 10. ⚠️ O ponto cego foi CORRIGIDO em doc e ficou de pé no código por 4 dias
+
+O #2103 nomeou este documento inteiro: "o filtro `probe` da §13.3 só via a sonda ATIVA — o eco
+passivo é a via maior, 4 → 8 edges". Foi um commit de **docs**. A query de
+`scripts/pendencias-deploy.ts` continuou exigindo `probe:true`.
+
+O custo veio em 2026-08-31 e de novo em 2026-09-04: a `analytics-outbox-drain` — cron de 5 em 5
+minutos, **72 respostas na janela**, `versao`/`edge`/`fonte` completos e `fonte` idêntico ao mapa
+commitado — saía classificada como `⚪ sem sonda na janela (ausência de dado)`. A cobertura caía
+abaixo do piso, o script devolvia exit 1, e nasceu um chip inteiro de verificação de deploy sobre
+uma edge que já estava provada no ar. O dado estava lá o tempo todo; quem estava cego era a query.
+
+A regra: **doc não filtra linha.** Quando o achado é sobre um PREDICADO — uma query, um gate, um
+`if` —, o resíduo durável é o predicado mudado com teste que falsifique; a nota é o acompanhamento,
+não a entrega. Um documento que descreve o próprio ponto cego e não o fecha deixa o instrumento
+exatamente tão cego quanto antes, e agora com a aparência de resolvido — que é pior, porque a
+próxima sessão lê o doc, reconhece o problema e segue em frente.
+
+Medido na correção (2026-09-04, mesma janela de 6h, `psql-ro`): a query antiga via **2** edges, a
+nova vê **3**; das 76 linhas com corpo de edge instrumentada, **72 eram eco passivo** e ~4 sonda
+ativa. E o teto estrutural é maior que o de uma janela: **6 das 40 edges do mapa** plantam
+`{...body, versao, edge, fonte}` em TODA resposta (`analytics-outbox-drain`, `omie-sync-sku-items`,
+`omie-sync-ctes-recebidos`, `omie-sync-nfes-recebidas`, `omie-sync-pedidos-compra`,
+`omie-sync-vendas-items`) e eram 100% invisíveis sem alguém lembrar de colar a sonda.
+
+### 10.1 ⚠️ A falsificação por `sed` no ARQUIVO acertou o COMENTÁRIO, e o guard aprovou
+
+Cometido nesta entrega. Para provar que o gate do vitest era carga, sabotei o SQL com
+
+```
+perl -0pi -e "s/NOT \(r\.c \? 'probe'\)/(r.c ->> 'probe') <> 'true'/" scripts/pendencias-deploy.ts
+```
+
+e o guard anti-falsificação-vazia (`git diff --quiet` → "o alvo mudou?") **passou**: o arquivo
+tinha mudado mesmo. Só que a primeira ocorrência daquele texto no arquivo não é o SQL — é o
+comentário que **cita o SQL** para explicar por que `<> 'true'` seria NULL-blind. O `perl` reescreveu
+a prosa e deixou a query intacta. A suíte ficou verde, e a leitura natural ("gate frouxo") estava
+errada: o gate nunca tinha sido testado.
+
+O que torna isto provável e não exótico é o estilo desta casa: os comentários **citam o código
+verbatim**, então todo padrão que casa a linha casa também o parágrafo que a descreve — e o
+parágrafo vem ANTES no arquivo.
+
+- **Sabote o ALVO EXTRAÍDO, não o arquivo que o contém.** É o que
+  `db/test-pendencias-deploy-eco-passivo.sh` faz: importa `SQL` do script para um `.sql` sem
+  comentário nenhum e sabota ali — imune por construção.
+- Quando a edição tiver de ser no arquivo, **ancore na região do código** (recorte entre
+  `export const SQL = \`` e `` `.trim(); ``) e **falhe se o padrão não casar DENTRO dela**.
+- **"O arquivo mudou" é guard fraco.** O guard forte é "**o alvo** mudou": `cmp` sobre o artefato
+  extraído, ou substituição ancorada que sai não-zero quando não casa. Família
+  `evidencia-positiva-shell.md`: sinal colhido do objeto errado.

--- a/docs/historico/sonda-eco-passivo-sem-colagem.md
+++ b/docs/historico/sonda-eco-passivo-sem-colagem.md
@@ -138,30 +138,48 @@ Esta é a variante em que a falsificação roda **concorrente** ao commit, e ela
   provar que nada mutou a árvore durante a corrida. Suíte verde sobre um working tree que diverge do
   commit é medição do artefato errado: a família "evidência positiva do objeto ERRADO".
 
-## 10. ⚠️ O ponto cego foi CORRIGIDO em doc e ficou de pé no código por 4 dias
+## 10. O predicado, enfim, mudou — e o que a correção mediu
 
-O #2103 nomeou este documento inteiro: "o filtro `probe` da §13.3 só via a sonda ATIVA — o eco
-passivo é a via maior, 4 → 8 edges". Foi um commit de **docs**. A query de
-`scripts/pendencias-deploy.ts` continuou exigindo `probe:true`.
+O diagnóstico desta cegueira está em [`fix-em-doc-nao-alcanca-a-ferramenta.md`](fix-em-doc-nao-alcanca-a-ferramenta.md)
+(#2148): o #2103 nomeou o ponto cego e corrigiu o **doc**, a query de `scripts/pendencias-deploy.ts`
+seguiu exigindo `probe:true`, e o intervalo custou um chip inteiro de verificação sobre edges já no
+ar. Esta seção registra só o **desfecho** — o predicado mudado — e o que ele mediu.
 
-O custo veio em 2026-08-31 e de novo em 2026-09-04: a `analytics-outbox-drain` — cron de 5 em 5
-minutos, **72 respostas na janela**, `versao`/`edge`/`fonte` completos e `fonte` idêntico ao mapa
-commitado — saía classificada como `⚪ sem sonda na janela (ausência de dado)`. A cobertura caía
-abaixo do piso, o script devolvia exit 1, e nasceu um chip inteiro de verificação de deploy sobre
-uma edge que já estava provada no ar. O dado estava lá o tempo todo; quem estava cego era a query.
+A query passou a aceitar as DUAS vias: `probe:true` **ou** (`edge`+`versao` presentes, `probe`
+ausente). Três detalhes que o teste prende:
 
-A regra: **doc não filtra linha.** Quando o achado é sobre um PREDICADO — uma query, um gate, um
-`if` —, o resíduo durável é o predicado mudado com teste que falsifique; a nota é o acompanhamento,
-não a entrega. Um documento que descreve o próprio ponto cego e não o fecha deixa o instrumento
-exatamente tão cego quanto antes, e agora com a aparência de resolvido — que é pior, porque a
-próxima sessão lê o doc, reconhece o problema e segue em frente.
+- **`NOT (c ? 'probe')`, não `(c ->> 'probe') <> 'true'`.** O `<>` é NULL-blind — chave ausente
+  devolve NULL, que não é TRUE, e a linha sumiria de novo. Seria o mesmo bug com cara de conserto.
+- **O guard textual antes do cast ficou mais ESTRITO, não menos.** Sem o `LIKE '%"probe"%'`, o que
+  chega ao `content::jsonb` passou de ~1 para ~76 linhas por janela; entraram o `LIKE '%"versao"%'`
+  e o `IS JSON OBJECT` (PG16+; prod é 17.6), que pega o corpo TRUNCADO que começa com `{` e que o
+  `left(ltrim(content),1)='{'` sozinho mandava direto para o cast — onde ele abortaria a varredura
+  inteira, e uma varredura que morre por causa de uma linha alheia não serve de cron.
+- **O veredito continua julgando o `fonte`, não o `versao`.** O `coalesce(…, 'sem-campo')` faz eco
+  sem fingerprint cair em DIVERGE em vez de sumir: `versao` certo com `fonte` errado é exatamente o
+  deploy incompleto da ARMADILHA 2.
 
-Medido na correção (2026-09-04, mesma janela de 6h, `psql-ro`): a query antiga via **2** edges, a
-nova vê **3**; das 76 linhas com corpo de edge instrumentada, **72 eram eco passivo** e ~4 sonda
-ativa. E o teto estrutural é maior que o de uma janela: **6 das 40 edges do mapa** plantam
-`{...body, versao, edge, fonte}` em TODA resposta (`analytics-outbox-drain`, `omie-sync-sku-items`,
-`omie-sync-ctes-recebidos`, `omie-sync-nfes-recebidas`, `omie-sync-pedidos-compra`,
-`omie-sync-vendas-items`) e eram 100% invisíveis sem alguém lembrar de colar a sonda.
+Medido em prod na correção (2026-09-04, mesma janela de 6h, `psql-ro`): a query antiga via **2**
+edges, a nova vê **3** — e a diferença é a `analytics-outbox-drain`, que passou de
+`⚪ sem sonda na janela` a `✅ confere`. Das 76 linhas com corpo de edge instrumentada, **72 eram
+eco passivo** e ~4 sonda ativa: em LINHAS o eco é 95% do sinal. O teto estrutural é maior que o de
+uma janela — **6 das 40 edges do mapa** plantam `{...body, versao, edge, fonte}` em TODA resposta
+(`analytics-outbox-drain`, `omie-sync-sku-items`, `omie-sync-ctes-recebidos`,
+`omie-sync-nfes-recebidas`, `omie-sync-pedidos-compra`, `omie-sync-vendas-items`) e eram 100%
+invisíveis sem alguém lembrar de colar a sonda; dessas, 2 têm cron `net.http_post` próprio, então
+caem na janela sozinhas.
+
+⚠️ **O que a via nova admite de novo:** o filtro deixou de ter a assinatura forte `probe:true` e
+passou a confiar em "tem `edge` e `versao`". Um corpo de terceiro com as duas chaves entraria como
+`🟠 FORA_DO_MAPA` — que é exit 1 com o nome na tela, ou seja, alto e diagnosticável, não silencioso.
+Na janela medida não havia nenhum. É o lado certo para errar num instrumento de deploy.
+
+A prova é `db/test-pendencias-deploy-eco-passivo.sh`: sobe um PG17 local, semeia 9 fixtures em
+`net._http_response` e roda **o SQL importado do script**, não uma cópia — cópia vira segunda
+verdade, e a que não tem teste é a que decide errado. `--falsificar` reintroduz o bug original,
+troca por `<> 'true'`, remove o `IS JSON OBJECT` e remove o `coalesce`, e exige vermelho nos dois
+locales. Como `db/test-*.sh` precisa de Postgres local e não roda no CI, o gate textual do vitest
+acompanha — ele não prova filtro (ninguém prova filtro lendo string), só torna a regressão ruidosa.
 
 ### 10.1 ⚠️ A falsificação por `sed` no ARQUIVO acertou o COMENTÁRIO, e o guard aprovou
 
@@ -184,8 +202,8 @@ parágrafo vem ANTES no arquivo.
 - **Sabote o ALVO EXTRAÍDO, não o arquivo que o contém.** É o que
   `db/test-pendencias-deploy-eco-passivo.sh` faz: importa `SQL` do script para um `.sql` sem
   comentário nenhum e sabota ali — imune por construção.
-- Quando a edição tiver de ser no arquivo, **ancore na região do código** (recorte entre
-  `export const SQL = \`` e `` `.trim(); ``) e **falhe se o padrão não casar DENTRO dela**.
+- Quando a edição tiver de ser no arquivo, **ancore na região do código** e **falhe se o padrão não
+  casar DENTRO dela**.
 - **"O arquivo mudou" é guard fraco.** O guard forte é "**o alvo** mudou": `cmp` sobre o artefato
   extraído, ou substituição ancorada que sai não-zero quando não casa. Família
   `evidencia-positiva-shell.md`: sinal colhido do objeto errado.

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -9,6 +9,7 @@ import {
   PISO_COBERTURA_PADRAO,
   SEM_MAPA,
 } from './lib/pendencias-deploy';
+import { SQL } from './pendencias-deploy';
 
 const MAPA = { 'edge-a': 'aaa111', 'edge-b': 'bbb222' };
 const obs2 = (edge: string, fonte: string) => ({
@@ -145,5 +146,64 @@ describe('piso de cobertura', () => {
         /PENDENCIAS_COBERTURA_MINIMA inválido/,
       );
     }
+  });
+});
+
+/**
+ * O SQL como TEXTO — o único gate desta correção que roda no CI.
+ *
+ * A prova de verdade é `db/test-pendencias-deploy-eco-passivo.sh`, que EXECUTA a query num PG17
+ * com fixtures e falsifica. Mas `db/test-*.sh` precisa de Postgres local e não roda no CI, então
+ * sozinha ela não impede alguém de reintroduzir o filtro `probe:true` num refactor. Estas
+ * asserções são o cão de guarda barato: leem a query como texto e casam a MARCA de cada ramo.
+ * Não substituem a execução — ninguém prova filtro lendo string —, só tornam a regressão ruidosa.
+ */
+describe('SQL da varredura — as duas vias', () => {
+  const semEspacos = SQL.replace(/\s+/g, ' ');
+
+  it('aceita o ECO PASSIVO: `probe` AUSENTE com edge+versao ainda conta', () => {
+    expect(semEspacos).toContain("NOT (r.c ? 'probe')");
+  });
+
+  it('não regrediu a SONDA ATIVA', () => {
+    expect(semEspacos).toContain("(r.c ->> 'probe') = 'true'");
+  });
+
+  it('NÃO exige mais `probe` no filtro textual — era ele que cegava o eco passivo', () => {
+    expect(semEspacos).not.toContain('LIKE \'%"probe"%\'');
+  });
+
+  it('a chave ausente NÃO é testada por `<> true` (NULL-blind reintroduziria o bug)', () => {
+    expect(semEspacos).not.toContain("(r.c ->> 'probe') <> 'true'");
+  });
+
+  it('o guard textual antes do cast continua, e mais estrito', () => {
+    expect(semEspacos).toContain("left(ltrim(content), 1) = '{'");
+    expect(semEspacos).toContain('content IS JSON OBJECT');
+    expect(semEspacos).toContain('LIKE \'%"edge"%\'');
+    expect(semEspacos).toContain('LIKE \'%"versao"%\'');
+  });
+
+  it('o veredito segue julgando o FONTE: sem o coalesce, eco sem fingerprint sumiria', () => {
+    expect(semEspacos).toContain("coalesce(r.c ->> 'fonte', 'sem-campo')");
+  });
+});
+
+describe('julgar — o eco passivo chega inteiro na lib', () => {
+  it('O CASO REAL: analytics-outbox-drain respondeu sem `probe` e é CONFERE, não NAO_OBSERVADA', () => {
+    // `fonte` batendo com o mapa: era isto que prod devolvia 72x/janela enquanto o relatório
+    // dizia "⚪ sem sonda na janela (ausência de dado)".
+    const rel = julgar({ 'analytics-outbox-drain': 'b03bbf88' }, [
+      obs('analytics-outbox-drain', 'b03bbf88', '2026-09-04 10:05:00+00', 'v1.1-guard'),
+    ]);
+    expect(rel.vereditos[0].estado).toBe('CONFERE');
+    expect(rel.totalObservadas).toBe(1);
+  });
+
+  it('eco SEM fonte vira `sem-campo` → DIVERGE, e ainda assim CONTA como observada', () => {
+    const rel = julgar({ 'edge-a': 'aaa111' }, [obs('edge-a', 'sem-campo')]);
+    expect(rel.vereditos[0].estado).toBe('DIVERGE');
+    expect(rel.totalObservadas).toBe(1);
+    expect(rel.totalDivergentes).toBe(1);
   });
 });

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -37,11 +37,38 @@ import { lerMapaCommitado } from './sonda-fingerprint';
 const PSQL_RO = process.env.PSQL_RO ?? join(homedir(), '.config', 'afiacao', 'psql-ro');
 
 /**
- * Só respostas de SONDA: `probe:true` + campo `edge`. O filtro textual roda ANTES do cast para
- * jsonb de propósito — corpo não-JSON no meio da janela abortaria a query inteira, e uma varredura
- * que morre por causa de uma linha alheia não serve de cron.
+ * As DUAS vias pelas quais prod já disse qual bundle está no ar.
+ *
+ * 1. SONDA ATIVA (`probe:true`): alguém colou o `sonda:sql` no SQL Editor e a edge respondeu o
+ *    corpo de `criarRespostaSonda`. Depende de um humano lembrar.
+ * 2. ECO PASSIVO (`edge`+`versao` presentes, `probe` AUSENTE): as edges cujo `jsonRes` planta
+ *    `versao`/`edge`/`fonte` em TODA resposta — não só na da sonda. O cron chama a edge pelo seu
+ *    próprio motivo, o corpo cai em `net._http_response`, e o marcador se lê de graça.
+ *
+ * A via 2 é a MAIOR, e era 100% invisível: o filtro antigo exigia `probe:true`, então a
+ * `analytics-outbox-drain` — cron de 5 em 5 minutos, 72 respostas na janela, `fonte` batendo com o
+ * mapa commitado — saía como "⚪ sem sonda na janela (ausência de dado)". O dado estava lá o tempo
+ * todo; quem estava cego era a query. Medido em 2026-08-31 (7/40) e de novo em 2026-09-04, onde a
+ * cobertura ia de 1 para 2 edges só por aceitar o eco. O #2103 já tinha nomeado isto — em DOCS; o
+ * script nunca acompanhou, e um diagnóstico que documenta o próprio ponto cego continua cego.
+ *
+ * `NOT (r.c ? 'probe')` e não `(r.c ->> 'probe') <> 'true'`: o `<>` é NULL-blind (chave ausente
+ * devolve NULL, que não é TRUE, e a linha sumiria de novo — exatamente o bug). O `?` devolve
+ * booleano sempre. `probe` presente com valor que não é `true` fica DE FORA de propósito: é forma
+ * que não emitimos, e admitir shape desconhecido no instrumento de deploy é fail-OPEN.
+ *
+ * O filtro textual continua ANTES do cast para jsonb: corpo não-JSON no meio da janela abortaria a
+ * query inteira, e uma varredura que morre por causa de uma linha alheia não serve de cron. Ele
+ * ficou mais ESTRITO, não menos — sem o `LIKE '%"probe"%'`, o que chega ao cast passou de ~1 para
+ * ~76 linhas por janela, então entram o `LIKE '%"versao"%'` (que o predicado externo exige de todo
+ * jeito) e o `IS JSON OBJECT` do PG16+ (prod é 17.6), que pega o corpo truncado que começa com `{`
+ * e que o `left(...)` sozinho deixava passar direto para o cast.
+ *
+ * O veredito continua julgando o `fonte`, não o `versao`: o `coalesce(..., 'sem-campo')` faz eco
+ * sem fingerprint cair em DIVERGE em vez de sumir — e `versao` certo com `fonte` errado é
+ * exatamente o deploy incompleto que a ARMADILHA 2 da lib descreve.
  */
-const SQL = `
+export const SQL = `
 SELECT r.c ->> 'edge', r.c ->> 'versao', coalesce(r.c ->> 'fonte', 'sem-campo'), r.created
 FROM (
   SELECT (content::jsonb) AS c, created
@@ -49,10 +76,12 @@ FROM (
   WHERE status_code = 200
     AND content IS NOT NULL
     AND left(ltrim(content), 1) = '{'
-    AND content LIKE '%"probe"%'
+    AND content IS JSON OBJECT
     AND content LIKE '%"edge"%'
+    AND content LIKE '%"versao"%'
 ) r
-WHERE r.c ? 'edge' AND r.c ? 'versao' AND (r.c ->> 'probe') = 'true'
+WHERE r.c ? 'edge' AND r.c ? 'versao'
+  AND ((r.c ->> 'probe') = 'true' OR NOT (r.c ? 'probe'))
 ORDER BY r.created DESC;
 `.trim();
 


### PR DESCRIPTION
## O que estava errado

`scripts/pendencias-deploy.ts` filtrava por `(r.c ->> 'probe') = 'true'`. Mas o `jsonRes` da
`analytics-outbox-drain` planta `versao`/`edge`/`fonte` em **toda** resposta, não só na da sonda —
e o cron bate nela de 5 em 5 minutos. Resultado: **72 respostas por janela**, com `fonte` idêntico
ao mapa commitado, classificadas como `⚪ sem sonda na janela (ausência de dado)`. A cobertura caía
abaixo do piso, o script devolvia exit 1, e nasceu um chip inteiro de verificação de deploy sobre
uma edge que já estava provada no ar.

O #2103 e o #2148 já tinham nomeado este ponto cego. Os dois foram commits de **docs** — a query
nunca mudou. Doc não filtra linha.

## O que mudou

A query aceita as DUAS vias: `probe:true` **ou** (`edge`+`versao` presentes, `probe` ausente).

- **`NOT (c ? 'probe')`, não `(c ->> 'probe') <> 'true'`** — o `<>` é NULL-blind: chave ausente
  devolve NULL, que não é TRUE, e a linha sumiria de novo. Seria o mesmo bug com cara de conserto.
- **O guard textual antes do cast ficou mais ESTRITO, não menos.** Sem o `LIKE '%"probe"%'` o que
  chega ao `content::jsonb` passou de ~1 para ~76 linhas/janela, então entraram o
  `LIKE '%"versao"%'` e o `IS JSON OBJECT` (PG16+; prod é 17.6), que pega o corpo **truncado** que
  começa com `{` e que o `left(ltrim(content),1)='{'` sozinho mandava direto ao cast — onde
  abortaria a varredura inteira.
- **O veredito continua julgando o `fonte`, não o `versao`:** o `coalesce(…, 'sem-campo')` faz eco
  sem fingerprint cair em DIVERGE em vez de sumir do relatório.

## Medido em prod (`psql-ro`, janela de 6h, 2026-09-04)

| | antes | depois |
|---|---|---|
| edges observadas (mesma janela) | 2 | **3** |
| `analytics-outbox-drain` | `⚪ sem sonda na janela` | **`✅ confere`** |

Das 76 linhas com corpo de edge instrumentada, **72 eram eco passivo** e ~4 sonda ativa — em linhas,
o eco é 95% do sinal. O teto estrutural é maior que o de uma janela: **6 das 40 edges do mapa**
plantam `{...body, versao, edge, fonte}` em toda resposta e eram 100% invisíveis sem alguém lembrar
de colar a sonda (`analytics-outbox-drain`, `omie-sync-sku-items`, `omie-sync-ctes-recebidos`,
`omie-sync-nfes-recebidas`, `omie-sync-pedidos-compra`, `omie-sync-vendas-items`); dessas, 2 têm
cron `net.http_post` próprio e caem na janela sozinhas.

⚠️ **O que a via nova admite de novo:** o filtro deixou de ter a assinatura forte `probe:true`.
Um corpo de terceiro com `edge`+`versao` entraria como `🟠 FORA_DO_MAPA` — exit 1 com o nome na
tela, alto e diagnosticável, não silencioso. Na janela medida não havia nenhum.

## Provas

- **`db/test-pendencias-deploy-eco-passivo.sh`** — sobe um PG17 local, semeia 9 fixtures em
  `net._http_response` e roda **o SQL importado do script**, não uma cópia (cópia vira segunda
  verdade, e a que não tem teste é a que decide errado). Tem sonda POSITIVA de mecânica antes e
  dentro da suíte: banco morto aborta com exit 2 em vez de virar "a query abortou" — sem isso a
  falsificação veria vermelho em tudo e se declararia OK sem provar nada.
- **`--falsificar`** reintroduz o bug original, troca por `<> 'true'`, remove o `IS JSON OBJECT` e
  remove o `coalesce` → **4/4 vermelhos nos dois locales**.
- **Gate textual no vitest** (`db/test-*.sh` precisa de Postgres local e não roda no CI) —
  falsificado à parte, **5/5 vermelhos**.

Verde local: `test` 751 arquivos / 7572 testes · `typecheck` · `lint` · `shellcheck` ·
`docs:{citacoes,indice,links}` · `claude:size` · `sonda:{bump,fingerprint,nova}` · `knip` ·
`test:falsificacao` · `mutcheck` — todos exit 0.

## Resíduo

`docs/historico/sonda-eco-passivo-sem-colagem.md` §10 (desfecho + medições + o que a via nova
admite) e **§10.1**, que é lição nova: a falsificação por `sed` no ARQUIVO acertou o **comentário**
que cita o SQL verbatim, e o guard `git diff --quiet` aprovou — "o arquivo mudou" é guard fraco, o
forte é "o **alvo** mudou". Provável nesta casa justamente porque os comentários citam o código
verbatim, e o parágrafo vem antes no arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)