### PR TITLE
fix(fecho): "nenhuma sonda na janela" não se resolve esperando — 24 das 54 edges do mapa não têm cron

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -201,6 +201,18 @@ ESTREITA o diff, e sem ele nenhum par casa e a via (a) emite o mapa INTEIRO como
 devolve **16 `NO_AR` provadas + 25 `SEM_PROVA`** no lugar de 41 pendências cegas. Degradar aqui é
 AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por prova positiva.
 
+🕳️ **`SEM_PROVA` por "nenhuma sonda na janela" NÃO se resolve esperando — DISPARE.** Não existe
+cron de sondagem neste projeto (`cron.job` tem 93 jobs e **zero** com `probe`). Quem dá prova
+passiva é só a edge cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) e tem cron frequente —
+`analytics-outbox-drain` (5 em 5 min) é o caso típico. Medido 2026-09-05: **24 das 54 edges do
+mapa não têm cron NENHUM** (webhook, ou invocada sob demanda pelo app), e para essas a prova
+passiva é *impossível*; ainda por cima `net._http_response` expira no TTL do pg_net (6h), então a
+janela só encolhe. O remédio é `bun run sonda:sql <edge>…` — PASSO 1 (escrita + vault) o founder
+cola no SQL Editor do Lovable; PASSO 2 julga em SELECT puro (`--so-leitura`, roda no `psql-ro`).
+⚠️ Aprendido caro: o autor do próprio script leu este ramo como "espere o próximo tick do cron"
+**horas depois de escrevê-lo**, e a espera nunca terminaria. O script hoje imprime o remédio no
+rodapé, preso pelo caso 3b e pela sabotagem (a5).
+
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
 de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.

--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -189,6 +189,18 @@ Medido em 2026-08-28 numa janela real de 24h: 7 edges na janela, 3 provadas no a
 vez de 7**. E não é só corte: o `DESATUALIZADA` é sinal que o gatilho velho nunca teve — ele
 mostra bundle velho SERVINDO, que é a falha silenciosa que este passo existe para pegar.
 
+⚠️ **`_shared/` na janela: a ponta que FALTA decide se é cegueira ou só lista mais larga.** O guard
+das duas pontas do mapa nasceu com um `||` — faltando QUALQUER uma, exit 2 por atacado —, e isso
+travava o passo justamente na janela de MAIOR risco: quando `_shared/` muda é quando mais edge é
+afetada por transitividade. Medido 2026-09-05 (`--desde "2026-08-21 20:00"`): 26 arquivos de
+`_shared/` tocados, 41 das 95 edges afetadas, e **veredito nenhum** — porque o commit-base era
+anterior ao #1998, que CRIOU o mapa. As duas pontas não têm o mesmo papel: `mapa_agora` (main) é a
+fonte do `esperado` de toda edge, e sem ele a cegueira é real (exit 2 segue certo); `mapa_base` só
+ESTREITA o diff, e sem ele nenhum par casa e a via (a) emite o mapa INTEIRO como alvo — o
+**superconjunto seguro**, a lista larga e não a vazia. Corrigida a assimetria, a MESMA janela
+devolve **16 `NO_AR` provadas + 25 `SEM_PROVA`** no lugar de 41 pendências cegas. Degradar aqui é
+AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por prova positiva.
+
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
 de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -236,6 +236,7 @@ fi
 
 # ------------------------------------------------------------ veredito ---
 : > "$tmp/chips"
+: > "$tmp/sem_sonda"
 echo "== edges da janela: precisa de chip? =="
 if [ "$mecanica_ok" = 0 ]; then
   echo "⚠️ MECÂNICA NÃO CONFIÁVEL — $motivo"
@@ -261,6 +262,7 @@ while read -r slug; do
   elif [ -z "$esperado" ]; then
     printf '  SEM_PROVA      %-34s fora do mapa de sondas — não há prova passiva possível\n' "$slug"
   elif [ -z "$servido" ]; then
