### PR TITLE
docs(skill): o critério do `--caro` é o EFEITO medido, não a FORMA do handler

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -554,6 +554,46 @@ Passo 4b** — o maior sinal sem o founder continua sendo este, pelos bytes.
     Depois leia pelos ids devolvidos (`WHERE id IN (…)`, nunca `ORDER BY id DESC`), exigindo os
     **três**: `versao` da main, `fonte` idêntico ao `sonda-fingerprints.ts` (é ele que prova que o
     `_shared/` subiu junto, não só o `index.ts`) e o eco `probe:true`.
+  - 💰 **QUEM entra no `--caro` — o critério é o EFEITO, não a FORMA do handler (2026-09-05).** A
+    trava existe porque o bundle **PRÉ-sensor ignora o `{"probe":true}` e roda o fluxo real**;
+    `bun run sonda:sql <edges> --caro=<subconjunto>` separa as caras num bloco com trava por `CASE`,
+    mas por **default trata TODAS como baratas** — o subconjunto é decisão sua, e ela erra silenciosa
+    nos dois sentidos (de menos = pedido criado no Omie à toa; de mais = trava que o founder destrava
+    no braço sem precisar). Decida em duas metades, **MEDINDO cada uma**:
+    1. **A edge ESCREVE ou chama serviço externo no fluxo real?** Uma linha faz a triagem:
+       ```bash
+       grep -nE '\.(upsert|insert|update|delete)\(|\.rpc\(|fetch\(' supabase/functions/<edge>/index.ts
+       ```
+       **Zero efeito ⇒ BARATA**, qualquer que seja a forma do handler. Mas o grep é TRIAGEM, não
+       veredito — contagem 0 só vira resposta depois de **LER** os hits, porque dois deles mentem:
+       (a) `fetch(` de **GET de leitura** (`/auth/v1/user`, `?select=…`) é gate de auth, não efeito;
+       (b) **`.delete(` casa com `Set.delete` do JS**, que não toca banco nenhum. Foi assim que a
+       `fin-valor-cockpit` (738 linhas) se provou BARATA: zero `.upsert/.insert/.update/.rpc`, os
+       três `fetch` são GETs de `/auth/v1/user` + `user_roles` + `commercial_roles`, e o único
+       `.delete(` é
+       `supabase/functions/fin-valor-cockpit/index.ts:564`<!--cita: custoBaixaConfianca.delete(-->,
+       um `Set` de JS. Pior caso de sondá-la com bundle pré-sensor: **computar e devolver** — NULO.
+    2. **Se escreve: o efeito é REVERSÍVEL, e qual o ALCANCE?** "Cara" não é binário, e o que a trava
+       compra varia em ordens de grandeza. `carteira-positivacao-snapshot` faz **UM upsert
+       idempotente** por
+       `supabase/functions/carteira-positivacao-snapshot/index.ts:104`<!--cita: onConflict: 'mes,customer_user_id'-->,
+       sem chamada externa, e o cron dela é **MENSAL** (`jobid` 80, `0 8 1 * *`) ⇒ disparar fora de
+       hora custa **uma linha parcial do mês corrente que o próximo tick reescreve**. Já
+       `omie-sync-pedidos-compra` escreve em vários pontos, publica por RPC e **dispara sync real de
+       pedidos de compra no Omie** (`fetch` com `method: "POST"`) — outra ordem de grandeza. As duas
+       merecem o `--caro`; só a segunda justifica **adiar a sonda** até depois do deploy em vez de só
+       travar o bloco.
+    ⛔ **PROXY REPROVADO: "a edge despacha por `body.action`?" (medido e descartado 2026-09-05).** O
+    raciocínio era — se despacha e o `default:` recusa, `{"probe":true}` sem `action` é inócuo; se
+    não despacha, roda o fluxo único ⇒ cara. A metade POSITIVA continua valendo, e os três `default:`
+    que medi de fato recusam (`omie-analytics-sync` e `sync-reprocess` devolvem 400 "Ação
+    desconhecida", `omie-vendas-sync` faz `throw`). **É a AUSÊNCIA de dispatch que não prova o
+    contrário** — `ausente ≠ zero` aplicado à FORMA do handler: `fin-valor-cockpit` não tem `switch`
+    nenhum, e mesmo assim não escreve nada. O proxy a marcou cara; medir o efeito a devolveu barata.
+    Forma é preditor, efeito é prova. Guardado por `evals/criterio-caro-eval.sh`, que **EXECUTA** o
+    grep acima — extraído desta própria seção, fail-CLOSED se sumir — contra as três edges e exige a
+    classificação de volta: o `docs:citacoes` prova que a LINHA citada existe, só o eval prova que
+    ela ainda **diz aquilo**, e é o que impede o exemplo de apodrecer no repo vivo.
   - **N3 PASSIVO — a FORMA do JSON prova a versão quando a edge JÁ é chamada por cron (2026-08-26).**
     Dispensa as duas dependências acima (founder logado / cron secret): `net._http_response` retém o
     **corpo** da resposta que o cron já produziu. Se as duas versões do código retornam objetos com

--- a/.claude/skills/lovable-deploy-verify/evals/criterio-caro-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/criterio-caro-eval.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# criterio-caro-eval.sh — o critério MEDIDO do `--caro` do `bun run sonda:sql` (escada de edge).
+#
+# O QUE ESTE EVAL GUARDA. `--caro` põe a edge atrás de uma trava por CASE porque um bundle
+# PRÉ-sensor ignora o `{"probe":true}` e roda o fluxo real. Decidir QUEM entra na trava por um
+# proxy de FORMA ("a edge despacha por `body.action`?") reprovou em 2026-09-05: marcou
+# `fin-valor-cockpit` como cara, e ela não escreve NADA. O critério é o EFEITO, e a SKILL.md o
+# documenta como um `grep`. Este eval EXECUTA aquele grep — o extraído da própria SKILL.md, não
+# uma cópia — contra as três edges que ela cita, e exige a classificação de volta.
+#
+# Ele morde em dois eixos que nenhum outro gate cobre:
+#   (a) o recipe some/afrouxa na SKILL.md      -> extração fail-CLOSED, exit vermelho;
+#   (b) o exemplo APODRECE no repo vivo        -> `fin-valor-cockpit` ganha um `.upsert(` num PR
+#       futuro e a skill passa a ensinar "não escreve nada" sobre código que escreve. O gate
+#       `docs:citacoes` confere que a LINHA existe; só este confere que ela ainda diz aquilo.
+#
+# Exit 0 = tudo passou · 1 = divergência · 2 = via de prova não observável (fail-CLOSED).
+# --falsify: sabota cada asserção UMA POR VEZ e exige vermelho. Sabotagem que vira NO-OP (o alvo
+#   sumiu do arquivo) é CEGUEIRA, não aprovação — conta como falha, igual às MUTACOES do run.sh.
+set -uo pipefail
+cd "$(dirname "$0")" || exit 2
+
+RAIZ_REAL="$(cd ../../../.. && pwd)" || exit 2
+SKILL_REAL="$(cd .. && pwd)/SKILL.md"
+
+BARATA="fin-valor-cockpit"
+REVERSIVEL="carteira-positivacao-snapshot"
+CARA="omie-sync-pedidos-compra"
+
+# Globais que a suíte lê; --falsify os re-aponta para um sandbox sabotado.
+RAIZ="$RAIZ_REAL"
+SKILL="$SKILL_REAL"
+
+FALSIFY=0
+[ "${1:-}" = "--falsify" ] && FALSIFY=1
+
+# --- via de prova: sem ela o eval RECUSA, nunca aprova em silêncio -----------------------------
+[ -f "$SKILL_REAL" ] || { echo "❌ via não observável: SKILL.md ausente ($SKILL_REAL)"; exit 2; }
+for e in "$BARATA" "$REVERSIVEL" "$CARA"; do
+  [ -f "$RAIZ_REAL/supabase/functions/$e/index.ts" ] || {
+    echo "❌ via não observável: supabase/functions/$e/index.ts ausente"; exit 2; }
+done
+
+idx() { printf '%s/supabase/functions/%s/index.ts' "$RAIZ" "$1"; }
+conta() { grep -cE "$1" "$2" 2>/dev/null || true; }
+
+# Extrai o recipe DOCUMENTADO. Fail-CLOSED nos dois lados: zero ocorrências (alguém apagou o
+# bloco) e duas ou mais (ambíguo — o eval não escolhe qual é o critério) recusam igual.
+extrair_recipe() {
+  local achados n
+  achados=$(grep -oE "grep -nE '[^']+'" "$SKILL" 2>/dev/null | grep -F 'upsert' || true)
+  n=$(printf '%s\n' "$achados" | grep -c . || true)
+  [ "$n" -eq 1 ] || return 1
+  printf '%s' "$achados" | sed -E "s/^grep -nE '//; s/'\$//"
+}
+
+# --- a suíte -----------------------------------------------------------------------------------
+f=0
+reg() { if [ "$2" -eq 0 ]; then echo "  [ok ] $1"; else echo "  [XX ] $1"; f=$((f + 1)); fi; }
+
+rodar_suite() {
+  f=0
+  local recipe n linha
+  local fb fr fc
+  fb=$(idx "$BARATA"); fr=$(idx "$REVERSIVEL"); fc=$(idx "$CARA")
+
+  if ! recipe=$(extrair_recipe); then
+    reg "recipe do critério extraível da SKILL.md (1 e só 1 ocorrência)" 1
+    return "$f"   # fail-CLOSED: sem o critério documentado não há o que verificar
+  fi
+  reg "recipe do critério extraível da SKILL.md (1 e só 1 ocorrência)" 0
+
+  # CONTROLE POSITIVO: o recipe da skill tem de ACHAR algo na edge barata. Um regex que não casa
+  # nada devolveria "zero efeito" para qualquer edge do repo — aprovação por cegueira.
+  n=$(conta "$recipe" "$fb")
+  reg "controle positivo: o recipe acha $n hit(s) em $BARATA (>0)" "$([ "$n" -gt 0 ] && echo 0 || echo 1)"
+
+  # (1) BARATA — zero escrita de banco. `delete` fica FORA deste padrão de propósito: é o
+  #     ambíguo, julgado no check (2).
+  n=$(conta '\.(upsert|insert|update)\(|\.rpc\(' "$fb")
+  reg "$BARATA: zero escrita de banco (upsert/insert/update/rpc = $n)" "$([ "$n" -eq 0 ] && echo 0 || echo 1)"
+
+  # (2) BARATA — o `.delete(` que o recipe acha é `Set.delete` de JS, não do banco. É a armadilha
+  #     que fez o critério parecer "escreve": contar o hit sem LER a linha inverte o veredito.
+  n=$(conta '\.delete\(' "$fb")
+  linha=$(grep -nE '\.delete\(' "$fb" 2>/dev/null | grep -cE 'custoBaixaConfianca\.delete\(' || true)
+  reg "$BARATA: o(s) $n \`.delete(\` são Set.delete de JS ($linha casam a coleção JS)" \
+    "$([ "$n" -ge 1 ] && [ "$linha" -eq "$n" ] && echo 0 || echo 1)"
+  n=$(conta 'const custoBaixaConfianca = new Set' "$fb")
+  reg "$BARATA: \`custoBaixaConfianca\` é mesmo um \`new Set\` (e não um client)" \
+    "$([ "$n" -ge 1 ] && echo 0 || echo 1)"
+
+  # (3) BARATA — todo `fetch(` é GET de leitura. Nenhum call site declara `method:`, e o arquivo
+  #     não tem verbo de escrita em lugar nenhum.
+  n=$(grep -E 'fetch\(' "$fb" 2>/dev/null | grep -c 'method' || true)
+  reg "$BARATA: nenhum call site de fetch( declara method: ($n)" "$([ "$n" -eq 0 ] && echo 0 || echo 1)"
+  n=$(conta 'method: *"(POST|PUT|PATCH|DELETE)"' "$fb")
+  reg "$BARATA: zero verbo HTTP de escrita no arquivo ($n)" "$([ "$n" -eq 0 ] && echo 0 || echo 1)"
+
+  # (4) O PROXY REPROVADO ainda erraria — é isto que mantém o contra-exemplo honesto. Se um dia
+  #     `fin-valor-cockpit` ganhar dispatch por action, os dois critérios passam a concordar e a
+  #     lição perde o dente: melhor descobrir aqui do que num deploy.
+  n=$(conta 'switch *\(|body\.action' "$fb")
+  reg "$BARATA NÃO despacha por action ($n) ⇒ o proxy reprovado a chamaria de cara" \
+    "$([ "$n" -eq 0 ] && echo 0 || echo 1)"
+
+  # (5) REVERSÍVEL — uma escrita só, idempotente por onConflict, e nenhuma chamada externa.
+  n=$(conta '\.(upsert|insert|update)\(|\.rpc\(' "$fr")
+  linha=$(grep -cE '\.upsert\(.*onConflict|onConflict' "$fr" 2>/dev/null || true)
+  reg "$REVERSIVEL: exatamente 1 escrita ($n) e ela é upsert com onConflict ($linha)" \
+    "$([ "$n" -eq 1 ] && [ "$linha" -ge 1 ] && echo 0 || echo 1)"
+  n=$(conta 'fetch\(' "$fr")
+  reg "$REVERSIVEL: zero chamada a serviço externo ($n)" "$([ "$n" -eq 0 ] && echo 0 || echo 1)"
+
+  # (6) CARA de verdade — o contraste. Escreve E dispara POST externo.
+  n=$(conta '\.(upsert|insert|update)\(|\.rpc\(' "$fc")
+  linha=$(conta 'method: *"POST"' "$fc")
+  reg "$CARA: escreve ($n) E dispara POST externo ($linha)" \
+    "$([ "$n" -ge 1 ] && [ "$linha" -ge 1 ] && echo 0 || echo 1)"
+
+  # (7) O proxy reprovado está REGISTRADO — apagar a lição é regressão, não faxina.
+  n=$(grep -cF 'PROXY REPROVADO' "$SKILL" 2>/dev/null || true)
+  reg "SKILL.md registra o PROXY REPROVADO ($n)" "$([ "$n" -ge 1 ] && echo 0 || echo 1)"
+
+  return "$f"
+}
+
+# --- sandbox para a falsificação ----------------------------------------------------------------
+preparar_sandbox() {
+  local dest="$1" e
+  for e in "$BARATA" "$REVERSIVEL" "$CARA"; do
+    mkdir -p "$dest/supabase/functions/$e"
+    cp "$RAIZ_REAL/supabase/functions/$e/index.ts" "$dest/supabase/functions/$e/index.ts"
+  done
+  cp "$SKILL_REAL" "$dest/SKILL.md"
+}
+
+if [ "$FALSIFY" = 0 ]; then
+  echo "  critério --caro (efeito medido, não forma do handler)"
+  rodar_suite
+  rc=$?
+  if [ "$rc" -eq 0 ]; then echo "  ✅ criterio-caro: OK"; else echo "  ❌ criterio-caro: $rc divergência(s)"; fi
+  exit "$((rc > 0 ? 1 : 0))"
+fi
+
+# Cada sabotagem: (nome | arquivo-alvo | string procurada | substituta). Alvo ausente = NO-OP,
+# que é cegueira: o eval estaria passando por acidente naquele eixo.
+cegas=0
+sabotar() {
+  local nome="$1" alvo="$2" de="$3" para="$4" td
+  td=$(mktemp -d) || { echo "  [XX ] mktemp falhou"; cegas=$((cegas + 1)); return; }
+  preparar_sandbox "$td"
+  local arquivo="$td/$alvo"
+  if ! grep -qF "$de" "$arquivo"; then
+    echo "  [XX ] sabotagem NO-OP (alvo sumiu de $alvo): $nome"
+    cegas=$((cegas + 1)); rm -rf "$td"; return
+  fi
+  # Índice LITERAL: `sed` leria `.`/`(`/`"` do alvo como regex. E os literais entram pelo ENVIRON,
+  # nunca por `-v`: `awk -v x='\.'` processa a sequência de escape e entrega `.` — foi assim que a
+  # 1ª sabotagem virou NO-OP silencioso (o alvo casava no `grep -F`, e não no `index()` do awk).
+  cp "$arquivo" "$arquivo.orig"
+  de="$de" para="$para" awk 'BEGIN{de=ENVIRON["de"]; para=ENVIRON["para"]}
+    { i=index($0,de); if(i>0) $0=substr($0,1,i-1) para substr($0,i+length(de)); print }' \
+    "$arquivo" > "$arquivo.novo" && mv "$arquivo.novo" "$arquivo"
+  # PÓS-CONDIÇÃO: o `grep -F` acima diz que o alvo EXISTE; só a comparação diz que a sabotagem
+  # PEGOU. Sem ela, qualquer divergência futura entre as duas mecânicas volta a passar batido —
+  # ausência de mudança não é sabotagem aplicada.
+  if cmp -s "$arquivo" "$arquivo.orig"; then
+    echo "  [XX ] sabotagem NÃO ALTEROU o arquivo (NO-OP silencioso): $nome"
+    cegas=$((cegas + 1)); rm -rf "$td"; return
+  fi
+  RAIZ="$td"; SKILL="$td/SKILL.md"
+  local saida
+  saida=$(rodar_suite); local rc=$?
+  RAIZ="$RAIZ_REAL"; SKILL="$SKILL_REAL"
+  if [ "$rc" -gt 0 ]; then
+    echo "  [ok ] pega ($rc asserção(ões) vermelha(s)): $nome"
+  else
+    echo "  [XX ] passou despercebida: $nome"
+    printf '%s\n' "$saida" | sed 's/^/        /'
+    cegas=$((cegas + 1))
+  fi
+  rm -rf "$td"
+}
+
+echo "  falsificação do critério --caro (sabota e exige vermelho)"
+sabotar "recipe apagado da SKILL.md" "SKILL.md" \
+  "grep -nE '\\.(upsert|insert|update|delete)\\(|\\.rpc\\(|fetch\\('" "grep -n 'nada'"
+sabotar "lição do proxy reprovado apagada" "SKILL.md" "PROXY REPROVADO" "proxy antigo"
+sabotar "$BARATA ganha escrita de banco" "supabase/functions/$BARATA/index.ts" \
+  'const custoBaixaConfianca = new Set' 'await supabase.from("x").upsert({}); const custoBaixaConfianca = new Set'
+sabotar "o Set.delete de $BARATA vira delete de BANCO" "supabase/functions/$BARATA/index.ts" \
+  'custoBaixaConfianca.delete(' 'supabase.from("custos").delete('
+sabotar "$BARATA passa a mandar POST" "supabase/functions/$BARATA/index.ts" \
+  '/auth/v1/user`, { headers' '/auth/v1/user`, { method: "POST", headers'
+sabotar "$BARATA passa a despachar por action" "supabase/functions/$BARATA/index.ts" \
+  'if (req.method === "OPTIONS")' 'switch (body.action) { default: break; } if (req.method === "OPTIONS")'
+sabotar "upsert de $REVERSIVEL perde o onConflict" "supabase/functions/$REVERSIVEL/index.ts" \
+  "onConflict: 'mes,customer_user_id'" "ignoreDuplicates: false"
+sabotar "$CARA deixa de chamar o Omie" "supabase/functions/$CARA/index.ts" \
+  'method: "POST"' 'method_: "POST"'
+
+echo "  --falsify: $cegas cegueira(s) (esperado: 0)"
+[ "$cegas" -eq 0 ]

--- a/.claude/skills/lovable-deploy-verify/evals/run.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/run.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# run.sh — GATE de regressão da skill lovable-deploy-verify. Roda os DOIS evals:
+# run.sh — GATE de regressão da skill lovable-deploy-verify. Roda os SEIS evals:
 #   (1) classify        — classificação de diff do Passo 1 (classify.sh vs classify-eval.json)
 #   (2) verify-frontend — enumeração + exit codes do Passo 4 (harness local determinístico)
 #   (3) verify-edge-eco  — guard TEMPORAL do N3 passivo (só ticks pré-merge ⇒ indeterminado)
 #   (4) verify-edge-escrita — N3 passivo por escrita de aplicação
 #   (5) sonda-veredito-401  — guard de CREDENCIAL do SQL de sondagem (401 é ambíguo; EXECUTA o SQL)
+#   (6) criterio-caro      — critério MEDIDO do `--caro` (efeito, não forma do handler)
 # Exit 0 = tudo passou. Exit 1 = alguma divergência.
-# Falsificação (prova que os evals têm dente): --falsify sabota AMBOS e exige vermelho
+# Falsificação (prova que os evals têm dente): --falsify sabota TODOS e exige vermelho
 #   (classify sabota o gabarito UMA CHAVE POR VEZ e depois muta o classify.sh real; verify-frontend
 #   sabota a enumeração; verify-edge-eco arranca o guard temporal, o fail-closed do ping e o filtro
-#   do tick mais recente). Exit 0 só se pegou tudo.
+#   do tick mais recente; criterio-caro sabota SKILL.md e as três edges-exemplo, uma por vez).
+#   Exit 0 só se pegou tudo.
 set -uo pipefail
 cd "$(dirname "$0")" || exit 2
 
@@ -160,6 +162,17 @@ if [ "$FALSIFY" = 1 ]; then
   bash sonda-veredito-401-eval.sh --falsify || rc=1
 else
   bash sonda-veredito-401-eval.sh || rc=1
+fi
+
+echo ""
+# (6) Prosa que cita CÓDIGO VIVO apodrece calada: o `docs:citacoes` prova que a linha citada
+# existe, e mais nada. Este eval EXECUTA o grep do critério — extraído da própria SKILL.md,
+# fail-CLOSED se sumir — contra as três edges que ela classifica, e exige o veredito de volta.
+echo "== (6) criterio-caro — quem entra no --caro: efeito medido, não forma do handler =="
+if [ "$FALSIFY" = 1 ]; then
+  bash criterio-caro-eval.sh --falsify || rc=1
+else
+  bash criterio-caro-eval.sh || rc=1
 fi
 
 echo ""


### PR DESCRIPTION
## O defeito

`bun run sonda:sql <edges> --caro=<subconjunto>` põe as edges caras atrás de uma trava por `CASE`
— o bundle **PRÉ-sensor ignora o `{\"probe\":true}` e roda o fluxo real**. A skill descrevia a
trava e o porquê, mas **não dizia como escolher o subconjunto**, e o gerador por default trata
TODAS como baratas.

Em 2026-09-05, auditando as edges mergeadas entre 26 e 31/08, classifiquei por um proxy de **FORMA**
— "a edge despacha por `body.action`?" — e ele marcou `fin-valor-cockpit` como cara.

**Estava errado, e o erro é medível.** `fin-valor-cockpit` (738 linhas) não escreve nada: zero
`.upsert/.insert/.update/.rpc`; os três `fetch` são GETs de auth (`/auth/v1/user`, `user_roles`,
`commercial_roles`); e o único `.delete(` é `Set.delete` de JS (`index.ts:564`). Pior caso de
sondá-la com bundle pré-sensor: **computar e devolver** — efeito NULO.

## O que entra

Bloco novo na **escada de edge** da skill (onde o "efeito caro" é justificado), com as duas metades
**medidas**:

1. **Escreve ou chama serviço externo?** O `grep` de triagem — e as duas armadilhas que invertem a
   leitura: `fetch(` de GET de leitura é gate de auth, não efeito; `.delete(` casa com `Set.delete`
   de JS. Contagem 0 só vira resposta depois de **LER** os hits.
2. **Se escreve: reversível, e qual o alcance?** "Cara" não é binário.
   `carteira-positivacao-snapshot` faz UM upsert idempotente (`onConflict: 'mes,customer_user_id'`),
   sem chamada externa, com cron **MENSAL** (jobid 80, `0 8 1 * *`) ⇒ custo de disparar fora de hora
   é uma linha parcial que o próximo tick reescreve. `omie-sync-pedidos-compra` dispara **sync real
   de pedidos de compra no Omie** — outra ordem de grandeza.

E o **PROXY REPROVADO** fica registrado com o porquê, para ninguém reinventá-lo: a metade POSITIVA
vale (os três `default:` que medi de fato recusam — `omie-analytics-sync` e `sync-reprocess`
devolvem 400, `omie-vendas-sync` faz `throw`), mas a **AUSÊNCIA de dispatch não prova o contrário**.
É `ausente ≠ zero` aplicado à forma do handler.

## Rede de regressão nova — `evals/criterio-caro-eval.sh`, item (6) do gate

Prosa que cita código vivo apodrece calada: o `docs:citacoes` prova que a linha citada **existe**, e
mais nada. Este eval **EXTRAI o grep da própria SKILL.md** (fail-CLOSED: sumiu ou duplicou, recusa)
e o **EXECUTA** contra as três edges, exigindo a classificação de volta — inclusive um controle
positivo (o recipe tem de achar algo) e o discriminador que mantém o contra-exemplo honesto (se
`fin-valor-cockpit` ganhar dispatch por `action`, os dois critérios passam a concordar e a lição
perde o dente).

**8 sabotagens, 0 cegueiras.** A falsificação já se pagou: pegou um NO-OP silencioso no próprio eval
— `awk -v` processa sequências de escape e comia o `\.` do alvo, então a sabotagem "apaga o recipe"
passava despercebida enquanto o guard de NO-OP (`grep -F`, com a string intacta) dizia que estava
tudo bem. Fechado com `ENVIRON` + uma **pós-condição** que exige que o arquivo tenha mudado de fato.

## Evidência

| gate | resultado |
|---|---|
| `bun run evals:deploy-verify` | exit 0 — 6/6 evals |
| `bun run evals:deploy-verify:falsificacao` | exit 0 — 0 cegueiras em todos os 6 |
| `bun run docs:citacoes` | exit 0 — 32 citações verificadas (2 novas, ancoradas) |
| `bun run claude:size` | exit 0 (CLAUDE.md intocado — a lição é de skill) |
| `bun run typecheck` | exit 0 |
| `shellcheck` nos 2 scripts | exit 0 |
| `heavy bun run test` | 7571 passaram · 1 **timeout flake** em `escrita-critica-gate` (20301ms vs teto 20000ms) sob contenção de ~26 sessões — **passa isolado, 6/6**, e nenhum arquivo de `src/` foi tocado |

🤖 Generated with [Claude Code](https://claude.com/claude-code)