### PR TITLE
docs(reposicao): prompt da fatia "janela preço-velho no PO Omie" sai do chip e vira destino durável

### DIFF
--- a/docs/historico/sayerlack-captura-custo-cega.md
+++ b/docs/historico/sayerlack-captura-custo-cega.md
@@ -149,6 +149,23 @@ por `enviado_portal_em`, e não trata esta linha como trabalho a fazer.
   e o banco fica com o novo. Nesta edge a captura roda ANTES de `registrarPedidoOmieAposPortal` (sequencial);
   a janela só existe com um disparo concorrente por outra via. Fecho seria o `disparar` reler o custo sob o
   mesmo lock — fatia própria.
+
+  **Prompt auto-contido da fatia** (estava só num chip da sessão de 2026-09-05; chip morre com a
+  sessão, então fica aqui — "pendência sem destino não existe" vale também quando o destino é
+  perecível):
+
+  > Contexto: a RPC `public.sayerlack_aplicar_custo_portal` (migration `20260905090000`, aplicada em
+  > prod) grava custo com CAS `omie_pedido_compra_numero IS NULL AND status_envio_portal =
+  > 'sucesso_portal'`. Risco residual: `supabase/functions/disparar-pedidos-aprovados/index.ts` lê
+  > `preco_unitario` (≈l.842) ANTES de criar o PO no Omie (`nValUnit`, ≈l.985) e grava
+  > `omie_pedido_compra_numero` DEPOIS (≈l.1073/1128). Se a RPC gravar nessa janela — só com disparo
+  > concorrente por outra via; nesta edge a captura é sequencial —, o PO nasce com o preço velho.
+  > Tarefa: enumerar TODAS as vias que criam PO Omie a partir de `pedido_compra_sugerido` (money-path
+  > §5), medir em prod (`psql-ro`) se a janela já se materializou, e fechar — o disparo relendo o
+  > custo sob o mesmo row-lock, ou reservando o número do PO antes de chamar o Omie para a RPC
+  > recusar. Prove com `prove-sql-money-path` (PG17, falsificação); migration pelo
+  > `lovable-db-operator` (apply manual). Rode os 5 gates de edge e arme `scripts/pr-watch.sh`.
+  > Leia antes: `CLAUDE.md`, `docs/agent/money-path.md`, `docs/agent/database.md` e este arquivo.
 - Preço do portal é **líquido pré-imposto**; o `preco_unitario` do Omie hoje mistura origens (WP06:
   R$ 172,20 no Omie vs R$ 129,32 líquido no portal). Decisão de produto do #627 mantida; o PO Omie
   passa a nascer com o preço que o fornecedor de fato cobrou.


### PR DESCRIPTION
## Por que

Ritual `/fecho`: **chip é destino perecível.** Ele mora dentro da sessão que o criou, o `/tasks` é por-sessão e não há fila global. Arquivada a sessão antes do clique, não há caminho conhecido de volta — e **não está documentado** se o chip sobrevive ao arquivamento. Ausência de dado não é "sobrevive"; num ritual que termina em arquivamento, isso é fail-closed.

## O que entra

O risco residual (o `disparar-pedidos-aprovados` lê `preco_unitario` antes de criar o PO no Omie e grava o número depois) já estava descrito em prosa em `docs/historico/sayerlack-captura-custo-cega.md`. Faltava o **prompt auto-contido** que uma sessão nova precisa, já que ela não vê a conversa que o gerou: as vias a enumerar, as linhas aproximadas, a medição de prod a fazer, as duas formas de fecho consideradas e as skills obrigatórias.

O chip continua existindo como atalho. Este texto é o destino que sobrevive a ele.

Só documentação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)