### PR TITLE
feat(preco): ",5"/".5" no input de preço vale 0,5 — sem fabricar 0 no separador solto [money-path]

### DIFF
--- a/scripts/mutcheck.d/parse-decimal-br.mut
+++ b/scripts/mutcheck.d/parse-decimal-br.mut
@@ -17,7 +17,8 @@ PEGA      | só ponto: milhar malformado aceito                | $arm = 1 if /re
 PEGA      | ambíguo "1.234": 3 casas → 4 casas                | s/frac\.length === 3 &&/frac.length === 4 \&\&/
 PEGA      | ambíguo: inteiro "0" também vira ambíguo          | s/\[1-9\]\\d\{0,2\}/\\d{1,3}/
 PEGA      | sinal negativo descartado                         | s/\(neg \? '-' : ''\)/(neg ? '' : '')/
-?         | finish aceita inteiro vazio (".5"/",5" → 0.5)     | s/\^\\d\+\(\\\.\\d\+\)\?\$/^\\d*(\\.\\d+)?\$/
+PEGA      | inteiro vazio rejeitado (\d*\. → \d+\.)            | s/\\d\*\\\.\\d\+/\\d+\\.\\d+/
+PEGA      | separador solto vira 0 (alternância → tudo opcional)| s/\(\\d\+\|\\d\*\\\.\\d\+\)/\\d*(\\.\\d+)?/
 SOBREVIVE | groups.length>1 → >=1 (inalcançável: grpSep sempre antes do decSep único) | s/groups\.length > 1 &&/groups.length >= 1 \&\&/
 SOBREVIVE | isFinite → n (inalcançável: só dígitos, finito)   | s/Number\.isFinite\(n\) \? n : null/n/
 SOBREVIVE | typeof guard removido (inalcançável pelo tipo TS) | s/typeof input !== 'string'/false/

--- a/src/lib/preco/parse-decimal-br.test.ts
+++ b/src/lib/preco/parse-decimal-br.test.ts
@@ -56,6 +56,14 @@ describe('parseDecimalBR', () => {
     expect(parseDecimalBR('-1.234,56')).toBe(-1234.56);
   });
 
+  it('aceita inteiro vazio com fração (",5" do teclado numérico = 0,5) sem fabricar zero no separador solto', () => {
+    expect(parseDecimalBR(',5')).toBe(0.5);
+    expect(parseDecimalBR('.5')).toBe(0.5);
+    expect(parseDecimalBR('-,5')).toBe(-0.5);
+    expect(parseDecimalBR(',')).toBeNull(); // Number('') seria 0 — money-path: null
+    expect(parseDecimalBR('.')).toBeNull();
+  });
+
   it('NÃO rejeita decimal legítimo com 3 casas quando não parece milhar', () => {
     expect(parseDecimalBR('0,999')).toBe(0.999);
     expect(parseDecimalBR('0.999')).toBe(0.999); // inteiro "0" não é grupo de milhar válido

--- a/src/lib/preco/parse-decimal-br.ts
+++ b/src/lib/preco/parse-decimal-br.ts
@@ -10,6 +10,7 @@
  *  - Só ponto: 1-2 casas ou inteiro "0…" = decimal (`"12.5"`,`"0.999"`); vários pontos = milhar pt-BR.
  *    Exatamente 3 casas com inteiro que parece grupo de milhar (`"1.234"`) é AMBÍGUO → `null`.
  *  - Agrupamento mal formado (grupos ≠ 3 dígitos) → `null`.
+ *  - Inteiro vazio com fração (`",5"`, `".5"`, `"-,5"`) = 0,5 · separador solto (`","`, `"."`) → `null`.
  *
  * Existe porque `parseFloat("12,5")` = 12 (engole a vírgula do teclado decimal pt-BR),
  * transformando 12,50 em 1250 no input de preço do pedido.
@@ -25,7 +26,9 @@ export function parseDecimalBR(input: string): number | null {
 
   const finish = (intPart: string, frac: string): number | null => {
     const norm = frac ? `${intPart}.${frac}` : intPart;
-    if (!/^\d+(\.\d+)?$/.test(norm)) return null;
+    // Inteiro vazio é legítimo SÓ com fração (",5"/".5" → 0,5); vazio total (","/".") → null,
+    // nunca 0 — `Number('') === 0` seria fabricação de zero.
+    if (!/^(\d+|\d*\.\d+)$/.test(norm)) return null;
     const n = Number((neg ? '-' : '') + norm);
     return Number.isFinite(n) ? n : null;
   };

--- a/supabase/functions/tint-import/index.ts
+++ b/supabase/functions/tint-import/index.ts
@@ -20,7 +20,9 @@ export function parseDecimalBR(input: string): number | null {
 
   const finish = (intPart: string, frac: string): number | null => {
     const norm = frac ? `${intPart}.${frac}` : intPart;
-    if (!/^\d+(\.\d+)?$/.test(norm)) return null;
+    // Inteiro vazio é legítimo SÓ com fração (",5"/".5" → 0,5); vazio total (","/".") → null,
+    // nunca 0 — `Number('') === 0` seria fabricação de zero.
+    if (!/^(\d+|\d*\.\d+)$/.test(norm)) return null;
     const n = Number((neg ? '-' : '') + norm);
     return Number.isFinite(n) ? n : null;
   };


### PR DESCRIPTION
## O que

Segue o #2183. Decisão do Lucas: `",5"` (teclado numérico pt-BR) vale **0,5**. Antes `parseDecimalBR(",5")` era `null`.

## A armadilha que NÃO caí

Afrouxar o regex de `finish` de `^\d+(\.\d+)?$` para `^\d*(\.\d+)?$` faz `","` e `"."` casarem com `norm = ''` → `Number('') === 0` → **preço zero fabricado** no pedido. O regex novo é `^(\d+|\d*\.\d+)$`: inteiro vazio só quando há fração; separador solto continua `null`.

| Entrada | Antes | Agora |
|---|---|---|
| `,5` · `.5` | `null` | 0.5 |
| `-,5` | `null` | -0.5 |
| `,` · `.` | `null` | `null` (nunca 0) |

## Mutation-check

O `?` exploratório do #2183 virou **2 PEGA**: "inteiro vazio rejeitado" e "separador solto vira 0" (a mutação planta exatamente a fabricação de zero e a suíte a mata). 15 mutações · 12/12 PEGA · 3 SOBREVIVE rotulados · 0 inválidas · controle+ ✓ · rc=0.

## Edge espelhada

`parseDecimalBR` vive VERBATIM em `supabase/functions/tint-import/index.ts` (a edge não importa de `src/`; `edge-parse-parity.test.ts` exige identidade textual). Espelho atualizado por script com a mesma extração do teste.

Gates rodados localmente (todos rc=0): paridade vitest 3/3 · `deno test` tint-import 3/3 · `sonda:bump` · `sonda:fingerprint` (edge sem `versao.ts` — não instrumentada) · `edges:typecheck` (0 erros de classe-crash) · eslint.

## ⚠ Pós-merge

**Deploy manual da edge `tint-import`** (Lovable). Sem ele, src aceita `",5"` e a edge em prod rejeita — discordância fail-closed (import tintométrico com `",5"` falha no servidor), não fabricação. Consumidor de UI: `PriceInput` só chama `onValueChange` quando o parse ≠ null, comportamento inalterado para o resto.

Não registrei em `docs/historico/` de propósito: arquivo-diário compartilhado é ímã de conflito entre as ~89 worktrees; o registro é este PR + o contrato `.mut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)