### PR TITLE
fix(fecho): `--desde` sem fuso deslocava a janela e suprimia TODOS os chips em verde [money-path]

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -152,8 +152,15 @@ git diff --name-only origin/main...HEAD -- supabase/functions/
 #
 # Este script enumera a janela INTEIRA (a desta sessão e a das outras) e já classifica quem
 # precisa de chip. Use-o em vez do `git log` cru — o cru é o gatilho velho, ver abaixo.
-bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início da sessão>"
-# aceita DATA ou REVISÃO — se você anotou o SHA de origin/main ao abrir a sessão, prefira o SHA
+bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início da sessão> UTC"
+# aceita REVISÃO (SHA), DATA RELATIVA ("3 hours ago") ou DATA ABSOLUTA **com fuso explícito**.
+# ⚠️ Data absoluta SEM fuso é RECUSADA (exit 3, marca `DESDE_SEM_FUSO`). Aqui o `--desde` cai no
+#    `git rev-list --before=`, que lê data nua como hora LOCAL, enquanto TODO timestamp da doc
+#    deste repo é UTC — e os scripts irmãos (verify-edge-eco/escrita) mandam o mesmo flag para o
+#    psql, que é UTC. Copiar um timestamp UTC acerta lá e erra aqui, por um offset inteiro e em
+#    silêncio: medido 2026-09-05, `--desde "2026-09-05 17:34"` em GMT-3 pulou o merge das 19:40Z e
+#    devolveu `✅ nenhuma edge na janela` sobre uma janela de DUAS. Escreva "… 17:34 UTC".
+# Se você anotou o SHA de origin/main ao abrir a sessão, prefira o SHA: não tem fuso para errar.
 # exit 0 = nada pendente · 1 = abra chip para a lista · 2 = MECÂNICA não confiável (o script já
 # imprime tudo como pendente; trate assim) · 3 = uso inválido
 #

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -134,15 +134,58 @@ if [ "$1" = "--desde" ]; then
   desde="${2:-}"
   [ -n "$desde" ] || { echo "uso: edges-pendentes.sh --desde \"<git-since>\""; exit 3; }
 
-  # aceita DATA ("3 hours ago", "2026-08-28 14:00") ou REVISÃO (o SHA do início da sessão, que é
-  # o dado mais preciso que o /fecho tem à mão). Revisão primeiro: um SHA nunca é data válida.
+  # aceita DATA ("3 hours ago", "2026-08-28 14:00 UTC") ou REVISÃO (o SHA do início da sessão, que
+  # é o dado mais preciso que o /fecho tem à mão). Revisão primeiro: um SHA nunca é data válida.
   base="$(git -C "$RAIZ" rev-parse --verify --quiet "${desde}^{commit}" 2>/dev/null)"
