### PR TITLE
fix(fecho): o "DISPARE" do Passo 3 saía pronto-para-colar — e cego à triagem barato/caro

### DIFF
--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -486,14 +486,35 @@ echo "    chip por fail-closed · INERTE = aposentada, deploy sem efeito, NÃO e
 # só encolhe. O autor deste script leu este ramo como "espere o próximo tick do cron" HORAS depois
 # de escrevê-lo, ao verificar dois deploys reais: a espera nunca terminaria, e o `SEM_PROVA`
 # persistente passaria por pendência real — chip eterno numa edge que já está no ar.
+# ⚠️ E "DISPARE" NÃO É INCONDICIONAL: o bundle PRÉ-sensor não conhece o campo `probe`, então a
+# sonda não é lida como sonda — ela entra como REQUISIÇÃO NORMAL e o handler executa o fluxo
+# REAL. É a mesma assimetria da triagem de script destrutivo: a sonda é barata na edge que recusa
+# cedo (400/401 antes de todo IO) e CARA na que cai no caminho default (`?? "OBEN"`, `dias = 30`)
+# ou que sequer LÊ o corpo. Medido 2026-09-05, 12ª leva: das 9 instrumentadas, 3 eram caras —
+# `process-recurring-orders` (não lê o corpo: CRIA `orders` e AVANÇA o `next_order_date`, então o
+# run legítimo do dia seguinte PULA a data que a sonda consumiu), `omie-nfe-recebimento-sync` e
+# `omie-sync-metadados`. Emitir um comando pronto para colar com as 9 juntas convida exatamente
+# esse disparo. O `--caro` do `sonda:sql` é a trava (bloco separado com `confirmei_o_deploy`), e
+# ele é fail-CLOSED: nome que não casa com a leva ABORTA sem emitir SQL. Por isso a flag sai já
+# no comando, com valor SINTATICAMENTE INVÁLIDO — a regra do `deploy.md` de nunca deixar valor de
+# EXEMPLO no campo que o operador substitui: o erro ecoa a própria instrução em vez de disparar.
 if [ -s "$tmp/sem_sonda" ]; then
   n_ss="$(wc -l < "$tmp/sem_sonda" | tr -d "[:space:]")"
-  amostra="$(head -6 "$tmp/sem_sonda" | tr '\n' ' ')"
-  [ "$n_ss" -gt 6 ] && amostra="$amostra… (+$((n_ss - 6)))"
+  # A lista vai INTEIRA no comando. Truncar em 6 com `… (+N)` colocava o literal `…` e `(+3)`
+  # DENTRO do `bun run sonda:sql`, então o comando só era colável até 6 edges — acima disso quem
+  # colasse passaria `…` como nome de edge, e quem não colasse reconstruiria a lista à mão
+  # (feito em 2026-09-05, com 9). O resumo pode truncar; o COMANDO, não.
+  todas="$(tr '\n' ' ' < "$tmp/sem_sonda")"
   echo
   echo "ℹ️  as $n_ss sem sonda NÃO se resolvem esperando: não há cron de sondagem, e boa parte"
   echo "   destas edges não tem cron nenhum (webhook/sob demanda) — prova passiva é impossível."
