### PR TITLE
chore(authz): carimbo pós-apply — a RPC sayerlack_aplicar_custo_portal existe em prod e o achado fechou

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-09-05T12:22:12.144Z",
-  "sourceHead": "90d65299a0edabfbb07d7662f4fc397671718e1b",
+  "medidoEm": "2026-09-05T17:42:39.686Z",
+  "sourceHead": "e4951ec5b59d04951f15ced758d7adf580f62b9b",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -11,19 +11,12 @@
   "audits": {
     "funcoes": {
       "script": "authz:funcoes:prod",
-      "exit": 1,
-      "resumo": "authz:funcoes:prod — 1 divergência(s) de EXECUTE. Ver scripts/authz-funcoes-fechadas.ts.",
-      "denominador": "🔎 authz:funcoes:prod — 43 definição(ões) lida(s) para 44 chave(s) da allowlist.",
+      "exit": 0,
+      "resumo": "✅ o EXECUTE de prod bate com o contrato nas 44 função(ões) da allowlist.",
+      "denominador": "🔎 authz:funcoes:prod — 44 definição(ões) lida(s) para 44 chave(s) da allowlist.",
       "contratoFingerprint": "04c6fe6a1994d8042a4a22d9c7833e6c67c01da66a8819493dc2d586f660e7bf",
       "auditorFingerprint": "caabc19be3ea3ea381bc8c37617f9d7c1f0b5491958f5f8ffdc9a9ca851e508e",
-      "achados": [
-        {
-          "id": "ef43258a5a7946e8",
-          "linha": "❌ public.sayerlack_aplicar_custo_portal — [FUNCAO_AUSENTE_EM_PROD] public.sayerlack_aplicar_custo_portal está na allowlist e NÃO existe no banco — foi removida, renomeada, ou a allowlist ficou obsoleta.",
-          "primeiraVez": "2026-09-05",
-          "ultimaVez": "2026-09-05"
-        }
-      ]
+      "achados": []
     },
     "grants": {
       "script": "authz:grants:prod",


### PR DESCRIPTION
## O que mudou

O founder colou a migration `20260905090000_sayerlack_custo_portal_cas.sql` (do #2176). Este PR só atualiza a evidência de prod que o gate do CI lê.

**Medido agora via `psql-ro`** — a RPC `public.sayerlack_aplicar_custo_portal` existe com a assinatura do contrato (`p_pedido_id bigint, p_itens jsonb, p_valor_total numeric`), é `SECURITY DEFINER`, tem `search_path` preso em `public`, `anon` e `authenticated` **não** executam, e `service_role` executa. O REVOKE por nome pegou (o default privilege de `public` concede EXECUTE a `anon`+`authenticated`, então essa checagem não é decorativa).

Os cinco audits saem verdes: `funcoes` (44/44 batem), `grants`, `reescritas`, `claude-ro`, `rls`.

## Por que o achado sumiu

O carimbo anterior carregava `FUNCAO_AUSENTE_EM_PROD` para essa função. Ele era **honesto** — a allowlist declarava uma função que o banco não tinha, porque o apply é manual e ainda não havia acontecido. Agora ele fecha por ter sido **resolvido**, não por renovação de data: o runner preserva `primeiraVez` por id de achado justamente para que regravar o carimbo não lave dívida.

Sem mudança de comportamento; só evidência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