-  [ -n "$base" ] || base="$(git -C "$RAIZ" rev-list -1 --before="$desde" "$REF" 2>/dev/null)"
+
+  # 🔴 GUARD DE FUSO — data absoluta SEM fuso é RECUSADA (2026-09-05). Aqui o `--desde` cai em
+  # `git rev-list --before=`, e o git lê data nua como hora **LOCAL**; os scripts irmãos
+  # (`verify-edge-eco.sh`, `verify-edge-escrita.sh`) mandam o MESMO flag para o **psql**, cuja
+  # sessão é UTC — e a doc dos dois prescreve literalmente `--desde '<timestamp do merge, UTC>'`.
+  # Quem copia um timestamp UTC (o caminho ESPERADO neste repo) acerta em dois scripts e erra
+  # neste, deslocado por um offset inteiro e sem nenhum sinal. Medido em GMT-3:
+  #   --desde "2026-09-05 17:34"        -> base a10ef2383  (= o próprio merge das 19:40Z, EXCLUÍDO)
+  #   --desde "2026-09-05 17:34 UTC"    -> base ea67a6f65  (janela correta, 2 edges)
+  #   --desde "2026-09-05 17:34 -0300"  -> base a10ef2383  (prova de que data nua == local)
+  # A 1ª devolveu `✅ nenhuma edge na janela` com exit 0 sobre uma janela que tinha DUAS edges.
+  # Num script que APAGA pendência isso não gera um chip a mais: gera ZERO chips, em verde — a
+  # mesma "ausência fabricada" do ramo PRE_SONDA_FONTE (#2156), entrando pela porta da JANELA em
+  # vez da porta do CAMPO. Por isso RECUSA, e não normalização silenciosa para UTC: normalizar
+  # acertaria a intenção usual e mentiria para quem realmente quis local, trocando um erro visível
+  # por um invisível. SHA e data RELATIVA não passam por aqui — não são ambíguos.
+  if [ -z "$base" ]; then
+    case "$desde" in
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*|[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]*)
+        case "$desde" in
+          *Z|*z|*UTC*|*utc*|*GMT*|*gmt*|*[+-][0-9][0-9]:[0-9][0-9]|*[+-][0-9][0-9][0-9][0-9]) ;;
+          *)
+            # marcador ASCII, caixa fixa: o arnês roda nos DOIS locales (#1483) e casar "AMBÍGUO"
+            # (com acento) seria casar a codificação, não o ramo.
+            echo "⛔ edges-pendentes: DESDE_SEM_FUSO — --desde \"$desde\" é ambíguo (data absoluta sem fuso)."
+            echo "   O git lê isso como hora LOCAL (offset $(date +%z)); a doc deste repo escreve"
+            echo "   timestamp em UTC. As duas leituras diferem por um offset inteiro e podem pular"
+            echo "   commits da janela — e este script APAGA pendência, então janela errada não"
+            echo "   gera chip a mais: suprime TODOS, em verde."
+            echo "   Diga o fuso:  --desde \"$desde UTC\"   (ou \"$desde $(date +%z)\" se quis local)"
+            exit 3
+            ;;
+        esac
+        ;;
+    esac
+    base="$(git -C "$RAIZ" rev-list -1 --before="$desde" "$REF" 2>/dev/null)"
+  fi
+
   if [ -z "$base" ]; then
     echo "⚠️ edges-pendentes: não achei o commit-base de $REF antes de \"$desde\""
     echo "   (git fetch feito? a data é parseável pelo git, ou o SHA existe?) — exit 2"
     exit 2
   fi
+
+  # A janela EFETIVAMENTE usada, sempre impressa. O guard acima só alcança a forma ambígua; SHA e
+  # data relativa continuam podendo resolver para um base surpreendente (worktree atrás, REF errada)
+  # — e hoje isso se decidia em silêncio, inclusive no ramo "nenhuma edge na janela", o único que
+  # suprime TUDO. Base impressa = janela auditável na hora em que o veredito é lido.
+  echo "janela: $REF desde $(git -C "$RAIZ" log -1 --format='%h (%cd)' --date=iso-strict "$base" 2>/dev/null) — --desde \"$desde\""
 
   # (a) diff do mapa de fingerprints: pega mudança vinda de _shared/, cega para edge fora do mapa
   git -C "$RAIZ" show "$base:$MAPA_REL" 2>/dev/null \

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -394,6 +394,54 @@ MAPA2
   then ok "--desde: janela anterior ao mapa, sem sonda -> SEM_PROVA (fail-closed intacto)"
   else bad "sem sonda devia cair para SEM_PROVA, nunca NO_AR (rc=$rc): ${out:0:140}"; fi
 
