### PR TITLE
fix(fecho): as 2 pontas do mapa não têm o mesmo papel — `mapa_base` ausente é lista MAIS LARGA, não cegueira

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -189,6 +189,18 @@ Medido em 2026-08-28 numa janela real de 24h: 7 edges na janela, 3 provadas no a
 vez de 7**. E não é só corte: o `DESATUALIZADA` é sinal que o gatilho velho nunca teve — ele
 mostra bundle velho SERVINDO, que é a falha silenciosa que este passo existe para pegar.
 
+⚠️ **`_shared/` na janela: a ponta que FALTA decide se é cegueira ou só lista mais larga.** O guard
+das duas pontas do mapa nasceu com um `||` — faltando QUALQUER uma, exit 2 por atacado —, e isso
+travava o passo justamente na janela de MAIOR risco: quando `_shared/` muda é quando mais edge é
+afetada por transitividade. Medido 2026-09-05 (`--desde "2026-08-21 20:00"`): 26 arquivos de
+`_shared/` tocados, 41 das 95 edges afetadas, e **veredito nenhum** — porque o commit-base era
+anterior ao #1998, que CRIOU o mapa. As duas pontas não têm o mesmo papel: `mapa_agora` (main) é a
+fonte do `esperado` de toda edge, e sem ele a cegueira é real (exit 2 segue certo); `mapa_base` só
+ESTREITA o diff, e sem ele nenhum par casa e a via (a) emite o mapa INTEIRO como alvo — o
+**superconjunto seguro**, a lista larga e não a vazia. Corrigida a assimetria, a MESMA janela
+devolve **16 `NO_AR` provadas + 25 `SEM_PROVA`** no lugar de 41 pendências cegas. Degradar aqui é
+AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por prova positiva.
+
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
 de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -107,10 +107,29 @@ if [ "$1" = "--desde" ]; then
   # do arquivo. Sem essa trava, mudança só em `_shared/` sairia como "nenhuma edge na janela": chip
   # suprimido por AUSÊNCIA DE DADO, que é o modo de falha caro de um script que APAGA pendência.
   if command grep -q '^supabase/functions/_shared/' "$tmp/paths" 2>/dev/null; then
-    if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then
-      echo "⚠️ edges-pendentes: \`_shared/\` mudou na janela e o mapa de fingerprints não pôde ser"
-      echo "   lido nas duas pontas — não sei QUAIS edges isso afetou. MECÂNICA NÃO CONFIÁVEL, exit 2."
+    # ⚠️ As duas pontas do mapa NÃO têm o mesmo papel, e juntá-las num `||` só é o que travava o
+    # Passo 3 em exit 2 na janela de MAIOR risco. Medido 2026-09-05, `--desde "2026-08-21 20:00"`:
+    # 26 arquivos de `_shared/` tocados, 41 das 95 edges afetadas por transitividade — e veredito
+    # nenhum, porque o commit-base é anterior ao #1998, que CRIOU o mapa. A ponta que faltava era
+    # a inútil para a decisão.
+    #   · `mapa_agora` (origin/main) é INDISPENSÁVEL: é a fonte do `esperado` de toda edge e a
+    #     única via que enxerga o efeito de `_shared/`. Sem ele não há o que enumerar nem com o
+    #     que comparar — cegueira de verdade, exit 2.
+    #   · `mapa_base` só ESTREITA: o diff existe para TIRAR da lista quem não mudou. Sem ele
+    #     nenhum par casa e a via (a) já emitiu o mapa INTEIRO como alvo — o superconjunto
+    #     SEGURO. Degradar aqui AMPLIA a lista, e cada alvo segue classificado um a um por prova
+    #     positiva. Desistir jogaria fora o NO_AR de quem TEM prova, e "trate as 95 como
+    #     pendentes" é ingerível: vira chip para tudo, e fila de chip igual enterra o chip que
+    #     importa — exatamente o custo que este script existe para cortar.
+    if [ ! -s "$tmp/mapa_agora" ]; then
+      echo "⚠️ edges-pendentes: \`_shared/\` mudou na janela e o mapa de fingerprints da MAIN não"
+      echo "   pôde ser lido — não sei QUAIS edges isso afetou. MECÂNICA NÃO CONFIÁVEL, exit 2."
       exit 2
+    fi
+    if [ ! -s "$tmp/mapa_base" ]; then
+      echo "ℹ️  mapa_base ausente — a janela começa antes de \`$MAPA_REL\` existir."
+      echo "   O diff não estreitou nada: a via (a) emitiu o mapa INTEIRO como alvo. Enumeração"
+      echo "   AMPLIADA (superconjunto seguro), não cega — cada alvo segue classificado abaixo."
     fi
     if [ ! -s "$tmp/alvos" ]; then
       echo "⚠️ \`_shared/\` mudou na janela e NENHUM fingerprint mudou. Ou a mudança não entra em"

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -219,6 +219,50 @@ MAPA1
   then ok "--desde: _shared/ sem mapa legivel -> exit 2, nunca 'nenhuma edge'"
   else bad "_shared sem mapa devia dar exit 2 e nao absolver (rc=$rc): ${out:0:120}"; fi
 
