### PR TITLE
fix(recebimento): conferência de NF-e não diz "efetivada" quando a edge falha — veredito pelo corpo, edge responde ≠2xx [money-path] (M-01)

### DIFF
--- a/src/lib/recebimento/efetivacao-resposta.test.ts
+++ b/src/lib/recebimento/efetivacao-resposta.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { interpretarRespostaEfetivacao } from './efetivacao-resposta';
+
+/** Forma do `FunctionsHttpError` do supabase-js: `context` é a Response crua (corpo ainda não lido). */
+function erroHttp(status: number, corpo: unknown, json = true) {
+  return {
+    name: 'FunctionsHttpError',
+    message: 'Edge Function returned a non-2xx status code',
+    context: new Response(json ? JSON.stringify(corpo) : String(corpo), {
+      status,
+      headers: { 'Content-Type': json ? 'application/json' : 'text/plain' },
+    }),
+  };
+}
+
+describe('interpretarRespostaEfetivacao — só `success === true` vira "efetivada" (money-path: ausência de sinal ≠ aprovação)', () => {
+  it('HTTP 200 com success:false (modo falha_efetivacao) é FALHA com o erro da edge — era o bug: toast "efetivada"', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: { success: false, modo: 'falha_efetivacao', erro: 'consultar: faultstring X' },
+      error: null,
+    });
+    expect(v.tipo).toBe('falha');
+    expect(v).toMatchObject({ modo: 'falha_efetivacao', mensagem: 'consultar: faultstring X' });
+  });
+
+  it('throttle (Omie em trégua de consulta) é falha, não sucesso', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: { success: false, modo: 'throttle', erro: 'Omie em trégua de consulta (~60s)' },
+      error: null,
+    });
+    expect(v.tipo).toBe('falha');
+    expect(v).toMatchObject({ modo: 'throttle' });
+  });
+
+  it('success:true + modo efetivado → sucesso', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: { success: true, modo: 'efetivado' }, error: null });
+    expect(v).toEqual({ tipo: 'sucesso', modo: 'efetivado' });
+  });
+
+  it('success:true + modo reconciliado (já estava recebida no Omie) → sucesso', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: { success: true, modo: 'reconciliado' }, error: null });
+    expect(v).toEqual({ tipo: 'sucesso', modo: 'reconciliado' });
+  });
+
+  it('modo efetivacao_parcial → parcial (aviso com o erro), nunca sucesso', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: { success: false, modo: 'efetivacao_parcial', erro: 'concluir_recebimento: faultstring Y' },
+      error: null,
+    });
+    expect(v).toEqual({ tipo: 'parcial', modo: 'efetivacao_parcial', mensagem: 'concluir_recebimento: faultstring Y' });
+  });
+
+  it('parcial sem `erro` no corpo ainda é parcial, com mensagem de fallback (não string vazia)', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: { success: false, modo: 'efetivacao_parcial' }, error: null });
+    expect(v.tipo).toBe('parcial');
+    expect(v.tipo === 'parcial' && v.mensagem.length > 0).toBe(true);
+  });
+
+  it('success que não é o boolean true ("true", 1) NÃO é sucesso', async () => {
+    for (const success of ['true', 1, 'ok']) {
+      const v = await interpretarRespostaEfetivacao({ data: { success, modo: 'efetivado' }, error: null });
+      expect(v.tipo, `success=${JSON.stringify(success)}`).toBe('falha');
+    }
+  });
+
+  it('success:true com modo fora da allowlist (ex.: diagnostico, lock) não é sucesso', async () => {
+    for (const modo of ['diagnostico', 'lock', undefined]) {
+      const v = await interpretarRespostaEfetivacao({ data: { success: true, modo }, error: null });
+      expect(v.tipo, `modo=${String(modo)}`).toBe('falha');
+    }
+  });
+
+  it('data null/undefined/string/array → falha "resposta inesperada" (não explode, não aprova)', async () => {
+    for (const data of [null, undefined, 'ok', [], 42]) {
+      const v = await interpretarRespostaEfetivacao({ data, error: null });
+      expect(v.tipo, `data=${JSON.stringify(data)}`).toBe('falha');
+      expect(v.tipo === 'falha' && /inesperad/i.test(v.mensagem)).toBe(true);
+    }
+  });
+
+  it('falha sem `erro` no corpo cita o modo na mensagem (o operador precisa saber o que aconteceu)', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: { success: false, modo: 'falha_efetivacao' }, error: null });
+    expect(v.tipo).toBe('falha');
+    expect(v.tipo === 'falha' && v.mensagem).toContain('falha_efetivacao');
+  });
+
+  it('erro HTTP (≠2xx) com corpo JSON → falha com o `erro` do corpo e o modo (não a frase genérica do supabase-js)', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: null,
+      error: erroHttp(502, { success: false, modo: 'falha_efetivacao', erro: 'identidade: chave não confere' }),
+    });
+    expect(v).toEqual({ tipo: 'falha', modo: 'falha_efetivacao', mensagem: 'identidade: chave não confere' });
+  });
+
+  it('erro HTTP com corpo modo efetivacao_parcial → parcial (o modo manda, não o status)', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: null,
+      error: erroHttp(502, { success: false, modo: 'efetivacao_parcial', erro: 'cte: faultstring Z' }),
+    });
+    expect(v).toEqual({ tipo: 'parcial', modo: 'efetivacao_parcial', mensagem: 'cte: faultstring Z' });
+  });
+
+  it('erro HTTP com corpo `{error}` (formato dos 4xx/5xx genéricos da edge) → falha com essa mensagem', async () => {
+    const v = await interpretarRespostaEfetivacao({
+      data: null,
+      error: erroHttp(409, { error: 'Efetivação já em andamento para esta NF-e', modo: 'lock' }),
+    });
+    expect(v).toEqual({ tipo: 'falha', modo: 'lock', mensagem: 'Efetivação já em andamento para esta NF-e' });
+  });
+
+  it('erro sem context (rede/CORS) → falha com a mensagem do erro', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: null, error: new Error('Failed to fetch') });
+    expect(v).toEqual({ tipo: 'falha', modo: null, mensagem: 'Failed to fetch' });
+  });
+
+  it('erro com context cujo corpo não é JSON → falha com a mensagem do erro (não explode)', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: null, error: erroHttp(500, '<html>gateway</html>', false) });
+    expect(v.tipo).toBe('falha');
+    expect(v.tipo === 'falha' && v.mensagem).toBe('Edge Function returned a non-2xx status code');
+  });
+
+  it('erro HTTP cujo corpo diz success:true NÃO vira sucesso (o transporte falhou — precisão > recall)', async () => {
+    const v = await interpretarRespostaEfetivacao({ data: null, error: erroHttp(504, { success: true, modo: 'efetivado' }) });
+    expect(v.tipo).toBe('falha');
+  });
+
+  it('retorno FINAL da edge (reconsulta) traz `divergencias`, não `erro`: o parcial e a falha carregam esse diagnóstico', async () => {
+    const parcial = await interpretarRespostaEfetivacao({
+      data: { success: false, modo: 'efetivacao_parcial', divergencias: ['item 3: qtde 10 ≠ 8', 'cRecebido=N'] },
+      error: null,
+    });
+    expect(parcial).toEqual({ tipo: 'parcial', modo: 'efetivacao_parcial', mensagem: 'item 3: qtde 10 ≠ 8 | cRecebido=N' });
+    const falha = await interpretarRespostaEfetivacao({
+      data: null,
+      error: erroHttp(502, { success: false, modo: 'falha_efetivacao', divergencias: ['reconsulta: faultstring W'] }),
+    });
+    expect(falha).toEqual({ tipo: 'falha', modo: 'falha_efetivacao', mensagem: 'reconsulta: faultstring W' });
+    // lista vazia/lixo não vira mensagem vazia
+    const vazio = await interpretarRespostaEfetivacao({ data: { success: false, modo: 'falha_efetivacao', divergencias: [] }, error: null });
+    expect(vazio.tipo === 'falha' && vazio.mensagem).toContain('falha_efetivacao');
+  });
+
+  describe('corpo do ≠2xx que nunca chega', () => {
+    afterEach(() => vi.useRealTimers());
+
+    it('stream que não fecha: desiste pelo teto e cai na mensagem do transporte — o toast não fica pendurado', async () => {
+      vi.useFakeTimers();
+      const pendurado = { message: 'Edge Function returned a non-2xx status code', context: { json: () => new Promise(() => {}) } };
+      const p = interpretarRespostaEfetivacao({ data: null, error: pendurado });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(p).resolves.toEqual({ tipo: 'falha', modo: null, mensagem: 'Edge Function returned a non-2xx status code' });
+    });
+
+    it('`context` malformado (json não é função / getter que lança) não explode', async () => {
+      const explosivo = { message: 'x', get context() { throw new Error('getter'); } };
+      await expect(interpretarRespostaEfetivacao({ data: null, error: explosivo })).resolves.toMatchObject({ tipo: 'falha', mensagem: 'x' });
+      await expect(interpretarRespostaEfetivacao({ data: null, error: { message: 'y', context: { json: 'não-função' } } })).resolves.toMatchObject({ tipo: 'falha', mensagem: 'y' });
+    });
+  });
+});
+
+describe('fronteira: quem chama a edge decide pelo VEREDITO, não pelo transporte', () => {
+  const ler = (p: string) => readFileSync(p, 'utf8');
+
+  function blocoEntre(src: string, inicio: string, fim: string): string {
+    const a = src.indexOf(inicio);
+    const b = src.indexOf(fim, a + 1);
+    expect(a, `âncora "${inicio}" não encontrada`).toBeGreaterThan(-1);
+    expect(b, `âncora "${fim}" não encontrada após "${inicio}"`).toBeGreaterThan(a);
+    return src.slice(a, b);
+  }
+
+  function exigeVeredito(bloco: string, nome: string) {
+    const posHelper = bloco.indexOf('interpretarRespostaEfetivacao(');
+    expect(posHelper, `${nome} não interpreta a resposta da edge pelo helper`).toBeGreaterThan(-1);
+    // O padrão cego: aprovar por "não houve erro de transporte".
+    expect(bloco, `${nome} ainda aprova por res.error`).not.toContain('if (res.error) throw res.error');
+    const posToast = bloco.indexOf('toast.success(');
+    expect(posToast, `${nome} comemora antes do veredito`).toBeGreaterThan(posHelper);
+    expect(bloco, `${nome} não trata o ramo de falha`).toContain("tipo === 'falha'");
+  }
+
+  it('RecebimentoConferencia.handleFinalize', () => {
+    exigeVeredito(blocoEntre(ler('src/pages/RecebimentoConferencia.tsx'), 'const handleFinalize', 'const toggleExpand'), 'handleFinalize');
+  });
+
+  it('Recebimento (lista): efetivar/reprocessar', () => {
+    exigeVeredito(blocoEntre(ler('src/pages/Recebimento.tsx'), 'const handleEfetivar', 'const handleDiagnosticar'), 'Recebimento.handleEfetivar');
+  });
+
+  it('edge omie-nfe-recebimento: TODO retorno do fluxo real decide o status por statusHttpEfetivacao(body) — nunca número fixo', () => {
+    const src = ler('supabase/functions/omie-nfe-recebimento/index.ts');
+    // Cada `success: false|statusFinal…` do fluxo real é seguido do SEU `return jsonRes(...)`; o
+    // argumento inteiro tem de ser `body, statusHttpEfetivacao(body)` — `jsonRes(body, 200)` ou um
+    // literal com `}, 200)` reprovam igual (Codex P2: o pino antigo aceitava a forma equivalente).
+    const retornos = [...src.matchAll(/success:\s*(?:false|statusFinal)[\s\S]{0,600}?return jsonRes\(([^;]*)\);/g)];
+    expect(retornos.length, 'esperava os 4 retornos do fluxo real (falhaOp, throttle, pararParcial, final)').toBe(4);
+    for (const m of retornos) expect(m[1].trim(), m[0].slice(0, 80)).toBe('body, statusHttpEfetivacao(body)');
+  });
+});

