### PR TITLE
docs(sayerlack): a query que verifica a captura de custo aprova o pedido CEGO — e a RPC nunca foi chamada [money-path]

### DIFF
--- a/docs/historico/sayerlack-captura-custo-cega.md
+++ b/docs/historico/sayerlack-captura-custo-cega.md
@@ -76,6 +76,22 @@ Sinal positivo esperado após o deploy: `fonte='json_total_unico'` nos pedidos d
 `portal_resposta->'scrape_debug'` (headers/idx/amostra) diz qual coluna faltou. **Bundle pré-deploy responde
 sem `captura_custo`** (ausência = versão velha, não "nenhuma captura").
 
+⚠️ **A leitura pela RAIZ do `portal_resposta` é CEGA — e mente "OK" (medido 2026-09-05 19:20Z).** O
+veredito vive em `portal_resposta->'captura_custo'->>'motivo'`; ler `portal_resposta->>'motivo'` (sem o
+salto) devolve **NULL em todo pedido**, inclusive nos cegos. Combinado com a heurística "`valor_total`
+preenchido ⇒ capturou", isso aprova exatamente os casos que a entrega existe para pegar:
+
+| id | `->>'motivo'` (raiz) | `valor_total` | casas | tem `captura_custo`? | veredito REAL |
+|---|---|---|---|---|---|
+| 2459 | NULL | 387,832503 | 6 | sim | **`erro_rpc`** (PGRST202, cego) |
+| 2443 | NULL | 1802,52 | **2** | **não** | nenhum — envio pré-deploy |
+
+O 2443 é o caso letal: passa também no desempate por casas decimais (2 casas ⇒ "veio do portal via
+`round2`"), e mesmo assim **nunca teve captura** — o `1802,52` é coincidência aritmética do valor estimado
+interno (CMC × qtde), não assinatura do fornecedor. **`scale(valor_total)` não discrimina origem.** O
+discriminante é a **presença da chave** `captura_custo` e o par `fonte`/`cego` dentro dela: ausente = versão
+velha; presente com `cego=true` = capturou e recusou-se a gravar; presente com `cego=false` = sinal positivo.
+
 ## Fecho do CAS (2ª fatia, 2026-09-05): a escrita virou UMA RPC transacional
 
 O challenge do Codex apontou dois buracos na escrita da 1ª fatia: (a) escrita **parcial** entre itens
@@ -140,6 +156,33 @@ resolve os R$ 13,06.** Não reprocessar, não "corrigir" o #2459: ele não é pe
 encerrado. O `cego=true` com `sqlstate_rpc=PGRST202` que ele carrega no `portal_resposta` é **registro
 histórico do intervalo de deploy**, não alarme vivo — quem varrer o sensor procurando cegueira filtra
 por `enviado_portal_em`, e não trata esta linha como trabalho a fazer.
+
+## Pós-apply: a RPC está em pé e AINDA NÃO FOI EXERCITADA (medido 2026-09-05 19:20Z)
+
+A migration foi colada entre 17:30:09Z e 17:34:01Z e a edge está no ar em `v1.5-custo-portal-rpc-cas`.
+**1h46 depois, ZERO envios ao portal.** O último continua sendo o #2459, de 13:38:14Z — dentro da janela de
+cegueira, e **caso encerrado** (decisão do founder, acima). Provado por duas vias independentes, porque um
+zero só vale com controle positivo:
+
+```
+max(enviado_portal_em) = 2026-09-05 13:38:14+00   -- ANTERIOR ao apply; não depende do filtro estar certo
+filtro enviado_portal_em > '2026-09-05 17:34:01+00' → 0 linhas   (censo: 512 pedidos, 132 já enviados)
+```
+
+⇒ **Isto é ausência de dado, não aprovação.** A RPC nunca recebeu chamada em produção; o
+`fonte='json_total_unico'` com `cego=false` que provaria a entrega **ainda não existe em lugar nenhum**.
+Não adianta esperar: **não há cron que dispare envio ao portal** — o gatilho é o founder enviando um
+pedido. O primeiro envio real é que vira o sinal, e a hora de olhar é logo depois dele.
+
+Duas coisas a saber antes desse primeiro envio:
+
+- **Multi-item ainda não está coberto** até o PR #2194 mergear **e** a edge ser publicada: o `dom_checksum`
+  multiplicava `Preço Venda` (que já é o **total da linha**) por `Qtd UN`, reprovando todo pedido de N itens
+  por `checksum_divergente`. Pedido de 1 item não passa por esse ramo (cai em `json_total_unico`), então um
+  primeiro envio unitário **não** exercita o caminho consertado.
+- **Sinal negativo também é sinal.** Se o primeiro envio vier `motivo='erro_rpc'` com `sqlstate_rpc` nulo ou
+  `42883`/`PGRST202`, não é o portal nem o DOM: é schema cache do PostgREST ou assinatura divergente — a
+  função em si já foi conferida byte-a-byte contra o repo (md5 `fdf607ecb4a5f184c98fba5793e484dc`).
 
 ## Risco residual (chips)
 


### PR DESCRIPTION
## Verificação pedida: a captura de custo funcionou no primeiro envio real pós-RPC?

**Não houve primeiro envio.** Medido em prod (`psql-ro`, 2026-09-05 19:20Z): a migration foi colada
17:30–17:34Z, a edge está no ar em `v1.5-custo-portal-rpc-cas`, e **1h46 depois há ZERO envios ao
portal**. O último continua sendo o #2459 (13:38:14Z), da janela de cegueira, já encerrado pelo founder
no #2190 — não reaberto aqui.

Zero só vale com controle positivo, então provei por duas vias independentes:

| via | resultado |
|---|---|
| `max(enviado_portal_em)` global | `2026-09-05 13:38:14+00` — **anterior ao apply**, não depende do filtro |
| filtro `enviado_portal_em > 17:34:01Z` | 0 linhas (censo de controle: 512 pedidos, 132 já enviados) |

⇒ **ausência de dado, não aprovação.** A RPC está em pé e **nunca recebeu chamada**. Não adianta
esperar: não há cron que dispare envio ao portal — o gatilho é humano.

## O achado que não estava no roteiro

A query de verificação que eu recebi lê `portal_resposta->>'motivo'` na **raiz**; o veredito mora em
`portal_resposta->'captura_custo'->>'motivo'`. Sem o salto o campo vem **NULL em todo pedido**, e a
regra "motivo nulo + `valor_total` preenchido ⇒ captura OK" aprova justamente os cegos:

| id | motivo (raiz) | valor_total | casas | tem `captura_custo`? | veredito REAL |
|---|---|---|---|---|---|
| 2459 | NULL | 387,832503 | 6 | sim | `erro_rpc` (PGRST202, cego) |
| 2443 | NULL | 1802,52 | **2** | **não** | nenhum — envio pré-deploy |

O **2443** é o caso letal: passa **também** no desempate por casas decimais ("2 casas ⇒ veio do portal
via `round2`") e mesmo assim nunca teve captura — o valor é coincidência aritmética do estimado interno
(CMC × qtde). `scale(valor_total)` não discrimina origem. O discriminante é a **presença da chave**
`captura_custo` e o par `fonte`/`cego` dentro dela.

Mesma classe do gate cego já catalogada no repo: o verificador media a coisa errada e responderia VERDE.
Hoje só não mentiu porque não havia linha nenhuma para aprovar.

## O que este PR faz

Só documenta, em `docs/historico/sayerlack-captura-custo-cega.md`, ao lado da query correta que o doc já
carregava:

1. o estado medido pós-apply (RPC em pé, zero exercício, e por que isso não é falha);
2. a armadilha da leitura pela raiz, com a prova nos dois pedidos;
3. o aviso de que **multi-item só fica coberto** depois que o #2194 mergear **e** a edge for publicada —
   um primeiro envio de 1 item cai em `json_total_unico` e **não** exercita o ramo consertado.

**Nada de código tocado. Nada re-aplicado no banco.** Toda leitura foi read-only via `psql-ro`.

Gates: `docs:links` ✓ · `docs:citacoes` ✓ · `docs:indice` ✓ (revalidados após rebase na main)

⚠️ Colisão conhecida: o #2194 toca o mesmo arquivo. Se ele mergear antes, resolvo o conflito aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ PENDÊNCIA DE DEPLOY detectada no fecho desta sessão (2026-09-05 ~19:55Z)

Registrada aqui porque o chip que a carrega é **perecível** (morre com a sessão) e esta é a pendência
mais cara que o fecho encontrou. O `edges-pendentes.sh` classificou a edge deste próprio caso como
**`DESATUALIZADA`** — bundle VELHO servindo:

| | fingerprint | `VERSAO` |
|---|---|---|
| no ar | `d98f4188…` | `v1.5-custo-portal-rpc-cas` |
| main | `00b92076…` | **`v1.6-preco-venda-e-total-da-linha`** |

O #2194 mergeou às 19:40:10Z (merge `a10ef2383`) e **não foi publicado**. Enquanto o v1.5 estiver no ar,
a captura pelo DOM segue morta para pedido **multi-item** (`checksum_divergente`) — fail-closed, nunca
fabrica custo, mas também nunca captura. Pedido de 1 item cai em `json_total_unico` e **não** exercita
esse ramo, então um envio unitário não prova o conserto.

**Prompt para o chat do Lovable** — fatia de 3 arquivos, todos `M`, nenhum novo (derivada de
`git show --name-status a10ef2383`, não de memória):

> Edit the existing edge function `enviar-pedido-portal-sayerlack` and replace its code with the current
> contents of these files from the `main` branch, all of them:
> - `supabase/functions/enviar-pedido-portal-sayerlack/index.ts`
> - `supabase/functions/enviar-pedido-portal-sayerlack/versao.ts`
> - `supabase/functions/enviar-pedido-portal-sayerlack/captura-custo.ts`
> - `supabase/functions/_shared/sonda-fingerprints.ts`
> Deploy it **verbatim** — do NOT modify, reinterpret, "improve", or reformat the code.
> After deploying, confirm it shows **Active**.

Verificação (exigir positiva): `bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde a10ef2383~1`
deve sair **`NO_AR`**. Sem cron sondando esta edge, use `bun run sonda:sql enviar-pedido-portal-sayerlack`
e feche o vínculo com `--request-ids`.

Chip equivalente: **"Publicar edge sayerlack v1.6 (captura multi-item)"**.
