### PR TITLE
fix(reposicao): rejeição em lote/inline do Cockpit passa pela RPC com guard de status — nunca UPDATE cru que cancelava pedido já disparado [money-path] (M-02)

### DIFF
--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -91,7 +91,7 @@ export function PedidoRow({
       }
 
       // Rejeição: RPC com guard de status (nunca UPDATE cru — cancelava pedido já disparado, M-02).
-      const r = await rejeitarPedidos([row], { usuario: who, justificativa: "Rejeitado inline no Cockpit" });
+      const r = await rejeitarPedidos([row], { usuario: who, justificativa: "Rejeitado inline no Cockpit", via: "individual" });
       const motivo = r.falhas[0]?.motivo ?? r.pulados[0]?.motivo ?? null;
       await logAudit({
         userId: user?.id ?? null,

--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -14,6 +14,7 @@ import { formatBRL, logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
 import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
+import { podeCancelarPeloHumano, rejeitarPedidos } from "../pedidos/rejeitar-pedido";
 import { EMPRESA } from "../pedidos/shared";
 import { PrecoCell, ConfiancaBadge } from "./PedidoRowCells";
 import { mensagemDeErro } from '@/lib/erro-mensagem';
@@ -57,7 +58,6 @@ export function PedidoRow({
   const act = async (kind: "approve" | "reject") => {
     if (busy) return;
     setBusy(kind);
-    const nowIso = new Date().toISOString();
     const who = user?.email ?? user?.id ?? "cockpit";
     try {
       if (kind === "approve") {
@@ -90,24 +90,17 @@ export function PedidoRow({
         return;
       }
 
-      // Rejeição: UPDATE direto (não passa pela trilha de disparo).
-      const { error } = await supabase
-        .from("pedido_compra_sugerido")
-        .update({
-          cancelado_em: nowIso,
-          cancelado_por: who,
-          status: "cancelado" as const,
-          justificativa_cancelamento: "Rejeitado inline no Cockpit",
-        })
-        .eq("id", row.id);
-      if (error) throw error;
+      // Rejeição: RPC com guard de status (nunca UPDATE cru — cancelava pedido já disparado, M-02).
+      const r = await rejeitarPedidos([row], { usuario: who, justificativa: "Rejeitado inline no Cockpit" });
+      const motivo = r.falhas[0]?.motivo ?? r.pulados[0]?.motivo ?? null;
       await logAudit({
         userId: user?.id ?? null,
         action: "Rejeição inline",
-        result: "Sucesso",
+        result: motivo ? `Erro: ${motivo}` : "Sucesso",
         metadata: { id: row.id, qty },
       });
-      toast.success("Pedido rejeitado");
+      if (motivo) toast.error(`Não rejeitado: ${motivo}`);
+      else toast.success("Pedido rejeitado");
       onChanged();
     } catch (err) {
       const msg = mensagemDeErro(err) ?? 'Erro sem mensagem — tente de novo ou avise a equipe.';
@@ -225,7 +218,7 @@ export function PedidoRow({
                   size="icon"
                   variant="ghost"
                   className="h-8 w-8 text-destructive hover:bg-destructive/10"
-                  disabled={isRejected || busy !== null}
+                  disabled={isRejected || busy !== null || !podeCancelarPeloHumano(row.status)}
                   onClick={() => act("reject")}
                   title="Rejeitar"
                 >

--- a/src/components/reposicao/cicloHoje/__tests__/useCicloHoje.rejeicao.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/useCicloHoje.rejeicao.test.tsx
@@ -23,6 +23,18 @@ import { useCicloHoje } from '../useCicloHoje';
 
 const mockedRpc = vi.mocked(supabase.rpc);
 const mockedFrom = vi.mocked(supabase.from);
+/** Status ATUAL no banco (o helper relê antes de decidir). */
+let statusNoBanco: Record<number, string> = {};
+let updates = 0;
+function builder() {
+  const b = {
+    select: () => b,
+    in: (_c: string, ids: number[]) => Promise.resolve({ data: ids.filter((id) => id in statusNoBanco).map((id) => ({ id, status: statusNoBanco[id] })), error: null }),
+    update: () => { updates += 1; return b; },
+    eq: () => b,
+  };
+  return b;
+}
 
 function item(id: number, status: string, extra: Partial<PedidoItem> = {}): PedidoItem {
   return {
@@ -46,7 +58,8 @@ function montar(filteredItems: PedidoItem[]) {
 
 beforeEach(() => {
   mockedRpc.mockReset();
-  mockedFrom.mockReset();
+  mockedFrom.mockReset().mockImplementation(builder as never);
+  statusNoBanco = {}; updates = 0;
   vi.mocked(toast.success).mockReset();
   vi.mocked(toast.warning).mockReset();
   vi.mocked(toast.error).mockReset();
@@ -54,7 +67,8 @@ beforeEach(() => {
 });
 
 describe('useCicloHoje.runBatch("reject") — guard de status na fronteira', () => {
-  it('"selecionar tudo" + rejeitar: só os canceláveis vão à RPC; o disparado é PULADO e o resumo diz isso (não "3 rejeitados")', async () => {
+  it('"selecionar tudo" + rejeitar: só o pendente vai à RPC; disparado e auto-aprovado são PULADOS (status RELIDO do banco) e o resumo diz isso', async () => {
+    statusNoBanco = { 1: 'pendente_aprovacao', 2: 'disparado', 3: 'aprovado_aguardando_disparo' };
     mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
     const itens = [
       item(1, 'pendente_aprovacao'),
@@ -67,37 +81,41 @@ describe('useCicloHoje.runBatch("reject") — guard de status na fronteira', () 
 
     await act(async () => { await result.current.runBatch('reject'); });
 
-    expect(mockedRpc.mock.calls.map((c) => (c[1] as { p_pedido_id: number }).p_pedido_id)).toEqual([1, 3]);
+    expect(mockedRpc.mock.calls.map((c) => (c[1] as { p_pedido_id: number }).p_pedido_id)).toEqual([1]);
     expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({
       p_usuario: 'lucas@x.com', p_justificativa: expect.stringContaining('lote'),
     }));
-    // nunca UPDATE cru na tabela
-    expect(mockedFrom).not.toHaveBeenCalled();
-    // o resumo NÃO pode dizer sucesso pleno: 1 pulado
+    // nunca UPDATE cru na tabela (a leitura do status é permitida)
+    expect(updates).toBe(0);
+    // o resumo NÃO pode dizer sucesso pleno: 2 pulados, com o status de cada um
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.warning).toHaveBeenCalledTimes(1);
     const resumo = vi.mocked(toast.warning).mock.calls[0][0] as string;
-    expect(resumo).toMatch(/2 rejeitado/);
-    expect(resumo).toMatch(/1 pulado/);
-    // auditoria carrega a partição
+    expect(resumo).toMatch(/1 rejeitado/);
+    expect(resumo).toMatch(/2 pulado/);
+    expect(resumo).toMatch(/disparado/);
+    // auditoria carrega a partição COM os motivos
     expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
       action: 'Rejeição em lote',
-      metadata: expect.objectContaining({ rejeitados: [1, 3], pulados: [2] }),
+      metadata: expect.objectContaining({ rejeitados: [1], pulados: [expect.objectContaining({ id: 2, status: 'disparado' }), expect.objectContaining({ id: 3 })] }),
     }));
-    // seleção limpa após o lote
-    expect(result.current.selected.size).toBe(0);
+    // só o rejeitado sai da seleção: os pulados ficam marcados para o operador agir
+    expect([...result.current.selected].sort()).toEqual([2, 3]);
   });
 
-  it('todos canceláveis e RPC ok → toast de sucesso com a contagem real', async () => {
+  it('todos canceláveis e RPC ok → toast de sucesso com a contagem real (e a seleção zera)', async () => {
+    statusNoBanco = { 1: 'pendente_aprovacao', 2: 'bloqueado_guardrail' };
     mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
     const { result } = montar([item(1, 'pendente_aprovacao'), item(2, 'bloqueado_guardrail')]);
     act(() => result.current.toggleAll());
     await act(async () => { await result.current.runBatch('reject'); });
     expect(toast.success).toHaveBeenCalledWith('2 pedido(s) rejeitado(s)');
     expect(toast.warning).not.toHaveBeenCalled();
+    expect(result.current.selected.size).toBe(0);
   });
 
   it('a RPC recusando um (guard do servidor) → toast de ERRO com "1 com falha" e auditoria com o motivo', async () => {
+    statusNoBanco = { 1: 'pendente_aprovacao', 2: 'pendente_aprovacao' };
     mockedRpc
       .mockResolvedValueOnce({ data: { error: 'pedido já foi disparado em 2026-09-05' }, error: null } as never)
       .mockResolvedValueOnce({ data: { status: 'ok' }, error: null } as never);
@@ -112,7 +130,8 @@ describe('useCicloHoje.runBatch("reject") — guard de status na fronteira', () 
     }));
   });
 
-  it('id selecionado que saiu da lista filtrada NÃO vai à RPC (status desconhecido = não rejeita)', async () => {
+  it('id selecionado que saiu da lista filtrada é decidido pelo status do BANCO, não pelo que o browser mostra', async () => {
+    statusNoBanco = { 1: 'pendente_aprovacao', 2: 'disparado' };
     mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
     const { result, rerender } = renderHook(
       ({ itens }: { itens: PedidoItem[] }) =>

--- a/src/components/reposicao/cicloHoje/__tests__/useCicloHoje.rejeicao.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/useCicloHoje.rejeicao.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { PedidoItem } from '@/types/reposicao';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: vi.fn(), from: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/reposicao', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/reposicao')>()),
+  logAudit: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/components/reposicao/pedidos/aprovar-disparar', () => ({ aprovarEDisparar: vi.fn() }));
+
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { logAudit } from '@/lib/reposicao';
+import { useCicloHoje } from '../useCicloHoje';
+
+const mockedRpc = vi.mocked(supabase.rpc);
+const mockedFrom = vi.mocked(supabase.from);
+
+function item(id: number, status: string, extra: Partial<PedidoItem> = {}): PedidoItem {
+  return {
+    id, status, fornecedor_nome: 'ACME', grupo_codigo: 'G1', num_skus: 2, valor_total: 100,
+    pedido_anterior_valor: null, aprovado_em: null, cancelado_em: null, horario_disparo_real: null,
+    ...extra,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function montar(filteredItems: PedidoItem[]) {
+  return renderHook(
+    () => useCicloHoje({ user: { id: 'u1', email: 'lucas@x.com' }, reviewMode: true, filteredItems, setFilters: vi.fn() }),
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  mockedRpc.mockReset();
+  mockedFrom.mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.warning).mockReset();
+  vi.mocked(toast.error).mockReset();
+  vi.mocked(logAudit).mockClear();
+});
+
+describe('useCicloHoje.runBatch("reject") — guard de status na fronteira', () => {
+  it('"selecionar tudo" + rejeitar: só os canceláveis vão à RPC; o disparado é PULADO e o resumo diz isso (não "3 rejeitados")', async () => {
+    mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
+    const itens = [
+      item(1, 'pendente_aprovacao'),
+      item(2, 'disparado', { aprovado_em: '2026-09-05T09:00:00Z', horario_disparo_real: '2026-09-05T09:05:00Z' }),
+      item(3, 'aprovado_aguardando_disparo', { aprovado_em: '2026-09-05T09:00:00Z' }),
+    ];
+    const { result } = montar(itens);
+    act(() => result.current.toggleAll());
+    expect(result.current.selected.size).toBe(3);
+
+    await act(async () => { await result.current.runBatch('reject'); });
+
+    expect(mockedRpc.mock.calls.map((c) => (c[1] as { p_pedido_id: number }).p_pedido_id)).toEqual([1, 3]);
+    expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({
+      p_usuario: 'lucas@x.com', p_justificativa: expect.stringContaining('lote'),
+    }));
+    // nunca UPDATE cru na tabela
+    expect(mockedFrom).not.toHaveBeenCalled();
+    // o resumo NÃO pode dizer sucesso pleno: 1 pulado
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+    const resumo = vi.mocked(toast.warning).mock.calls[0][0] as string;
+    expect(resumo).toMatch(/2 rejeitado/);
+    expect(resumo).toMatch(/1 pulado/);
+    // auditoria carrega a partição
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'Rejeição em lote',
+      metadata: expect.objectContaining({ rejeitados: [1, 3], pulados: [2] }),
+    }));
+    // seleção limpa após o lote
+    expect(result.current.selected.size).toBe(0);
+  });
+
+  it('todos canceláveis e RPC ok → toast de sucesso com a contagem real', async () => {
+    mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
+    const { result } = montar([item(1, 'pendente_aprovacao'), item(2, 'bloqueado_guardrail')]);
+    act(() => result.current.toggleAll());
+    await act(async () => { await result.current.runBatch('reject'); });
+    expect(toast.success).toHaveBeenCalledWith('2 pedido(s) rejeitado(s)');
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it('a RPC recusando um (guard do servidor) → toast de ERRO com "1 com falha" e auditoria com o motivo', async () => {
+    mockedRpc
+      .mockResolvedValueOnce({ data: { error: 'pedido já foi disparado em 2026-09-05' }, error: null } as never)
+      .mockResolvedValueOnce({ data: { status: 'ok' }, error: null } as never);
+    const { result } = montar([item(1, 'pendente_aprovacao'), item(2, 'pendente_aprovacao')]);
+    act(() => result.current.toggleAll());
+    await act(async () => { await result.current.runBatch('reject'); });
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toMatch(/1 com falha/);
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.stringMatching(/Parcial/),
+      metadata: expect.objectContaining({ falhas: [{ id: 1, motivo: 'pedido já foi disparado em 2026-09-05' }] }),
+    }));
+  });
+
+  it('id selecionado que saiu da lista filtrada NÃO vai à RPC (status desconhecido = não rejeita)', async () => {
+    mockedRpc.mockResolvedValue({ data: { status: 'ok' }, error: null } as never);
+    const { result, rerender } = renderHook(
+      ({ itens }: { itens: PedidoItem[] }) =>
+        useCicloHoje({ user: { id: 'u1', email: 'lucas@x.com' }, reviewMode: true, filteredItems: itens, setFilters: vi.fn() }),
+      { wrapper, initialProps: { itens: [item(1, 'pendente_aprovacao'), item(2, 'pendente_aprovacao')] } },
+    );
+    act(() => result.current.toggleAll());
+    rerender({ itens: [item(1, 'pendente_aprovacao')] }); // o 2 saiu do filtro, mas segue em `selected`
+    await act(async () => { await result.current.runBatch('reject'); });
+    expect(mockedRpc).toHaveBeenCalledTimes(1);
+    expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 1 }));
+  });
+});

--- a/src/components/reposicao/cicloHoje/useCicloHoje.ts
+++ b/src/components/reposicao/cicloHoje/useCicloHoje.ts
@@ -8,7 +8,7 @@ import { logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { PedidoItem } from "@/types/reposicao";
 import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
-import { rejeitarPedidos } from "../pedidos/rejeitar-pedido";
+import { rejeitarPedidos, resumirRejeicao } from "../pedidos/rejeitar-pedido";
 import { EMPRESA } from "../pedidos/shared";
 import { ALL, type CicloFilters } from "./types";
 import { mensagemDeErro } from '@/lib/erro-mensagem';
@@ -148,19 +148,19 @@ export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: Us
     try {
       const porId = new Map(filteredItems.map((i) => [i.id, i]));
       const alvo = ids.map((id) => porId.get(id) ?? { id, status: null });
-      const r = await rejeitarPedidos(alvo, { usuario: who, justificativa: "Rejeitado em lote no Cockpit" });
-      const tudoOk = r.pulados.length === 0 && r.falhas.length === 0;
-      const resumo = `${r.rejeitados.length} rejeitado(s), ${r.pulados.length} pulado(s) (já disparado/terminal), ${r.falhas.length} com falha — reveja`;
+      const r = await rejeitarPedidos(alvo, { usuario: who, justificativa: "Rejeitado em lote no Cockpit", via: "lote" });
+      const { texto, nivel } = resumirRejeicao(r);
       await logAudit({
         userId: user?.id ?? null,
         action: "Rejeição em lote",
-        result: tudoOk ? "Sucesso" : `Parcial: ${resumo}`,
-        metadata: { ids, count: ids.length, rejeitados: r.rejeitados, pulados: r.pulados.map((p) => p.id), falhas: r.falhas },
+        result: nivel === "success" ? "Sucesso" : `${r.rejeitados.length === 0 ? "Nada rejeitado" : "Parcial"}: ${texto}`,
+        metadata: { ids, count: ids.length, rejeitados: r.rejeitados, pulados: r.pulados, falhas: r.falhas },
       });
-      if (tudoOk) toast.success(`${r.rejeitados.length} pedido(s) rejeitado(s)`);
-      else if (r.falhas.length > 0) toast.error(resumo);
-      else toast.warning(resumo);
-      setSelected(new Set());
+      if (nivel === "success") toast.success(`${r.rejeitados.length} pedido(s) rejeitado(s)`);
+      else if (nivel === "error") toast.error(`${texto} — reveja`);
+      else toast.warning(`${texto} — reveja`);
+      // Só o que foi rejeitado sai da seleção: pulados/falhas ficam marcados para o operador agir.
+      setSelected(new Set(ids.filter((id) => !r.rejeitados.includes(id))));
       invalidate();
     } catch (err) {
       const msg = mensagemDeErro(err) ?? 'Erro sem mensagem — tente de novo ou avise a equipe.';

--- a/src/components/reposicao/cicloHoje/useCicloHoje.ts
+++ b/src/components/reposicao/cicloHoje/useCicloHoje.ts
@@ -8,6 +8,7 @@ import { logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { PedidoItem } from "@/types/reposicao";
 import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
+import { rejeitarPedidos } from "../pedidos/rejeitar-pedido";
 import { EMPRESA } from "../pedidos/shared";
 import { ALL, type CicloFilters } from "./types";
 import { mensagemDeErro } from '@/lib/erro-mensagem';
@@ -92,7 +93,6 @@ export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: Us
     if (selected.size === 0 || busy) return;
     setBusy(true);
     const ids = Array.from(selected);
-    const nowIso = new Date().toISOString();
     const who = user?.email ?? user?.id ?? "cockpit";
 
     if (kind === "approve") {
@@ -142,26 +142,24 @@ export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: Us
       return;
     }
 
-    // Rejeição em lote: UPDATE direto (não passa pela trilha de disparo).
+    // Rejeição em lote: RPC por pedido (guard de status no servidor + higiene do portal), NUNCA
+    // UPDATE cru `.in("id", ids)` — esse caminho cancelava pedido já disparado (M-02). Só quem
+    // está na lista filtrada tem status conhecido; id selecionado que saiu do filtro não vai.
     try {
-      const { error } = await supabase
-        .from("pedido_compra_sugerido")
-        .update({
-          cancelado_em: nowIso,
-          cancelado_por: who,
-          status: "cancelado" as const,
-          justificativa_cancelamento: "Rejeitado em lote no Cockpit",
-        })
-        .in("id", ids);
-      if (error) throw error;
-
+      const porId = new Map(filteredItems.map((i) => [i.id, i]));
+      const alvo = ids.map((id) => porId.get(id) ?? { id, status: null });
+      const r = await rejeitarPedidos(alvo, { usuario: who, justificativa: "Rejeitado em lote no Cockpit" });
+      const tudoOk = r.pulados.length === 0 && r.falhas.length === 0;
+      const resumo = `${r.rejeitados.length} rejeitado(s), ${r.pulados.length} pulado(s) (já disparado/terminal), ${r.falhas.length} com falha — reveja`;
       await logAudit({
         userId: user?.id ?? null,
         action: "Rejeição em lote",
-        result: "Sucesso",
-        metadata: { ids, count: ids.length },
+        result: tudoOk ? "Sucesso" : `Parcial: ${resumo}`,
+        metadata: { ids, count: ids.length, rejeitados: r.rejeitados, pulados: r.pulados.map((p) => p.id), falhas: r.falhas },
       });
-      toast.success(`${ids.length} pedido(s) rejeitado(s)`);
+      if (tudoOk) toast.success(`${r.rejeitados.length} pedido(s) rejeitado(s)`);
+      else if (r.falhas.length > 0) toast.error(resumo);
+      else toast.warning(resumo);
       setSelected(new Set());
       invalidate();
     } catch (err) {

--- a/src/components/reposicao/pedidos/CancelarModal.tsx
+++ b/src/components/reposicao/pedidos/CancelarModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { rejeitarPedidos } from './rejeitar-pedido';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -29,12 +29,16 @@ export function CancelarModal({
   const cancelarMutation = useMutation({
     mutationFn: async () => {
       if (!pedido) return;
-      const { error } = await supabase.rpc('cancelar_pedido_sugerido', {
-        p_pedido_id: pedido.id,
-        p_usuario: user?.email ?? 'sistema',
-        p_justificativa: justificativa.trim(),
+      // Mesma fronteira do Cockpit (M-02). A RPC devolve `{error}` no jsonb SEM erro de transporte
+      // quando recusa (ex.: já disparado) — ler só `error` do PostgREST mostrava "Pedido cancelado"
+      // sobre uma compra que seguiu (Codex P1).
+      const r = await rejeitarPedidos([pedido], {
+        usuario: user?.email ?? 'sistema',
+        justificativa: justificativa.trim(),
+        via: 'individual',
       });
-      if (error) throw error;
+      const motivo = r.falhas[0]?.motivo ?? r.pulados[0]?.motivo;
+      if (motivo) throw new Error(motivo);
     },
     onSuccess: () => {
       toast.success('Pedido cancelado');

--- a/src/components/reposicao/pedidos/CiclosAnteriores.tsx
+++ b/src/components/reposicao/pedidos/CiclosAnteriores.tsx
@@ -34,7 +34,8 @@ export function CiclosAnteriores({ data, onChange }: { data: string; onChange: (
         g.pedidos += 1;
         g.valor += Number(r.valor_total ?? 0);
         if (r.status === 'disparado') g.disparados += 1;
-        if (r.status === 'cancelado') g.cancelados += 1;
+        // 'cancelado_humano' é o vocabulário da RPC (Cancelar da lista e, desde o M-02, o Cockpit).
+        if (r.status === 'cancelado' || r.status === 'cancelado_humano') g.cancelados += 1;
       }
       return Array.from(grupos.entries()).map(([dia, g]) => ({
         dia,

--- a/src/components/reposicao/pedidos/PedidoRow.tsx
+++ b/src/components/reposicao/pedidos/PedidoRow.tsx
@@ -6,6 +6,7 @@ import { PedidoSugerido } from './types';
 import { formatBRL, ehGateMinimoFaturamento } from './shared';
 import { StatusComMotivo, SplitInfo, PortalBadge } from './badges';
 import { OverrideMinimoButton } from './OverrideMinimoButton';
+import { podeCancelarPeloHumano } from './rejeitar-pedido';
 
 export function PedidoRow({
   p,
@@ -28,7 +29,7 @@ export function PedidoRow({
   disparando: boolean;
 }) {
   const podeAprovar = p.status === 'pendente_aprovacao' || p.status === 'bloqueado_guardrail';
-  const podeCancelar = ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo'].includes(p.status);
+  const podeCancelar = podeCancelarPeloHumano(p.status);
   // Pedido preso ESPECIFICAMENTE pelo gate de mínimo de faturamento + caller pode overridar
   // → oferece "Disparar mesmo assim" NO LUGAR do "Re-disparar" (que só re-bateria no gate).
   const mostrarOverride = ehGateMinimoFaturamento(p) && !!onDispararIgnorandoMinimo;

--- a/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
@@ -134,12 +134,17 @@ describe('rejeitarPedidos — decide pelo status RELIDO do banco e passa pela RP
     expect(r.rejeitados).toEqual([9]);
   });
 
-  it('resposta que não afirma `status:"ok"` NÃO conta como rejeitado (ausência de sinal ≠ sucesso)', async () => {
-    statusNoBanco = { 9: 'pendente_aprovacao', 10: 'pendente_aprovacao' };
-    mockedRpc.mockResolvedValueOnce({ data: null, error: null } as never).mockResolvedValueOnce({ data: 'ok', error: null } as never);
-    const r = await rejeitarPedidos([{ id: 9, status: 'pendente_aprovacao' }, { id: 10, status: 'pendente_aprovacao' }], lote);
+  it('resposta que não afirma `status:"ok"` NÃO conta como rejeitado (ausência de sinal ≠ sucesso) — inclusive um OBJETO sem o ok', async () => {
+    statusNoBanco = { 9: 'pendente_aprovacao', 10: 'pendente_aprovacao', 11: 'pendente_aprovacao' };
+    mockedRpc
+      .mockResolvedValueOnce({ data: null, error: null } as never)
+      .mockResolvedValueOnce({ data: 'ok', error: null } as never)
+      // a falsificação pegou: sem este caso, `confirmouOk` sabotado para "qualquer objeto" ficava verde
+      .mockResolvedValueOnce({ data: { pedido_id: 11 }, error: null } as never);
+    const r = await rejeitarPedidos([9, 10, 11].map((id) => ({ id, status: 'pendente_aprovacao' })), lote);
     expect(r.rejeitados).toEqual([]);
-    expect(r.falhas.map((f) => f.id)).toEqual([9, 10]);
+    expect(r.falhas.map((f) => f.id)).toEqual([9, 10, 11]);
+    expect(r.falhas[2].motivo).toMatch(/sem status ok/);
   });
 });
 

--- a/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
@@ -7,125 +7,199 @@ vi.mock('@/integrations/supabase/client', () => ({
 
 import { supabase } from '@/integrations/supabase/client';
 import {
+  STATUS_CANCELAVEIS_EM_LOTE,
   STATUS_CANCELAVEIS_PELO_HUMANO,
   podeCancelarPeloHumano,
   rejeitarPedidos,
+  resumirRejeicao,
 } from '../rejeitar-pedido';
 
 const mockedRpc = vi.mocked(supabase.rpc);
 const mockedFrom = vi.mocked(supabase.from);
 
+/** O status ATUAL no banco, por id — o helper RELÊ antes de decidir (o do browser pode ter minutos). */
+let statusNoBanco: Record<number, string | null> = {};
+let erroLeitura: { message: string } | null = null;
+let updates = 0;
+function builder(table: string) {
+  const b = {
+    select: () => b,
+    in: (_c: string, ids: number[]) => {
+      const data = ids.filter((id) => id in statusNoBanco).map((id) => ({ id, status: statusNoBanco[id] }));
+      return Promise.resolve(erroLeitura ? { data: null, error: erroLeitura } : { data, error: null });
+    },
+    update: () => { updates += 1; return b; },
+    eq: () => b,
+  };
+  if (table !== 'pedido_compra_sugerido') throw new Error(`tabela inesperada: ${table}`);
+  return b;
+}
+
 const ok = { data: { status: 'ok' }, error: null } as never;
-const opts = { usuario: 'lucas@x.com', justificativa: 'Rejeitado em lote no Cockpit' };
+const lote = { usuario: 'lucas@x.com', justificativa: 'Rejeitado em lote no Cockpit', via: 'lote' as const };
+const individual = { ...lote, justificativa: 'Rejeitado inline no Cockpit', via: 'individual' as const };
 
 beforeEach(() => {
   mockedRpc.mockReset();
-  mockedFrom.mockReset();
+  mockedFrom.mockReset().mockImplementation(builder as never);
+  statusNoBanco = {}; erroLeitura = null; updates = 0;
 });
 
-describe('podeCancelarPeloHumano — a regra de produto "cancelável até o disparo" (fonte única)', () => {
-  it('pendente_aprovacao, bloqueado_guardrail e aprovado_aguardando_disparo (veto do auto-aprovado) podem', () => {
-    for (const s of ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo']) {
-      expect(podeCancelarPeloHumano(s), s).toBe(true);
-      expect(STATUS_CANCELAVEIS_PELO_HUMANO.has(s), s).toBe(true);
-    }
+describe('allowlists — a regra de produto "cancelável até o disparo", por via (fonte única)', () => {
+  it('lote: só o que NUNCA foi aprovado; individual: também o veto do auto-aprovado', () => {
+    expect([...STATUS_CANCELAVEIS_EM_LOTE].sort()).toEqual(['bloqueado_guardrail', 'pendente_aprovacao']);
+    expect([...STATUS_CANCELAVEIS_PELO_HUMANO].sort()).toEqual(['aprovado_aguardando_disparo', 'bloqueado_guardrail', 'pendente_aprovacao']);
+    for (const s of STATUS_CANCELAVEIS_PELO_HUMANO) expect(podeCancelarPeloHumano(s), s).toBe(true);
   });
 
-  it('disparado, terminais, split e ausente NÃO podem — era o bug: `.in("id", ids)` sem guard rejeitava pedido já disparado', () => {
+  it('disparado, falha_envio (tentativa de envio já feita), terminais, split e ausente NÃO podem', () => {
     for (const s of ['disparado', 'concluido_recebido', 'falha_envio', 'cancelado', 'cancelado_humano', 'expirado_sem_aprovacao', 'split_em_filhos', null, undefined, '']) {
       expect(podeCancelarPeloHumano(s), String(s)).toBe(false);
     }
   });
 });
 
-describe('rejeitarPedidos — passa pela RPC cancelar_pedido_sugerido (fronteira com guard), nunca UPDATE cru', () => {
+describe('rejeitarPedidos — decide pelo status RELIDO do banco e passa pela RPC (fronteira), nunca UPDATE cru', () => {
   it('chama a RPC com os args canônicos, um pedido por vez, na ordem dada', async () => {
+    statusNoBanco = { 10: 'pendente_aprovacao', 11: 'aprovado_aguardando_disparo' };
     mockedRpc.mockResolvedValue(ok);
-    const r = await rejeitarPedidos(
-      [{ id: 10, status: 'pendente_aprovacao' }, { id: 11, status: 'aprovado_aguardando_disparo' }],
-      opts,
-    );
-    expect(mockedRpc).toHaveBeenCalledTimes(2);
-    expect(mockedRpc).toHaveBeenNthCalledWith(1, 'cancelar_pedido_sugerido', {
-      p_pedido_id: 10, p_usuario: 'lucas@x.com', p_justificativa: 'Rejeitado em lote no Cockpit',
-    });
+    const r = await rejeitarPedidos([{ id: 10, status: 'pendente_aprovacao' }, { id: 11, status: 'aprovado_aguardando_disparo' }], individual);
+    expect(mockedRpc).toHaveBeenNthCalledWith(1, 'cancelar_pedido_sugerido', { p_pedido_id: 10, p_usuario: 'lucas@x.com', p_justificativa: 'Rejeitado inline no Cockpit' });
     expect(mockedRpc).toHaveBeenNthCalledWith(2, 'cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 11 }));
     expect(r).toEqual({ rejeitados: [10, 11], pulados: [], falhas: [] });
-    expect(mockedFrom).not.toHaveBeenCalled();
+    expect(updates).toBe(0);
   });
 
-  it('status fora da allowlist é PULADO antes de chamar a RPC (com o status no motivo) — os demais seguem', async () => {
+  it('o status do BROWSER não manda: browser diz "pendente", banco diz "disparado" → pulado, RPC nem é chamada (Codex P1)', async () => {
+    statusNoBanco = { 1: 'disparado', 2: 'falha_envio', 3: 'pendente_aprovacao' };
     mockedRpc.mockResolvedValue(ok);
     const r = await rejeitarPedidos(
-      [{ id: 1, status: 'disparado' }, { id: 2, status: 'pendente_aprovacao' }, { id: 3, status: 'cancelado_humano' }],
-      opts,
+      [{ id: 1, status: 'pendente_aprovacao' }, { id: 2, status: 'aprovado_aguardando_disparo' }, { id: 3, status: 'pendente_aprovacao' }],
+      individual,
     );
     expect(mockedRpc).toHaveBeenCalledTimes(1);
-    expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 2 }));
-    expect(r.rejeitados).toEqual([2]);
-    expect(r.pulados.map((p) => p.id)).toEqual([1, 3]);
+    expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 3 }));
+    expect(r.rejeitados).toEqual([3]);
+    expect(r.pulados.map((p) => [p.id, p.status])).toEqual([[1, 'disparado'], [2, 'falha_envio']]);
     expect(r.pulados[0].motivo).toContain('disparado');
-    expect(r.pulados[1].motivo).toContain('cancelado_humano');
-    expect(r.falhas).toEqual([]);
+  });
+
+  it('via LOTE não veta auto-aprovado (aguardando o cron): pulado com a dica de vetar individualmente', async () => {
+    statusNoBanco = { 1: 'aprovado_aguardando_disparo', 2: 'bloqueado_guardrail' };
+    mockedRpc.mockResolvedValue(ok);
+    const r = await rejeitarPedidos([{ id: 1, status: 'aprovado_aguardando_disparo' }, { id: 2, status: 'bloqueado_guardrail' }], lote);
+    expect(mockedRpc).toHaveBeenCalledTimes(1);
+    expect(r.rejeitados).toEqual([2]);
+    expect(r.pulados[0].motivo).toMatch(/individual/);
+  });
+
+  it('pedido que sumiu do banco (removido/regenerado) → pulado, sem RPC', async () => {
+    statusNoBanco = { 2: 'pendente_aprovacao' };
+    mockedRpc.mockResolvedValue(ok);
+    const r = await rejeitarPedidos([{ id: 1, status: 'pendente_aprovacao' }, { id: 2, status: 'pendente_aprovacao' }], lote);
+    expect(r.rejeitados).toEqual([2]);
+    expect(r.pulados).toEqual([{ id: 1, status: null, motivo: expect.stringMatching(/não encontrado/) }]);
+  });
+
+  it('se nem o status dá para reler, NINGUÉM é rejeitado (fail-closed): tudo em falhas, RPC não chamada', async () => {
+    erroLeitura = { message: 'permission denied for table pedido_compra_sugerido' };
+    const r = await rejeitarPedidos([{ id: 1, status: 'pendente_aprovacao' }, { id: 2, status: 'pendente_aprovacao' }], lote);
+    expect(mockedRpc).not.toHaveBeenCalled();
+    expect(r.rejeitados).toEqual([]);
+    expect(r.falhas.map((f) => f.id)).toEqual([1, 2]);
+    expect(r.falhas[0].motivo).toContain('permission denied');
   });
 
   it('a RPC recusando pelo guard do servidor ({error} no jsonb) vira FALHA com o motivo — não "rejeitado"', async () => {
+    statusNoBanco = { 5: 'pendente_aprovacao', 6: 'pendente_aprovacao' };
     mockedRpc
       .mockResolvedValueOnce({ data: { error: 'pedido já foi disparado em 2026-09-05 10:00' }, error: null } as never)
       .mockResolvedValueOnce(ok);
-    const r = await rejeitarPedidos([{ id: 5, status: 'pendente_aprovacao' }, { id: 6, status: 'pendente_aprovacao' }], opts);
+    const r = await rejeitarPedidos([{ id: 5, status: 'pendente_aprovacao' }, { id: 6, status: 'pendente_aprovacao' }], lote);
     expect(r.rejeitados).toEqual([6]);
     expect(r.falhas).toEqual([{ id: 5, motivo: 'pedido já foi disparado em 2026-09-05 10:00' }]);
   });
 
-  it('erro de transporte (PostgREST) vira FALHA com a mensagem, e não aborta os seguintes', async () => {
+  it('erro de transporte e exceção viram FALHA daquele pedido, sem derrubar o lote', async () => {
+    statusNoBanco = { 7: 'pendente_aprovacao', 8: 'pendente_aprovacao', 9: 'pendente_aprovacao' };
     mockedRpc
       .mockResolvedValueOnce({ data: null, error: { message: 'permission denied for function cancelar_pedido_sugerido', code: '42501' } } as never)
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
       .mockResolvedValueOnce(ok);
-    const r = await rejeitarPedidos([{ id: 7, status: 'pendente_aprovacao' }, { id: 8, status: 'pendente_aprovacao' }], opts);
-    expect(r.falhas).toEqual([{ id: 7, motivo: 'permission denied for function cancelar_pedido_sugerido' }]);
-    expect(r.rejeitados).toEqual([8]);
+    const r = await rejeitarPedidos([7, 8, 9].map((id) => ({ id, status: 'pendente_aprovacao' })), lote);
+    expect(r.falhas).toEqual([
+      { id: 7, motivo: 'permission denied for function cancelar_pedido_sugerido' },
+      { id: 8, motivo: 'Failed to fetch' },
+    ]);
+    expect(r.rejeitados).toEqual([9]);
   });
 
   it('resposta que não afirma `status:"ok"` NÃO conta como rejeitado (ausência de sinal ≠ sucesso)', async () => {
+    statusNoBanco = { 9: 'pendente_aprovacao', 10: 'pendente_aprovacao' };
     mockedRpc.mockResolvedValueOnce({ data: null, error: null } as never).mockResolvedValueOnce({ data: 'ok', error: null } as never);
-    const r = await rejeitarPedidos([{ id: 9, status: 'pendente_aprovacao' }, { id: 10, status: 'pendente_aprovacao' }], opts);
+    const r = await rejeitarPedidos([{ id: 9, status: 'pendente_aprovacao' }, { id: 10, status: 'pendente_aprovacao' }], lote);
     expect(r.rejeitados).toEqual([]);
     expect(r.falhas.map((f) => f.id)).toEqual([9, 10]);
   });
+});
 
-  it('a RPC lançando (rede) vira FALHA daquele pedido, sem derrubar o lote', async () => {
-    mockedRpc.mockRejectedValueOnce(new Error('Failed to fetch')).mockResolvedValueOnce(ok);
-    const r = await rejeitarPedidos([{ id: 1, status: 'pendente_aprovacao' }, { id: 2, status: 'pendente_aprovacao' }], opts);
-    expect(r.falhas).toEqual([{ id: 1, motivo: 'Failed to fetch' }]);
-    expect(r.rejeitados).toEqual([2]);
+describe('resumirRejeicao — o resumo não pode enganar o operador', () => {
+  it('0 rejeitados + N pulados NÃO é sucesso nem "parcial": é aviso com os status', () => {
+    const r = resumirRejeicao({ rejeitados: [], pulados: [{ id: 1, status: 'disparado', motivo: 'x' }, { id: 2, status: 'disparado', motivo: 'x' }], falhas: [] });
+    expect(r.nivel).toBe('warning');
+    expect(r.texto).toMatch(/0 rejeitado/);
+    expect(r.texto).toMatch(/2× disparado/);
+  });
+  it('qualquer falha → erro, com o primeiro motivo', () => {
+    const r = resumirRejeicao({ rejeitados: [1], pulados: [], falhas: [{ id: 2, motivo: 'pedido já foi disparado' }] });
+    expect(r.nivel).toBe('error');
+    expect(r.texto).toContain('pedido já foi disparado');
+  });
+  it('tudo rejeitado → sucesso', () => {
+    expect(resumirRejeicao({ rejeitados: [1, 2], pulados: [], falhas: [] }).nivel).toBe('success');
   });
 });
 
-describe('fronteira: nenhum caminho do Cockpit grava cancelamento por UPDATE cru', () => {
+describe('fronteira: nenhum caminho humano grava cancelamento por UPDATE cru nem lê só o erro de transporte da RPC', () => {
   const ler = (p: string) => readFileSync(p, 'utf8');
   const semUpdateCru = (src: string, nome: string) => {
-    expect(src, `${nome}: UPDATE cru com status "cancelado"`).not.toContain('status: "cancelado"');
-    expect(src, `${nome}: UPDATE cru gravando cancelado_em`).not.toMatch(/\.from\(["']pedido_compra_sugerido["']\)[\s\S]{0,400}?cancelado_em/);
+    expect(src, `${nome}: UPDATE cru com status cancelado`).not.toMatch(/status:\s*["']cancelado(_humano)?["']/);
+    expect(src, `${nome}: UPDATE cru gravando cancelado_em`).not.toMatch(/\.from\(["']pedido_compra_sugerido["']\)[\s\S]{0,2000}?\.update\([\s\S]{0,600}?cancelado_em/);
+    expect(src, `${nome}: chama a RPC direto, fora da fronteira`).not.toContain("rpc('cancelar_pedido_sugerido'");
     expect(src, `${nome}: não passa por rejeitarPedidos`).toContain('rejeitarPedidos(');
   };
 
-  it('useCicloHoje (rejeição em lote)', () => {
-    semUpdateCru(ler('src/components/reposicao/cicloHoje/useCicloHoje.ts'), 'useCicloHoje');
+  it('useCicloHoje (rejeição em lote) — via lote', () => {
+    const src = ler('src/components/reposicao/cicloHoje/useCicloHoje.ts');
+    semUpdateCru(src, 'useCicloHoje');
+    expect(src).toMatch(/via:\s*["']lote["']/);
   });
 
-  it('PedidoRow do ciclo (rejeição inline — mesma classe)', () => {
-    semUpdateCru(ler('src/components/reposicao/cicloHoje/PedidoRow.tsx'), 'cicloHoje/PedidoRow');
+  it('PedidoRow do ciclo (rejeição inline) — via individual', () => {
+    const src = ler('src/components/reposicao/cicloHoje/PedidoRow.tsx');
+    semUpdateCru(src, 'cicloHoje/PedidoRow');
+    expect(src).toMatch(/via:\s*["']individual["']/);
   });
 
-  it('PedidoRow da lista de pedidos usa a MESMA allowlist (não uma lista inline própria)', () => {
+  it('CancelarModal (lista de pedidos) — mesma fronteira; a recusa da RPC vira erro, não "Pedido cancelado"', () => {
+    const src = ler('src/components/reposicao/pedidos/CancelarModal.tsx');
+    semUpdateCru(src, 'CancelarModal');
+    expect(src).toMatch(/if \(motivo\) throw new Error\(motivo\)/);
+  });
+
+  it('PedidoRow da lista usa a MESMA allowlist (não uma lista inline própria)', () => {
     const src = ler('src/components/reposicao/pedidos/PedidoRow.tsx');
     expect(src).toContain('podeCancelarPeloHumano(');
-    expect(src).not.toMatch(/\[\s*'pendente_aprovacao',\s*'bloqueado_guardrail',\s*'aprovado_aguardando_disparo'\s*\]\.includes/);
+    expect(src).not.toMatch(/\[\s*['"]pendente_aprovacao['"],\s*['"]bloqueado_guardrail['"],\s*['"]aprovado_aguardando_disparo['"]\s*\]\.includes/);
   });
 
-  it('CiclosAnteriores conta cancelado_humano como cancelado (o Cockpit agora grava esse vocabulário)', () => {
+  it('CiclosAnteriores conta cancelado_humano como cancelado — na CONDIÇÃO, não num comentário', () => {
     const src = ler('src/components/reposicao/pedidos/CiclosAnteriores.tsx');
-    expect(src).toContain('cancelado_humano');
+    expect(src).toMatch(/r\.status === ['"]cancelado['"] \|\| r\.status === ['"]cancelado_humano['"]\) g\.cancelados \+= 1/);
+  });
+
+  it('o rótulo de cancelado_humano não é mais "vazio"', () => {
+    const src = ler('src/components/reposicao/pedidos/shared.ts');
+    expect(src).not.toMatch(/cancelado_humano:\s*\{\s*label:\s*['"]Cancelado \(vazio\)['"]/);
   });
 });

--- a/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: vi.fn(), from: vi.fn() },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import {
+  STATUS_CANCELAVEIS_PELO_HUMANO,
+  podeCancelarPeloHumano,
+  rejeitarPedidos,
+} from '../rejeitar-pedido';
+
+const mockedRpc = vi.mocked(supabase.rpc);
+const mockedFrom = vi.mocked(supabase.from);
+
+const ok = { data: { status: 'ok' }, error: null } as never;
+const opts = { usuario: 'lucas@x.com', justificativa: 'Rejeitado em lote no Cockpit' };
+
+beforeEach(() => {
+  mockedRpc.mockReset();
+  mockedFrom.mockReset();
+});
+
+describe('podeCancelarPeloHumano — a regra de produto "cancelável até o disparo" (fonte única)', () => {
+  it('pendente_aprovacao, bloqueado_guardrail e aprovado_aguardando_disparo (veto do auto-aprovado) podem', () => {
+    for (const s of ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo']) {
+      expect(podeCancelarPeloHumano(s), s).toBe(true);
+      expect(STATUS_CANCELAVEIS_PELO_HUMANO.has(s), s).toBe(true);
+    }
+  });
+
+  it('disparado, terminais, split e ausente NÃO podem — era o bug: `.in("id", ids)` sem guard rejeitava pedido já disparado', () => {
+    for (const s of ['disparado', 'concluido_recebido', 'falha_envio', 'cancelado', 'cancelado_humano', 'expirado_sem_aprovacao', 'split_em_filhos', null, undefined, '']) {
+      expect(podeCancelarPeloHumano(s), String(s)).toBe(false);
+    }
+  });
+});
+
+describe('rejeitarPedidos — passa pela RPC cancelar_pedido_sugerido (fronteira com guard), nunca UPDATE cru', () => {
+  it('chama a RPC com os args canônicos, um pedido por vez, na ordem dada', async () => {
+    mockedRpc.mockResolvedValue(ok);
+    const r = await rejeitarPedidos(
+      [{ id: 10, status: 'pendente_aprovacao' }, { id: 11, status: 'aprovado_aguardando_disparo' }],
+      opts,
+    );
+    expect(mockedRpc).toHaveBeenCalledTimes(2);
+    expect(mockedRpc).toHaveBeenNthCalledWith(1, 'cancelar_pedido_sugerido', {
+      p_pedido_id: 10, p_usuario: 'lucas@x.com', p_justificativa: 'Rejeitado em lote no Cockpit',
+    });
+    expect(mockedRpc).toHaveBeenNthCalledWith(2, 'cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 11 }));
+    expect(r).toEqual({ rejeitados: [10, 11], pulados: [], falhas: [] });
+    expect(mockedFrom).not.toHaveBeenCalled();
+  });
+
+  it('status fora da allowlist é PULADO antes de chamar a RPC (com o status no motivo) — os demais seguem', async () => {
+    mockedRpc.mockResolvedValue(ok);
+    const r = await rejeitarPedidos(
+      [{ id: 1, status: 'disparado' }, { id: 2, status: 'pendente_aprovacao' }, { id: 3, status: 'cancelado_humano' }],
+      opts,
+    );
+    expect(mockedRpc).toHaveBeenCalledTimes(1);
+    expect(mockedRpc).toHaveBeenCalledWith('cancelar_pedido_sugerido', expect.objectContaining({ p_pedido_id: 2 }));
+    expect(r.rejeitados).toEqual([2]);
+    expect(r.pulados.map((p) => p.id)).toEqual([1, 3]);
+    expect(r.pulados[0].motivo).toContain('disparado');
+    expect(r.pulados[1].motivo).toContain('cancelado_humano');
+    expect(r.falhas).toEqual([]);
+  });
+
+  it('a RPC recusando pelo guard do servidor ({error} no jsonb) vira FALHA com o motivo — não "rejeitado"', async () => {
+    mockedRpc
+      .mockResolvedValueOnce({ data: { error: 'pedido já foi disparado em 2026-09-05 10:00' }, error: null } as never)
+      .mockResolvedValueOnce(ok);
+    const r = await rejeitarPedidos([{ id: 5, status: 'pendente_aprovacao' }, { id: 6, status: 'pendente_aprovacao' }], opts);
+    expect(r.rejeitados).toEqual([6]);
+    expect(r.falhas).toEqual([{ id: 5, motivo: 'pedido já foi disparado em 2026-09-05 10:00' }]);
+  });
+
+  it('erro de transporte (PostgREST) vira FALHA com a mensagem, e não aborta os seguintes', async () => {
+    mockedRpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'permission denied for function cancelar_pedido_sugerido', code: '42501' } } as never)
+      .mockResolvedValueOnce(ok);
+    const r = await rejeitarPedidos([{ id: 7, status: 'pendente_aprovacao' }, { id: 8, status: 'pendente_aprovacao' }], opts);
+    expect(r.falhas).toEqual([{ id: 7, motivo: 'permission denied for function cancelar_pedido_sugerido' }]);
+    expect(r.rejeitados).toEqual([8]);
+  });
+
+  it('resposta que não afirma `status:"ok"` NÃO conta como rejeitado (ausência de sinal ≠ sucesso)', async () => {
+    mockedRpc.mockResolvedValueOnce({ data: null, error: null } as never).mockResolvedValueOnce({ data: 'ok', error: null } as never);
+    const r = await rejeitarPedidos([{ id: 9, status: 'pendente_aprovacao' }, { id: 10, status: 'pendente_aprovacao' }], opts);
+    expect(r.rejeitados).toEqual([]);
+    expect(r.falhas.map((f) => f.id)).toEqual([9, 10]);
+  });
+
+  it('a RPC lançando (rede) vira FALHA daquele pedido, sem derrubar o lote', async () => {
+    mockedRpc.mockRejectedValueOnce(new Error('Failed to fetch')).mockResolvedValueOnce(ok);
+    const r = await rejeitarPedidos([{ id: 1, status: 'pendente_aprovacao' }, { id: 2, status: 'pendente_aprovacao' }], opts);
+    expect(r.falhas).toEqual([{ id: 1, motivo: 'Failed to fetch' }]);
+    expect(r.rejeitados).toEqual([2]);
+  });
+});
+
+describe('fronteira: nenhum caminho do Cockpit grava cancelamento por UPDATE cru', () => {
+  const ler = (p: string) => readFileSync(p, 'utf8');
+  const semUpdateCru = (src: string, nome: string) => {
+    expect(src, `${nome}: UPDATE cru com status "cancelado"`).not.toContain('status: "cancelado"');
+    expect(src, `${nome}: UPDATE cru gravando cancelado_em`).not.toMatch(/\.from\(["']pedido_compra_sugerido["']\)[\s\S]{0,400}?cancelado_em/);
+    expect(src, `${nome}: não passa por rejeitarPedidos`).toContain('rejeitarPedidos(');
+  };
+
+  it('useCicloHoje (rejeição em lote)', () => {
+    semUpdateCru(ler('src/components/reposicao/cicloHoje/useCicloHoje.ts'), 'useCicloHoje');
+  });
+
+  it('PedidoRow do ciclo (rejeição inline — mesma classe)', () => {
+    semUpdateCru(ler('src/components/reposicao/cicloHoje/PedidoRow.tsx'), 'cicloHoje/PedidoRow');
+  });
+
+  it('PedidoRow da lista de pedidos usa a MESMA allowlist (não uma lista inline própria)', () => {
+    const src = ler('src/components/reposicao/pedidos/PedidoRow.tsx');
+    expect(src).toContain('podeCancelarPeloHumano(');
+    expect(src).not.toMatch(/\[\s*'pendente_aprovacao',\s*'bloqueado_guardrail',\s*'aprovado_aguardando_disparo'\s*\]\.includes/);
+  });
+
+  it('CiclosAnteriores conta cancelado_humano como cancelado (o Cockpit agora grava esse vocabulário)', () => {
+    const src = ler('src/components/reposicao/pedidos/CiclosAnteriores.tsx');
+    expect(src).toContain('cancelado_humano');
+  });
+});

--- a/src/components/reposicao/pedidos/rejeitar-pedido.ts
+++ b/src/components/reposicao/pedidos/rejeitar-pedido.ts
@@ -6,20 +6,30 @@
 // (`status_envio_portal`/`portal_proximo_retry_em`), que só a RPC faz. A RPC é a fronteira que
 // TODA via cruza (money-path §5): guard de status no servidor (recusa `disparado`/
 // `concluido_recebido`), carimbo de quem cancelou, limpeza do sub-fluxo do portal e vocabulário
-// único (`cancelado_humano`, o mesmo do botão Cancelar da lista). Aqui só pré-filtramos
-// (defense-in-depth) e traduzimos a resposta — precisão > recall: status fora da allowlist NÃO
-// vai à RPC, e ausência de `status:"ok"` na resposta NÃO conta como rejeitado.
+// único (`cancelado_humano`, o mesmo do botão Cancelar da lista).
+//
+// Aqui: (1) o status é RELIDO do banco imediatamente antes de decidir — o que o browser mostra pode
+// ter minutos (Codex P1: `falha_envio` depois de uma tentativa de envio NÃO pode ser cancelado por
+// quem ainda vê "aprovado"); (2) a allowlist depende da VIA: em lote só o que nunca foi aprovado; o
+// veto de um auto-aprovado (`aprovado_aguardando_disparo`) é ação individual; (3) precisão > recall:
+// fora da allowlist NÃO vai à RPC, e ausência de `status:"ok"` na resposta NÃO conta como rejeitado.
+//
+// ⚠️ A RPC em si lê o status e faz `UPDATE … WHERE id` sem repetir o predicado (TOCTOU com o
+// disparador) — fechar isso é migration (`WHERE id AND status NOT IN (…) RETURNING`), pendência do
+// founder registrada no PR; este helper reduz a janela, não a elimina.
 import { supabase as defaultClient } from '@/integrations/supabase/client';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 
+/** Nunca aprovado: nada foi enviado ao fornecedor. É o que o LOTE pode rejeitar. */
+export const STATUS_CANCELAVEIS_EM_LOTE: ReadonlySet<string> = new Set(['pendente_aprovacao', 'bloqueado_guardrail']);
+
 /**
- * Status em que um humano ainda pode cancelar: nada foi enviado ao fornecedor. Mesma régua do
- * botão Cancelar da lista de pedidos (antes uma lista inline lá; agora fonte única).
- * `falha_envio` fica FORA de propósito: a tentativa de envio já aconteceu — conciliar antes.
+ * Cancelável por um humano numa ação INDIVIDUAL (linha do ciclo, botão Cancelar da lista): inclui o
+ * veto de um auto-aprovado que ainda aguarda o cron. `falha_envio` fica FORA de propósito: a
+ * tentativa de envio já aconteceu — conciliar antes de cancelar.
  */
 export const STATUS_CANCELAVEIS_PELO_HUMANO: ReadonlySet<string> = new Set([
-  'pendente_aprovacao',
-  'bloqueado_guardrail',
+  ...STATUS_CANCELAVEIS_EM_LOTE,
   'aprovado_aguardando_disparo',
 ]);
 
@@ -35,18 +45,20 @@ export interface PedidoRejeitavel {
 export interface RejeitarOpts {
   usuario: string;
   justificativa: string;
+  /** Via da ação: `lote` usa a allowlist estreita; `individual` inclui o veto do auto-aprovado. */
+  via: 'lote' | 'individual';
 }
 
 export interface ResultadoRejeicao {
   rejeitados: number[];
-  /** Nem foram à RPC: status fora da allowlist (ou desconhecido). */
-  pulados: { id: number; motivo: string }[];
+  /** Nem foram à RPC: status ATUAL (relido do banco) fora da allowlist, ou pedido que sumiu. */
+  pulados: { id: number; status: string | null; motivo: string }[];
   /** A RPC recusou (guard do servidor) ou o transporte falhou. */
   falhas: { id: number; motivo: string }[];
 }
 
 // Cliente mínimo injetável (testabilidade). O default é o supabase real.
-type RejeitarClient = Pick<typeof defaultClient, 'rpc'>;
+type RejeitarClient = Pick<typeof defaultClient, 'rpc' | 'from'>;
 
 // A RPC sinaliza regra de negócio devolvendo { error: '...' } no jsonb (não lança).
 function erroDoJsonb(data: unknown): string | null {
@@ -62,19 +74,43 @@ function confirmouOk(data: unknown): boolean {
   return !!data && typeof data === 'object' && (data as { status?: unknown }).status === 'ok';
 }
 
+/** Status ATUAL dos pedidos, relido do banco (o do browser pode ter minutos). Lança em erro de leitura. */
+async function statusAtual(ids: number[], client: RejeitarClient): Promise<Map<number, string | null>> {
+  const { data, error } = await client.from('pedido_compra_sugerido').select('id, status').in('id', ids);
+  if (error) throw error;
+  return new Map(((data ?? []) as { id: number; status: string | null }[]).map((r) => [r.id, r.status]));
+}
+
 /**
- * Rejeita (cancela) pedidos um a um pela RPC. Sequencial e best-effort: a falha de um não aborta
- * os demais; o resultado particiona o lote para o caller resumir com honestidade.
+ * Rejeita (cancela) pedidos um a um pela RPC, decidindo pelo status RELIDO do banco. Sequencial e
+ * best-effort: a falha de um não aborta os demais; o resultado particiona o lote para o caller
+ * resumir com honestidade. Se nem o status der para ler, ninguém é rejeitado (fail-closed).
  */
 export async function rejeitarPedidos(
   pedidos: readonly PedidoRejeitavel[],
-  { usuario, justificativa }: RejeitarOpts,
+  { usuario, justificativa, via }: RejeitarOpts,
   client: RejeitarClient = defaultClient,
 ): Promise<ResultadoRejeicao> {
   const r: ResultadoRejeicao = { rejeitados: [], pulados: [], falhas: [] };
+  if (pedidos.length === 0) return r;
+  const permitidos = via === 'lote' ? STATUS_CANCELAVEIS_EM_LOTE : STATUS_CANCELAVEIS_PELO_HUMANO;
+  let atual: Map<number, string | null>;
+  try {
+    atual = await statusAtual(pedidos.map((p) => p.id), client);
+  } catch (e) {
+    const motivo = `não consegui reler o status: ${mensagemDeErro(e) ?? 'erro sem mensagem'}`;
+    r.falhas.push(...pedidos.map((p) => ({ id: p.id, motivo })));
+    return r;
+  }
   for (const p of pedidos) {
-    if (!podeCancelarPeloHumano(p.status)) {
-      r.pulados.push({ id: p.id, motivo: `status "${p.status ?? 'desconhecido'}" não pode ser rejeitado aqui` });
+    if (!atual.has(p.id)) {
+      r.pulados.push({ id: p.id, status: null, motivo: 'pedido não encontrado (removido ou regenerado)' });
+      continue;
+    }
+    const status = atual.get(p.id) ?? null;
+    if (status === null || !permitidos.has(status)) {
+      const dica = via === 'lote' && status === 'aprovado_aguardando_disparo' ? ' — vete individualmente' : '';
+      r.pulados.push({ id: p.id, status, motivo: `status atual "${status ?? 'desconhecido'}" não pode ser rejeitado por esta via${dica}` });
       continue;
     }
     try {
@@ -102,4 +138,19 @@ export async function rejeitarPedidos(
     }
   }
   return r;
+}
+
+/** Resumo humano da partição — usado no toast e na auditoria. Sem "Sucesso" quando nada foi rejeitado. */
+export function resumirRejeicao(r: ResultadoRejeicao): { texto: string; nivel: 'success' | 'warning' | 'error' } {
+  const partes = [`${r.rejeitados.length} rejeitado(s)`];
+  if (r.pulados.length > 0) {
+    const porStatus = new Map<string, number>();
+    for (const p of r.pulados) porStatus.set(p.status ?? 'desconhecido', (porStatus.get(p.status ?? 'desconhecido') ?? 0) + 1);
+    partes.push(`${r.pulados.length} pulado(s) (${[...porStatus].map(([s, n]) => `${n}× ${s}`).join(', ')})`);
+  }
+  if (r.falhas.length > 0) partes.push(`${r.falhas.length} com falha (${r.falhas[0].motivo}${r.falhas.length > 1 ? ', …' : ''})`);
+  const texto = partes.join(', ');
+  if (r.falhas.length > 0) return { texto, nivel: 'error' };
+  if (r.pulados.length > 0 || r.rejeitados.length === 0) return { texto, nivel: 'warning' };
+  return { texto, nivel: 'success' };
 }

--- a/src/components/reposicao/pedidos/rejeitar-pedido.ts
+++ b/src/components/reposicao/pedidos/rejeitar-pedido.ts
@@ -1,0 +1,105 @@
+// Rejeição/cancelamento HUMANO de pedido sugerido — fronteira única: RPC `cancelar_pedido_sugerido`.
+//
+// Antes (M-02), o Cockpit (lote em useCicloHoje e inline em cicloHoje/PedidoRow) cancelava por
+// UPDATE cru `.in("id", ids)` SEM guard de status: um pedido já DISPARADO (PO no portal/Omie)
+// virava "cancelado" no banco com a compra em andamento — e sem a higiene do portal
+// (`status_envio_portal`/`portal_proximo_retry_em`), que só a RPC faz. A RPC é a fronteira que
+// TODA via cruza (money-path §5): guard de status no servidor (recusa `disparado`/
+// `concluido_recebido`), carimbo de quem cancelou, limpeza do sub-fluxo do portal e vocabulário
+// único (`cancelado_humano`, o mesmo do botão Cancelar da lista). Aqui só pré-filtramos
+// (defense-in-depth) e traduzimos a resposta — precisão > recall: status fora da allowlist NÃO
+// vai à RPC, e ausência de `status:"ok"` na resposta NÃO conta como rejeitado.
+import { supabase as defaultClient } from '@/integrations/supabase/client';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
+
+/**
+ * Status em que um humano ainda pode cancelar: nada foi enviado ao fornecedor. Mesma régua do
+ * botão Cancelar da lista de pedidos (antes uma lista inline lá; agora fonte única).
+ * `falha_envio` fica FORA de propósito: a tentativa de envio já aconteceu — conciliar antes.
+ */
+export const STATUS_CANCELAVEIS_PELO_HUMANO: ReadonlySet<string> = new Set([
+  'pendente_aprovacao',
+  'bloqueado_guardrail',
+  'aprovado_aguardando_disparo',
+]);
+
+export function podeCancelarPeloHumano(status: string | null | undefined): boolean {
+  return typeof status === 'string' && STATUS_CANCELAVEIS_PELO_HUMANO.has(status);
+}
+
+export interface PedidoRejeitavel {
+  id: number;
+  status: string | null | undefined;
+}
+
+export interface RejeitarOpts {
+  usuario: string;
+  justificativa: string;
+}
+
+export interface ResultadoRejeicao {
+  rejeitados: number[];
+  /** Nem foram à RPC: status fora da allowlist (ou desconhecido). */
+  pulados: { id: number; motivo: string }[];
+  /** A RPC recusou (guard do servidor) ou o transporte falhou. */
+  falhas: { id: number; motivo: string }[];
+}
+
+// Cliente mínimo injetável (testabilidade). O default é o supabase real.
+type RejeitarClient = Pick<typeof defaultClient, 'rpc'>;
+
+// A RPC sinaliza regra de negócio devolvendo { error: '...' } no jsonb (não lança).
+function erroDoJsonb(data: unknown): string | null {
+  if (data && typeof data === 'object' && 'error' in data) {
+    const e = (data as { error?: unknown }).error;
+    if (e == null) return null;
+    return typeof e === 'string' ? e : JSON.stringify(e);
+  }
+  return null;
+}
+
+function confirmouOk(data: unknown): boolean {
+  return !!data && typeof data === 'object' && (data as { status?: unknown }).status === 'ok';
+}
+
+/**
+ * Rejeita (cancela) pedidos um a um pela RPC. Sequencial e best-effort: a falha de um não aborta
+ * os demais; o resultado particiona o lote para o caller resumir com honestidade.
+ */
+export async function rejeitarPedidos(
+  pedidos: readonly PedidoRejeitavel[],
+  { usuario, justificativa }: RejeitarOpts,
+  client: RejeitarClient = defaultClient,
+): Promise<ResultadoRejeicao> {
+  const r: ResultadoRejeicao = { rejeitados: [], pulados: [], falhas: [] };
+  for (const p of pedidos) {
+    if (!podeCancelarPeloHumano(p.status)) {
+      r.pulados.push({ id: p.id, motivo: `status "${p.status ?? 'desconhecido'}" não pode ser rejeitado aqui` });
+      continue;
+    }
+    try {
+      const { data, error } = await client.rpc('cancelar_pedido_sugerido', {
+        p_pedido_id: p.id,
+        p_usuario: usuario,
+        p_justificativa: justificativa,
+      });
+      if (error) {
+        r.falhas.push({ id: p.id, motivo: mensagemDeErro(error) ?? 'erro sem mensagem' });
+        continue;
+      }
+      const erro = erroDoJsonb(data);
+      if (erro) {
+        r.falhas.push({ id: p.id, motivo: erro });
+        continue;
+      }
+      if (!confirmouOk(data)) {
+        r.falhas.push({ id: p.id, motivo: 'resposta inesperada da RPC (sem status ok)' });
+        continue;
+      }
+      r.rejeitados.push(p.id);
+    } catch (e) {
+      r.falhas.push({ id: p.id, motivo: mensagemDeErro(e) ?? 'erro sem mensagem' });
+    }
+  }
+  return r;
+}

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -17,7 +17,9 @@ export const statusMeta: Record<string, { label: string; variant: 'default' | 's
   disparado_simulado: { label: 'Disparo simulado', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
   falha_envio: { label: 'Falha no envio', variant: 'destructive' },
   cancelado: { label: 'Cancelado', variant: 'outline' },
-  cancelado_humano: { label: 'Cancelado (vazio)', variant: 'outline' },
+  // Vocabulário da RPC cancelar_pedido_sugerido: Cancelar da lista, remoção de todos os itens e,
+  // desde o M-02, a rejeição do Cockpit — humano, não "vazio" (rótulo antigo, Codex P2).
+  cancelado_humano: { label: 'Cancelado (humano)', variant: 'outline' },
   expirado_sem_aprovacao: { label: 'Expirado sem aprovação', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
   // PR5: pedido pai de um split — não tem mais itens próprios, foi dividido em filhos.
   split_em_filhos: { label: 'Dividido', variant: 'secondary', className: 'bg-status-purple-bg text-status-purple-foreground border-status-purple/30' },


### PR DESCRIPTION
## O bug (M-02 do plano `docs/superpowers/plans/2026-09-05-plano-melhorias-codebase`, P1 aberto desde a revisão de 2026-07-04)

A rejeição em **lote** do Cockpit (`useCicloHoje.runBatch('reject')`) e a rejeição **inline** (`cicloHoje/PedidoRow.act('reject')`) faziam `UPDATE … .in("id", ids)` cru, **sem guard de status**: um pedido já **disparado** (PO no portal/Omie) virava `cancelado` no banco com a compra em andamento. E sem a higiene do portal (`status_envio_portal`/`portal_proximo_retry_em`) que só a RPC faz — o cancelado ficava "sujo" e o check `reposicao_portal_pipeline` o contava.

## A correção — a fronteira que TODA via cruza
- **`rejeitarPedidos`** (`src/components/reposicao/pedidos/rejeitar-pedido.ts`): passa pela RPC **`cancelar_pedido_sugerido`** (a mesma do botão Cancelar da lista — guard de status no servidor, carimbo, higiene do portal, vocabulário `cancelado_humano`), um pedido por vez, best-effort. **Decide pelo status RELIDO do banco** (o do browser pode ter minutos — `falha_envio` depois de uma tentativa de envio nunca vai à RPC); se nem o status der para ler, ninguém é rejeitado. Particiona em `rejeitados | pulados (status atual fora da allowlist / pedido sumiu) | falhas (RPC recusou / transporte)`. Ausência de `status:"ok"` **não** conta.
- **Allowlist por VIA**: lote = `pendente_aprovacao · bloqueado_guardrail` (nunca aprovado — o disparador nunca pega esses); individual (linha do ciclo, Cancelar da lista) = + `aprovado_aguardando_disparo` (veto do auto-aprovado). Fonte única (`pedidos/PedidoRow` usava uma lista inline).
- **`CancelarModal` pela mesma fronteira**: a recusa da RPC (`{error}` no jsonb, sem erro de transporte) vira erro visível — antes mostrava "Pedido cancelado" sobre uma compra que seguiu.
- **Resumo honesto**: toast e `logAudit` dizem `N rejeitado(s), N pulado(s) (2× disparado, …), N com falha (motivo)`; 0 rejeitados nunca é "Sucesso"; só o rejeitado sai da seleção (pulados/falhas ficam marcados). `CiclosAnteriores` conta `cancelado_humano`; rótulo `cancelado_humano` = "Cancelado (humano)" (era "(vazio)").

## Prova
- `rejeitar-pedido.test.ts` (14 casos): allowlists por via; args canônicos; **status do browser não manda** (banco diz disparado/falha_envio → pulado, RPC nem é chamada); lote não veta auto-aprovado; pedido sumido; leitura de status falhando → fail-closed; `{error}` da RPC; transporte/exceção não abortam o lote; sem `status:"ok"` não conta; `resumirRejeicao` (0 rejeitados = aviso, falha = erro). Pinos: nenhum caminho humano faz UPDATE cru nem chama a RPC fora da fronteira; `CiclosAnteriores` pinado na condição; rótulo.
- `useCicloHoje.rejeicao.test.tsx` (hook real, supabase mockado): "selecionar tudo" com pendente + disparado + auto-aprovado → só o pendente vai à RPC, toast de aviso com `2× …`, auditoria com motivos, seleção preserva os 2 pulados; tudo cancelável → sucesso e seleção zera; RPC recusando → erro "1 com falha"; id fora do filtro decidido pelo banco.
- RED observado antes do GREEN nas duas versões (v1 e v2 pós-Codex) — logs no comentário; falsificação no comentário.
- Verificado em prod (psql-ro): a RPC tem o guard (md5 conferido); a única função SQL que distingue `cancelado` de `cancelado_humano` é um ramo do em-trânsito que só vale com protocolo do portal — que a RPC zera.

## Deploy
🖱️ Publish do front. Sem migration, sem edge.

## ⚠️ Pendência que só o founder decide (do Codex, [P1] mitigado aqui, não fechado)

A RPC `cancelar_pedido_sugerido` lê o status e faz `UPDATE … WHERE id` **sem repetir o predicado**; o disparador (`disparar-pedidos-aprovados`) também finaliza com `UPDATE … WHERE id`. Entre o `SELECT` de um e o `UPDATE` do outro, um `aprovado_aguardando_disparo` pode virar PO no Omie **e** `cancelado_humano` no banco. Este PR reduz a janela (lote nunca toca aprovado; status relido), mas fechar é migration: `UPDATE pedido_compra_sugerido SET … WHERE id = p_pedido_id AND status NOT IN ('disparado','concluido_recebido') RETURNING id` (e o disparador espelhando `AND status = 'aprovado_aguardando_disparo'`), provada com `prove-sql-money-path`. É uma fatia própria.

## Codex (2ª opinião, gpt-5.6-sol · xhigh) — parecer CRU

<details><summary>saída íntegra do <code>scripts/codex-async.sh</code></summary>

```text
=== PARECER CODEX (modelo gpt-5.6-sol · reasoning xhigh · tentativa 1) ===
## Achados

- [P1] O guard continua sujeito a TOCTOU; M-02 ainda é reproduzível. A RPC lê o status sem lock e depois faz `UPDATE ... WHERE id`, sem repetir o predicado ([cancelar_pedido_limpa_portal.sql:25](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/migrations/20260530210001_cancelar_pedido_limpa_portal.sql:25), [cancelar_pedido_limpa_portal.sql:32](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/migrations/20260530210001_cancelar_pedido_limpa_portal.sql:32)). Em paralelo, o disparador seleciona `aprovado_aguardando_disparo`, mantém a linha em memória ([index.ts:1572](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/functions/disparar-pedidos-aprovados/index.ts:1572)), chama `IncluirPedCompra` ([index.ts:1054](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/functions/disparar-pedidos-aprovados/index.ts:1054)) e também finaliza com `UPDATE ... WHERE id` ([index.ts:1069](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/functions/disparar-pedidos-aprovados/index.ts:1069)). Cenário A: RPC lê “aprovado”; disparador cria o PO e grava “disparado”; RPC grava por último e volta a deixar a compra real como `cancelado_humano`. Cenário B: RPC cancela primeiro; o disparador já selecionado cria o PO e grava “disparado”; o operador recebeu confirmação de rejeição, mas a compra aconteceu. É o mesmo risco estrutural já existente no `CancelarModal` e nos updates crus, não uma permissão nova deste PR; porém o objetivo “nunca cancelar disparado” não foi atingido. Retirar `aprovado_aguardando_disparo` do lote — idealmente da allowlist compartilhada — é contenção barata sem migration, mas não fecha a corrida. O fechamento exige claim atômico do disparo e cancelamento condicional no banco.

- [P1] A allowlist não é política de servidor; ela valida apenas o status potencialmente obsoleto vindo do browser. O helper decide antes da RPC com `p.status` ([rejeitar-pedido.ts:76](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/rejeitar-pedido.ts:76)), enquanto a RPC recusa somente `disparado` e `concluido_recebido` ([cancelar_pedido_limpa_portal.sql:29](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/migrations/20260530210001_cancelar_pedido_limpa_portal.sql:29)). Cenário: a UI ainda mostra “aprovado”; o Omie recebe ou pode ter recebido o PO, a edge termina em `falha_envio` ([index.ts:1160](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/supabase/functions/disparar-pedidos-aprovados/index.ts:1160)); a RPC então lê `falha_envio`, aceita o cancelamento e apaga o estado que exigia conciliação — exatamente o status que o próprio helper declara não cancelável porque já houve tentativa ([rejeitar-pedido.ts:18](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/rejeitar-pedido.ts:18)). A RPC também aceita `split_em_filhos`, expirados e cancelamentos repetidos se o snapshot do cliente estiver atrasado.

- [P1] O `CancelarModal` mente quando a RPC recusa por regra de negócio. Ele ignora `data.error` e verifica apenas o erro de transporte ([CancelarModal.tsx:32](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/CancelarModal.tsx:32)); como a RPC devolve `{error: ...}` com erro PostgREST nulo, a mutation entra em `onSuccess`, mostra “Pedido cancelado” e fecha o modal ([CancelarModal.tsx:39](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/CancelarModal.tsx:39)). Cenário: modal aberto em pedido aprovado, cron o dispara, RPC recusa, mas o comprador acredita que cancelou uma compra externa. O helper novo trata esse contrato, mas essa via continua chamando a RPC diretamente.

- [P2] `pulados` mistura estados diferentes e perde a informação necessária para recuperação. ID ausente de `filteredItems` vira status desconhecido ([useCicloHoje.ts:149](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/cicloHoje/useCicloHoje.ts:149)), mas o toast descreve todo pulado como “já disparado/terminal” ([useCicloHoje.ts:153](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/cicloHoje/useCicloHoje.ts:153)); isso também é falso para `falha_envio`. A auditoria descarta os motivos e guarda somente IDs, e chama de “Parcial” até o caso `0 rejeitados + N pulados` ([useCicloHoje.ts:157](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/cicloHoje/useCicloHoje.ts:157)). Depois a seleção inteira é apagada ([useCicloHoje.ts:163](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/cicloHoje/useCicloHoje.ts:163)). Um pedido ainda pendente que saiu do filtro permanece apto a ser aprovado/disparado, mas o operador recebe apenas uma contagem genérica e perde o ID selecionado.

- [P2] O novo vocabulário é exibido com significado errado. `cancelado_humano` está rotulado como “Cancelado (vazio)” ([shared.ts:20](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/shared.ts:20)), e esse rótulo é usado diretamente pelos badges da lista e detalhes ([badges.tsx:8](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/badges.tsx:8)). Toda rejeição humana nova do Cockpit será mostrada como cancelamento por pedido vazio, ocultando a natureza da decisão.

- [P2] Os pinos textuais aceitam regressões equivalentes. A proibição de update cru só procura `status: "cancelado"` com aspas duplas e limita a busca de `cancelado_em` a 400 caracteres ([rejeitar-pedido.test.ts:107](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts:107)); aspas simples, constante intermediária ou uma cadeia maior passam. O teste de `CiclosAnteriores` exige apenas que o arquivo contenha a palavra `cancelado_humano` ([rejeitar-pedido.test.ts:127](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts:127)); o comentário sozinho já satisfaz o teste se a condição for revertida. O teste que afirma execução sequencial verifica apenas ordem de chamadas após o término ([rejeitar-pedido.test.ts:42](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/pedidos/__tests__/rejeitar-pedido.test.ts:42)); uma implementação concorrente iniciada em ordem pode passar. Nenhum teste cobre a corrida SQL, o falso sucesso do `CancelarModal` ou a recuperação do ID pulado; o teste de ID fora do filtro apenas cristaliza o skip ([useCicloHoje.rejeicao.test.tsx:115](/Users/lucassardenberg/Projetos/afiacao-claude-m02-rejeicao-lote-guard-status/src/components/reposicao/cicloHoje/__tests__/useCicloHoje.rejeicao.test.tsx:115)).

## Concedo

- Os dois updates crus do Cockpit saíram do diff.
- O helper não trata resposta sem `status: "ok"` como sucesso.
- `CiclosAnteriores` e `STATUS_TERMINAIS_CICLO` contemplam os dois status.
- Não encontrei outro consumidor estático ativo que diferencie os dois; o ramo de `gerar_pedidos_sugeridos_ciclo` fica inerte após um cancelamento sem corrida porque a RPC zera `status_envio_portal`.
- O typecheck passou. O Vitest não iniciou porque o sandbox somente leitura impediu o arquivo temporário criado pelo Vite.

(cópia em /var/folders/cz/94l8x0rn6hqfk080j49r247r0000gn/T/codex-async.XXXXXX.tscHjQKW6m)
```

</details>

**Calibração (minha, separada do parecer):** Aplicados no PR: [P1] status RELIDO do banco antes de decidir (o do browser pode ter minutos; `falha_envio` nunca vai à RPC), com fail-closed se a leitura falhar; [P1] `CancelarModal` passa pela mesma fronteira e a recusa da RPC vira erro visível (era "Pedido cancelado" sobre compra que seguiu); [P2] resumo por status real (`2× disparado`), auditoria com motivos, seleção preserva pulados/falhas, "Nada rejeitado" em vez de "Parcial"; [P2] rótulo `cancelado_humano` → "Cancelado (humano)"; [P2] pinos aceitam as duas aspas, janela maior, `CiclosAnteriores` pinado na CONDIÇÃO e `CancelarModal` proibido de chamar a RPC direto. **Mitigado, não fechado:** [P1] TOCTOU dentro da RPC (`SELECT` status → `UPDATE … WHERE id` sem repetir o predicado) — a via LOTE passa a rejeitar só o que nunca foi aprovado (o disparador nunca pega esses), o veto do auto-aprovado fica individual; fechar de vez é migration (`UPDATE … WHERE id AND status NOT IN ('disparado','concluido_recebido') RETURNING`, com `prove-sql-money-path`) → pendência do founder abaixo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