+  # 14b. A JANELA ANTERIOR AO MAPA — o caso que travava o Passo 3 do /fecho em exit 2 (medido
+  #      2026-09-05 com `--desde "2026-08-21 20:00"`: o commit-base e anterior ao #1998, que criou
+  #      `sonda-fingerprints.ts`). As duas pontas do mapa NAO tem o mesmo papel: `mapa_agora` e
+  #      indispensavel (sem ele nao ha `esperado` para ninguem), mas `mapa_base` so ESTREITA a
+  #      enumeracao. Faltando ele o diff nao casa par nenhum e a via (a) emite o mapa INTEIRO como
+  #      alvo — superconjunto SEGURO. Desistir ai joga fora o sinal justamente na janela em que
+  #      MAIS edge foi afetada (41 das 95, na janela medida).
+  local repo2="$tmp/repo-nasce-${LC_ALL:-x}"
+  if [ ! -d "$repo2" ]; then
+    mkdir -p "$repo2/supabase/functions/_shared" "$repo2/supabase/functions/edge-do-shared"
+    git -C "$repo2" init -q -b main 2>/dev/null
+    git -C "$repo2" config user.email t@t; git -C "$repo2" config user.name t
+    printf 'x\n' > "$repo2/supabase/functions/_shared/lib.ts"
+    printf 'import "../_shared/lib.ts"\n' > "$repo2/supabase/functions/edge-do-shared/index.ts"
+    # commit-base SEM o mapa: e exatamente como a main estava antes do #1998
+    git -C "$repo2" add -A >/dev/null; git -C "$repo2" commit -qm "base sem mapa"
+    git -C "$repo2" rev-parse HEAD > "$tmp/base2_sha"
+    printf 'y\n' > "$repo2/supabase/functions/_shared/lib.ts"
+    cat > "$repo2/supabase/functions/_shared/sonda-fingerprints.ts" <<MAPA2
+export const FONTE_SHA256: Record<string, string> = {
+  "edge-do-shared": "$SHA_NOVO",
+};
+MAPA2
+    git -C "$repo2" add -A >/dev/null; git -C "$repo2" commit -qm "shared + mapa nasce"
+    git -C "$repo2" update-ref refs/remotes/origin/main HEAD
+  fi
+  printf 'edge-do-shared %s\n' "$SHA_NOVO" > "$tmp/pares-shared.txt"
+
+  # o SINAL tem de sobreviver: com a fonte servida batendo, a edge sai NO_AR e o chip some
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo2" \
+         STUB_PARES="$tmp/pares-shared.txt" FECHO_MAPA_FONTE="" \
+         bash "$ALVO" --desde "$(cat "$tmp/base2_sha")" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ] && tem 'NO_AR' "$out" && tem 'mapa_base ausente' "$out"
+  then ok "--desde: janela anterior ao mapa -> enumera pelo mapa INTEIRO e preserva o NO_AR"
+  else bad "janela anterior ao mapa devia classificar, nao exit 2 (rc=$rc): ${out:0:140}"; fi
+
+  # e o fail-closed CONTINUA: sem fonte servida, a MESMA edge cai para SEM_PROVA, nunca NO_AR
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo2" \
+         STUB_PARES=/dev/null FECHO_MAPA_FONTE="" \
+         bash "$ALVO" --desde "$(cat "$tmp/base2_sha")" 2>&1)"; rc=$?
+  if [ "$rc" -eq 1 ] && tem 'SEM_PROVA' "$out" && ! tem 'NO_AR' "$out"
+  then ok "--desde: janela anterior ao mapa, sem sonda -> SEM_PROVA (fail-closed intacto)"
+  else bad "sem sonda devia cair para SEM_PROVA, nunca NO_AR (rc=$rc): ${out:0:140}"; fi
+
   # 12. guardrail de FORMA do SQL: o stub nao executa SQL, entao o que da para provar aqui e que a
   #     consulta pede a resposta MAIS RECENTE por edge. Sem isso, um deploy no meio da janela deixa
   #     o bundle velho no resultado e ele seria lido como prova (o caso do omie-vendas-sync).
@@ -285,6 +329,13 @@ if [ "${1:-}" = "--falsificar" ]; then
   # (a3) o fail-closed do `_shared/` sem mapa vira aviso: enumeracao voltaria a absolver por ausencia
   sabota "_shared sem mapa deixando de ser exit 2" \
     's%      exit 2$%      :%'