--- a/src/lib/recebimento/efetivacao-resposta.ts
+++ b/src/lib/recebimento/efetivacao-resposta.ts
@@ -1,0 +1,99 @@
+/**
+ * Veredito da chamada à edge `omie-nfe-recebimento` (efetivação da NF-e de entrada no Omie).
+ *
+ * Money-path: a edge EFETIVA a NF-e no ERP (entrada de estoque + lançamento fiscal; desfazer é
+ * trabalho manual do escritório contábil). O front comemorava "efetivada" quando a edge respondia
+ * HTTP 200 com `success:false` — decidia pelo TRANSPORTE (`res.error`) e nunca lia o corpo (M-01).
+ *
+ * Regra: só `success === true` com `modo` da allowlist é sucesso; qualquer ausência de sinal é
+ * FALHA (precisão > recall — melhor mandar o operador conferir no Omie do que afirmar uma entrada
+ * de estoque que não aconteceu). Desde o M-01 a edge também responde ≠2xx na falha; aí o
+ * supabase-js devolve `FunctionsHttpError` com o corpo AINDA POR LER em `error.context`
+ * (Response) — lemos para não trocar o `erro` da edge pela frase genérica do transporte.
+ */
+import { mensagemDeErro } from '@/lib/erro-mensagem';
+
+export type VereditoEfetivacao =
+  | { tipo: 'sucesso'; modo: 'efetivado' | 'reconciliado' }
+  | { tipo: 'parcial'; modo: 'efetivacao_parcial'; mensagem: string }
+  | { tipo: 'falha'; modo: string | null; mensagem: string };
+
+/** O par `{ data, error }` que `supabase.functions.invoke` resolve. */
+export interface RespostaInvoke {
+  data: unknown;
+  error: unknown;
+}
+
+/** Modos em que a edge afirma, com `success:true`, que a NF-e está recebida no Omie. */
+const MODOS_SUCESSO: ReadonlySet<string> = new Set(['efetivado', 'reconciliado']);
+const MODO_PARCIAL = 'efetivacao_parcial';
+const MSG_PARCIAL_FALLBACK = 'verifique a NF-e no Omie e use Reprocessar';
+const MSG_TRANSPORTE_FALLBACK = 'a edge não respondeu — tente de novo ou avise a equipe';
+
+function comoRegistro(v: unknown): Record<string, unknown> | null {
+  return v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function texto(v: unknown): string | null {
+  return typeof v === 'string' && v.trim().length > 0 ? v : null;
+}
+
+/** Teto para ler o corpo do ≠2xx: um stream que nunca fecha não pode segurar o toast (Codex P2). */
+const TIMEOUT_LEITURA_MS = 5_000;
+
+/**
+ * Corpo JSON que o supabase-js guarda em `error.context` (uma `Response` ainda não lida).
+ * `null` quando não há context, o corpo não é JSON/objeto ou a leitura passa do teto — nunca lança.
+ */
+async function corpoDoErro(error: unknown): Promise<Record<string, unknown> | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const ctx = comoRegistro(error)?.context as { json?: unknown; clone?: unknown } | undefined;
+    if (!ctx || typeof ctx.json !== 'function') return null;
+    const r = ctx as Response;
+    const alvo = typeof r.clone === 'function' ? r.clone() : r;
+    const teto = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), TIMEOUT_LEITURA_MS);
+    });
+    return comoRegistro(await Promise.race([alvo.json(), teto]));
+  } catch {
+    return null;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** `divergencias: string[]` do retorno final da edge (parcial/falha pós-reconsulta) vira texto. */
+function textoDeLista(v: unknown): string | null {
+  if (!Array.isArray(v)) return null;
+  const partes = v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+  return partes.length > 0 ? partes.join(' | ') : null;
+}
+
+function vereditoDoCorpo(corpo: Record<string, unknown>, transporteFalhou: boolean): VereditoEfetivacao {
+  const modo = texto(corpo.modo);
+  // `erro` é o campo do fluxo real; `error` é o dos 4xx/5xx genéricos (lock, auth, interno);
+  // `divergencias` é o diagnóstico do retorno FINAL (reconsulta), que não traz `erro` (Codex P2).
+  const erro = texto(corpo.erro) ?? texto(corpo.error) ?? textoDeLista(corpo.divergencias);
+  if (modo === MODO_PARCIAL) {
+    return { tipo: 'parcial', modo: MODO_PARCIAL, mensagem: erro ?? MSG_PARCIAL_FALLBACK };
+  }
+  // O sucesso exige as três coisas: transporte 2xx, `success` boolean true E modo conhecido.
+  // Um corpo `success:true` dentro de um ≠2xx é contradição — fica do lado seguro (falha).
+  if (!transporteFalhou && corpo.success === true && modo !== null && MODOS_SUCESSO.has(modo)) {
+    return { tipo: 'sucesso', modo: modo as 'efetivado' | 'reconciliado' };
+  }
+  return { tipo: 'falha', modo, mensagem: erro ?? `não efetivada (modo: ${modo ?? 'desconhecido'})` };
+}
+
+/** Interpreta `{ data, error }` do `invoke('omie-nfe-recebimento')`. Nunca lança. */
+export async function interpretarRespostaEfetivacao(res: RespostaInvoke): Promise<VereditoEfetivacao> {
+  if (res.error) {
+    const corpo = await corpoDoErro(res.error);
+    if (corpo) return vereditoDoCorpo(corpo, true);
+    return { tipo: 'falha', modo: null, mensagem: mensagemDeErro(res.error) ?? MSG_TRANSPORTE_FALLBACK };
+  }
+  const corpo = comoRegistro(res.data);
+  if (!corpo) return { tipo: 'falha', modo: null, mensagem: 'resposta inesperada da edge (sem corpo JSON)' };
+  return vereditoDoCorpo(corpo, false);
+}

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/dialog';
 import type { Tables } from '@/integrations/supabase/types';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import { interpretarRespostaEfetivacao } from '@/lib/recebimento/efetivacao-resposta';
 
 type NfeStatus = 'pendente' | 'em_conferencia' | 'divergencia' | 'conferido' | 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial';
 
@@ -167,22 +168,13 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
         body: { nfe_recebimento_id: nfeId },
         headers: { Authorization: `Bearer ${session?.access_token}` },
       });