+    printf '%s\n' "$slug" >> "$tmp/sem_sonda"
     printf '  SEM_PROVA      %-34s nenhuma sonda em %s (ausência ≠ pendência: INDETERMINADO)\n' "$slug" "$JANELA"
   elif [ "$servido" = "sem-campo-fonte" ]; then
     # Irmão do ramo abaixo, e MAIS FORTE que ele: `nao-mapeada` é o bundle novo servindo uma prova
@@ -287,5 +289,24 @@ fi
 echo "🎫 abra chip para: $(tr '\n' ' ' < "$tmp/chips")"
 echo "   (DESATUALIZADA / PRE_SONDA_FONTE = deploy pendente PROVADO · SEM_PROVA = indeterminado,"
 echo "    chip por fail-closed)"
+# ⚠️ "nenhuma sonda na janela" NÃO se resolve esperando, e dizer só "INDETERMINADO" convida o
+# leitor a esperar. Não há cron de sondagem: medido 2026-09-05, 24 das 54 edges do mapa não têm
+# cron NENHUM (webhook, ou invocada sob demanda pelo app) — para essas a prova passiva é
+# IMPOSSÍVEL, e `net._http_response` ainda expira no TTL do pg_net. Quem dá prova passiva é a edge
+# cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) e tem cron frequente.
+# O próprio autor deste script leu este ramo como "espere o próximo tick do cron" HORAS depois de
+# escrevê-lo, e a espera nunca terminaria: mensagem que engana quem a escreveu engana qualquer um.
+if [ -s "$tmp/sem_sonda" ]; then
+  n_ss="$(wc -l < "$tmp/sem_sonda" | tr -d "[:space:]")"
+  amostra="$(head -6 "$tmp/sem_sonda" | tr '\n' ' ')"
+  [ "$n_ss" -gt 6 ] && amostra="$amostra… (+$((n_ss - 6)))"
+  echo
+  echo "ℹ️  as $n_ss sem sonda NÃO se resolvem esperando — não há cron de sondagem, e boa parte"
+  echo "   destas edges não tem cron nenhum (webhook/sob demanda). DISPARE a sonda:"
+  echo "     bun run sonda:sql $amostra"
+  echo "   (o PASSO 1 gerado é escrita + vault: cola no SQL Editor do Lovable; o PASSO 2 julga e"
+  echo "    roda no read-only com --so-leitura)"
+fi
+
 [ "$mecanica_ok" = 1 ] && exit 1
 exit 2

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -107,10 +107,29 @@ if [ "$1" = "--desde" ]; then
   # do arquivo. Sem essa trava, mudança só em `_shared/` sairia como "nenhuma edge na janela": chip
   # suprimido por AUSÊNCIA DE DADO, que é o modo de falha caro de um script que APAGA pendência.
   if command grep -q '^supabase/functions/_shared/' "$tmp/paths" 2>/dev/null; then
-    if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then
-      echo "⚠️ edges-pendentes: \`_shared/\` mudou na janela e o mapa de fingerprints não pôde ser"
-      echo "   lido nas duas pontas — não sei QUAIS edges isso afetou. MECÂNICA NÃO CONFIÁVEL, exit 2."
+    # ⚠️ As duas pontas do mapa NÃO têm o mesmo papel, e juntá-las num `||` só é o que travava o
+    # Passo 3 em exit 2 na janela de MAIOR risco. Medido 2026-09-05, `--desde "2026-08-21 20:00"`:
+    # 26 arquivos de `_shared/` tocados, 41 das 95 edges afetadas por transitividade — e veredito
+    # nenhum, porque o commit-base é anterior ao #1998, que CRIOU o mapa. A ponta que faltava era
+    # a inútil para a decisão.
+    #   · `mapa_agora` (origin/main) é INDISPENSÁVEL: é a fonte do `esperado` de toda edge e a
+    #     única via que enxerga o efeito de `_shared/`. Sem ele não há o que enumerar nem com o
+    #     que comparar — cegueira de verdade, exit 2.
+    #   · `mapa_base` só ESTREITA: o diff existe para TIRAR da lista quem não mudou. Sem ele
+    #     nenhum par casa e a via (a) já emitiu o mapa INTEIRO como alvo — o superconjunto
+    #     SEGURO. Degradar aqui AMPLIA a lista, e cada alvo segue classificado um a um por prova
+    #     positiva. Desistir jogaria fora o NO_AR de quem TEM prova, e "trate as 95 como
+    #     pendentes" é ingerível: vira chip para tudo, e fila de chip igual enterra o chip que
+    #     importa — exatamente o custo que este script existe para cortar.
+    if [ ! -s "$tmp/mapa_agora" ]; then
+      echo "⚠️ edges-pendentes: \`_shared/\` mudou na janela e o mapa de fingerprints da MAIN não"
+      echo "   pôde ser lido — não sei QUAIS edges isso afetou. MECÂNICA NÃO CONFIÁVEL, exit 2."
       exit 2
