### PR TITLE
docs(deploy): a mecânica do `--caro` passa a apontar para o critério que a decide

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -235,6 +235,18 @@ desfecho é redeployar edge de money-path à toa), ou o inverso. Edge sem `versa
 mapa de fingerprints** derruba a geração inteira (nada de SQL parcial em silêncio), e `--caro` que
 não casa um nome da leva também — o typo deixaria a edge cara no bloco SEM trava.
 
+**QUEM entra no `--caro` é MEDIDO, não presumido — o critério é o EFEITO, não a FORMA do handler.**
+Regra curta: edge que **não escreve nem chama serviço externo** no fluxo real é BARATA, e o pior
+caso de sondá-la com bundle pré-sensor é computar e devolver. O proxy "a edge despacha por
+`body.action`?" está **REPROVADO** — marcou `fin-valor-cockpit`, que não escreve nada, como cara
+(`ausente ≠ zero` aplicado à forma do handler: o `default:` que recusa prova que AQUELE caminho é
+inócuo, a ausência de dispatch não prova o contrário). O `grep` de triagem, as duas armadilhas que
+invertem a leitura (`fetch(` de GET de auth não é efeito; `.delete(` casa com `Set.delete` do JS) e
+o eixo reversibilidade/alcance ficam na **escada de edge** da skill `lovable-deploy-verify` —
+**cópia única de propósito**, porque só lá o critério é EXECUTADO pelo gate, que extrai o grep da
+própria skill e o roda contra as edges-exemplo
+(`.claude/skills/lovable-deploy-verify/evals/criterio-caro-eval.sh`).
+
 ⚠️ **O veredito julga o `fonte`, não só o `versao` — e o ramo `DEPLOY PARCIAL` vem ANTES do de
 confirmação.** O `versao` sai do `versao.ts` da PRÓPRIA edge: um deploy que suba `index.ts` +
 `versao.ts` e deixe `_shared/sonda-fingerprints.ts` para trás (o risco do Passo 3 da skill


### PR DESCRIPTION
Follow-up do #2159, que deu ao `--caro` um critério medido dentro da skill
`lovable-deploy-verify`. O `docs/agent/deploy.md` ficou sendo o **único lugar que fala de `--caro`
sem caminho para esse critério**: documenta a trava por `CASE`, o fail-closed do typo e os quatro
blocos gerados — tudo sobre COMO o flag funciona, nada sobre QUEM entra nele.

Entram 12 linhas:

- a **regra curta** — edge que não escreve nem chama serviço externo no fluxo real é BARATA, e o
  pior caso de sondá-la com bundle pré-sensor é computar e devolver;
- o **proxy REPROVADO por nome** ("a edge despacha por `body.action`?", que marcou
  `fin-valor-cockpit` — que não escreve nada — como cara), para quem nunca abrir a skill não o
  reinventar;
- o ponteiro para a escada de edge e para o eval que guarda o critério.

**O `grep` de triagem NÃO é duplicado aqui, de propósito.** Só na skill ele é EXECUTADO pelo gate:
o `criterio-caro-eval.sh` extrai o comando da própria `SKILL.md` (fail-CLOSED se sumir ou duplicar)
e o roda contra as edges-exemplo. Uma segunda cópia fora do alcance dele seria exatamente a
divergência silenciosa que o eval existe para impedir — a referência aponta, não espelha.

## Evidência

| gate | resultado |
|---|---|
| `bun run docs:citacoes` | exit 0 |
| `bun run docs:links` | exit 0 — 641 docs, todo link relativo resolve |
| `bun run docs:indice` | exit 0 |
| `bun run claude:size` | exit 0 (CLAUDE.md intocado) |
| `bun run evals:deploy-verify` | exit 0 — 6/6 |

Diff: 1 arquivo, 12 inserções, 0 remoções.

🤖 Generated with [Claude Code](https://claude.com/claude-code)