+  # (a4) a assimetria de papel entre as duas pontas do mapa some, e `mapa_base` volta a valer por
+  #      cegueira — o defeito medido em 2026-09-05: janela cujo base e anterior ao #1998 (que criou
+  #      o mapa) desistia por atacado, sem veredito nenhum, justo quando `_shared/` afetou 41 das
+  #      95 edges. Sem esta sabotagem o caso 14b passaria a ser decorativo.
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "mapa_base ausente voltando a ser tratado como cegueira" \
+    's%if \[ ! -s "$tmp/mapa_agora" \]; then%if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then%'
   # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "classificar como NO_AR mesmo com mecanica quebrada" \


### PR DESCRIPTION
## O sintoma

`edges-pendentes.sh` — a sonda do Passo 3 do `/fecho` — devolvia **exit 2 (MECÂNICA NÃO CONFIÁVEL)** numa janela longa, deixando o passo **sem sinal útil justamente na janela de maior risco**: quando `_shared/` muda é quando MAIS edge é afetada por transitividade, e era exatamente aí que a sonda desistia. O veredito "trate tudo como pendente" é ingerível — o agente ignora ou abre chip para tudo, e fila de chips iguais enterra o chip que importa.

## Causa raiz (provada, não intuída)

Não era parse, nem fingerprint faltando para o `_shared` novo. O commit-base da janela (`3a85e0c2`, 2026-08-21 22:56) é **anterior ao nascimento do próprio mapa**: `sonda-fingerprints.ts` foi criado em 2026-08-25 pelo #1998.

| ponta | linhas parseadas |
|---|---|
| `mapa_base` (commit-base) | **0** — o arquivo não existia ainda |
| `mapa_agora` (origin/main) | 40 — íntegro |

O guard juntava as duas num `||`, então a ponta ausente derrubava tudo. **A ponta que faltava era a inútil para a decisão.**

## A assimetria de papel

- **`mapa_agora` (main) é INDISPENSÁVEL** — é a fonte do `esperado` de toda edge e a única via que enxerga o efeito de `_shared/`. Sem ele a cegueira é real: **exit 2 segue certo** (o caso 14 do teste continua exigindo isso).
- **`mapa_base` só ESTREITA** — o diff existe para *tirar* da lista quem não mudou. Sem ele nenhum par casa e a via (a) já emite o **mapa INTEIRO** como alvo.

Medido no momento exato do exit 2: o script já tinha **41 alvos** em mãos. Não estava cego — estava com a lista *maximamente larga*, o lado seguro. E abortava.

## O fail-closed não foi afrouxado — foi tornado mais preciso

Degradar aqui **AMPLIA** a enumeração, nunca absolve. Cada alvo segue classificado um a um por prova positiva; nada vira `NO_AR` sem `fonte` servido == main.

Contra o banco real, a mesma janela do relato:

| | antes | depois |
|---|---|---|
| exit | 2 (zero veredito) | 1 |
| `NO_AR` provadas | — | **16** |
| `SEM_PROVA` | 41 (cegas) | 25 |

16 edges saíram da fila de chips **com evidência positiva**.

## Prova

- **Teste 14b** (novo, `scripts/test-fecho-edges-pendentes.sh`): repo sintético onde o mapa nasce *depois* do base. Casa a **marca do ramo nos dois sentidos** — com fonte servida batendo → `NO_AR`/exit 0; sem sonda → `SEM_PROVA`/exit 1 e **nunca** `NO_AR`.
- **Falsificação (a4)** (nova): recoloca o `||` e exige a suite **vermelha nos 2 locales**. Sem ela o caso 14b seria decorativo.
- Escrito **vermelho primeiro** (exit 1 com a mensagem exata do bug), depois verde.
- `11/11` sabotagens vermelhas, **0 vazias**, exit 0. Suite verde nos 2 locales. `shellcheck` limpo nos dois arquivos. `docs:indice`, `docs:citacoes`, `claude:size` verdes.

## O que NÃO entrou (e por quê)

Avaliei computar o grafo de imports (`fecharGrafo` de `scripts/sonda-fingerprint.ts`) para marcar exatamente as edges afetadas. **Funciona** — 269 ms, 0 erros de fecho, e identifica 41 das 95 edges afetadas na janela medida, incluindo 1 (`visit-score-recalc-client`) que hoje escapa das duas vias.

Mas medi o furo inteiro: **41 edges estão fora do mapa E importam `_shared/`**. Elas não têm `versao.ts`, logo não respondem sonda — acrescentá-las produziria até 41 chips `SEM_PROVA`, ou seja, *mais* ruído, contra o propósito declarado do script. O caminho certo para essas é **instrumentá-las** (`sonda:nova`), não compensar a falta de instrumentação inundando o founder de chips. Fica registrado como achado, fora deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)