+    fi
+    if [ ! -s "$tmp/mapa_base" ]; then
+      echo "ℹ️  mapa_base ausente — a janela começa antes de \`$MAPA_REL\` existir."
+      echo "   O diff não estreitou nada: a via (a) emitiu o mapa INTEIRO como alvo. Enumeração"
+      echo "   AMPLIADA (superconjunto seguro), não cega — cada alvo segue classificado abaixo."
     fi
     if [ ! -s "$tmp/alvos" ]; then
       echo "⚠️ \`_shared/\` mudou na janela e NENHUM fingerprint mudou. Ou a mudança não entra em"

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -104,6 +104,16 @@ suite() {
   then ok "sem sonda na janela -> SEM_PROVA, exit 1"
   else bad "edge sem sonda devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
 
+  # 3b. ...e a saida tem de dizer O QUE FAZER. "nenhuma sonda na janela" NAO se resolve esperando:
+  #     medido 2026-09-05, 24 das 54 edges do mapa nao tem cron nenhum (webhook/sob demanda), e
+  #     `net._http_response` expira em 6h — para essas, prova passiva e IMPOSSIVEL e a espera nunca
+  #     termina. O proprio autor do script leu esse ramo como "espere o proximo tick do cron" horas
+  #     depois de escreve-lo; mensagem que engana quem a escreveu engana qualquer um.
+  run ok "$tmp/psql-stub" edge-muda
+  if tem 'sonda:sql' "$out"
+  then ok "ramo 'nenhuma sonda' aponta o remedio (bun run sonda:sql)"
+  else bad "ramo 'nenhuma sonda' sem remedio — o leitor conclui 'espere o cron', que nunca vem"; fi
+
   # 4. as ~55 edges fora do mapa continuam virando chip como hoje (sem regressao)
   run ok "$tmp/psql-stub" edge-fora-do-mapa
   if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 1 ]
@@ -336,6 +346,12 @@ if [ "${1:-}" = "--falsificar" ]; then
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "mapa_base ausente voltando a ser tratado como cegueira" \
     's%if \[ ! -s "$tmp/mapa_agora" \]; then%if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then%'
+  # (a5) o remedio some do rodape: o ramo "nenhuma sonda" volta a dizer so "INDETERMINADO", e o
+  #      leitor conclui "espere o cron" — que para 24 das 54 edges do mapa NUNCA vem (webhook/sob
+  #      demanda, sem cron nenhum). Foi o erro cometido ao vivo pelo autor do proprio script.
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "registro do ramo 'nenhuma sonda' indo para o vazio (rodape sem remedio)" \
+    's#>> "$tmp/sem_sonda"#>> /dev/null#'
   # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "classificar como NO_AR mesmo com mecanica quebrada" \

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -219,6 +219,50 @@ MAPA1
   then ok "--desde: _shared/ sem mapa legivel -> exit 2, nunca 'nenhuma edge'"
   else bad "_shared sem mapa devia dar exit 2 e nao absolver (rc=$rc): ${out:0:120}"; fi
 