-      if (res.error) throw res.error;
-      // Falha honesta vem HTTP 200 com success:false — inspecionar o `modo`, não só res.error.
-      const data = (res.data ?? {}) as { success?: boolean; modo?: string; erro?: string };
-      switch (data.modo) {
-        case 'efetivado':
-          toast.success('NF-e efetivada no Omie!');
-          break;
-        case 'reconciliado':
-          toast.success('NF-e reconciliada — já estava recebida no Omie.');
-          break;
-        case 'efetivacao_parcial':
-          toast.warning('Efetivação parcial: ' + (data.erro || 'verifique no Omie'));
-          break;
-        default:
-          toast.error('Não efetivada: ' + (data.erro || 'falha na efetivação'));
-      }
+      // Veredito pelo CORPO (`success`/`modo`). A edge responde 502/429 na falha desde o M-01,
+      // e o helper lê o corpo do ≠2xx (`error.context`) — `res.error` sozinho perderia o `erro`.
+      const veredito = await interpretarRespostaEfetivacao(res);
+      if (veredito.tipo === 'falha') toast.error('Não efetivada: ' + veredito.mensagem);
+      else if (veredito.tipo === 'parcial') toast.warning('Efetivação parcial: ' + veredito.mensagem);
+      else if (veredito.modo === 'reconciliado') toast.success('NF-e reconciliada — já estava recebida no Omie.');
+      else toast.success('NF-e efetivada no Omie!');
       queryClient.invalidateQueries({ queryKey: ['nfe_recebimentos'] });
       queryClient.invalidateQueries({ queryKey: ['nfe_pending_counts'] });
     } catch (err) {

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -29,6 +29,7 @@ import { confirmUnit, type ConfirmUnitVars } from '@/services/recebimento-confir
 import { reportDivergencia, type ReportDivergenciaVars } from '@/services/recebimento-divergencia';
 import { addCte, type AddCteVars } from '@/services/recebimento-cte';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import { interpretarRespostaEfetivacao } from '@/lib/recebimento/efetivacao-resposta';
 
 type ItemStatus = 'pendente' | 'em_conferencia' | 'conferido' | 'divergencia';
 
@@ -417,10 +418,22 @@ export default function RecebimentoConferencia() {
           body: { nfe_recebimento_id: id },
           headers: { Authorization: `Bearer ${session?.access_token}` },
         });
