### PR TITLE
test(preco): mutation-check de parseDecimalBR — 9 testes verdes deixavam 4 jeitos de fabricar preço passarem [money-path]

### DIFF
--- a/scripts/mutcheck.d/parse-decimal-br.mut
+++ b/scripts/mutcheck.d/parse-decimal-br.mut
@@ -1,0 +1,23 @@
+# @src: src/lib/preco/parse-decimal-br.ts
+# @test: src/lib/preco/parse-decimal-br.test.ts
+# Invariantes money-path do parser de preço digitado (pt-BR/en): NUNCA fabricar número a
+# partir de entrada ambígua/malformada (precisão > recall). `parseFloat("12,5")` = 12 era o
+# bug de origem (12,50 → 1250 no pedido). Cada PEGA abaixo é um jeito de fabricar preço errado.
+# Rode: scripts/mutcheck.sh src/lib/preco/parse-decimal-br.ts src/lib/preco/parse-decimal-br.test.ts scripts/mutcheck.d/parse-decimal-br.mut
+# Nota: o ternário `validGrouping(parts) ? finish(...) : null` aparece 2× (ramo só-vírgula e
+# só-ponto) — cada mutação ARMA num trecho único do ramo e aplica só na 1ª ocorrência seguinte
+# (`$done` recebe o RESULTADO do s///, nunca contador por efeito colateral — ver references/mutation-check.md).
+PEGA      | milhar: grupo ≠3 díg aceito (===3 → <=3)         | s/g\.length === 3/g.length <= 3/
+PEGA      | milhar: 1º grupo com 4 díg aceito (<=3 → <=4)     | s/groups\[0\]\.length <= 3/groups[0].length <= 4/
+PEGA      | ambos seps: !==2 decimais vira !==3               | s/parts\.length !== 2\) return null/parts.length !== 3) return null/
+PEGA      | só vírgula: várias viram decimal (===2 → >=2)     | s/if \(parts\.length === 2\) return finish/if (parts.length >= 2) return finish/
+PEGA      | só vírgula: milhar malformado aceito              | $arm = 1 if /body\.split\(','\)/; if ($arm && !$done) { $done = s/return validGrouping\(parts\) \? finish\(parts\.join\(''\), ''\) : null;/return finish(parts.join(''), '');/ }
+PEGA      | só ponto: várias viram decimal (===2 → >=2)       | s/if \(parts\.length === 2\) \{/if (parts.length >= 2) {/
+PEGA      | só ponto: milhar malformado aceito                | $arm = 1 if /return finish\(intP, frac\)/; if ($arm && !$done) { $done = s/return validGrouping\(parts\) \? finish\(parts\.join\(''\), ''\) : null;/return finish(parts.join(''), '');/ }
+PEGA      | ambíguo "1.234": 3 casas → 4 casas                | s/frac\.length === 3 &&/frac.length === 4 \&\&/
+PEGA      | ambíguo: inteiro "0" também vira ambíguo          | s/\[1-9\]\\d\{0,2\}/\\d{1,3}/
+PEGA      | sinal negativo descartado                         | s/\(neg \? '-' : ''\)/(neg ? '' : '')/
+?         | finish aceita inteiro vazio (".5"/",5" → 0.5)     | s/\^\\d\+\(\\\.\\d\+\)\?\$/^\\d*(\\.\\d+)?\$/
+SOBREVIVE | groups.length>1 → >=1 (inalcançável: grpSep sempre antes do decSep único) | s/groups\.length > 1 &&/groups.length >= 1 \&\&/
+SOBREVIVE | isFinite → n (inalcançável: só dígitos, finito)   | s/Number\.isFinite\(n\) \? n : null/n/
+SOBREVIVE | typeof guard removido (inalcançável pelo tipo TS) | s/typeof input !== 'string'/false/

--- a/src/lib/preco/parse-decimal-br.test.ts
+++ b/src/lib/preco/parse-decimal-br.test.ts
@@ -45,6 +45,17 @@ describe('parseDecimalBR', () => {
     expect(parseDecimalBR('1,23.456')).toBeNull();
   });
 
+  it('aceita milhar pt-BR só com pontos e rejeita agrupamento malformado (regra "vários pontos = milhar")', () => {
+    expect(parseDecimalBR('1.234.567')).toBe(1234567);
+    expect(parseDecimalBR('1.2.3')).toBeNull(); // grupos ≠ 3 dígitos
+    expect(parseDecimalBR('1234.567,89')).toBeNull(); // 1º grupo com 4 dígitos não é milhar
+  });
+
+  it('preserva o sinal negativo (documentado no regex de entrada)', () => {
+    expect(parseDecimalBR('-12,5')).toBe(-12.5);
+    expect(parseDecimalBR('-1.234,56')).toBe(-1234.56);
+  });
+
   it('NÃO rejeita decimal legítimo com 3 casas quando não parece milhar', () => {
     expect(parseDecimalBR('0,999')).toBe(0.999);
     expect(parseDecimalBR('0.999')).toBe(0.999); // inteiro "0" não é grupo de milhar válido


### PR DESCRIPTION
## O que

Contrato de mutação `scripts/mutcheck.d/parse-decimal-br.mut` (14 mutações) para `parseDecimalBR` — o parser do preço digitado no pedido, onde `parseFloat("12,5") = 12` foi o bug de origem. Entra no gate `bun run mutcheck` do CI.

## Medição

**1ª rodada (suíte original, 9 testes):** 4 mutações PEGA sobreviveram — a suíte estava verde sem poder sobre:

| Buraco | Entrada | Antes (mutante) | Contrato |
|---|---|---|---|
| 1º grupo de milhar com 4 dígitos | `1234.567,89` | 1234567.89 | `null` |
| milhar só com pontos (regra documentada, 0 teste) | `1.234.567` | `null` | 1234567 |
| só-ponto malformado | `1.2.3` | 123 | `null` |
| sinal negativo descartado | `-12,5` | 12.5 | -12.5 |

**2ª rodada (+2 `it` de borda):** 10/10 PEGA · 4 sobreviventes rotulados · 0 inválidas · controle+ ✓ · rc=0.

Sobreviventes: 3 `SOBREVIVE` inalcançáveis pelo contrato (`groups.length>1` — o separador de milhar está sempre antes do decimal único; `isFinite` sobre só-dígitos; `typeof` guard sob TS) e 1 `?` exploratório: `".5"`/`",5"` retornam `null` hoje. **Não impus contrato nisso** — aceitar `,5` como 0,5 é decisão de produto (precisão > recall diz `null`; UX diz 0,5). Fica rotulado, não gate.

## Método (auto-ensino, técnica: mutation-check)

- Previsão estática dos sobreviventes ANTES de rodar: **4/4**.
- Guard falsificado: âncora deslocada de propósito → `INVÁLIDO (não casou)` + rc≠0.
- Ternário `validGrouping ? … : null` repetido nos 2 ramos → ancorado em texto único do ramo com `$done = s///` (regra da referência), não em nº de linha.
- Lint do teste: rc=0. Não rodei `bun run mutcheck` inteiro (21 contratos × vitest na M2 com 50 sessões) — o contrato isolado rodou 3× e `mutcheck-all` lê as diretivas `@src/@test` (conferido com o mesmo `sed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)