+  # 14b. A JANELA ANTERIOR AO MAPA — o caso que travava o Passo 3 do /fecho em exit 2 (medido
+  #      2026-09-05 com `--desde "2026-08-21 20:00"`: o commit-base e anterior ao #1998, que criou
+  #      `sonda-fingerprints.ts`). As duas pontas do mapa NAO tem o mesmo papel: `mapa_agora` e
+  #      indispensavel (sem ele nao ha `esperado` para ninguem), mas `mapa_base` so ESTREITA a
+  #      enumeracao. Faltando ele o diff nao casa par nenhum e a via (a) emite o mapa INTEIRO como
+  #      alvo — superconjunto SEGURO. Desistir ai joga fora o sinal justamente na janela em que
+  #      MAIS edge foi afetada (41 das 95, na janela medida).
+  local repo2="$tmp/repo-nasce-${LC_ALL:-x}"
+  if [ ! -d "$repo2" ]; then
+    mkdir -p "$repo2/supabase/functions/_shared" "$repo2/supabase/functions/edge-do-shared"
+    git -C "$repo2" init -q -b main 2>/dev/null
+    git -C "$repo2" config user.email t@t; git -C "$repo2" config user.name t
+    printf 'x\n' > "$repo2/supabase/functions/_shared/lib.ts"
+    printf 'import "../_shared/lib.ts"\n' > "$repo2/supabase/functions/edge-do-shared/index.ts"
+    # commit-base SEM o mapa: e exatamente como a main estava antes do #1998
+    git -C "$repo2" add -A >/dev/null; git -C "$repo2" commit -qm "base sem mapa"
+    git -C "$repo2" rev-parse HEAD > "$tmp/base2_sha"
+    printf 'y\n' > "$repo2/supabase/functions/_shared/lib.ts"
+    cat > "$repo2/supabase/functions/_shared/sonda-fingerprints.ts" <<MAPA2
+export const FONTE_SHA256: Record<string, string> = {
+  "edge-do-shared": "$SHA_NOVO",
+};
+MAPA2
+    git -C "$repo2" add -A >/dev/null; git -C "$repo2" commit -qm "shared + mapa nasce"
+    git -C "$repo2" update-ref refs/remotes/origin/main HEAD
+  fi
+  printf 'edge-do-shared %s\n' "$SHA_NOVO" > "$tmp/pares-shared.txt"
+
+  # o SINAL tem de sobreviver: com a fonte servida batendo, a edge sai NO_AR e o chip some
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo2" \
+         STUB_PARES="$tmp/pares-shared.txt" FECHO_MAPA_FONTE="" \
+         bash "$ALVO" --desde "$(cat "$tmp/base2_sha")" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ] && tem 'NO_AR' "$out" && tem 'mapa_base ausente' "$out"
+  then ok "--desde: janela anterior ao mapa -> enumera pelo mapa INTEIRO e preserva o NO_AR"
+  else bad "janela anterior ao mapa devia classificar, nao exit 2 (rc=$rc): ${out:0:140}"; fi
+
+  # e o fail-closed CONTINUA: sem fonte servida, a MESMA edge cai para SEM_PROVA, nunca NO_AR
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo2" \
+         STUB_PARES=/dev/null FECHO_MAPA_FONTE="" \
+         bash "$ALVO" --desde "$(cat "$tmp/base2_sha")" 2>&1)"; rc=$?
+  if [ "$rc" -eq 1 ] && tem 'SEM_PROVA' "$out" && ! tem 'NO_AR' "$out"
+  then ok "--desde: janela anterior ao mapa, sem sonda -> SEM_PROVA (fail-closed intacto)"
+  else bad "sem sonda devia cair para SEM_PROVA, nunca NO_AR (rc=$rc): ${out:0:140}"; fi
+
   # 12. guardrail de FORMA do SQL: o stub nao executa SQL, entao o que da para provar aqui e que a
   #     consulta pede a resposta MAIS RECENTE por edge. Sem isso, um deploy no meio da janela deixa
   #     o bundle velho no resultado e ele seria lido como prova (o caso do omie-vendas-sync).
