### PR TITLE
fix(fecho): "nenhuma sonda na janela" não se resolve esperando — não há cron de sondagem

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -218,6 +218,21 @@ ESTREITA o diff, e sem ele nenhum par casa e a via (a) emite o mapa INTEIRO como
 devolve **16 `NO_AR` provadas + 25 `SEM_PROVA`** no lugar de 41 pendências cegas. Degradar aqui é
 AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por prova positiva.
 
+🕳️ **`SEM_PROVA` por "nenhuma sonda na janela" NÃO se resolve esperando — DISPARE.** Não existe
+cron de sondagem: `cron.job` tem 93 jobs e **zero** com `probe`. Quem dá prova passiva é só a edge
+cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) **e** tem cron frequente —
+`analytics-outbox-drain` (5 em 5 min) é o caso típico. Medido 2026-09-05: **24 das 54 edges do
+mapa não têm cron NENHUM** (webhook como `omie-nfe-webhook`, ou invocada sob demanda pelo app como
+`analyze-unified-order`), e para essas a prova passiva é *impossível*; ainda por cima
+`net._http_response` expira no TTL do pg_net, então a janela só encolhe. O remédio é
+`bun run sonda:sql <edge>…` — PASSO 1 (escrita + vault) o founder cola no SQL Editor do Lovable;
+PASSO 2 julga em SELECT puro (`--so-leitura`, roda no `psql-ro`); com o id em mãos, `--request-ids
+<slug>=<id>` fecha o vínculo. ⚠️ Aprendido caro: o autor do próprio script leu este ramo como
+"espere o próximo tick do cron" **horas depois de escrevê-lo**, ao verificar dois deploys reais — a
+espera nunca terminaria, e o `SEM_PROVA` persistente passaria por pendência real (chip eterno numa
+edge que já está no ar). O script hoje imprime o remédio no rodapé, preso pelo caso 3b e pela
+sabotagem (a6).
+
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
 de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -379,6 +379,7 @@ fi
 
 # ------------------------------------------------------------ veredito ---
 : > "$tmp/chips"
+: > "$tmp/sem_sonda"
 echo "== edges da janela: precisa de chip? =="
 if [ "$mecanica_ok" = 0 ]; then
   echo "⚠️ MECÂNICA NÃO CONFIÁVEL — $motivo"
@@ -412,6 +413,7 @@ while read -r slug; do
     printf '  SEM_PROVA      %-34s SONDA_ANONIMA: nenhuma resposta ECOANDO este slug, mas %s resposta(s) de sonda sem eco de slug na janela (200 com `probe`+`versao` e SEM `edge` = bundle anterior ao #1789). Uma delas PODE ser desta edge; nenhuma é atribuível sem o disparo → INDETERMINADO. Para determinar: --request-ids %s=<request_id>\n' \
       "$slug" "$n_anonimas" "$slug"
   elif [ -z "$servido" ]; then
+    printf '%s\n' "$slug" >> "$tmp/sem_sonda"
     printf '  SEM_PROVA      %-34s nenhuma sonda em %s (ausência ≠ pendência: INDETERMINADO)\n' "$slug" "$JANELA"
   elif [ "$servido" = "sem-campo-fonte" ]; then
     # Irmão do ramo abaixo, e MAIS FORTE que ele: `nao-mapeada` é o bundle novo servindo uma prova
@@ -438,5 +440,26 @@ fi
 echo "🎫 abra chip para: $(tr '\n' ' ' < "$tmp/chips")"
 echo "   (DESATUALIZADA / PRE_SONDA_FONTE = deploy pendente PROVADO · SEM_PROVA = indeterminado,"
 echo "    chip por fail-closed)"