+  # 14c. GUARD DE FUSO: data absoluta SEM fuso e AMBIGUA e tem de RECUSAR (2026-09-05). O `--desde`
+  #      deste script vai para `git rev-list --before=`, que le data nua como hora LOCAL; os scripts
+  #      irmaos (verify-edge-eco / verify-edge-escrita) mandam o MESMO flag para o psql, cuja sessao
+  #      e UTC — e a doc dos dois prescreve "timestamp do merge, UTC". Quem copia um timestamp UTC
+  #      acerta em dois e erra neste. Medido em GMT-3: `--desde "2026-09-05 17:34"` resolveu para o
+  #      proprio merge das 19:40Z (excluindo-o) e devolveu `nenhuma edge na janela` com exit 0 sobre
+  #      uma janela de DUAS edges. Num script que APAGA pendencia, janela deslocada nao gera um chip
+  #      a mais: gera ZERO chips, em verde — a "ausencia fabricada" do PRE_SONDA_FONTE (#2156)
+  #      entrando pela porta da JANELA em vez da porta do CAMPO.
+  #      Marcador ASCII de caixa fixa de proposito: a suite roda nos DOIS locales (#1483), e casar
+  #      "AMBIGUO" com acento casaria a codificacao, nao o ramo.
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+         bash "$ALVO" --desde "2026-08-28 14:00" 2>&1)"; rc=$?
+  if [ "$rc" -eq 3 ] && tem 'DESDE_SEM_FUSO' "$out" && ! tem 'nenhuma edge' "$out"
+  then ok "--desde: data sem fuso -> DESDE_SEM_FUSO, exit 3, nunca 'nenhuma edge'"
+  else bad "data sem fuso devia RECUSAR com exit 3 (rc=$rc): ${out:0:140}"; fi
+
+  # o PAR MINIMO e o que da valor ao caso acima: MESMA data, so o sufixo muda. Sem este lado, um
+  # guard que recusasse TUDO passaria no 14c sem guardar coisa nenhuma.
+  for _suf in "UTC" "Z" "-0300" "+00:00"; do
+    case "$_suf" in
+      Z) _d="2026-08-28T14:00:00Z" ;;
+      *) _d="2026-08-28 14:00 $_suf" ;;
+    esac
+    out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+           bash "$ALVO" --desde "$_d" 2>&1)"; rc=$?
+    if [ "$rc" -ne 3 ] && ! tem 'DESDE_SEM_FUSO' "$out"
+    then ok "--desde: fuso explicito ($_suf) passa pelo guard"
+    else bad "fuso explicito ($_suf) nao devia ser recusado (rc=$rc): ${out:0:140}"; fi
+  done
+
+  # ...e as formas NAO-absolutas (data relativa, SHA) nunca sao ambiguas: nao podem ser recusadas.
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+         bash "$ALVO" --desde "3 hours ago" 2>&1)"; rc=$?
+  if [ "$rc" -ne 3 ] && ! tem 'DESDE_SEM_FUSO' "$out"
+  then ok "--desde: data RELATIVA nao e ambigua -> passa pelo guard"
+  else bad "data relativa nao devia ser recusada (rc=$rc): ${out:0:140}"; fi
+
+  # 14d. a JANELA EFETIVAMENTE USADA sai impressa. O guard so alcanca a forma ambigua; SHA e data
+  #      relativa ainda podem resolver para um base surpreendente (worktree atras, REF errada), e
+  #      isso se decidia em SILENCIO — inclusive no ramo "nenhuma edge na janela", o unico que
+  #      suprime TUDO. Base impresso = janela auditavel na hora em que o veredito e lido.
+  out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo" \
+         FECHO_MAPA_FONTE="" bash "$ALVO" --desde "$(cat "$tmp/base_sha")" 2>&1)"; rc=$?
+  if tem 'janela:' "$out" && tem "$(cut -c1-7 < "$tmp/base_sha")" "$out"
+  then ok "--desde: imprime a janela efetiva (REF + commit-base resolvido)"
+  else bad "janela efetiva devia sair impressa com o base resolvido (rc=$rc): ${out:0:140}"; fi
+
   # 12. guardrail de FORMA do SQL: o stub nao executa SQL, entao o que da para provar aqui e que a
   #     consulta pede a resposta MAIS RECENTE por edge. Sem isso, um deploy no meio da janela deixa
   #     o bundle velho no resultado e ele seria lido como prova (o caso do omie-vendas-sync).
@@ -623,6 +671,19 @@ if [ "${1:-}" = "--falsificar" ]; then
   # (d) a query perde o "mais recente por edge\"
   sabota "SQL sem DISTINCT ON (edge)" \
     's%SELECT DISTINCT ON (edge) edge%SELECT edge%'