@@ -285,6 +329,13 @@ if [ "${1:-}" = "--falsificar" ]; then
   # (a3) o fail-closed do `_shared/` sem mapa vira aviso: enumeracao voltaria a absolver por ausencia
   sabota "_shared sem mapa deixando de ser exit 2" \
     's%      exit 2$%      :%'
+  # (a4) a assimetria de papel entre as duas pontas do mapa some, e `mapa_base` volta a valer por
+  #      cegueira — o defeito medido em 2026-09-05: janela cujo base e anterior ao #1998 (que criou
+  #      o mapa) desistia por atacado, sem veredito nenhum, justo quando `_shared/` afetou 41 das
+  #      95 edges. Sem esta sabotagem o caso 14b passaria a ser decorativo.
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "mapa_base ausente voltando a ser tratado como cegueira" \
+    's%if \[ ! -s "$tmp/mapa_agora" \]; then%if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then%'
   # (b) o fail-closed some da classificacao: mecanica quebrada passaria a absolver
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "classificar como NO_AR mesmo com mecanica quebrada" \


### PR DESCRIPTION
## O sintoma

O ramo `SEM_PROVA` por ausência de sonda dizia apenas *"ausência ≠ pendência: INDETERMINADO"*. Correto — e **inacionável**. O leitor conclui "espere o próximo tick do cron". Não há tick.

## A evidência de que a mensagem enganava

O autor deste script leu esse ramo como *"espere o próximo tick do cron e repita"* **horas depois de escrevê-lo**, ao verificar dois deploys reais ([#2161](https://github.com/LucasSardenbergL/afiacao/pull/2161)). Mensagem que engana quem acabou de escrevê-la engana qualquer agente futuro — e o desfecho é caro: o `SEM_PROVA` persistente passa por pendência real, virando chip eterno numa edge que já está no ar. É o custo exato que este script existe para cortar.

## O fato, medido contra prod

| medida | valor |
|---|---|
| jobs em `cron.job` | 93 |
| jobs com `probe` | **0** — não existe cron de sondagem |
| edges no mapa de sondas | 54 |
| **edges do mapa sem cron nenhum** | **24** |

Prova passiva só existe para a edge cujo fluxo **normal** já ecoa o envelope (`edge`+`fonte`) e que tem cron frequente — `analytics-outbox-drain` (5 em 5 min) é o caso típico. Para webhook (`omie-nfe-webhook`) ou edge sob demanda (`analyze-unified-order`), a prova passiva é **impossível**. E `net._http_response` expira no TTL do pg_net (6h): a janela só encolhe, nunca enche sozinha.

## A correção

O rodapé passa a nomear o remédio e a dizer de quem é cada metade:

```
ℹ️  as 7 sem sonda NÃO se resolvem esperando — não há cron de sondagem, e boa parte
   destas edges não tem cron nenhum (webhook/sob demanda). DISPARE a sonda:
     bun run sonda:sql ai-ops-agent conciliar-pedido-portal … (+1)
   (o PASSO 1 gerado é escrita + vault: cola no SQL Editor do Lovable; o PASSO 2 julga e
    roda no read-only com --so-leitura)
```

Nada no fail-closed muda: a edge continua saindo como pendência e continua virando chip. O que muda é o leitor saber o que fazer.

## Prova

- **Caso 3b** (novo): exige `sonda:sql` na saída do ramo. Escrito **vermelho primeiro**.
- **Sabotagem (a5)** (nova): manda o registro do ramo para `/dev/null` e exige a suite **vermelha nos 2 locales**.
- `12/12` sabotagens vermelhas, **0 vazias**, exit 0. Suite verde nos 2 locales. `shellcheck` limpo. `docs:indice`/`docs:citacoes`/`claude:size` verdes.
- A regra também ficou gravada no passo 3 de `.claude/skills/fecho/SKILL.md`, com os números e a origem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)