+# ⚠️ "nenhuma sonda na janela" NÃO se resolve esperando, e dizer só "INDETERMINADO" convida o
+# leitor a esperar. NÃO HÁ cron de sondagem: `cron.job` tem 93 jobs e ZERO com `probe`. Quem dá
+# prova passiva é só a edge cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) E tem cron
+# frequente — `analytics-outbox-drain` (5/5min) é o caso típico. Medido 2026-09-05: 24 das 54
+# edges do mapa não têm cron NENHUM (webhook, ou invocada sob demanda pelo app), e para essas a
+# prova passiva é IMPOSSÍVEL; `net._http_response` ainda expira no TTL do pg_net, então a janela
+# só encolhe. O autor deste script leu este ramo como "espere o próximo tick do cron" HORAS depois
+# de escrevê-lo, ao verificar dois deploys reais: a espera nunca terminaria, e o `SEM_PROVA`
+# persistente passaria por pendência real — chip eterno numa edge que já está no ar.
+if [ -s "$tmp/sem_sonda" ]; then
+  n_ss="$(wc -l < "$tmp/sem_sonda" | tr -d "[:space:]")"
+  amostra="$(head -6 "$tmp/sem_sonda" | tr '\n' ' ')"
+  [ "$n_ss" -gt 6 ] && amostra="$amostra… (+$((n_ss - 6)))"
+  echo
+  echo "ℹ️  as $n_ss sem sonda NÃO se resolvem esperando: não há cron de sondagem, e boa parte"
+  echo "   destas edges não tem cron nenhum (webhook/sob demanda) — prova passiva é impossível."
+  echo "   DISPARE:  bun run sonda:sql $amostra"
+  echo "   (PASSO 1 é escrita + vault → SQL Editor do Lovable; PASSO 2 julga em SELECT puro,"
+  echo "    --so-leitura, roda no psql-ro. Com o id em mãos: --request-ids <slug>=<id>)"
+fi
+
 [ "$mecanica_ok" = 1 ] && exit 1
 exit 2

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -111,6 +111,15 @@ suite() {
   run ok "$tmp/psql-stub" edge-muda
   if tem 'SEM_PROVA' "$out" && [ "$rc" -eq 1 ]
   then ok "sem sonda na janela -> SEM_PROVA, exit 1"
+  if tem 'sonda:sql' "$out"
+  then ok "ramo 'nenhuma sonda' aponta o remedio (bun run sonda:sql)"
+  else bad "ramo 'nenhuma sonda' sem remedio — o leitor conclui 'espere o cron', que nunca vem"; fi
+  # 3b. ...e a saida tem de dizer O QUE FAZER. "nenhuma sonda na janela" NAO se resolve esperando:
+  #     nao ha cron de sondagem (93 jobs em cron.job, ZERO com probe) e, medido 2026-09-05, 24 das
+  #     54 edges do mapa nao tem cron NENHUM (webhook/sob demanda) — para essas a prova passiva e
+  #     IMPOSSIVEL, e net._http_response ainda expira no TTL. O autor do proprio script leu este
+  #     ramo como "espere o proximo tick do cron" HORAS depois de escreve-lo, ao verificar dois
+  #     deploys reais; a espera nunca terminaria. Mensagem que engana quem a escreveu engana todos.
   else bad "edge sem sonda devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
 
   # 4. as ~55 edges fora do mapa continuam virando chip como hoje (sem regressao)
@@ -442,6 +451,12 @@ if [ "${1:-}" = "--falsificar" ]; then
   # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
   sabota "mapa_base ausente voltando a ser tratado como cegueira" \
     's%if \[ ! -s "$tmp/mapa_agora" \]; then%if [ ! -s "$tmp/mapa_agora" ] || [ ! -s "$tmp/mapa_base" ]; then%'
+  # (a6) o remedio some do rodape: o ramo "nenhuma sonda" volta a dizer so "INDETERMINADO" e o
+  #      leitor conclui "espere o cron" — que para 24 das 54 edges do mapa NUNCA vem (sem cron
+  #      nenhum: webhook/sob demanda). Foi o erro cometido ao vivo pelo autor do proprio script.
+  # shellcheck disable=SC2016  # a expressao sed e PADRAO literal do alvo
+  sabota "registro do ramo 'nenhuma sonda' indo para o vazio (rodape sem remedio)" \
+    's#>> "$tmp/sem_sonda"#>> /dev/null#'
   # (a5) a via (c) para de contribuir alvos: a edge FORA do mapa afetada so por `_shared/` volta a
   #      ser invisivel — exatamente a classe de 41 edges medida em 2026-09-05. Sem esta sabotagem o
   #      caso 13b poderia estar verde por outro motivo (a via (b) pegando a pasta, p.ex.).


### PR DESCRIPTION
## O sintoma

O ramo `SEM_PROVA` por ausência de sonda dizia apenas *"ausência ≠ pendência: INDETERMINADO"*. Correto — e **inacionável**. O leitor conclui "espere o próximo tick do cron". Não há tick.

## A evidência de que a mensagem enganava

O autor deste script leu esse ramo como *"espere o próximo tick do cron e repita"* **horas depois de escrevê-lo**, ao verificar dois deploys reais ([#2161](https://github.com/LucasSardenbergL/afiacao/pull/2161)). Mensagem que engana quem acabou de escrevê-la engana qualquer agente futuro — e o desfecho é caro: o `SEM_PROVA` persistente passa por pendência real, virando chip eterno numa edge que já está no ar. É o custo exato que este script existe para cortar.

Demonstrado ao vivo nesta sessão: `analyze-unified-order` foi confirmada `NO_AR` por disparo e **voltou a `SEM_PROVA` seis horas depois**, sem nada ter mudado no ar.

## O fato, medido contra prod

| medida | valor |
|---|---|
| jobs em `cron.job` | 93 |
| jobs com `probe` | **0** — não existe cron de sondagem |
| edges no mapa de sondas | 54 |
| **edges do mapa sem cron nenhum** | **24** |

Prova passiva só existe para a edge cujo fluxo **normal** já ecoa o envelope (`edge`+`fonte`) **e** tem cron frequente — `analytics-outbox-drain` (5 em 5 min) é o caso típico. Para webhook (`omie-nfe-webhook`) ou edge sob demanda (`analyze-unified-order`), é **impossível**. E `net._http_response` expira no TTL do pg_net: a janela só encolhe.

## A correção

```
ℹ️  as 5 sem sonda NÃO se resolvem esperando: não há cron de sondagem, e boa parte
   destas edges não tem cron nenhum (webhook/sob demanda) — prova passiva é impossível.
   DISPARE:  bun run sonda:sql ai-ops-agent analyze-unified-order …
   (PASSO 1 é escrita + vault → SQL Editor do Lovable; PASSO 2 julga em SELECT puro,
    --so-leitura, roda no psql-ro. Com o id em mãos: --request-ids <slug>=<id>)
```

**Nada no fail-closed muda:** a edge continua saindo como pendência e continua virando chip. O que muda é o leitor saber o que fazer. Emenda no `--request-ids` do #2171.

## Prova

- **Caso 3b** (novo): exige `sonda:sql` na saída do ramo. Escrito **vermelho primeiro**, nos 2 locales.
- **Sabotagem (a6)** (nova): manda o registro do ramo para `/dev/null` e exige a suite **vermelha nos 2 locales**.
- `19/19` sabotagens vermelhas, **0 vazias**, exit 0. Suite verde nos 2 locales. `shellcheck` limpo. `docs:indice`/`docs:citacoes`/`claude:size` verdes.
- Regra gravada no passo 3 de `.claude/skills/fecho/SKILL.md`, com os números e a origem.

## Nota de processo

Um primeiro PR (#2186) foi aberto sobre base velha e fechado: carregava o commit já mergeado do #2161 (squash) e colidia com #2170/#2171, que mergearam ~10h antes. Este PR é o diferencial reaplicado sobre a `origin/main` atual — verificado por `git grep` do símbolo, não por título.

🤖 Generated with [Claude Code](https://claude.com/claude-code)