### PR TITLE
fix(docs): `.claude/skills` está DENTRO do `docs:citacoes` desde 2026-08-31 — o skills.md dizia o contrário e induzia a citar sem âncora

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -44,15 +44,23 @@
 - ⚠️ **Colisão de nome:** `/review` (gstack, **canônico**) vs `review` (oficial code-review) — invocar via gstack.
 - **Memória entre sessões:** **`claude-mem`** (plugin global ATIVO — **funcionando desde 2026-07-07**; 0 → 214 observações na 1ª hora). Conserto em 2 camadas: (1) o generator não achava o binário `claude` do app desktop — fix: shim `~/.claude-mem/claude-shim.sh` + `CLAUDE_CODE_PATH` em `~/.claude-mem/settings.json`; (2) o CLI headless não herda o login do app — resolvido com `/login` no CLI (se `Not logged in` voltar: terminal → `~/.claude-mem/claude-shim.sh` → `/login`). Limitação conhecida: memória fragmentada por worktree (cada um é um `project` distinto). Auto-memory nativo segue **desligado de propósito** (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` no settings global) — não ligar os dois (duplicaria).
 
-## Editar uma skill: nenhum gate confere as citações dela
+## Editar uma skill: a citação é conferida por gate; a cerca ```bash não
 
-`.claude/skills/` está **fora do `docs:citacoes`** — `ALVOS_VIVOS` é `CLAUDE.md` + `docs/agent`,
-`docs/visual-direction` e `docs/runbooks` (`scripts/docs-citacoes-gate-check.ts:130`<!--cita: ALVOS_VIVOS-->),
-e a skill não entra por nenhum dos dois lados: nem como doc varrido, nem pela âncora `<!--cita:-->` que
-resgata a citação do doc congelado. Medido em 2026-08-30 sabotando uma citação de
-`.claude/skills/lovable-deploy-verify/SKILL.md`: o gate passou com **exit 0 e sem mover o contador** —
-28 citações / 7 ancoradas antes e depois. ⇒ **Ao citar `arquivo:linha` numa skill, confira à mão**; verde
-ali é ausência de dado, não aprovação. Mesma família de `docs/historico/gates-textuais-cegos.md`, por
+`.claude/skills/` **entra no `docs:citacoes`** desde 2026-08-31 — `ALVOS_VIVOS` é <!--alvos-vivos:inicio-->`CLAUDE.md`,
+`docs/agent`, `docs/visual-direction`, `docs/runbooks` e `.claude/skills`<!--alvos-vivos:fim-->
+(`scripts/docs-citacoes-gate-check.ts:130`<!--cita: ALVOS_VIVOS-->). ⇒ **Citar `arquivo:linha` numa
+skill EXIGE a âncora** `<!--cita: <trecho literal da linha>-->`, e o trecho tem de ser substring
+LITERAL da linha citada; sem ela o gate reprova com "não tem âncora" mesmo que o número esteja certo.
+Falsificado em 2026-09-05 nos dois eixos, sabotando `lovable-deploy-verify/SKILL.md`: citação
+quebrada → **exit 1**, contador 35→34; âncora removida → **exit 1**. Antes era o oposto — a MESMA
+sabotagem passava com **exit 0 e sem mover o contador** (2026-08-30, #2130), e foi essa lacuna que
+criou o alvo: ligar a pasta custou zero vermelho e a 1ª varredura já achou a única citação
+`arquivo:linha` das 35 skills apontando para uma linha VAZIA (corrigida no #2137)
+(`scripts/docs-citacoes-gate-check.ts:115`<!--cita: entrou em 2026-08-31-->).
+
+⚠️ **O que segue descoberto na skill é a cerca ```bash** — o gate lê `arquivo:linha`, não executa a
+cerca (`scripts/docs-citacoes-gate-check.ts:126`<!--cita: continua descoberto-->). Verde ali é
+ausência de dado, não aprovação. Mesma família de `docs/historico/gates-textuais-cegos.md`, por
 ESCOPO DE VARREDURA em vez de stripper — e o custo é maior do que parece, porque a skill é justamente
 onde o próximo agente vai buscar o comando pronto para copiar.
 
@@ -78,7 +86,7 @@ fixture: **22 das 35 são puras** (texto/`git`, sem rede nem banco — a do #212
 denominador existe. Critério do "pura", para o número ser reproduzível: nenhuma POSIÇÃO DE COMANDO
 (início de linha ou depois de `|`/`;`/`&`) casa `psql|gh|curl|npx|supabase|bun|npm|deno|docker|ssh|
 nohup|~/.config` — o wrapper `~/.config/afiacao/psql-ro` conta como banco, e esquecê-lo devolve 27. Mas isso é mecanismo novo (anotação + fixture + runner), não configuração — e
-enquanto não existir, a cerca de skill se confere **à mão**, como as citações.
+enquanto não existir, a cerca de skill se confere **à mão** — ao contrário da citação `arquivo:linha`, que o gate já cobre.
 
 ⚠️ Ao contar cercas por natureza, filtre o COMANDO, não a substring: `supabase` casa o caminho
 `supabase/functions/` e classifica como "toca o banco" justamente a cerca de `git`/`grep` que é o

--- a/scripts/docs-citacoes-gate-check.test.ts
+++ b/scripts/docs-citacoes-gate-check.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
+  ALVOS_VIVOS,
   apenasAncoradas,
   auditarCitacoes,
   CONGELADOS,
@@ -417,5 +418,35 @@ describe('fora do escopo — o gate diz o que NÃO olhou', () => {
       emCerca: 0,
     });
     expect(s).toContain('0 fora do escopo');
+  });
+});
+
+describe('ALVOS_VIVOS × docs/agent/skills.md — a lista transcrita à mão drifa do código', () => {
+  // `.claude/skills` entrou em `ALVOS_VIVOS` em 2026-08-31 e o parágrafo do `skills.md` seguiu
+  // afirmando que a pasta estava FORA do gate. Quem lesse antes de escrever uma skill concluía que
+  // podia citar `arquivo:linha` sem a âncora `<!--cita:-->` — e descobria no CI, não na escrita; ou,
+  // pior, deixava de citar linha por achar que ninguém conferiria. O defeito é a transcrição à mão:
+  // ela envelhece calada. Este guard faz o doc falhar JUNTO com a mudança que o invalidou.
+  //
+  // A 1ª versão deste teste era TEATRO e a falsificação pegou: pedir que cada alvo aparecesse na
+  // SEÇÃO ficava VERDE com a lista sabotada — porque `.claude/skills` aparece na frase que abre o
+  // parágrafo. Teria passado no doc ERRADO também, que dizia a pasta FORA citando-a pelo nome. O
+  // que se mede é a ENUMERAÇÃO, delimitada por marcador co-locado, e por IGUALDADE DE CONJUNTO —
+  // `toContain` é cego a entrada sobrando.
+  const INICIO = '<!--alvos-vivos:inicio-->';
+  const FIM = '<!--alvos-vivos:fim-->';
+
+  const listaDoDoc = () => {
+    const md = readFileSync(join(process.cwd(), 'docs/agent/skills.md'), 'utf8');
+    const i = md.indexOf(INICIO);
+    const f = md.indexOf(FIM);
+    // Fail-CLOSED: sonda que não acha o alvo é ausência de dado, não aprovação.
+    expect(i, `marcador ${INICIO} sumiu de docs/agent/skills.md`).toBeGreaterThanOrEqual(0);
+    expect(f, `marcador ${FIM} sumiu de docs/agent/skills.md`).toBeGreaterThan(i);
+    return [...md.slice(i + INICIO.length, f).matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+  };
+
+  it('a enumeração do doc é exatamente `ALVOS_VIVOS`', () => {
+    expect([...listaDoDoc()].sort()).toEqual([...ALVOS_VIVOS].sort());
   });
 });


### PR DESCRIPTION

## O defeito

`docs/agent/skills.md` abria a seção com o título **"nenhum gate confere as citações dela"** e
afirmava que `.claude/skills/` estava **fora do `docs:citacoes`**. A pasta entrou em `ALVOS_VIVOS`
em 2026-08-31 (`scripts/docs-citacoes-gate-check.ts:130`) e a frase envelheceu calada por 5 dias.

Não é cosmético: quem lê `skills.md` **antes** de escrever uma skill concluía que podia citar
`arquivo:linha` sem a âncora `<!--cita:-->`. O gate reprova isso — então a descoberta acontecia no
CI, não na escrita. Pior: podia levar alguém a **não citar linha nenhuma**, por achar que não seria
conferida de qualquer jeito.

## Uma correção à premissa do report

O report dizia que a afirmação errava em **dois** eixos, o segundo sendo "a lista transcrita está
incompleta — faltam `docs/visual-direction` e `docs/runbooks`". **Isso não se confirma:** os dois
já estavam lá, na linha 50 — a frase quebra entre as linhas 49 e 50, e um `grep -n` de uma linha só
vê metade dela. O erro era de **um** eixo: `.claude/skills` ausente da lista, e a afirmação
afirmativa de que a pasta estava fora.

## Evidência (medida aqui, não herdada)

Falsificação sobre `.claude/skills/lovable-deploy-verify/SKILL.md` — o **mesmo** experimento que em
2026-08-30 saíra verde e que motivou o texto errado:

| sabotagem | resultado |
|---|---|
| citação apontada para linha errada | `docs:citacoes` **exit 1**, contador 35 → 34, mensagem nomeando o `SKILL.md` |
| âncora `<!--cita:-->` removida | **exit 1** — `"não tem âncora. Sem ela o número de linha é inverificável"` |

Ou seja: fail-closed nos dois eixos hoje.

## O guard — e por que a 1ª versão dele era teatro

Lista transcrita à mão em doc drifa do código; foi exatamente essa a classe. O guard lê
`ALVOS_VIVOS` **do módulo** e compara com a enumeração do `skills.md`.

A primeira versão pedia que cada alvo aparecesse na **seção** (`toContain`) — e a falsificação
pegou: com `.claude/skills` removido da lista, **ficava verde**, porque o nome aparece na frase que
abre o parágrafo. Teria passado no doc ERRADO também, que dizia a pasta "fora" citando-a pelo nome.
A versão que ficou mede a **enumeração**, delimitada por marcador co-locado
(`<!--alvos-vivos:inicio/fim-->`, invisível no render), por **igualdade de conjunto**.

Falsificado em três camadas, uma por vez — as três vermelhas:

| camada sabotada | exit |
|---|---|
| A — alvo removido da enumeração | **1** |
| B — alvo FANTASMA acrescentado (`toContain` seria cego) | **1** |
| C — marcador apagado (sonda ausente) | **1** |

Custo/benefício: ~25 linhas num teste que já existe (`scripts/docs-citacoes-gate-check.test.ts`,
co-localizado, fora de `src/` → sem manifesto), sem rede nem banco, ms de runtime. Fecha uma janela
que custou 5 dias de doc mentindo no exato ponto de uso.

## O que NÃO mudou

A cerca ` ```bash ` dentro de skill **segue descoberta** (o gate lê `arquivo:linha`, não executa a
cerca) — a subseção que mediu e RECUSOU um lint de shell continua válida e intocada. Só corrigi a
cauda `"...se confere à mão, **como as citações**"`, que virou falsa.

## Validação (exit 0 colado)

`docs:citacoes` **0** (37 citações, +2 novas ancoradas) · `docs:links` **0** · `docs:indice` **0** ·
`claude:size` **0** · `typecheck` **0** · `test` **0** (755 arquivos, 7626 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
