### PR TITLE
docs(reposicao): #2459 encerrado por decisão do founder — a nota fiscal resolve os R$ 13,06

### DIFF
--- a/docs/historico/sayerlack-captura-custo-cega.md
+++ b/docs/historico/sayerlack-captura-custo-cega.md
@@ -135,6 +135,11 @@ vigiado, não presumido inócuo.
 ⚠️ **O #2459 não se conserta sozinho depois do apply**: ele já tem `omie_pedido_compra_numero`, e o CAS
 recusa com **CP002 por desenho** (custo não muda depois do PO). Reprocessá-lo é decisão de produto, com
 correção do lado do Omie — não é rollback de código.
+**Decidido pelo founder em 2026-09-05: fica como está — a conferência da nota fiscal do fornecedor
+resolve os R$ 13,06.** Não reprocessar, não "corrigir" o #2459: ele não é pendência aberta, é caso
+encerrado. O `cego=true` com `sqlstate_rpc=PGRST202` que ele carrega no `portal_resposta` é **registro
+histórico do intervalo de deploy**, não alarme vivo — quem varrer o sensor procurando cegueira filtra
+por `enviado_portal_em`, e não trata esta linha como trabalho a fazer.
 
 ## Risco residual (chips)
 


### PR DESCRIPTION
## O que muda

Só uma anotação em `docs/historico/sayerlack-captura-custo-cega.md`.

O pedido **#2459** saiu no intervalo entre o Publish da edge e o apply da migration (`PGRST202`): foi ao fornecedor e o PO Omie 1219 nasceu **3,49% acima** do que o portal cobrou. O doc já dizia que reprocessá-lo era decisão de produto — a decisão foi tomada hoje: **fica como está, a conferência da nota fiscal do fornecedor resolve os R$ 13,06.**

## Por que registrar

Para que ninguém o trate como pendência aberta depois. Ele carrega `cego=true` e `sqlstate_rpc=PGRST202` no `portal_resposta`, e essa linha é **registro histórico do intervalo de deploy**, não alarme vivo. Quem varrer o sensor procurando cegueira filtra por `enviado_portal_em` em vez de tomar o #2459 como trabalho a fazer.

Nenhuma mudança de comportamento e nenhuma escrita no banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)