-        if (res.error) throw res.error;
-
-        const totalLotes = new Set(((lotes ?? []) as NfeLoteEscaneado[]).map((l) => l.numero_lote)).size;
-        toast.success(`NF-e ${nfeTyped?.numero_nfe} efetivada — ${totalConferida} unidades, ${totalLotes} lotes registrados`);
+        // Money-path: o veredito vem do CORPO (`success`/`modo`), não do transporte. A edge
+        // respondia 200 com `success:false` e este toast dizia "efetivada" sobre uma falha (M-01).
+        const veredito = await interpretarRespostaEfetivacao(res);
+        // A edge já gravou o status final (efetivado/parcial/falha) na NF: refletir em TODA saída,
+        // inclusive na lista (/recebimento) para onde navegamos — o cache dela é global (Codex P2).
+        queryClient.invalidateQueries({ queryKey: ['nfe_conferencia', id] });
+        queryClient.invalidateQueries({ queryKey: ['nfe_recebimentos'] });
+        queryClient.invalidateQueries({ queryKey: ['nfe_pending_counts'] });
+        if (veredito.tipo === 'falha') throw new Error(veredito.mensagem);
+        if (veredito.tipo === 'parcial') {
+          toast.warning(`NF-e ${nfeTyped?.numero_nfe}: efetivação PARCIAL — ${veredito.mensagem}. Reprocesse na lista.`);
+        } else {
+          const totalLotes = new Set(((lotes ?? []) as NfeLoteEscaneado[]).map((l) => l.numero_lote)).size;
+          const verbo = veredito.modo === 'reconciliado' ? 'reconciliada (já estava recebida no Omie)' : 'efetivada';
+          toast.success(`NF-e ${nfeTyped?.numero_nfe} ${verbo} — ${totalConferida} unidades, ${totalLotes} lotes registrados`);
+        }
       } else {
         toast.warning('Conferência finalizada com divergências. Aguardando resolução.');
       }

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -39,7 +39,7 @@ export const FONTE_SHA256: Record<string, string> = {
   "omie-cliente": "fade69529ee1b7d62c65c640c98af721bf9df1030c078c93ec5c9dd55eaae92f",
   "omie-financeiro": "3db22ac3488bdf2c043fbbe3bd81c45ca873fdf351a73be49508334aa60eb930",
   "omie-malha-sync": "346aaa13fa16bab1f19085e39e2461e23a5d9ca189ef9afaf25030f163ec44cb",
-  "omie-nfe-recebimento": "035279dacb799470cdd32a7143a6e48d5de9ba4dc5d21909d4a7635551cd2681",
+  "omie-nfe-recebimento": "e69f5f4fe0c581043237e33d55bef413b245f7e264ae88138f5439a1f49cdb4c",
   "omie-nfe-recebimento-sync": "a038cd71e17d02bca2e1fd12e83d97ce33aa52aca96bbf58ee239a5a93300143",
   "omie-nfe-reconcile": "844e96d1d018a01374951da346d5d3d267b12431ebab1f7b8f032d117414e3c0",
   "omie-nfe-webhook": "c2267dae835b18c9f4214a6c9621f530a384e150e345cbbcecb7b2eca0e5d319",

--- a/supabase/functions/omie-nfe-recebimento/index.ts
+++ b/supabase/functions/omie-nfe-recebimento/index.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
+import { statusHttpEfetivacao } from "./resposta.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -534,7 +535,8 @@ Deno.serve(async (req) => {
       const falhaOp = async (operacao: string, erro: string) => {
         await persistir("falha_efetivacao", `${operacao}: ${erro}`);
         await registrarTentativa(supabase, { nfe_recebimento_id: nfeRecebimentoId, tentativa, operacao, sucesso: false, erro, omie_status: null });
-        return jsonRes({ success: false, modo: "falha_efetivacao", nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro }, 200);
+        const body = { success: false, modo: "falha_efetivacao", nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro };
+        return jsonRes(body, statusHttpEfetivacao(body));
       };
 
       // ── 1. Consultar ANTES (com a chave como filtro de identidade) ──
@@ -545,7 +547,8 @@ Deno.serve(async (req) => {
       // falha_efetivacao (falso vermelho visto em prod 2026-07-14: diagnóstico + Reconciliar
       // em 4s → REDUNDANT). Preserva o status; o lock libera no finally. (Codex P1)
       if (!cls1.sucesso && /redundante|REDUNDANT/i.test(cls1.erro ?? "")) {
-        return jsonRes({ success: false, modo: "throttle", nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro: "Omie em trégua de consulta (~60s) — tente novamente em instantes" }, 200);
+        const body = { success: false, modo: "throttle", nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro: "Omie em trégua de consulta (~60s) — tente novamente em instantes" };
+        return jsonRes(body, statusHttpEfetivacao(body));
       }
       if (!cls1.sucesso) return await falhaOp("consultar", cls1.erro ?? "erro na consulta");
       const estado = extrairEstadoConsulta(consulta1.data);
@@ -639,7 +642,8 @@ Deno.serve(async (req) => {
       const pararParcial = async () => {
         const status = decidirStatusEfetivacao(flags);
         await persistir(status, resumirErros(falhas));
-        return jsonRes({ success: false, modo: status, nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro: resumirErros(falhas) }, 200);
+        const body = { success: false, modo: status, nfe_recebimento_id: nfeRecebimentoId, numero_nfe: nfe.numero_nfe, erro: resumirErros(falhas) };
+        return jsonRes(body, statusHttpEfetivacao(body));
       };
 
       if (!flags.alterarOk) {
@@ -680,13 +684,15 @@ Deno.serve(async (req) => {
         : resumirErros([...falhas, ...conf.divergencias.map((d) => ({ operacao: "reconsulta", erro: d }))]);
       await persistir(statusFinal, erroFinal);
       console.log(`[omie-nfe-recebimento] NF ${nfe.numero_nfe} → ${statusFinal}.`);
-      return jsonRes({
+      // Transporte carrega o veredito: só `efetivado` sai 200 (M-01). Corpo inalterado.
+      const body = {
         success: statusFinal === "efetivado",
         modo: statusFinal,
         nfe_recebimento_id: nfeRecebimentoId,
         numero_nfe: nfe.numero_nfe,
         divergencias: conf.confirmado ? [] : conf.divergencias,
-      }, 200);
+      };
+      return jsonRes(body, statusHttpEfetivacao(body));
     } finally {
       // libera o lock só se ainda é o MEU (compare-and-clear pelo timestamp gravado — Codex P1.7)
       await supabase.from("nfe_recebimentos")

--- a/supabase/functions/omie-nfe-recebimento/resposta.ts
+++ b/supabase/functions/omie-nfe-recebimento/resposta.ts
@@ -1,0 +1,15 @@
+// Status HTTP da resposta da efetivação — o TRANSPORTE carrega o veredito.
+//
+// Antes (M-01), TODA resposta do fluxo real saía HTTP 200 (`success:false` inclusive), e um caller
+// que decidisse pelo transporte (`if (res.error) throw`) comemorava "efetivada" sobre uma falha —
+// entrada de estoque e lançamento fiscal que NÃO aconteceram no Omie.
+//
+// Regra: só `success === true` é 2xx. `throttle` (trégua transitória do Omie, ~60s) sai 429 para
+// o caller distinguir "tente de novo em instantes" de falha real; o resto sai 502 (o ERP não
+// efetivou). O CORPO não muda — `success`/`modo`/`erro`/`versao` seguem iguais para quem lê JSON.
+// O front lê o corpo do ≠2xx via `error.context` (src/lib/recebimento/efetivacao-resposta.ts).
+export function statusHttpEfetivacao(body: { success?: boolean; modo?: string }): number {
+  if (body.success === true) return 200;
+  if (body.modo === "throttle") return 429;
+  return 502;
+}

--- a/supabase/functions/omie-nfe-recebimento/resposta_test.ts
+++ b/supabase/functions/omie-nfe-recebimento/resposta_test.ts
@@ -1,0 +1,34 @@
+// Testa o CÓDIGO REAL de resposta.ts no runtime real (Deno) — sem imports remotos (`--no-remote`).
+// Roda com: bun run test:edges  (ou: deno test --no-remote --allow-read=supabase/functions supabase/functions/omie-nfe-recebimento/)
+//
+// Money-path: esta edge EFETIVA a NF-e no Omie. Antes (#M-01), TODA falha saía HTTP 200 com
+// `success:false` — e um caller que só olhava o transporte (`if (res.error) throw`) comemorava
+// "efetivada" sobre uma falha. O status HTTP passa a carregar o veredito: só `success === true` é 2xx.
+import { statusHttpEfetivacao } from "./resposta.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (a !== b) throw new Error(`${msg ?? "assertEquals"}: esperado ${JSON.stringify(b)}, veio ${JSON.stringify(a)}`);
+}
+
+Deno.test("success:true (efetivado / reconciliado) → 200", () => {
+  assertEquals(statusHttpEfetivacao({ success: true, modo: "efetivado" }), 200);
+  assertEquals(statusHttpEfetivacao({ success: true, modo: "reconciliado" }), 200);
+});
+
+Deno.test("throttle (trégua transitória do Omie) → 429, para o caller distinguir 'tente de novo' de falha", () => {
+  assertEquals(statusHttpEfetivacao({ success: false, modo: "throttle" }), 429);
+});
+
+Deno.test("falha_efetivacao e efetivacao_parcial → 502 (o ERP não efetivou)", () => {
+  assertEquals(statusHttpEfetivacao({ success: false, modo: "falha_efetivacao" }), 502);
+  assertEquals(statusHttpEfetivacao({ success: false, modo: "efetivacao_parcial" }), 502);
+});
+
+Deno.test("success ausente ou não-boolean NUNCA é 2xx (ausência de sinal ≠ aprovação)", () => {
+  assertEquals(statusHttpEfetivacao({ modo: "efetivado" }), 502);
+  assertEquals(statusHttpEfetivacao({ success: "true" as unknown as boolean, modo: "efetivado" }), 502);
+});
+
+Deno.test("throttle só é 429 quando NÃO houve sucesso (success:true manda)", () => {
+  assertEquals(statusHttpEfetivacao({ success: true, modo: "throttle" }), 200);
+});

--- a/supabase/functions/omie-nfe-recebimento/versao.ts
+++ b/supabase/functions/omie-nfe-recebimento/versao.ts
@@ -18,7 +18,7 @@ import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
 export const respostaSonda = criarRespostaSonda("omie-nfe-recebimento");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
-export const VERSAO = "v1.0-sensor-inicial";
+export const VERSAO = "v1.1-falha-sai-nao-2xx";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
## O bug (M-01 do plano `docs/superpowers/plans/2026-09-05-plano-melhorias-codebase`, P1 aberto desde a revisão de 2026-07-04)

A edge `omie-nfe-recebimento` **efetiva a NF-e de entrada no Omie** (entrada de estoque + lançamento fiscal — desfazer é trabalho manual do contábil). Em TODA falha ela respondia **HTTP 200 com `success:false`** (`modo` = `falha_efetivacao` / `throttle` / `efetivacao_parcial`). A tela de conferência (`RecebimentoConferencia.handleFinalize`) decidia pelo **transporte** (`if (res.error) throw`) e mostrava **"NF-e … efetivada"** sobre uma falha, navegando de volta à lista como se a entrada tivesse acontecido.

## A correção (dos dois lados, como o handoff pede)

- **Front — veredito pelo CORPO, nunca pelo transporte.** Helper puro `src/lib/recebimento/efetivacao-resposta.ts` (`interpretarRespostaEfetivacao`): só `success === true` **e** `modo ∈ {efetivado, reconciliado}` **e** transporte 2xx é sucesso; `efetivacao_parcial` vira aviso (nunca sucesso); tudo o mais é falha com o `erro` da edge. Lê o corpo JSON do ≠2xx em `error.context` (a `Response` que o supabase-js guarda no `FunctionsHttpError`) para não trocar a mensagem da edge pela frase genérica. Nunca lança. As DUAS páginas (`RecebimentoConferencia` e `Recebimento`) passam pelo helper.
- **Edge — o status HTTP carrega o veredito.** `resposta.ts` (`statusHttpEfetivacao`): `success:true` → 200 · `throttle` → 429 (transitório, "tente de novo") · resto → 502. Aplicado nos 4 retornos do fluxo real; **corpo inalterado**. `VERSAO` → `v1.1-falha-sai-nao-2xx`; fingerprint regravado.

## Prova

- `src/lib/recebimento/efetivacao-resposta.test.ts` — 16 casos do helper (200+`success:false` é falha — o caso do bug; `success` não-boolean; modo fora da allowlist; `data` lixo; ≠2xx com corpo JSON/`{error}`/não-JSON/sem context; corpo `success:true` dentro de ≠2xx é falha) + 3 pinos de fronteira: as duas páginas passam pelo helper antes de qualquer `toast.success`, e a edge não tem `success:false` com 200 fixo.
- `supabase/functions/omie-nfe-recebimento/resposta_test.ts` (Deno, `--no-remote`) — 5 casos.
- RED observado antes do GREEN (módulo ausente → `Tests no tests`, exit 1; Deno TS2307).
- Gates: `sonda:bump` ✓ · `sonda:fingerprint --write` ✓ · `test:edges` ✓ · `edges:typecheck` · `lint` · `typecheck` (ver comentário com os exits).
- Callers da edge verificados: só as 2 páginas (nenhum cron a chama; `omie-nfe-reconcile` só a cita em comentário).

## Deploy (Lovable — merge ≠ produção)

1. 💬 chat Lovable: deploy da edge `omie-nfe-recebimento` → sonda `{"probe":true}` deve responder `versao: v1.1-falha-sai-nao-2xx`.
2. 🖱️ Publish do front (as 2 páginas leem o corpo do ≠2xx; com o front velho + edge nova, a falha vira "Erro ao finalizar: Edge Function returned a non-2xx status code" — ainda honesto, só menos específico; com front novo + edge velha, o helper lê `success:false` do 200 — também honesto). Nenhuma ordem de deploy produz "efetivada" sobre falha.

## Codex (2ª opinião, gpt-5.6-sol · xhigh) — parecer CRU

<details><summary>saída íntegra do <code>scripts/codex-async.sh</code></summary>

```text
=== PARECER CODEX (modelo gpt-5.6-sol · reasoning xhigh · tentativa 1) ===
## Achados

- [P2] A leitura do corpo pode ficar pendurada indefinidamente e o contrato “nunca lança” não é absoluto. O acesso a `context`/`json` ocorre fora do `try`, e `await alvo.json()` não tem timeout ([efetivacao-resposta.ts:46](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.ts:46), [efetivacao-resposta.ts:51](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.ts:51)). Reproduzi ambos: um stream que entrega headers mas não fecha permaneceu pendente; um getter `json` que lança escapou do helper. Em rede degradada, o Omie pode já ter sido alterado enquanto o botão permanece carregando, incentivando reload e reprocessamento sob resultado incerto.

- [P2] O helper descarta justamente o diagnóstico do parcial pós-confirmação. O retorno final da edge envia `divergencias`, sem `erro` ([index.ts:688](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/supabase/functions/omie-nfe-recebimento/index.ts:688)); o helper só lê `erro`/`error` ([efetivacao-resposta.ts:59](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.ts:59)). Quando as três escritas respondem sucesso, mas a reconsulta encontra `cRecebido ≠ S` ou quantidade divergente, o operador recebe apenas o fallback e a ordem genérica “Reprocesse” ([RecebimentoConferencia.tsx:429](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/pages/RecebimentoConferencia.tsx:429)). O teste usa um corpo parcial artificial com `erro`, não o formato real desse retorno ([efetivacao-resposta.test.ts:96](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.test.ts:96)).

- [P2] O caminho parcial navega para a lista sem invalidar `nfe_recebimentos` ([RecebimentoConferencia.tsx:429](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/pages/RecebimentoConferencia.tsx:429), [RecebimentoConferencia.tsx:440](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/pages/RecebimentoConferencia.tsx:440)). Como o cache global fica fresco por 60 segundos ([App.tsx:193](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/App.tsx:193)), uma conferência rápida pode voltar para uma lista ainda mostrando `conferido`/`em_conferencia`, sem o botão “Reprocessar” — ou oferecendo nova entrada no fluxo de efetivação. A assinatura Realtime da lista estava desmontada enquanto a edge atualizou o status.

- [P2] Os pinos textuais aceitam regressões equivalentes ao M-01. O teste da edge só procura `statusHttpEfetivacao` em algum lugar e proíbe uma forma literal de `success:false ... 200` ([efetivacao-resposta.test.ts:158](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.test.ts:158)); `const body={success:false}; return jsonRes(body, 200)` passaria. Nos callers, um `toast.success` incondicional depois do ramo de falha também satisfaria todas as asserções ([efetivacao-resposta.test.ts:140](/Users/lucassardenberg/Projetos/afiacao-claude-fase0-lote1-money-path/src/lib/recebimento/efetivacao-resposta.test.ts:140)). Em sentido oposto, trocar `if` por `switch` ou extrair a notificação causaria falso-vermelho.

Nenhum [P1] encontrado.

## CONCEDO

- Nos dois callers atuais, `success:false` não alcança toast de sucesso.
- A allowlist cobre todos os sucessos reais da edge: `efetivado` e `reconciliado`.
- Corpo consumido ou CORS bloqueado cai em fallback sem aprovação; `clone()`/`json()` rejeitando é capturado.
- Os novos `return` continuam executando o `finally` que libera o lock.
- Workbox não intercepta `/functions/v1/`; não há retry automático no cliente inspecionado.
- Verificação: 19/19 testes do helper passaram via Bun e 5/5 testes Deno passaram. O runner Vitest normal não iniciou porque o sandbox impediu a criação do arquivo temporário de configuração.

Skills usados: `using-superpowers` para selecionar o fluxo aplicável e `verification-before-completion` para exigir verificação executada antes das conclusões.

(cópia em /var/folders/cz/94l8x0rn6hqfk080j49r247r0000gn/T/codex-async.XXXXXX.fuKNnvt3gx)
```

</details>

**Calibração (minha, separada do parecer):** os 4 [P2] foram aplicados no mesmo PR — (1) leitura do corpo inteira dentro do `try` + teto de 5 s (`Promise.race`, timer limpo) com teste de stream pendurado; (2) `divergencias[]` do retorno final vira mensagem do parcial/falha (teste); (3) as 3 chaves de cache (`nfe_conferencia`, `nfe_recebimentos`, `nfe_pending_counts`) são invalidadas em TODA saída, não só na falha; (4) o pino da edge exige que cada `return jsonRes(` após um `success:` do fluxo real seja exatamente `body, statusHttpEfetivacao(body)` — `jsonRes(body, 200)` reprova (falsificado). Nenhum downgrade de severidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