+
+  # guard de fuso: as duas sabotagens sao SIMETRICAS de proposito, porque o guard erra dos DOIS
+  # lados e cada lado tem um caso diferente para pegar. Frouxo demais (aceita tudo) devolve o bug
+  # original — janela deslocada suprimindo chip em verde. Apertado demais (recusa tudo) quebraria o
+  # /fecho inteiro, e so o PAR MINIMO do 14c enxerga isso: sem ele, um guard que recusasse toda
+  # data passaria na suite alegando que "guarda".
+  sabota "fuso: sufixo aceitando QUALQUER coisa (guard frouxo, volta o bug)" \
+    '/\*gmt\*/s/.*/          *) ;;/'
+  sabota "fuso: sufixo nao casando NADA (guard apertado, recusa UTC legitimo)" \
+    '/\*gmt\*/s/.*/          __nunca_casa__) ;;/'
+  # e a janela impressa: sem ela o ramo que suprime TUDO volta a decidir em silencio.
+  sabota "janela efetiva deixando de ser impressa" \
+    '/echo "janela:/d'
 
   [ "$falhou" -eq 0 ] && { printf '\n== falsificacao: todas as sabotagens ficaram vermelhas ==\n'; exit 0; }
   printf '\n== falsificacao REPROVOU ==\n'; exit 1


### PR DESCRIPTION
## O bug

O `--desde` do `edges-pendentes.sh` (Passo 3 do `/fecho`) cai em `git rev-list --before=`, e **o git lê data nua como hora LOCAL**. Os scripts irmãos — `verify-edge-eco.sh` e `verify-edge-escrita.sh` — mandam o **mesmo flag** para o **psql**, cuja sessão é UTC, e a doc dos dois prescreve literalmente `--desde '<timestamp do merge, UTC>'`.

Quem copia um timestamp UTC — o caminho **esperado** neste repo — acerta em dois scripts e erra neste, deslocado por um offset inteiro e sem nenhum sinal.

## Medido (GMT-3), verificando o deploy de `enviar-pedido-portal-sayerlack`

| `--desde` | base resolvido |
|---|---|
| `"2026-09-05 17:34"` | `a10ef2383` — **o próprio merge das 19:40Z, EXCLUÍDO** |
| `"2026-09-05 17:34 UTC"` | `ea67a6f65` — janela correta, **2 edges** |
| `"2026-09-05 17:34 -0300"` | `a10ef2383` — prova de que data nua **== local** |

A primeira devolveu `✅ nenhuma edge na janela` com **exit 0** sobre uma janela que tinha duas edges.

## Por que é caro

Este script é o lado que **APAGA** pendência (`fail-CLOSED` por desenho — está no cabeçalho dele). Janela deslocada não gera um chip a mais: gera **ZERO** chips, em verde. É a mesma **ausência fabricada** que o próprio cabeçalho combate no ramo `PRE_SONDA_FONTE` (#2156), entrando pela porta da **JANELA** em vez da porta do **CAMPO**.

## A correção

**Recusa** (exit 3, marca ASCII `DESDE_SEM_FUSO`), **não** normalização silenciosa para UTC: normalizar acertaria a intenção usual e mentiria para quem quis local — trocaria um erro visível por um invisível. SHA e data relativa não são ambíguos e seguem passando.

E a **janela efetivamente usada passa a sair impressa sempre**. O guard só alcança a forma ambígua; SHA e data relativa ainda podem resolver para um base surpreendente (worktree atrás, `REF` errada) — e isso se decidia em silêncio, inclusive no único ramo que suprime tudo.

```
janela: origin/main desde ea67a6f65 (2026-09-05T17:33:56Z) — --desde "2026-09-05 17:34 UTC"
```

## Rede

`scripts/test-fecho-edges-pendentes.sh`: **+7 asserções × 2 locales**, verde. O **par mínimo** (mesma data, só o sufixo muda: `UTC` / `Z` / `-0300` / `+00:00`) é o que dá valor ao caso — sem ele, um guard que recusasse **tudo** passaria alegando que guarda.

**+3 sabotagens** no `--falsificar`, simétricas de propósito porque o guard erra dos dois lados:
- sufixo aceitando qualquer coisa (guard frouxo → volta o bug)
- sufixo não casando nada (guard apertado → recusa UTC legítimo)
- janela efetiva deixando de ser impressa

Marcador **ASCII de caixa fixa** (`DESDE_SEM_FUSO`) de propósito: a suíte roda nos dois locales (#1483), e casar `AMBÍGUO` com acento casaria a codificação, não o ramo.

## Acoplamento

`.claude/skills/fecho/SKILL.md` passa a prescrever a forma com fuso — senão o ritual começaria a recusar sem dizer por quê.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