-  echo "   DISPARE:  bun run sonda:sql $amostra"
+  echo
+  echo "   ⚠️ TRIE ANTES DE DISPARAR — bundle PRÉ-sensor ignora o \`probe\` e EXECUTA O FLUXO REAL."
+  echo "      A triagem barato/caro de cada leva mora em docs/agent/deploy.md; edge CARA não se"
+  echo "      sonda às cegas: nela a ordem é DEPLOY ANTES, sonda depois (só para CONFIRMAR)."
+  echo "   DISPARE:  bun run sonda:sql ${todas}--caro=trie-antes-veja-deploy-md"
+  echo "      (o \`--caro\` acima está inválido DE PROPÓSITO: o sonda:sql aborta sem emitir SQL até"
+  echo "       você trocar pelas caras da leva — ou remover a flag se TODAS forem baratas.)"
   echo "   (PASSO 1 é escrita + vault → SQL Editor do Lovable; PASSO 2 julga em SELECT puro,"
   echo "    --so-leitura, roda no psql-ro. Com o id em mãos: --request-ids <slug>=<id>)"
 fi

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -150,9 +150,14 @@ suite() {
   #     comando com valor INVALIDO de proposito (regra do deploy.md: campo que o operador
   #     substitui nunca carrega valor de EXEMPLO), e o sonda:sql aborta sem emitir SQL ate a
   #     triagem acontecer. Recado vira TRAVA — recado que depende de alguem lembrar nao vale.
-  if tem '--caro=trie-antes-veja-deploy-md' "$linha_cmd" && tem 'TRIE ANTES DE DISPARAR' "$out"
+  #     Invocacao PROPRIA, com 1 alvo: a trava nao pode depender do tamanho da leva. Reaproveitar
+  #     o `linha_cmd` do 3c acoplava as duas — medido ao falsificar: sabotar SO o truncamento
+  #     derrubou esta asercao junto, e caso que so falha junto com outro nao mede nada sozinho.
+  run ok "$tmp/psql-stub" edge-muda
+  linha_trava="$(printf '%s' "$out" | command grep 'sonda:sql' || true)"
+  if tem '--caro=trie-antes-veja-deploy-md' "$linha_trava" && tem 'TRIE ANTES DE DISPARAR' "$out"
   then ok "DISPARE carrega a trava --caro invalida + o aviso de fluxo REAL"
-  else bad "DISPARE saiu pronto-para-colar sem triagem: ${linha_cmd:0:150}"; fi
+  else bad "DISPARE saiu pronto-para-colar sem triagem: ${linha_trava:0:150}"; fi
 
   # 4. as ~55 edges fora do mapa continuam virando chip como hoje (sem regressao)
   run ok "$tmp/psql-stub" edge-fora-do-mapa

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -33,6 +33,13 @@ export const FONTE_SHA256: Record<string, string> = {
   "edge-muda": "$SHA_NOVO",
   "edge-cega": "$SHA_NOVO",
   "edge-pre-fonte": "$SHA_NOVO",
+  "edge-lote-1": "$SHA_NOVO",
+  "edge-lote-2": "$SHA_NOVO",
+  "edge-lote-3": "$SHA_NOVO",
+  "edge-lote-4": "$SHA_NOVO",
+  "edge-lote-5": "$SHA_NOVO",
+  "edge-lote-6": "$SHA_NOVO",
+  "edge-lote-7": "$SHA_NOVO",
 };
 MAPA
 
@@ -121,6 +128,31 @@ suite() {
   #     ramo como "espere o proximo tick do cron" HORAS depois de escreve-lo, ao verificar dois
   #     deploys reais; a espera nunca terminaria. Mensagem que engana quem a escreveu engana todos.
   else bad "edge sem sonda devia dar SEM_PROVA/exit 1 (rc=$rc): ${out:0:90}"; fi
+
+  # 3c. o comando sugerido tem de ser COLAVEL. A versao anterior truncava a lista em 6 e colava
+  #     `… (+N)` DENTRO do `bun run sonda:sql`: acima de 6 edges o comando saia quebrado, e quem
+  #     nao colasse reconstruia a lista na mao (feito em 2026-09-05, com 9 edges). Resumo pode
+  #     truncar; COMANDO nao. 7 alvos de proposito — 6 e o antigo limite, entao 7 e o 1o que falha.
+  run ok "$tmp/psql-stub" edge-lote-1 edge-lote-2 edge-lote-3 edge-lote-4 edge-lote-5 edge-lote-6 edge-lote-7
+  linha_cmd="$(printf '%s' "$out" | command grep 'sonda:sql' || true)"
+  faltou=""
+  for n in 1 2 3 4 5 6 7; do
+    tem "edge-lote-$n" "$linha_cmd" || faltou="$faltou edge-lote-$n"
+  done
+  if [ -z "$faltou" ] && ! tem '(+' "$linha_cmd"
+  then ok "DISPARE emite a lista INTEIRA (7/7), sem truncar o comando"
+  else bad "comando truncado — faltou:$faltou · linha: ${linha_cmd:0:150}"; fi
+
+  # 3d. ...e nao pode ser pronto-para-colar CEGO. Bundle PRE-sensor nao conhece `probe`: a sonda
+  #     entra como requisicao NORMAL e o handler roda o FLUXO REAL. Medido 2026-09-05 na 12a leva,
+  #     3 das 9 eram caras — `process-recurring-orders` CRIA `orders` e AVANCA `next_order_date`,
+  #     entao o run legitimo do dia seguinte PULA a data que a sonda consumiu. O `--caro` sai no
+  #     comando com valor INVALIDO de proposito (regra do deploy.md: campo que o operador
+  #     substitui nunca carrega valor de EXEMPLO), e o sonda:sql aborta sem emitir SQL ate a
+  #     triagem acontecer. Recado vira TRAVA — recado que depende de alguem lembrar nao vale.
+  if tem '--caro=trie-antes-veja-deploy-md' "$linha_cmd" && tem 'TRIE ANTES DE DISPARAR' "$out"
+  then ok "DISPARE carrega a trava --caro invalida + o aviso de fluxo REAL"
+  else bad "DISPARE saiu pronto-para-colar sem triagem: ${linha_cmd:0:150}"; fi
 
   # 4. as ~55 edges fora do mapa continuam virando chip como hoje (sem regressao)
   run ok "$tmp/psql-stub" edge-fora-do-mapa


### PR DESCRIPTION
## O que aconteceu

Verificando a 12ª leva de sonda hoje (Passo 3 do `/fecho`, 10 edges), o próprio bloco de remédio do
`edges-pendentes.sh` falhou de duas formas — as duas mordidas ao vivo, na mesma execução.

### 1. O comando saía incolável acima de 6 edges

A `amostra` truncava em 6 com `… (+N)` e era interpolada **dentro** do comando:

```
DISPARE:  bun run sonda:sql cmc-snapshot-backfill … (+3)
```

O literal `…` e `(+3)` viram nome de edge. Quem colasse, errava; quem não colasse, reconstruía a
lista de 9 na mão — foi o que aconteceu. Resumo pode truncar; **comando, não**.

### 2. O comando saía pronto-para-colar, cego à triagem barato/caro

Este é o caro. Bundle **PRÉ-sensor não conhece o campo `probe`**: a sonda não é lida como sonda,
entra como requisição normal e o handler **executa o fluxo REAL**. Emitir um comando pronto com a
leva inteira convida exatamente esse disparo.

Das 9 edges da 12ª leva, **3 eram caras** (triagem já commitada em `docs/agent/deploy.md`):

| edge | o que um disparo cego faria |
|---|---|
| `process-recurring-orders` | não lê o corpo: **cria `orders`** e **avança `next_order_date`** — o run legítimo do dia seguinte pula a data que a sonda consumiu |
| `omie-nfe-recebimento-sync` | não lê o corpo: cai no laço de sync de todas as credenciais |
| `omie-sync-metadados` | sem `accounts`, o default são as **duas** contas: sync inteiro + carimbo em `sync_state` |

## O remédio é trava, não recado

Recado que depende de alguém lembrar é como a armadilha da sentinela não-exclusiva passou. O
`--caro` agora sai **no próprio comando**, com valor sintaticamente inválido:

```
DISPARE:  bun run sonda:sql <lista inteira> --caro=trie-antes-veja-deploy-md
```

O `separar()` do `sonda:sql` é fail-CLOSED: aborta com *"nomeia edge(s) fora da leva … Nenhum SQL
foi emitido"* até a triagem acontecer. É a regra do `deploy.md` de nunca deixar valor de **exemplo**
no campo que o operador substitui — o erro ecoa a própria instrução em vez de disparar.

⚠️ O placeholder precisa passar no gate de **forma** (`^[a-z0-9][a-z0-9-]*$`) para falhar na
**semântica**. A 1ª versão usava `TRIE_ANTES_veja_deploy.md`: abortava, mas no gate de forma, com
mensagem genérica que não ensina nada. Travar pelo motivo errado é trava por acidente.

## Testes

Dois casos novos em `scripts/test-fecho-edges-pendentes.sh` (`bun run test:falsificacao`), com
**7 alvos de propósito** — 6 era o limite antigo, então 7 é o primeiro que falha.

**Falsificados um de cada vez**, porque a camada que fica verde é redundante ou inalcançada:

- sabotagem *restaurar o truncamento em 6* → o caso da lista fica **vermelho**;
- sabotagem *remover a flag `--caro`* → o caso da trava fica **vermelho**.

A 1ª falsificação pegou um defeito no próprio teste: o caso da trava reusava a variável do caso da
lista, então sabotar só o truncamento derrubava os dois. Agora ele faz a **invocação própria** — a
trava não pode depender do tamanho da leva.

Verdes nos dois locales (`LC_ALL=C` e `pt_BR.UTF-8`); `shellcheck` limpo.

## Escopo

Só o bloco de remédio do `sem_sonda`. Nenhuma mudança na classificação (`NO_AR` / `SEM_PROVA` /
`DESATUALIZADA` / `PRE_SONDA_FONTE`), nos exit codes, nem no SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebaseado sobre o #2195** (classe INERTE), que mexeu nos mesmos dois arquivos em outro aspecto —
sem conflito, e a suíte foi re-rodada **depois** do rebase (verde medido no código que sobe, não na
base antiga).
