### PR TITLE
chore(authz): renova o carimbo — prod mudou de autorização no #2164 [authz]

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-08-29T01:13:52.575Z",
-  "sourceHead": "81c9d9e9fdfd2a15571ebfefb3a88949f0b9d703",
+  "medidoEm": "2026-09-05T11:27:13.910Z",
+  "sourceHead": "ba7d6b3e220cee0137e4cf2640b0e244e8eb8472",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -48,7 +48,7 @@
     "rls": {
       "script": "authz:rls:prod",
       "exit": 0,
-      "resumo": "✅ audit-rls — 335 tabela(s) em public com RLS ligada (0 desligada); 21 tabela(s) curada(s), 54 policy(ies) e 13 funcao(oes)-predicado batem com o contrato (fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao); 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 7 ",
+      "resumo": "✅ audit-rls — 336 tabela(s) em public com RLS ligada (0 desligada); 21 tabela(s) curada(s), 54 policy(ies) e 13 funcao(oes)-predicado batem com o contrato (fecho transitivo, profundidade 1; 0 alcancada(s) so por outra funcao); 4 grupo(s) de lacuna conferido(s) — 78 tabela(s) distinta(s) no grafo, 7 ",
       "denominador": null,
       "contratoFingerprint": "983189279bc797985d2ff78f0ee10434d7c6ab7e582d223ff02d0bddd84841b0",
       "auditorFingerprint": "f24bdcecdcf841257b1c817fbeecddf0b47b91ae42c8784d68e110b86a126986",


### PR DESCRIPTION
## Por quê

O #2164 alterou o estado de autorização da **produção**:
- policy de SELECT de `margin_audit_log` ganhou o ramo `master` (12.393 linhas destrancadas);
- trigger `trg_auto_commercial_super_admin` e a função `auto_assign_commercial_super_admin` removidos.

O carimbo é a **única ponte** entre "o que prod tem" e o que o CI enxerga — e estava atestando um retrato de **2026-08-29**, anterior à mudança e já com 7,4 dias (dentro da janela de aviso).

## Evidência

Os 5 audits re-rodados contra a prod, todos `exit 0`:

| audit | resultado |
|---|---|
| `authz:funcoes:prod` | ✅ exit 0 |
| `authz:grants:prod` | ✅ exit 0 |
| `authz:audit:prod` | ✅ exit 0 |
| `authz:claude-ro:prod` | ✅ exit 0 |
| `authz:rls:prod` | ✅ exit 0 — 336 tabelas com RLS ligada, **0 desligada** |

**Nenhum achado novo e nenhum md5 de contrato se moveu.** Isso confirma por medição o que a análise previa:

- `public.margin_audit_log` está em `LACUNAS_DECLARADAS`, **não** no conjunto curado ⇒ mexer na policy dela não toca o eixo 2;
- a função removida não era predicado de nenhuma policy curada (verificado: **0** arquivos de contrato a citam) ⇒ não toca o eixo 3.

## Diff

3 linhas: `medidoEm`, `sourceHead`, e `335 → 336` tabelas com RLS — a tabela nova é de outra sessão, e o eixo 1 é por **contagem de violações** justamente para não gritar a cada migration.

Sem migration, sem edge, sem Publish: **nada a aplicar em produção neste PR** (as mudanças que ele atesta já foram aplicadas e validadas no #2164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)