### PR TITLE
docs(deploy): a triagem barata/cara das 25 edges — e o padrão real do custo não é o switch

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -309,6 +309,58 @@ como INDETERMINADO.**
 
 Verde = `status_code 200` **E** `canary true` **E** `contrato` batendo com a tabela acima **E** `ok true` **E** `casos_vermelhos NULL` (os cinco, não só o `ok`). `400` com `"Ação desconhecida"` = **bundle velho**, a probe não subiu — e a lista `acoes_disponiveis` da resposta é a confirmação (não cita a action nova). ⚠️ Probe é **dry-run**: se um dia uma delas abrir linha em `fin_sync_log`, ela fabrica frescor — `_data_health_compute` e `fin_calcular_confiabilidade` leem essa tabela **sem filtrar `action`** (só o `fin_sync_heartbeat` filtra). No `omie-financeiro` isso é o `PROBE_ACTIONS` → `logId=""`, pinado no `edge-money-path-invariants`.
 
+#### O CUSTO da sonda, edge a edge — a triagem que decide `--caro` (2026-09-04)
+
+O `sonda:sql` aceita `--caro=<edge>,…` e o doc só registrava **uma** decisão ("das 7 daquela leva, só
+a `sync-reprocess` é barata"). Quem chega depois refaz a leitura de cabo a rabo, ou — pior — chuta
+pelo nome. Triadas as **25 edges mapeadas que não responderam** numa janela de `pg_net.ttl`, lendo o
+`index.ts` de cada uma: **5 baratas, 20 caras**.
+
+A pergunta da triagem é sempre a mesma: *se o bloco de sonda não existisse, o que este handler faria
+com um body `{"probe": true}`* — ou seja, sem `action` e sem os demais campos?
+
+**Baratas — o bundle velho recusa antes de qualquer efeito:**
+
+| edge | o que barra |
+|---|---|
+| `conciliar-pedido-portal` | 400 `pedido_id inválido` (`Number(undefined)` não é inteiro) |
+| `analyze-unified-order` | 401 do gate `Bearer` antigo; passando, 400 por falta de `text`/imagem antes da Anthropic |
+| `omie-nfe-recebimento` | 401 do gate staff (JWT) |
+| `omie-nfe-webhook` | 401 do gate `x-webhook-secret` |
+| `process-nfe` | 401 (`Bearer` + `getUser`); `nf_number` obrigatório barraria em seguida |
+
+⚠️ **Quatro das cinco recusam com 401 — que é o único 4xx ambíguo** (bundle pré-sonda *ou*
+`CRON_SECRET` errado). O bloco gerado já cruza o `controle_credencial` e responde `INDETERMINADO`;
+só a `conciliar-pedido-portal` devolve um 400 inequívoco. "Barata" aqui quer dizer **segura de
+disparar**, não **conclusiva**.
+
+✅ E as cinco **são sondáveis**: o gate que protege a sonda é `authorizeCronOrStaff`, que aceita
+`x-cron-secret`. Em `omie-nfe-recebimento` e `omie-nfe-webhook` isso é DELIBERADO — a sonda tem gate
+**próprio**, porque atrás do gate da edge (JWT staff / webhook-secret, que o Omie e o SQL Editor não
+emitem) ela seria inalcançável por quem precisa dela.
+
+**Caras (20) — não sonde:** `algorithm-a-audit`, `calculate-scores`, `carteira-positivacao-snapshot`,
+`carteira-rebuild`, `disparar-pedidos-aprovados`, `gerar-pedidos-diario`, `monthly-report`,
+`omie-nfe-reconcile`, `omie-sync-ctes-recebidos`, `omie-sync-nfes-recebidas`,
+`omie-sync-pedidos-compra`, `omie-sync-sku-items`, `omie-sync-status-produtos`,
+`omie-sync-vendas-items`, `pedido-programado-enviar`, `reposicao-depara-sayerlack-auto`,
+`sayerlack-captura-precos`, `scoring-recalc-batch`, `tactical-plans-batch`, `visit-score-recalc-batch`.
+
+🔴 **O padrão que faz uma edge ser cara quase nunca é `switch(action)` sem `default` — é o DEFAULT
+que transforma "sem parâmetro" em ação real.** `body.empresa ?? "OBEN"`, `?? "ALL"`, `dias = 30`,
+`resolverEmpresas(null) → ["OBEN"]`: o corpo `{"probe":true}` não tem nenhum campo, e é exatamente
+por isso que o caminho padrão dispara inteiro. Os dois piores: `monthly-report`, onde
+`send_email !== false` é **true** por omissão e `user_id` ausente significa **todos** (a sonda
+manda e-mail de verdade para a base); e `pedido-programado-enviar`, onde a falta de `envio_id` cai
+no ramo cron e processa **todos os envios agendados do dia**. Ao triar, procure `??`, `||` e default
+de destructuring ANTES de procurar o `default:` do switch.
+
+⚠️ **A triagem lê o `index.ts` ATUAL descontando o bloco de sonda — é uma APROXIMAÇÃO do bundle
+velho, não o bundle velho.** Para rigor, confirme o guard no pai
+(`git show <sha-da-sonda>^:supabase/functions/<edge>/index.ts`); foi feito só na `process-nfe`. O
+erro possível é conservador nas que dependem de gate (um 401 a mais), mas não é nulo: guard que
+NASCEU com a fatia da sonda faria uma "barata" ser cara no bundle que está no ar.
+
 ### Assinatura no PRÓPRIO log da edge — N3 retroativo, sem canária e sem sonda
 
 Terceiro caminho, e o mais barato quando existe: **a edge que ESCREVE numa tabela já carrega a


### PR DESCRIPTION
## Por que

O `sonda:sql` aceita `--caro=<edge>,…`, mas o doc registrava **uma** decisão: *"das 7 daquela leva, só a `sync-reprocess` é barata"*. Quem chega depois refaz a leitura de cabo a rabo — ou chuta pelo nome, e chutar aqui **dispara efeito real em produção**.

Triadas as **25 edges mapeadas que não responderam** numa janela de `pg_net.ttl`, lendo o `index.ts` de cada uma: **5 baratas, 20 caras**, com a evidência de cada.

## O achado que vale mais que a lista

O que torna uma edge cara quase nunca é `switch(action)` sem `default`. É o **default que transforma "sem parâmetro" em ação real**:

```ts
body.empresa ?? "OBEN"      // vira sync completo
?? "ALL"                     // vira as duas empresas
dias = 30                    // vira janela real
resolverEmpresas(null) → ["OBEN"]
```

O corpo `{"probe":true}` não tem campo nenhum — e é **exatamente por isso** que o caminho padrão dispara inteiro. Os dois piores:

- **`monthly-report`** — `send_email !== false` é `true` por omissão e `user_id` ausente significa **todos**: a sonda manda e-mail de verdade para a base.
- **`pedido-programado-enviar`** — sem `envio_id` cai no ramo cron e processa **todos os envios agendados do dia**.

Ao triar, procure `??`, `||` e default de destructuring **antes** do `default:` do switch.

## Duas ressalvas que a lista sozinha esconderia

1. **4 das 5 baratas recusam com 401** — o único 4xx ambíguo (bundle pré-sonda *ou* `CRON_SECRET` errado). "Barata" quer dizer **segura de disparar**, não **conclusiva**; o `controle_credencial` do bloco gerado já responde `INDETERMINADO` nesses casos. Só `conciliar-pedido-portal` dá 400 inequívoco.
2. **A triagem lê o `index.ts` ATUAL descontando o bloco de sonda** — aproximação do bundle velho, não o bundle velho. Só `process-nfe` teve o guard confirmado no pai (`a086cc60a^`). O erro possível é conservador, mas **não é nulo**: um guard que nasceu junto com a fatia da sonda faria uma "barata" ser cara no bundle que está no ar.

Fica registrado também que as 5 **são sondáveis**: o gate da sonda é `authorizeCronOrStaff`, e em `omie-nfe-recebimento` / `omie-nfe-webhook` isso é **deliberado** — gate próprio, porque atrás do gate da edge (JWT staff / `x-webhook-secret`, que nem o Omie nem o SQL Editor emitem) a sonda seria inalcançável.

## Escopo

Só `docs/agent/deploy.md`, uma subseção nova sob a §Sonda de versão. Nenhum código tocado.

Gates: `docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` — verdes. Os 25 slugs conferidos um a um contra `supabase/functions/<edge>/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)