### PR TITLE
fix(reposicao): editor de quantidade do Cockpit grava o ITEM (cardinalidade pelos itens, fail-closed, compare-and-set) e "aprovar e disparar" salva a edição só-de-preço [money-path] (M-03)

### DIFF
--- a/src/components/reposicao/CicloHojePanel.tsx
+++ b/src/components/reposicao/CicloHojePanel.tsx
@@ -12,6 +12,7 @@ import { TabFallback } from "./TabFallback";
 import { type CicloFilters } from "./cicloHoje/types";
 import { useCicloHoje } from "./cicloHoje/useCicloHoje";
 import { PedidoRow } from "./cicloHoje/PedidoRow";
+import { useItensDosPedidos } from "./cicloHoje/useItensDosPedidos";
 import { FiltersToolbar } from "./cicloHoje/FiltersToolbar";
 import { AutoApproveDialog } from "./cicloHoje/AutoApproveDialog";
 import { BatchActionsBar } from "./cicloHoje/BatchActionsBar";
@@ -61,6 +62,12 @@ export function CicloHojePanel({
     runAutoApprove,
     clearFilters,
   } = useCicloHoje({ user, reviewMode, filteredItems, setFilters });
+
+  // Itens dos pedidos PENDENTES numa query só (M-03): cardinalidade real (1 SKU × vários) e a quantidade
+  // que o editor inline edita — nunca `num_skus`. `undefined` = carregando · `null` = falhou.
+  const idsPendentes = filteredItems.filter((i) => !i.aprovado_em && !i.cancelado_em).map((i) => i.id);
+  const { data: itensPorPedido, isError: itensErro } = useItensDosPedidos(idsPendentes);
+  const itensDe = (id: number) => (itensErro ? null : itensPorPedido === undefined ? undefined : itensPorPedido.get(id) ?? []);
 
   return (
     <div className="space-y-4">
@@ -120,6 +127,7 @@ export function CicloHojePanel({
                     cols={cols}
                     user={user}
                     onChanged={invalidate}
+                    itens={itensDe(r.id)}
                   />
                 ))}
               </TableBody>

--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -1,7 +1,11 @@
 // Linha de pedido do ciclo (estado local de quantidade + aprovação/rejeição inline).
 // Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+//
+// M-03: o editor de quantidade edita o ITEM (`pedido_compra_item.qtde_final`, o que o disparo compra),
+// nunca `num_skus` (CONTAGEM de SKUs). Cardinalidade pelos itens (prop `itens`, carregados pelo painel
+// numa query só), aprovação FAIL-CLOSED enquanto os itens não chegam, checagem do status do cabeçalho e
+// compare-and-set na gravação (Codex xhigh, 5 P1).
 import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { AlertTriangle, Check, Loader2, Pencil, X, Zap } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -13,21 +17,27 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { supabase } from "@/integrations/supabase/client";
 import { formatBRL, logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
+import { quantidadeCompraInteira } from "@/lib/reposicao/compras-otimizador-helpers";
+import { quantidadeCompraCanonica } from "@/lib/reposicao/qtde-portal";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
 import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
-import { EMPRESA } from "../pedidos/shared";
 import { montarUpdateItem } from "../pedidos/preco-edit";
 import { podeCancelarPeloHumano, rejeitarPedidos } from "../pedidos/rejeitar-pedido";
-import { quantidadeCompraInteira } from "@/lib/reposicao/compras-otimizador-helpers";
+import { EMPRESA } from "../pedidos/shared";
 import { PrecoCell, ConfiancaBadge } from "./PedidoRowCells";
+import type { ItemDoPedido } from "./types";
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 
-/** O único item de um pedido de 1 SKU — o que o editor inline edita de verdade. */
-interface ItemUnico {
-  id: number;
-  qtde_final: number | null;
-  qtde_sugerida: number | null;
-  preco_unitario: number | null;
+/** Status do cabeçalho em que a aprovação inline ainda pode gravar o item (mesma régua do modal). */
+const STATUS_APROVAVEIS: ReadonlySet<string> = new Set(["pendente_aprovacao", "bloqueado_guardrail"]);
+
+type Cardinalidade = "carregando" | "erro" | "vazio" | "unico" | "varios";
+
+function cardinalidadeDe(itens: ItemDoPedido[] | null | undefined): Cardinalidade {
+  if (itens === undefined) return "carregando";
+  if (itens === null) return "erro";
+  if (itens.length === 0) return "vazio";
+  return itens.length === 1 ? "unico" : "varios";
 }
 
 export function PedidoRow({
@@ -38,6 +48,7 @@ export function PedidoRow({
   cols,
   user,
   onChanged,
+  itens,
 }: {
   row: PedidoItem;
   reviewMode: boolean;
@@ -46,6 +57,8 @@ export function PedidoRow({
   cols: Record<ColKey, boolean>;
   user: { id?: string; email?: string | null } | null;
   onChanged: () => void;
+  /** Itens do pedido (do painel): `undefined` = carregando · `null` = falhou · `[]` = sem itens. */
+  itens?: ItemDoPedido[] | null;
 }) {
   const [busy, setBusy] = useState<null | "approve" | "reject">(null);
   const [editingAuto, setEditingAuto] = useState(false);
@@ -54,33 +67,19 @@ export function PedidoRow({
 
   const isApproved = !!row.aprovado_em;
   const isRejected = !!row.cancelado_em;
+  const terminal = isApproved || isRejected;
 
-  // Editor inline SÓ para pedido de 1 SKU. `num_skus` é CONTAGEM de SKUs, não quantidade: o editor
-  // antigo inicializava com ele e gravava `num_skus` — e o disparo lê `pedido_compra_item.qtde_final`,
-  // então a compra saía com a quantidade ORIGINAL (maior que a aprovada) e o cabeçalho mentia (M-03).
-  // Multi-SKU: ajuste por item no detalhe do pedido.
-  const itemUnico = row.num_skus === 1;
-  const { data: item } = useQuery({
-    queryKey: ["pedido-item-unico", row.id],
-    enabled: itemUnico && cols.qtdAprovada && !isApproved && !isRejected,
-    staleTime: 30_000,
-    queryFn: async (): Promise<ItemUnico> => {
-      const { data, error } = await supabase
-        .from("pedido_compra_item")
-        .select("id, qtde_final, qtde_sugerida, preco_unitario")
-        .eq("pedido_id", row.id);
-      if (error) throw error;
-      const [it] = (data ?? []) as ItemUnico[];
-      if (!it) throw new Error("pedido sem item"); // ausente ≠ zero: sem item, sem editor
-      return it;
-    },
-  });
-  // Quantidade ORIGINAL do item (inteira, como o disparo grava) — null enquanto não carregou/falhou.
+  // Cardinalidade pelos ITENS, nunca por `num_skus` (a coluna que o bug antigo corrompia).
+  const cardinalidade = cardinalidadeDe(itens);
+  const item = cardinalidade === "unico" ? (itens as ItemDoPedido[])[0] : null;
+  // Quantidade ORIGINAL do item (inteira, como o disparo grava) — null enquanto não há item.
   const qtdOriginal = item ? quantidadeCompraInteira(Number(item.qtde_final ?? item.qtde_sugerida ?? 0)) : null;
   const [qtd, setQtd] = useState<number | null>(null);
   useEffect(() => {
     setQtd(qtdOriginal);
   }, [qtdOriginal]);
+  // Fail-closed: sem os itens carregados (ou pedido sem item) o operador não vê o que vai comprar → não aprova.
+  const itensDesconhecidos = !terminal && cardinalidade !== "unico" && cardinalidade !== "varios";
 
   const rowBg = isApproved
     ? "bg-status-success-bg/40 hover:bg-status-success-bg"
@@ -95,23 +94,47 @@ export function PedidoRow({
     const who = user?.email ?? user?.id ?? "cockpit";
     try {
       if (kind === "approve") {
+        if (itensDesconhecidos) {
+          toast.error("Itens do pedido não carregados — recarregue antes de aprovar.");
+          return;
+        }
         // A edição inline (pedido de 1 SKU) vai ANTES do disparo e grava o ITEM (qtde_final/valor_linha)
         // + o cabeçalho (valor_total) — nunca `num_skus`. O disparo lê `qtde_final` do item.
-        if (itemUnico && item && qtd !== null && qtd !== qtdOriginal) {
+        if (item && qtd !== null && qtd !== qtdOriginal) {
           if (!(qtd > 0)) {
             toast.error("Quantidade inválida — informe um valor maior que zero.");
             return;
           }
+          // 1. O cabeçalho ainda aceita aprovação? Outra aba pode ter aprovado/disparado este pedido.
+          const { data: cab, error: cabErr } = await supabase
+            .from("pedido_compra_sugerido")
+            .select("status")
+            .eq("id", row.id)
+            .maybeSingle();
+          if (cabErr) throw cabErr;
+          if (!cab || !STATUS_APROVAVEIS.has(cab.status ?? "")) {
+            toast.error(`Pedido não está mais aprovável (status ${cab?.status ?? "desconhecido"}) — recarregue.`);
+            onChanged();
+            return;
+          }
+          // 2. Compare-and-set: só grava se o item ainda tem a quantidade que o operador VIU.
           const update = montarUpdateItem(item, qtd, undefined);
-          const { error: itemErr } = await supabase.from("pedido_compra_item").update(update).eq("id", item.id);
+          const base = supabase.from("pedido_compra_item").update(update).eq("id", item.id);
+          const cas = item.qtde_final === null ? base.is("qtde_final", null) : base.eq("qtde_final", item.qtde_final);
+          const { data: gravados, error: itemErr } = await cas.select("id");
           if (itemErr) throw itemErr;
+          if (!gravados || gravados.length === 0) {
+            toast.error("A quantidade do item mudou desde que você abriu a tela — recarregue e confira.");
+            onChanged();
+            return;
+          }
           // valor_linha null = custo desconhecido → não fabricar valor_total (ausente ≠ zero)
           if (update.valor_linha !== null) {
-            const { error: cabErr } = await supabase
+            const { error: cabUpErr } = await supabase
               .from("pedido_compra_sugerido")
-              .update({ valor_total: update.valor_linha, atualizado_em: new Date().toISOString() })
+              .update({ valor_total: update.valor_linha, atualizado_em: nowIso })
               .eq("id", row.id);
-            if (cabErr) throw cabErr;
+            if (cabUpErr) throw cabUpErr;
           }
         }
         // Trilha canônica: APROVAR = DISPARAR NA HORA (não mais só UPDATE + esperar o cron).
@@ -160,6 +183,26 @@ export function PedidoRow({
     }
   };
 
+  // Rótulo do que NÃO é editável inline: vários SKUs (ajuste no detalhe) ou estado desconhecido.
+  const rotuloSemEditor = () => {
+    if (terminal) return `${row.num_skus ?? 0} SKUs`;
+    if (cardinalidade === "varios") {
+      return (
+        <span
+          className="text-xs text-muted-foreground tabular-nums"
+          title="Pedido com vários SKUs — ajuste as quantidades no detalhe do pedido"
+        >
+          {(itens as ItemDoPedido[]).length} SKUs
+        </span>
+      );
+    }
+    return (
+      <span className="text-xs text-muted-foreground" title="Itens do pedido não carregados — recarregue">
+        {cardinalidade === "carregando" ? "…" : cardinalidade === "vazio" ? "sem itens" : "itens?"}
+      </span>
+    );
+  };
+
   return (
     <TableRow data-state={selected ? "selected" : undefined} className={rowBg}>
       {reviewMode && (
@@ -206,9 +249,9 @@ export function PedidoRow({
                   <Zap className="h-3 w-3" /> Auto
                 </Badge>
                 <span className="w-10 text-right tabular-nums font-medium">
-                  {itemUnico ? (qtd ?? "—") : `${row.num_skus ?? 0} SKUs`}
+                  {cardinalidade === "unico" && !terminal ? (qtd ?? "—") : rotuloSemEditor()}
                 </span>
-                {itemUnico && (
+                {cardinalidade === "unico" && !terminal && (
                   <Button
                     size="icon"
                     variant="outline"
@@ -239,32 +282,31 @@ export function PedidoRow({
                     </Tooltip>
                   </TooltipProvider>
                 )}
-                {itemUnico ? (
+                {cardinalidade === "unico" && !terminal ? (
                   <Input
                     type="number"
                     min={1}
                     value={qtd ?? ""}
-                    disabled={isApproved || isRejected || busy !== null || item == null}
-                    onChange={(e) => setQtd(Number(e.target.value) || 0)}
+                    disabled={busy !== null}
+                    // [QTDE-INTEIRA] o campo mostra o que vai ser gravado: inteiro (ceil) a cada tecla…
+                    onChange={(e) => setQtd(quantidadeCompraInteira(Number(e.target.value)))}
+                    // …e, no blur, o múltiplo da embalagem (37 L → 40 L com fator 0,2), como o modal (#2198);
+                    // `montarUpdateItem` repete a regra na gravação (fronteira).
+                    onBlur={() => setQtd((q) => (q === null ? q : quantidadeCompraCanonica(q, item?.fator_embalagem_portal)))}
                     onFocus={(e) => e.currentTarget.select()}
                     className="h-8 w-20 text-right"
                     aria-label="Quantidade do item"
                   />
                 ) : (
-                  <span
-                    className="text-xs text-muted-foreground tabular-nums"
-                    title="Pedido com vários SKUs — ajuste as quantidades no detalhe do pedido"
-                  >
-                    {row.num_skus ?? 0} SKUs
-                  </span>
+                  rotuloSemEditor()
                 )}
                 <Button
                   size="icon"
                   variant="ghost"
                   className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
-                  disabled={isApproved || busy !== null}
+                  disabled={isApproved || busy !== null || itensDesconhecidos}
                   onClick={() => act("approve")}
-                  title="Aprovar"
+                  title={itensDesconhecidos ? "Itens do pedido não carregados — recarregue" : "Aprovar"}
                 >
                   {busy === "approve" ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -1,6 +1,7 @@
 // Linha de pedido do ciclo (estado local de quantidade + aprovação/rejeição inline).
 // Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
 import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { AlertTriangle, Check, Loader2, Pencil, X, Zap } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -14,10 +15,20 @@ import { formatBRL, logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
 import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
-import { podeCancelarPeloHumano, rejeitarPedidos } from "../pedidos/rejeitar-pedido";
 import { EMPRESA } from "../pedidos/shared";
+import { montarUpdateItem } from "../pedidos/preco-edit";
+import { podeCancelarPeloHumano, rejeitarPedidos } from "../pedidos/rejeitar-pedido";
+import { quantidadeCompraInteira } from "@/lib/reposicao/compras-otimizador-helpers";
 import { PrecoCell, ConfiancaBadge } from "./PedidoRowCells";
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+
+/** O único item de um pedido de 1 SKU — o que o editor inline edita de verdade. */
+interface ItemUnico {
+  id: number;
+  qtde_final: number | null;
+  qtde_sugerida: number | null;
+  preco_unitario: number | null;
+}
 
 export function PedidoRow({
   row,
@@ -36,18 +47,40 @@ export function PedidoRow({
   user: { id?: string; email?: string | null } | null;
   onChanged: () => void;
 }) {
-  const [qty, setQty] = useState<number>(Number(row.num_skus ?? 0));
   const [busy, setBusy] = useState<null | "approve" | "reject">(null);
   const [editingAuto, setEditingAuto] = useState(false);
   const suggestion = calcApprovalSuggestion(row);
   const showInlineEditor = suggestion.mode === "review" || editingAuto;
 
-  useEffect(() => {
-    setQty(Number(row.num_skus ?? 0));
-  }, [row.num_skus]);
-
   const isApproved = !!row.aprovado_em;
   const isRejected = !!row.cancelado_em;
+
+  // Editor inline SÓ para pedido de 1 SKU. `num_skus` é CONTAGEM de SKUs, não quantidade: o editor
+  // antigo inicializava com ele e gravava `num_skus` — e o disparo lê `pedido_compra_item.qtde_final`,
+  // então a compra saía com a quantidade ORIGINAL (maior que a aprovada) e o cabeçalho mentia (M-03).
+  // Multi-SKU: ajuste por item no detalhe do pedido.
+  const itemUnico = row.num_skus === 1;
+  const { data: item } = useQuery({
+    queryKey: ["pedido-item-unico", row.id],
+    enabled: itemUnico && cols.qtdAprovada && !isApproved && !isRejected,
+    staleTime: 30_000,
+    queryFn: async (): Promise<ItemUnico> => {
+      const { data, error } = await supabase
+        .from("pedido_compra_item")
+        .select("id, qtde_final, qtde_sugerida, preco_unitario")
+        .eq("pedido_id", row.id);
+      if (error) throw error;
+      const [it] = (data ?? []) as ItemUnico[];
+      if (!it) throw new Error("pedido sem item"); // ausente ≠ zero: sem item, sem editor
+      return it;
+    },
+  });
+  // Quantidade ORIGINAL do item (inteira, como o disparo grava) — null enquanto não carregou/falhou.
+  const qtdOriginal = item ? quantidadeCompraInteira(Number(item.qtde_final ?? item.qtde_sugerida ?? 0)) : null;
+  const [qtd, setQtd] = useState<number | null>(null);
+  useEffect(() => {
+    setQtd(qtdOriginal);
+  }, [qtdOriginal]);
 
   const rowBg = isApproved
     ? "bg-status-success-bg/40 hover:bg-status-success-bg"
@@ -58,17 +91,28 @@ export function PedidoRow({
   const act = async (kind: "approve" | "reject") => {
     if (busy) return;
     setBusy(kind);
+    const nowIso = new Date().toISOString();
     const who = user?.email ?? user?.id ?? "cockpit";
     try {
       if (kind === "approve") {
-        // O edit on-the-spot da quantidade (num_skus) vai ANTES — a trilha canônica
-        // (RPC aprovar_pedido_sugerido) não toca num_skus, então gravamos aqui primeiro.
-        if (qty !== Number(row.num_skus ?? 0)) {
-          const { error: qtyErr } = await supabase
-            .from("pedido_compra_sugerido")
-            .update({ num_skus: qty })
-            .eq("id", row.id);
-          if (qtyErr) throw qtyErr;
+        // A edição inline (pedido de 1 SKU) vai ANTES do disparo e grava o ITEM (qtde_final/valor_linha)
+        // + o cabeçalho (valor_total) — nunca `num_skus`. O disparo lê `qtde_final` do item.
+        if (itemUnico && item && qtd !== null && qtd !== qtdOriginal) {
+          if (!(qtd > 0)) {
+            toast.error("Quantidade inválida — informe um valor maior que zero.");
+            return;
+          }
+          const update = montarUpdateItem(item, qtd, undefined);
+          const { error: itemErr } = await supabase.from("pedido_compra_item").update(update).eq("id", item.id);
+          if (itemErr) throw itemErr;
+          // valor_linha null = custo desconhecido → não fabricar valor_total (ausente ≠ zero)
+          if (update.valor_linha !== null) {
+            const { error: cabErr } = await supabase
+              .from("pedido_compra_sugerido")
+              .update({ valor_total: update.valor_linha, atualizado_em: new Date().toISOString() })
+              .eq("id", row.id);
+            if (cabErr) throw cabErr;
+          }
         }
         // Trilha canônica: APROVAR = DISPARAR NA HORA (não mais só UPDATE + esperar o cron).
         const r = await aprovarEDisparar({
@@ -80,7 +124,7 @@ export function PedidoRow({
           userId: user?.id ?? null,
           action: "Aprovação inline",
           result: r.ok ? "Sucesso" : `Erro: ${r.mensagem}`,
-          metadata: { id: row.id, qty },
+          metadata: { id: row.id, qtd },
         });
         if (!r.ok || r.tipo === "error") toast.error(r.mensagem);
         else if (r.tipo === "warning") toast.warning(r.mensagem);
@@ -97,7 +141,7 @@ export function PedidoRow({
         userId: user?.id ?? null,
         action: "Rejeição inline",
         result: motivo ? `Erro: ${motivo}` : "Sucesso",
-        metadata: { id: row.id, qty },
+        metadata: { id: row.id, qtd },
       });
       if (motivo) toast.error(`Não rejeitado: ${motivo}`);
       else toast.success("Pedido rejeitado");
@@ -161,16 +205,20 @@ export function PedidoRow({
                 >
                   <Zap className="h-3 w-3" /> Auto
                 </Badge>
-                <span className="w-10 text-right tabular-nums font-medium">{qty}</span>
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className="h-8 w-8"
-                  onClick={() => setEditingAuto(true)}
-                  title="Editar quantidade antes de aprovar"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
+                <span className="w-10 text-right tabular-nums font-medium">
+                  {itemUnico ? (qtd ?? "—") : `${row.num_skus ?? 0} SKUs`}
+                </span>
+                {itemUnico && (
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    className="h-8 w-8"
+                    onClick={() => setEditingAuto(true)}
+                    title="Editar quantidade antes de aprovar"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                )}
               </>
             ) : (
               <>
@@ -191,15 +239,25 @@ export function PedidoRow({
                     </Tooltip>
                   </TooltipProvider>
                 )}
-                <Input
-                  type="number"
-                  min={0}
-                  value={qty}
-                  disabled={isApproved || isRejected || busy !== null}
-                  onChange={(e) => setQty(Number(e.target.value) || 0)}
-                  onFocus={(e) => e.currentTarget.select()}
-                  className="h-8 w-20 text-right"
-                />
+                {itemUnico ? (
+                  <Input
+                    type="number"
+                    min={1}
+                    value={qtd ?? ""}
+                    disabled={isApproved || isRejected || busy !== null || item == null}
+                    onChange={(e) => setQtd(Number(e.target.value) || 0)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    className="h-8 w-20 text-right"
+                    aria-label="Quantidade do item"
+                  />
+                ) : (
+                  <span
+                    className="text-xs text-muted-foreground tabular-nums"
+                    title="Pedido com vários SKUs — ajuste as quantidades no detalhe do pedido"
+                  >
+                    {row.num_skus ?? 0} SKUs
+                  </span>
+                )}
                 <Button
                   size="icon"
                   variant="ghost"

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ColKey, PedidoItem } from '@/types/reposicao';
+import type { ItemDoPedido } from '../types';
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: vi.fn(), rpc: vi.fn(), functions: { invoke: vi.fn() } },
@@ -21,23 +21,25 @@ import { aprovarEDisparar } from '@/components/reposicao/pedidos/aprovar-dispara
 import { PedidoRow } from '../PedidoRow';
 
 /** Builder mínimo do PostgREST: registra cada operação (tabela, op, payload, filtros) e resolve. */
-interface Op { table: string; op: 'select' | 'update'; payload?: unknown; filtros: [string, unknown][] }
+interface Op { table: string; op: 'select' | 'update' | 'disparo'; payload?: unknown; filtros: [string, unknown][]; selectApos?: boolean }
 let ops: Op[] = [];
-let itensDoPedido: unknown[] = [];
-let erroSelect: { message: string } | null = null;
+let cabecalhoStatus = 'pendente_aprovacao';
+let updateRetornaVazio = false; // simula o compare-and-set NÃO casando (0 linhas)
 
 function builder(table: string) {
   const op: Op = { table, op: 'select', filtros: [] };
   const b = {
-    select: () => b,
+    select: () => { if (op.op === 'update') op.selectApos = true; return b; },
     update: (payload: unknown) => { op.op = 'update'; op.payload = payload; return b; },
     eq: (c: string, v: unknown) => { op.filtros.push([c, v]); return b; },
+    is: (c: string, v: unknown) => { op.filtros.push([`is:${c}`, v]); return b; },
+    maybeSingle: () => b,
     order: () => b,
     then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => {
       ops.push(op);
-      const out = op.op === 'select'
-        ? { data: erroSelect ? null : itensDoPedido, error: erroSelect }
-        : { data: null, error: null };
+      let out: unknown;
+      if (op.op === 'select') out = { data: table === 'pedido_compra_sugerido' ? { status: cabecalhoStatus } : [], error: null };
+      else out = { data: op.selectApos ? (updateRetornaVazio ? [] : [{ id: 501 }]) : null, error: null };
       return Promise.resolve(out).then(res, rej);
     },
   };
@@ -52,20 +54,18 @@ function linha(over: Partial<PedidoItem> = {}): PedidoItem {
     ...over,
   };
 }
+const ITEM: ItemDoPedido = { id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 };
 const cols: Record<ColKey, boolean> = {
   fornecedor: true, grupo: false, skus: false, valor: true, preco: false, confianca: false, status: true, qtdAprovada: true,
 };
 
-function montar(row: PedidoItem) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function montar(row: PedidoItem, itens: ItemDoPedido[] | null | undefined) {
   const onChanged = vi.fn();
   render(
-    <QueryClientProvider client={qc}>
-      <table><tbody>
-        <PedidoRow row={row} reviewMode={false} selected={false} onToggle={() => {}} cols={cols}
-          user={{ id: 'u1', email: 'lucas@x.com' }} onChanged={onChanged} />
-      </tbody></table>
-    </QueryClientProvider>,
+    <table><tbody>
+      <PedidoRow row={row} reviewMode={false} selected={false} onToggle={() => {}} cols={cols}
+        user={{ id: 'u1', email: 'lucas@x.com' }} onChanged={onChanged} itens={itens} />
+    </tbody></table>,
   );
   return { onChanged };
 }
@@ -76,45 +76,52 @@ const gravouNumSkus = () =>
   ops.some((o) => o.op === 'update' && !!o.payload && typeof o.payload === 'object' && 'num_skus' in (o.payload as object));
 
 beforeEach(() => {
-  ops = []; itensDoPedido = []; erroSelect = null;
+  ops = []; cabecalhoStatus = 'pendente_aprovacao'; updateRetornaVazio = false;
   vi.mocked(supabase.from).mockReset().mockImplementation(builder as never);
-  vi.mocked(aprovarEDisparar).mockReset().mockResolvedValue({ ok: true, tipo: 'success', mensagem: 'ok' });
+  vi.mocked(aprovarEDisparar).mockReset().mockImplementation(async () => {
+    ops.push({ table: 'edge', op: 'disparo', filtros: [] }); // entra no MESMO log: a ordem é testável
+    return { ok: true, tipo: 'success', mensagem: 'ok' };
+  });
   vi.mocked(toast.error).mockReset();
 });
 
 describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, nunca num_skus (M-03)', () => {
-  it('pedido de 1 SKU: o campo mostra a quantidade do ITEM (40), não a contagem de SKUs (1)', async () => {
-    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
-    montar(linha({ num_skus: 1 }));
+  it('pedido de 1 item: o campo mostra a quantidade do ITEM (40), não `num_skus` — e a linha NÃO consulta o item (o painel já trouxe)', async () => {
+    montar(linha({ num_skus: 7 /* corrompido pelo bug antigo: a cardinalidade vem dos ITENS */ }), [ITEM]);
     expect(await screen.findByDisplayValue('40')).toBeTruthy();
-    expect(screen.queryByDisplayValue('1')).toBeNull();
-    const sel = ops.find((o) => o.table === 'pedido_compra_item' && o.op === 'select');
-    expect(sel?.filtros).toContainEqual(['pedido_id', 1]);
+    expect(screen.queryByDisplayValue('7')).toBeNull();
+    expect(ops.filter((o) => o.table === 'pedido_compra_item' && o.op === 'select')).toEqual([]);
   });
 
-  it('editar 40→35 e aprovar grava qtde_final/valor_linha no ITEM e valor_total no cabeçalho — NUNCA num_skus — e só então dispara', async () => {
-    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
-    montar(linha({ num_skus: 1 }));
+  it('editar 40→35 e aprovar: checa o status do cabeçalho, grava o ITEM com compare-and-set na quantidade vista, recalcula valor_total e SÓ ENTÃO dispara — nunca num_skus', async () => {
+    montar(linha(), [ITEM]);
     const input = await screen.findByDisplayValue('40');
     fireEvent.change(input, { target: { value: '35' } });
     fireEvent.click(botaoAprovar());
     await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
 
-    const [upItem] = updatesDe('pedido_compra_item');
-    expect(upItem, 'não gravou o item').toBeTruthy();
+    const iStatus = ops.findIndex((o) => o.table === 'pedido_compra_sugerido' && o.op === 'select');
+    const iItem = ops.findIndex((o) => o.table === 'pedido_compra_item' && o.op === 'update');
+    const iCab = ops.findIndex((o) => o.table === 'pedido_compra_sugerido' && o.op === 'update');
+    const iDisparo = ops.findIndex((o) => o.op === 'disparo');
+    expect([iStatus, iItem, iCab, iDisparo].every((i) => i >= 0), JSON.stringify(ops.map((o) => `${o.table}:${o.op}`))).toBe(true);
+    expect(iStatus).toBeLessThan(iItem);
+    expect(iItem).toBeLessThan(iCab);
+    expect(iCab).toBeLessThan(iDisparo);
+
+    const upItem = ops[iItem];
     expect(upItem.payload).toEqual({ qtde_final: 35, valor_linha: 437.5, ajustado_humano: true });
     expect(upItem.filtros).toContainEqual(['id', 501]);
-    const [upCab] = updatesDe('pedido_compra_sugerido');
-    expect(upCab, 'não recalculou o cabeçalho').toBeTruthy();
-    expect(upCab.payload).toEqual(expect.objectContaining({ valor_total: 437.5 }));
-    expect(upCab.filtros).toContainEqual(['id', 1]);
+    expect(upItem.filtros, 'sem compare-and-set na quantidade que o operador VIU').toContainEqual(['qtde_final', 40]);
+    expect(upItem.selectApos, 'sem .select() depois do update não dá para saber se casou').toBe(true);
+    expect(ops[iCab].payload).toEqual(expect.objectContaining({ valor_total: 437.5 }));
+    expect(ops[iCab].filtros).toContainEqual(['id', 1]);
     expect(gravouNumSkus(), 'gravou num_skus (era o bug: contagem de SKUs ≠ quantidade)').toBe(false);
     expect(aprovarEDisparar).toHaveBeenCalledWith(expect.objectContaining({ pedidoId: 1 }));
   });
 
   it('quantidade inalterada: aprova sem tocar no item nem no cabeçalho', async () => {
-    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
-    montar(linha({ num_skus: 1 }));
+    montar(linha(), [ITEM]);
     await screen.findByDisplayValue('40');
     fireEvent.click(botaoAprovar());
     await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
@@ -123,10 +130,10 @@ describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, n
     expect(gravouNumSkus()).toBe(false);
   });
 
-  it('pedido multi-SKU: SEM editor inline (num_skus não é quantidade), mostra "7 SKUs"; aprovar não grava item nem num_skus', async () => {
-    montar(linha({ num_skus: 7 }));
+  it('pedido com VÁRIOS itens: sem editor inline, mostra "2 SKUs" (dos itens, não de num_skus); aprovar não grava item nem num_skus', async () => {
+    montar(linha({ num_skus: 1 /* corrompido */ }), [ITEM, { ...ITEM, id: 502 }]);
     expect(screen.queryByRole('spinbutton')).toBeNull();
-    expect(screen.getByText(/7 SKUs/)).toBeTruthy();
+    expect(screen.getByText(/2 SKUs/)).toBeTruthy();
     fireEvent.click(botaoAprovar());
     await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
     expect(ops.filter((o) => o.table === 'pedido_compra_item')).toEqual([]);
@@ -134,20 +141,17 @@ describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, n
   });
 
   it('quantidade ≤ 0 bloqueia a aprovação (toast de erro), sem gravar nem disparar', async () => {
-    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
-    montar(linha({ num_skus: 1 }));
+    montar(linha(), [ITEM]);
     const input = await screen.findByDisplayValue('40');
     fireEvent.change(input, { target: { value: '0' } });
     fireEvent.click(botaoAprovar());
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(aprovarEDisparar).not.toHaveBeenCalled();
     expect(updatesDe('pedido_compra_item')).toEqual([]);
-    expect(gravouNumSkus()).toBe(false);
   });
 
   it('item sem preço conhecido: grava valor_linha null (ausente ≠ zero) e NÃO reescreve valor_total', async () => {
-    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: null }];
-    montar(linha({ num_skus: 1, valor_total: null }));
+    montar(linha({ valor_total: null }), [{ ...ITEM, preco_unitario: null }]);
     const input = await screen.findByDisplayValue('40');
     fireEvent.change(input, { target: { value: '35' } });
     fireEvent.click(botaoAprovar());
@@ -156,16 +160,74 @@ describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, n
     expect(updatesDe('pedido_compra_sugerido')).toEqual([]);
   });
 
-  it('falha ao carregar o item: o campo fica desabilitado e vazio (sem número fabricado); aprovar segue sem edição', async () => {
-    erroSelect = { message: 'boom' };
-    montar(linha({ num_skus: 1 }));
-    await waitFor(() => expect(ops.some((o) => o.table === 'pedido_compra_item')).toBe(true));
-    const input = await screen.findByRole('spinbutton');
-    await waitFor(() => expect(input).toBeDisabled());
-    expect((input as HTMLInputElement).value).toBe('');
+  it('FAIL-CLOSED: com os itens carregando, falhos ou vazios, o botão Aprovar fica DESABILITADO (o operador não vê o que vai comprar)', async () => {
+    for (const [itens, rotulo] of [[undefined, 'carregando'], [null, 'falhou'], [[], 'vazio']] as const) {
+      ops = [];
+      const { unmount } = render(
+        <table><tbody>
+          <PedidoRow row={linha()} reviewMode={false} selected={false} onToggle={() => {}} cols={cols}
+            user={{ id: 'u1', email: 'lucas@x.com' }} onChanged={() => {}} itens={itens as ItemDoPedido[] | null | undefined} />
+        </tbody></table>,
+      );
+      expect(screen.queryByRole('spinbutton'), rotulo).toBeNull();
+      expect(botaoAprovar(), `aprovar habilitado com itens ${rotulo}`).toBeDisabled();
+      fireEvent.click(botaoAprovar());
+      expect(aprovarEDisparar, rotulo).not.toHaveBeenCalled();
+      unmount();
+    }
+  });
+
+  it('decimal digitado (35,1) vira 36 no campo (ceil) e é 36 que se grava — o campo mostra o que compra', async () => {
+    montar(linha(), [ITEM]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35.1' } });
+    expect(await screen.findByDisplayValue('36')).toBeTruthy();
     fireEvent.click(botaoAprovar());
     await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')[0].payload).toEqual({ qtde_final: 36, valor_linha: 450, ajustado_humano: true });
+  });
+
+  it('fator de embalagem (0,2 = balde de 5 L): 37 sobe a 40 no blur; e mesmo sem blur (33) a gravação repete a regra (35)', async () => {
+    montar(linha(), [{ ...ITEM, fator_embalagem_portal: 0.2 }]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '37' } });
+    fireEvent.blur(input);
+    expect(await screen.findByDisplayValue('40')).toBeTruthy();
+    fireEvent.change(input, { target: { value: '33' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')[0].payload).toEqual({ qtde_final: 35, valor_linha: 437.5, ajustado_humano: true });
+  });
+
+  it('compare-and-set NÃO casa (outra aba mudou a quantidade): erro visível, nada disparado, lista recarregada', async () => {
+    updateRetornaVazio = true;
+    const { onChanged } = montar(linha(), [ITEM]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/mudou/)));
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+    expect(updatesDe('pedido_compra_sugerido')).toEqual([]);
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('cabeçalho já não aprovável (disparado em outra aba): não grava o item nem dispara', async () => {
+    cabecalhoStatus = 'disparado';
+    montar(linha(), [ITEM]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/aprov/)));
     expect(updatesDe('pedido_compra_item')).toEqual([]);
-    expect(gravouNumSkus()).toBe(false);
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+  });
+
+  it('item com qtde_final NULL (só sugerida): o compare-and-set usa IS NULL, não eq null', async () => {
+    montar(linha(), [{ ...ITEM, qtde_final: null }]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')[0].filtros).toContainEqual(['is:qtde_final', null]);
   });
 });

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ColKey, PedidoItem } from '@/types/reposicao';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/reposicao', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/reposicao')>()),
+  logAudit: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/components/reposicao/pedidos/aprovar-disparar', () => ({ aprovarEDisparar: vi.fn() }));
+
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { aprovarEDisparar } from '@/components/reposicao/pedidos/aprovar-disparar';
+import { PedidoRow } from '../PedidoRow';
+
+/** Builder mínimo do PostgREST: registra cada operação (tabela, op, payload, filtros) e resolve. */
+interface Op { table: string; op: 'select' | 'update'; payload?: unknown; filtros: [string, unknown][] }
+let ops: Op[] = [];
+let itensDoPedido: unknown[] = [];
+let erroSelect: { message: string } | null = null;
+
+function builder(table: string) {
+  const op: Op = { table, op: 'select', filtros: [] };
+  const b = {
+    select: () => b,
+    update: (payload: unknown) => { op.op = 'update'; op.payload = payload; return b; },
+    eq: (c: string, v: unknown) => { op.filtros.push([c, v]); return b; },
+    order: () => b,
+    then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => {
+      ops.push(op);
+      const out = op.op === 'select'
+        ? { data: erroSelect ? null : itensDoPedido, error: erroSelect }
+        : { data: null, error: null };
+      return Promise.resolve(out).then(res, rej);
+    },
+  };
+  return b;
+}
+
+function linha(over: Partial<PedidoItem> = {}): PedidoItem {
+  return {
+    id: 1, fornecedor_nome: 'ACME', grupo_codigo: 'G1', num_skus: 1, valor_total: 500,
+    pedido_anterior_valor: null, // "primeiro pedido" → modo revisão → editor inline visível
+    status: 'pendente_aprovacao', aprovado_em: null, cancelado_em: null, horario_disparo_real: null,
+    ...over,
+  };
+}
+const cols: Record<ColKey, boolean> = {
+  fornecedor: true, grupo: false, skus: false, valor: true, preco: false, confianca: false, status: true, qtdAprovada: true,
+};
+
+function montar(row: PedidoItem) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onChanged = vi.fn();
+  render(
+    <QueryClientProvider client={qc}>
+      <table><tbody>
+        <PedidoRow row={row} reviewMode={false} selected={false} onToggle={() => {}} cols={cols}
+          user={{ id: 'u1', email: 'lucas@x.com' }} onChanged={onChanged} />
+      </tbody></table>
+    </QueryClientProvider>,
+  );
+  return { onChanged };
+}
+// Os dois botões da célula "qtd aprovada" são, nesta ordem, aprovar (✓) e rejeitar (✕).
+const botaoAprovar = () => screen.getAllByRole('button')[0];
+const updatesDe = (table: string) => ops.filter((o) => o.table === table && o.op === 'update');
+const gravouNumSkus = () =>
+  ops.some((o) => o.op === 'update' && !!o.payload && typeof o.payload === 'object' && 'num_skus' in (o.payload as object));
+
+beforeEach(() => {
+  ops = []; itensDoPedido = []; erroSelect = null;
+  vi.mocked(supabase.from).mockReset().mockImplementation(builder as never);
+  vi.mocked(aprovarEDisparar).mockReset().mockResolvedValue({ ok: true, tipo: 'success', mensagem: 'ok' });
+  vi.mocked(toast.error).mockReset();
+});
+
+describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, nunca num_skus (M-03)', () => {
+  it('pedido de 1 SKU: o campo mostra a quantidade do ITEM (40), não a contagem de SKUs (1)', async () => {
+    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
+    montar(linha({ num_skus: 1 }));
+    expect(await screen.findByDisplayValue('40')).toBeTruthy();
+    expect(screen.queryByDisplayValue('1')).toBeNull();
+    const sel = ops.find((o) => o.table === 'pedido_compra_item' && o.op === 'select');
+    expect(sel?.filtros).toContainEqual(['pedido_id', 1]);
+  });
+
+  it('editar 40→35 e aprovar grava qtde_final/valor_linha no ITEM e valor_total no cabeçalho — NUNCA num_skus — e só então dispara', async () => {
+    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
+    montar(linha({ num_skus: 1 }));
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+
+    const [upItem] = updatesDe('pedido_compra_item');
+    expect(upItem, 'não gravou o item').toBeTruthy();
+    expect(upItem.payload).toEqual({ qtde_final: 35, valor_linha: 437.5, ajustado_humano: true });
+    expect(upItem.filtros).toContainEqual(['id', 501]);
+    const [upCab] = updatesDe('pedido_compra_sugerido');
+    expect(upCab, 'não recalculou o cabeçalho').toBeTruthy();
+    expect(upCab.payload).toEqual(expect.objectContaining({ valor_total: 437.5 }));
+    expect(upCab.filtros).toContainEqual(['id', 1]);
+    expect(gravouNumSkus(), 'gravou num_skus (era o bug: contagem de SKUs ≠ quantidade)').toBe(false);
+    expect(aprovarEDisparar).toHaveBeenCalledWith(expect.objectContaining({ pedidoId: 1 }));
+  });
+
+  it('quantidade inalterada: aprova sem tocar no item nem no cabeçalho', async () => {
+    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
+    montar(linha({ num_skus: 1 }));
+    await screen.findByDisplayValue('40');
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')).toEqual([]);
+    expect(updatesDe('pedido_compra_sugerido')).toEqual([]);
+    expect(gravouNumSkus()).toBe(false);
+  });
+
+  it('pedido multi-SKU: SEM editor inline (num_skus não é quantidade), mostra "7 SKUs"; aprovar não grava item nem num_skus', async () => {
+    montar(linha({ num_skus: 7 }));
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    expect(screen.getByText(/7 SKUs/)).toBeTruthy();
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(ops.filter((o) => o.table === 'pedido_compra_item')).toEqual([]);
+    expect(gravouNumSkus()).toBe(false);
+  });
+
+  it('quantidade ≤ 0 bloqueia a aprovação (toast de erro), sem gravar nem disparar', async () => {
+    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5 }];
+    montar(linha({ num_skus: 1 }));
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+    expect(updatesDe('pedido_compra_item')).toEqual([]);
+    expect(gravouNumSkus()).toBe(false);
+  });
+
+  it('item sem preço conhecido: grava valor_linha null (ausente ≠ zero) e NÃO reescreve valor_total', async () => {
+    itensDoPedido = [{ id: 501, qtde_final: 40, qtde_sugerida: 40, preco_unitario: null }];
+    montar(linha({ num_skus: 1, valor_total: null }));
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')[0].payload).toEqual({ qtde_final: 35, valor_linha: null, ajustado_humano: true });
+    expect(updatesDe('pedido_compra_sugerido')).toEqual([]);
+  });
+
+  it('falha ao carregar o item: o campo fica desabilitado e vazio (sem número fabricado); aprovar segue sem edição', async () => {
+    erroSelect = { message: 'boom' };
+    montar(linha({ num_skus: 1 }));
+    await waitFor(() => expect(ops.some((o) => o.table === 'pedido_compra_item')).toBe(true));
+    const input = await screen.findByRole('spinbutton');
+    await waitFor(() => expect(input).toBeDisabled());
+    expect((input as HTMLInputElement).value).toBe('');
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    expect(updatesDe('pedido_compra_item')).toEqual([]);
+    expect(gravouNumSkus()).toBe(false);
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PedidoRow } from "../PedidoRow";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
 
@@ -20,7 +21,9 @@ function renderRow(opts: { reviewMode?: boolean; cols?: Partial<Record<ColKey, b
     cancelado_em: null,
     pedido_anterior_valor: null,
   } as unknown as PedidoItem;
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
+    <QueryClientProvider client={qc}>
     <table>
       <tbody>
         <PedidoRow
@@ -33,7 +36,8 @@ function renderRow(opts: { reviewMode?: boolean; cols?: Partial<Record<ColKey, b
           onChanged={() => {}}
         />
       </tbody>
-    </table>,
+    </table>
+    </QueryClientProvider>,
   );
 }
 

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PedidoRow } from "../PedidoRow";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
 
@@ -21,9 +20,7 @@ function renderRow(opts: { reviewMode?: boolean; cols?: Partial<Record<ColKey, b
     cancelado_em: null,
     pedido_anterior_valor: null,
   } as unknown as PedidoItem;
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>
     <table>
       <tbody>
         <PedidoRow
@@ -36,8 +33,7 @@ function renderRow(opts: { reviewMode?: boolean; cols?: Partial<Record<ColKey, b
           onChanged={() => {}}
         />
       </tbody>
-    </table>
-    </QueryClientProvider>,
+    </table>,
   );
 }
 

--- a/src/components/reposicao/cicloHoje/__tests__/useItensDosPedidos.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/useItensDosPedidos.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: vi.fn() } }));
+import { supabase } from '@/integrations/supabase/client';
+import { useItensDosPedidos } from '../useItensDosPedidos';
+
+let chamadas: { table: string; select?: string; inCol?: string; inVals?: unknown[] }[] = [];
+let linhas: unknown[] = [];
+function builder(table: string) {
+  const c: (typeof chamadas)[number] = { table };
+  chamadas.push(c);
+  const b = {
+    select: (cols: string) => { c.select = cols; return b; },
+    in: (col: string, vals: unknown[]) => { c.inCol = col; c.inVals = vals; return b; },
+    order: () => b,
+    then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => Promise.resolve({ data: linhas, error: null }).then(res, rej),
+  };
+  return b;
+}
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+beforeEach(() => { chamadas = []; linhas = []; vi.mocked(supabase.from).mockReset().mockImplementation(builder as never); });
+
+describe('useItensDosPedidos — itens de todos os pedidos do ciclo numa query só (sem N+1)', () => {
+  it('uma única query .in("pedido_id", ids ordenados) e o mapa por pedido', async () => {
+    linhas = [
+      { id: 501, pedido_id: 2, qtde_final: 40, qtde_sugerida: 40, preco_unitario: 12.5, fator_embalagem_portal: null },
+      { id: 502, pedido_id: 1, qtde_final: 3, qtde_sugerida: 3, preco_unitario: 9, fator_embalagem_portal: 0.2 },
+      { id: 503, pedido_id: 1, qtde_final: 8, qtde_sugerida: 8, preco_unitario: 1, fator_embalagem_portal: null },
+    ];
+    const { result } = renderHook(() => useItensDosPedidos([3, 1, 2]), { wrapper });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(chamadas).toHaveLength(1);
+    expect(chamadas[0].table).toBe('pedido_compra_item');
+    expect(chamadas[0].inCol).toBe('pedido_id');
+    expect(chamadas[0].inVals).toEqual([1, 2, 3]);
+    expect(chamadas[0].select).toContain('fator_embalagem_portal');
+    const m = result.current.data!;
+    expect(m.get(1)?.map((i) => i.id)).toEqual([502, 503]);
+    expect(m.get(2)?.map((i) => i.id)).toEqual([501]);
+    expect(m.get(3)).toBeUndefined(); // pedido sem itens → o painel traduz para []
+  });
+
+  it('sem ids não consulta nada', async () => {
+    const { result } = renderHook(() => useItensDosPedidos([]), { wrapper });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(chamadas).toEqual([]);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('bater na capa de 1.000 linhas do PostgREST é ERRO, não mapa parcial (leitura parcial ≠ verdade)', async () => {
+    linhas = Array.from({ length: 1000 }, (_, i) => ({ id: i, pedido_id: 1, qtde_final: 1, qtde_sugerida: 1, preco_unitario: 1, fator_embalagem_portal: null }));
+    const { result } = renderHook(() => useItensDosPedidos([1]), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/components/reposicao/cicloHoje/types.ts
+++ b/src/components/reposicao/cicloHoje/types.ts
@@ -11,3 +11,13 @@ export interface CicloFilters {
   fornecedor: string;
   status: string;
 }
+
+/**
+ * Item de `pedido_compra_item` que o editor inline do ciclo enxerga (M-03). Derivado do tipo canônico
+ * do item da lista de pedidos; `fator_embalagem_portal` entra porque a edge do portal RECUSA quantidade
+ * fora do múltiplo da embalagem (#2198).
+ */
+export type ItemDoPedido = Pick<
+  import("../pedidos/types").PedidoItem,
+  "id" | "qtde_final" | "qtde_sugerida" | "preco_unitario" | "fator_embalagem_portal"
+>;

--- a/src/components/reposicao/cicloHoje/useItensDosPedidos.ts
+++ b/src/components/reposicao/cicloHoje/useItensDosPedidos.ts
@@ -1,0 +1,40 @@
+// Itens de TODOS os pedidos pendentes do ciclo numa única query (M-03, Codex P1/P2).
+//
+// A cardinalidade (1 SKU × vários) tem de vir dos ITENS, nunca de `num_skus`: essa coluna é justamente a
+// que o editor antigo corrompia. E carregar por linha seria N+1 (~36 GETs num ciclo de 100 pedidos).
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import type { ItemDoPedido } from "./types";
+
+/** Capa silenciosa do PostgREST (CLAUDE.md): bater nela = leitura PARCIAL, que aqui vira erro, não "ok". */
+const CAPA_POSTGREST = 1000;
+
+export type ItensPorPedido = Map<number, ItemDoPedido[]>;
+
+export function useItensDosPedidos(ids: readonly number[]) {
+  const chave = [...ids].sort((a, b) => a - b);
+  return useQuery({
+    queryKey: ["cockpit-itens-dos-pedidos", chave],
+    enabled: chave.length > 0,
+    staleTime: 30_000,
+    queryFn: async (): Promise<ItensPorPedido> => {
+      const { data, error } = await supabase
+        .from("pedido_compra_item")
+        .select("id, pedido_id, qtde_final, qtde_sugerida, preco_unitario, fator_embalagem_portal")
+        .in("pedido_id", chave)
+        .order("id");
+      if (error) throw error;
+      const linhas = (data ?? []) as (ItemDoPedido & { pedido_id: number })[];
+      if (linhas.length >= CAPA_POSTGREST) {
+        throw new Error(`itens do ciclo acima da capa de ${CAPA_POSTGREST} linhas — leitura parcial não vale como verdade`);
+      }
+      const m: ItensPorPedido = new Map();
+      for (const it of linhas) {
+        const lista = m.get(it.pedido_id) ?? [];
+        lista.push(it);
+        m.set(it.pedido_id, lista);
+      }
+      return m;
+    },
+  });
+}

--- a/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx
@@ -18,27 +18,30 @@ import { supabase } from '@/integrations/supabase/client';
 import { aprovarEDisparar } from '../aprovar-disparar';
 import { useDetalhesModal } from '../useDetalhesModal';
 
-interface Op { table: string; op: 'select' | 'update'; payload?: unknown; filtros: [string, unknown][] }
+interface Op { table: string; op: 'select' | 'update' | 'disparo'; payload?: unknown; filtros: [string, unknown][]; selectApos?: boolean }
 let ops: Op[] = [];
-const tabelas: Record<string, unknown[]> = {
+let updateRetornaVazio = false;
+const ITEM_BASE = { id: 501, pedido_id: 1, sku_codigo_omie: '123', sku_descricao: 'Tinta X', qtde_final: 10, qtde_sugerida: 10, valor_linha: null as number | null };
+let itemFixture: Record<string, unknown> = { ...ITEM_BASE, preco_unitario: null };
+const tabelas = (): Record<string, unknown[]> => ({
   omie_condicao_pagamento_catalogo: [{ codigo: '001', descricao: 'À vista', num_parcelas: 1, dias_parcelas: '0' }],
-  pedido_compra_item: [{
-    id: 501, pedido_id: 1, sku_codigo_omie: '123', sku_descricao: 'Tinta X', qtde_final: 10, qtde_sugerida: 10,
-    preco_unitario: 20, valor_linha: 200,
-  }],
-};
+  pedido_compra_item: [itemFixture],
+});
 
 function builder(table: string) {
   const op: Op = { table, op: 'select', filtros: [] };
   const b = {
-    select: () => b,
+    select: () => { if (op.op === 'update') op.selectApos = true; return b; },
     update: (payload: unknown) => { op.op = 'update'; op.payload = payload; return b; },
     eq: (c: string, v: unknown) => { op.filtros.push([c, v]); return b; },
+    is: (c: string, v: unknown) => { op.filtros.push([`is:${c}`, v]); return b; },
     in: () => b,
     order: () => b,
     then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => {
       ops.push(op);
-      const out = op.op === 'select' ? { data: tabelas[table] ?? [], error: null } : { data: null, error: null };
+      const out = op.op === 'select'
+        ? { data: tabelas()[table] ?? [], error: null }
+        : { data: op.selectApos ? (updateRetornaVazio ? [] : [{ id: 501 }]) : null, error: null };
       return Promise.resolve(out).then(res, rej);
     },
   };
@@ -47,7 +50,7 @@ function builder(table: string) {
 
 const pedido = {
   id: 1, empresa: 'OBEN', fornecedor_nome: 'ACME', grupo_codigo: null, data_ciclo: '2026-09-05',
-  horario_geracao: null, horario_corte_planejado: null, horario_disparo_real: null, valor_total: 200, num_skus: 1,
+  horario_geracao: null, horario_corte_planejado: null, horario_disparo_real: null, valor_total: 0, num_skus: 1,
   pedido_anterior_valor: null, delta_vs_anterior_perc: null, status: 'pendente_aprovacao', mensagem_bloqueio: null,
   omie_pedido_compra_numero: null, aprovado_em: null, aprovado_por: null, condicao_pagamento_codigo: '001',
   condicao_pagamento_descricao: 'À vista', num_parcelas: 1, dias_parcelas: '0', condicao_origem: null,
@@ -70,28 +73,37 @@ async function montarPronto() {
 }
 
 beforeEach(() => {
-  ops = [];
+  ops = []; updateRetornaVazio = false; itemFixture = { ...ITEM_BASE, preco_unitario: null };
   vi.mocked(supabase.from).mockReset().mockImplementation(builder as never);
-  vi.mocked(aprovarEDisparar).mockReset().mockResolvedValue({ ok: true, tipo: 'success', mensagem: 'ok' });
+  vi.mocked(aprovarEDisparar).mockReset().mockImplementation(async () => {
+    ops.push({ table: 'edge', op: 'disparo', filtros: [] }); // mesmo log: ordem testável
+    return { ok: true, tipo: 'success', mensagem: 'ok' };
+  });
 });
 
 describe('useDetalhesModal.aprovarMutation — "Aprovar e disparar" não descarta edição SÓ de preço (M-03)', () => {
-  it('edição só de preço (20→25) é gravada no item e o cabeçalho recalculado ANTES de disparar', async () => {
+  it('primeira compra (preço nulo): digitar 25 e aprovar grava o preço no item (com compare-and-set na quantidade) e recalcula o cabeçalho ANTES de disparar', async () => {
     const { result } = await montarPronto();
+    expect(result.current.podeEditarPreco).toBe(true); // o fluxo real: preço nulo é o único editável
     act(() => result.current.onEditPreco(501, '25'));
     await act(async () => { await result.current.aprovarMutation.mutateAsync(); });
 
-    const up = updatesDe('pedido_compra_item');
-    expect(up, 'a edição só-de-preço foi descartada (era o bug: só salvava se `edits` de quantidade não fosse vazio)').toHaveLength(1);
-    expect(up[0].payload).toEqual(expect.objectContaining({ preco_unitario: 25, valor_linha: 250, qtde_final: 10 }));
-    expect(up[0].filtros).toContainEqual(['id', 501]);
-    expect(updatesDe('pedido_compra_sugerido')[0]?.payload).toEqual(expect.objectContaining({ valor_total: 250 }));
+    const iItem = ops.findIndex((o) => o.table === 'pedido_compra_item' && o.op === 'update');
+    const iCab = ops.findIndex((o) => o.table === 'pedido_compra_sugerido' && o.op === 'update');
+    const iDisparo = ops.findIndex((o) => o.op === 'disparo');
+    expect(iItem, 'a edição só-de-preço foi descartada (era o bug)').toBeGreaterThan(-1);
+    expect(iItem).toBeLessThan(iDisparo);
+    expect(iCab).toBeLessThan(iDisparo);
+    expect(ops[iItem].payload).toEqual(expect.objectContaining({ preco_unitario: 25, valor_linha: 250, qtde_final: 10 }));
+    expect(ops[iItem].filtros).toContainEqual(['id', 501]);
+    expect(ops[iItem].filtros, 'sem compare-and-set, o preço-só reescreve a quantidade velha').toContainEqual(['qtde_final', 10]);
+    expect(ops[iItem].selectApos).toBe(true);
+    expect(ops[iCab].payload).toEqual(expect.objectContaining({ valor_total: 250 }));
     expect(aprovarEDisparar).toHaveBeenCalledWith(expect.objectContaining({ pedidoId: 1 }));
-    // ordem: gravou o item ANTES de disparar (o disparo lê preco_unitario do banco)
-    expect(ops.findIndex((o) => o.table === 'pedido_compra_item' && o.op === 'update')).toBeGreaterThan(-1);
   });
 
-  it('edição só de quantidade continua salvando (regressão)', async () => {
+  it('edição só de quantidade (preço já conhecido) continua salvando (regressão)', async () => {
+    itemFixture = { ...ITEM_BASE, preco_unitario: 20, valor_linha: 200 };
     const { result } = await montarPronto();
     act(() => result.current.onEditQty(501, '12'));
     await act(async () => { await result.current.aprovarMutation.mutateAsync(); });
@@ -112,5 +124,14 @@ describe('useDetalhesModal.aprovarMutation — "Aprovar e disparar" não descart
     await expect(act(async () => { await result.current.aprovarMutation.mutateAsync(); })).rejects.toThrow(/Custo inválido/);
     expect(aprovarEDisparar).not.toHaveBeenCalled();
     expect(updatesDe('pedido_compra_item')).toEqual([]);
+  });
+
+  it('compare-and-set não casa (outra aba mudou a quantidade): a aprovação falha com erro visível e NADA dispara', async () => {
+    updateRetornaVazio = true;
+    const { result } = await montarPronto();
+    act(() => result.current.onEditPreco(501, '25'));
+    await expect(act(async () => { await result.current.aprovarMutation.mutateAsync(); })).rejects.toThrow(/outra pessoa/);
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+    expect(updatesDe('pedido_compra_sugerido')).toEqual([]);
   });
 });

--- a/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { PedidoSugerido } from '../types';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'u1', email: 'lucas@x.com' } }) }));
+vi.mock('../aprovar-disparar', () => ({ aprovarEDisparar: vi.fn() }));
+
+import { supabase } from '@/integrations/supabase/client';
+import { aprovarEDisparar } from '../aprovar-disparar';
+import { useDetalhesModal } from '../useDetalhesModal';
+
+interface Op { table: string; op: 'select' | 'update'; payload?: unknown; filtros: [string, unknown][] }
+let ops: Op[] = [];
+const tabelas: Record<string, unknown[]> = {
+  omie_condicao_pagamento_catalogo: [{ codigo: '001', descricao: 'À vista', num_parcelas: 1, dias_parcelas: '0' }],
+  pedido_compra_item: [{
+    id: 501, pedido_id: 1, sku_codigo_omie: '123', sku_descricao: 'Tinta X', qtde_final: 10, qtde_sugerida: 10,
+    preco_unitario: 20, valor_linha: 200,
+  }],
+};
+
+function builder(table: string) {
+  const op: Op = { table, op: 'select', filtros: [] };
+  const b = {
+    select: () => b,
+    update: (payload: unknown) => { op.op = 'update'; op.payload = payload; return b; },
+    eq: (c: string, v: unknown) => { op.filtros.push([c, v]); return b; },
+    in: () => b,
+    order: () => b,
+    then: (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) => {
+      ops.push(op);
+      const out = op.op === 'select' ? { data: tabelas[table] ?? [], error: null } : { data: null, error: null };
+      return Promise.resolve(out).then(res, rej);
+    },
+  };
+  return b;
+}
+
+const pedido = {
+  id: 1, empresa: 'OBEN', fornecedor_nome: 'ACME', grupo_codigo: null, data_ciclo: '2026-09-05',
+  horario_geracao: null, horario_corte_planejado: null, horario_disparo_real: null, valor_total: 200, num_skus: 1,
+  pedido_anterior_valor: null, delta_vs_anterior_perc: null, status: 'pendente_aprovacao', mensagem_bloqueio: null,
+  omie_pedido_compra_numero: null, aprovado_em: null, aprovado_por: null, condicao_pagamento_codigo: '001',
+  condicao_pagamento_descricao: 'À vista', num_parcelas: 1, dias_parcelas: '0', condicao_origem: null,
+  status_envio_portal: null, enviado_portal_em: null, portal_protocolo: null, portal_resposta: null,
+  portal_screenshot_url: null, portal_tentativas: null, portal_proximo_retry_em: null, portal_erro: null,
+  resposta_canal: null,
+} as PedidoSugerido;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+const updatesDe = (table: string) => ops.filter((o) => o.table === table && o.op === 'update');
+
+async function montarPronto() {
+  const r = renderHook(() => useDetalhesModal({ pedido, open: true, onOpenChange: vi.fn(), onApproved: vi.fn() }), { wrapper });
+  await waitFor(() => expect(r.result.current.linhas).toHaveLength(1));
+  await waitFor(() => expect(r.result.current.condicaoSelecionada?.codigo).toBe('001'));
+  return r;
+}
+
+beforeEach(() => {
+  ops = [];
+  vi.mocked(supabase.from).mockReset().mockImplementation(builder as never);
+  vi.mocked(aprovarEDisparar).mockReset().mockResolvedValue({ ok: true, tipo: 'success', mensagem: 'ok' });
+});
+
+describe('useDetalhesModal.aprovarMutation — "Aprovar e disparar" não descarta edição SÓ de preço (M-03)', () => {
+  it('edição só de preço (20→25) é gravada no item e o cabeçalho recalculado ANTES de disparar', async () => {
+    const { result } = await montarPronto();
+    act(() => result.current.onEditPreco(501, '25'));
+    await act(async () => { await result.current.aprovarMutation.mutateAsync(); });
+
+    const up = updatesDe('pedido_compra_item');
+    expect(up, 'a edição só-de-preço foi descartada (era o bug: só salvava se `edits` de quantidade não fosse vazio)').toHaveLength(1);
+    expect(up[0].payload).toEqual(expect.objectContaining({ preco_unitario: 25, valor_linha: 250, qtde_final: 10 }));
+    expect(up[0].filtros).toContainEqual(['id', 501]);
+    expect(updatesDe('pedido_compra_sugerido')[0]?.payload).toEqual(expect.objectContaining({ valor_total: 250 }));
+    expect(aprovarEDisparar).toHaveBeenCalledWith(expect.objectContaining({ pedidoId: 1 }));
+    // ordem: gravou o item ANTES de disparar (o disparo lê preco_unitario do banco)
+    expect(ops.findIndex((o) => o.table === 'pedido_compra_item' && o.op === 'update')).toBeGreaterThan(-1);
+  });
+
+  it('edição só de quantidade continua salvando (regressão)', async () => {
+    const { result } = await montarPronto();
+    act(() => result.current.onEditQty(501, '12'));
+    await act(async () => { await result.current.aprovarMutation.mutateAsync(); });
+    expect(updatesDe('pedido_compra_item')[0]?.payload).toEqual(expect.objectContaining({ qtde_final: 12, valor_linha: 240 }));
+    expect(aprovarEDisparar).toHaveBeenCalledTimes(1);
+  });
+
+  it('sem nenhuma edição: aprova sem gravar nada no item', async () => {
+    const { result } = await montarPronto();
+    await act(async () => { await result.current.aprovarMutation.mutateAsync(); });
+    expect(updatesDe('pedido_compra_item')).toEqual([]);
+    expect(aprovarEDisparar).toHaveBeenCalledTimes(1);
+  });
+
+  it('preço inválido (0) na edição só-de-preço BLOQUEIA a aprovação (não dispara com custo fabricado)', async () => {
+    const { result } = await montarPronto();
+    act(() => result.current.onEditPreco(501, '0'));
+    await expect(act(async () => { await result.current.aprovarMutation.mutateAsync(); })).rejects.toThrow(/Custo inválido/);
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+    expect(updatesDe('pedido_compra_item')).toEqual([]);
+  });
+});

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -160,11 +160,17 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
         const item = (itens ?? []).find((i) => i.id === itemId);
         if (!item) continue; // item saiu do cache — não grava (evita zerar preço). Codex [P1].
         const update = montarUpdateItem(item, edits[itemId], precoEdits[itemId]);
-        const { error } = await supabase
-          .from('pedido_compra_item')
-          .update(update)
-          .eq('id', itemId);
+        // Compare-and-set (Codex P1): `montarUpdateItem` recompõe a linha INTEIRA (qtde_final inclusive),
+        // então uma edição só-de-preço reescreveria a quantidade que ESTE modal carregou por cima de uma
+        // redução feita em outra aba. Só grava se o item ainda tem a quantidade vista; 0 linhas = mudou.
+        const base = supabase.from('pedido_compra_item').update(update).eq('id', itemId);
+        const cas = item.qtde_final === null ? base.is('qtde_final', null) : base.eq('qtde_final', item.qtde_final);
+        const { data: gravados, error } = await cas.select('id');
         if (error) throw error;
+        if (!gravados || gravados.length === 0) {
+          queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido.id] });
+          throw new Error(`Item ${item.sku_codigo_omie ?? itemId} foi alterado por outra pessoa — recarregue e confira.`);
+        }
       }
       // Header null-safe: _valor já trata custo desconhecido (preco_unitario null/0)
       // como 0, então valor_total = SUM(COALESCE(valor_linha,0)) — consistente com o

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -228,8 +228,9 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       if (!condicaoSelecionada) {
         throw new Error('Selecione uma condição de pagamento antes de aprovar');
       }
-      // salvar ajustes primeiro se houver
-      if (Object.keys(edits).length > 0) {
+      // Salvar ajustes primeiro se houver — de QUANTIDADE ou de PREÇO. Só olhar `edits` descartava
+      // a edição só-de-preço no "Aprovar e disparar", e o disparo lia o preço velho do banco (M-03).
+      if (Object.keys(edits).length > 0 || Object.keys(precoEdits).length > 0) {
         await salvarMutation.mutateAsync();
       }
       // salvar condição se mudou ou se ainda não havia


### PR DESCRIPTION
## O bug (M-03 do plano `docs/superpowers/plans/2026-09-05-plano-melhorias-codebase`, P1 aberto desde a revisão de 2026-07-04)

A linha do Cockpit (`cicloHoje/PedidoRow.tsx`) tinha um "editor de quantidade" **inicializado com `num_skus`** (a CONTAGEM de SKUs do pedido) que, ao aprovar, gravava `num_skus = qty` no cabeçalho. O operador achava que reduzia a compra; os itens seguiam intactos e o disparo — que lê `pedido_compra_item.qtde_final` — comprava a quantidade **original** (compra maior que a aprovada). Em prod, 64% dos pedidos são multi-SKU: o número exibido nem era quantidade.

Mesmo item, segunda metade: no modal de detalhes, "Aprovar e disparar" só salvava se houvesse edição de **quantidade** — a edição só-de-**preço** (`precoEdits`) era descartada e o disparo lia o preço velho.

## A correção
- **Cardinalidade pelos ITENS, nunca por `num_skus`** (a coluna que o bug corrompia): o painel carrega os itens de todos os pedidos pendentes **numa query só** (`useItensDosPedidos`, `.in('pedido_id', ids)`, capa de 1.000 = erro, não parcial) e passa à linha.
- **Pedido de 1 item**: o editor mostra e edita o ITEM — inteiro a cada tecla (ceil), múltiplo da embalagem no blur (fator carregado; o mesmo do modal, #2198). Ao aprovar com valor alterado: **(1)** relê o status do cabeçalho (outra aba pode ter aprovado/disparado), **(2)** grava `qtde_final`/`valor_linha`/`ajustado_humano` via `montarUpdateItem` com **compare-and-set** na quantidade que o operador VIU (`eq/is qtde_final` + `.select('id')`; 0 linhas = mudou → aborta com erro e recarrega), **(3)** `valor_total` do cabeçalho (só com custo conhecido), **(4)** dispara. **`num_skus` nunca mais é escrito por esta tela.**
- **Vários itens**: sem editor inline ("N SKUs" dos itens, dica para o detalhe). **Itens carregando/falhos/vazios**: botão Aprovar **desabilitado** (fail-closed — o operador não vê o que vai comprar).
- **Modal**: salva se `edits` **ou** `precoEdits` tiverem algo, antes de disparar — com o **mesmo compare-and-set** (uma edição só-de-preço não reescreve uma quantidade reduzida em outra aba).

## Prova
- `PedidoRow.qtd-item.test.tsx` (12 casos, supabase mockado por builder que registra operações — o mock do disparo entra no MESMO log, então a ORDEM é testada): mostra 40 (item) com `num_skus` corrompido = 7; editar 40→35: status → CAS (`['qtde_final',40]` + `.select('id')`) → cabeçalho → disparo, nunca `num_skus`; inalterado não grava; vários itens sem editor; `≤0` bloqueia; custo desconhecido → `valor_linha` null; **fail-closed** para carregando/falhou/vazio; 35,1 → 36; fator 0,2: 37 → 40 no blur e 33 → 35 na gravação; CAS não casa → erro, nada dispara; cabeçalho disparado → nada grava; `qtde_final` null → `IS NULL`.
- `useItensDosPedidos.test.tsx` (3): uma query `.in` ordenada, mapa por pedido, sem ids não consulta, capa de 1.000 = erro.
- `useDetalhesModal.aprovar-preco.test.tsx` (5, hook real): primeira compra (preço nulo → 25) grava com CAS e recalcula o cabeçalho antes de disparar (ordem no mesmo log); só-quantidade; sem edição; preço 0 bloqueia; CAS não casa → rejeita e nada dispara.
- RED observado antes do GREEN (v1 e v2) — logs no comentário; falsificação no comentário.

## Deploy

🖱️ Publish do front. Sem migration, sem edge.

## Codex (2ª opinião, gpt-5.6-sol · xhigh) — parecer CRU

<details><summary>saída íntegra do <code>scripts/codex-async.sh</code></summary>

```text
=== PARECER CODEX (modelo gpt-5.6-sol · reasoning xhigh · tentativa 1) ===
- [P1] [`PedidoRow.tsx:61`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:61) confia em `num_skus === 1`, justamente a coluna corrompida pelo bug antigo; [`PedidoRow.tsx:72`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:72) aceita várias linhas e escolhe silenciosamente a primeira. Cenário: pedido multi-SKU teve `num_skus` alterado para `1`, mas a aprovação antiga falhou; agora o operador edita só o primeiro item e [`PedidoRow.tsx:111`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:111) reduz `valor_total` ao valor dessa linha, enquanto o disparador busca e compra todos os itens em [`index.ts:840`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/functions/disparar-pedidos-aprovados/index.ts:840). É preciso provar cardinalidade real, não confiar no cabeçalho legado.

- [P1] [`PedidoRow.tsx:99`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:99) simplesmente pula o ajuste quando o item ainda está carregando ou falhou, mas o botão de aprovação continua habilitado em [`PedidoRow.tsx:271`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:271). O operador pode clicar enquanto vê “—”/campo desabilitado e o sistema dispara a quantidade original, não exibida nem confirmada. O teste inclusive cristaliza esse fail-open em [`PedidoRow.qtd-item.test.tsx:159`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx:159).

- [P1] O editor inline tem TOCTOU sem CAS: mantém o item fresco por 30 segundos em [`PedidoRow.tsx:63`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:63), depois atualiza apenas por `id` em [`PedidoRow.tsx:105`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:105), sem comparar `qtde_final`, versão ou status. Cenário: A vê 40; B reduz para 20; A, ainda vendo 40, digita 35 e aprova: sobrescreve 20 e compra 35. Se B já tiver disparado, A ainda pode corromper retrospectivamente item e cabeçalho, pois a policy de UPDATE só verifica permissão do usuário, não status do pedido, em [`20260723140000_authz_pedido_compra_item_cap_compras.sql:77`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/migrations/20260723140000_authz_pedido_compra_item_cap_compras.sql:77).

- [P1] A correção de preço introduz o mesmo lost-update na quantidade: numa edição somente de preço, [`useDetalhesModal.ts:159`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/useDetalhesModal.ts:159) usa o item carregado anteriormente, e [`preco-edit.ts:63`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/preco-edit.ts:63) sempre recompõe `qtde_final`, incluída no UPDATE em [`preco-edit.ts:69`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/preco-edit.ts:69). Cenário: modal A carregou quantidade 10; aba B reduziu para 5; A informa apenas o preço faltante e aprova: grava novamente quantidade 10 e dispara 10. Preço-only não deveria reescrever quantidade sem CAS.

- [P1] O campo não representa necessariamente o quantum físico comprado. Ele guarda o número digitado cru em [`PedidoRow.tsx:249`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:249), mas `montarUpdateItem` aplica `ceil` em [`preco-edit.ts:63`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/preco-edit.ts:63): digitar e aprovar `35,1` exibe 35,1 e grava/compra 36. Pior, a query nem carrega `fator_embalagem_portal`; com fator 0,2, digitar 37 L vira `ceil(37×0,2)=8` baldes em [`enviar-pedido-portal-sayerlack/index.ts:1945`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/functions/enviar-pedido-portal-sayerlack/index.ts:1945), e o banco é normalizado para 40 L em [`enviar-pedido-portal-sayerlack/index.ts:1963`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/functions/enviar-pedido-portal-sayerlack/index.ts:1963). Continua existindo exatamente “compra maior que a quantidade aprovada”.

- [P2] Há N+1 real e sem paginação: [`CicloHojePanel.tsx:113`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/CicloHojePanel.tsx:113) monta todas as linhas do dia, e cada pedido classificado como 1 SKU abre seu próprio GET em [`PedidoRow.tsx:62`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/cicloHoje/PedidoRow.tsx:62). Com 100 pedidos, a distribuição informada produz cerca de 36 round-trips simultâneos, além da consulta do cabeçalho. Dá para fazer uma única consulta `.in('pedido_id', ids)` no `CicloHojePanel` e passar o mapa às linhas, sem tocar `useReposicaoSessao`.

- [P2] O teste de ordem não testa ordem. [`useDetalhesModal.aprovar-preco.test.tsx:90`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx:90) afirma “antes de disparar”, mas a asserção seguinte só verifica que algum UPDATE existe; o disparo não participa do mesmo log de eventos. Uma regressão que disparasse antes e salvasse depois poderia continuar verde.

- [P2] O principal teste de preço usa um caminho que a UI proíbe: a fixture começa com `preco_unitario: 20` em [`useDetalhesModal.aprovar-preco.test.tsx:25`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/__tests__/useDetalhesModal.aprovar-preco.test.tsx:25), mas preço positivo é read-only por [`preco-edit.ts:23`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/preco-edit.ts:23). O teste chama o handler diretamente e não prova o fluxo real “primeira compra com preço nulo/zero → digitar → aprovar”. Também faltam casos de cardinalidade divergente, clique durante loading, concorrência e fator de embalagem.

## CONCEDO

- Para um pedido comprovadamente unitário e sem corrida, `valor_total = valor_linha` está alinhado ao motor atual, que usa `SUM(qtde_final × preco_unitario)` em [`20260904232555_reposicao_qtde_multiplo_embalagem_portal.sql:495`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/migrations/20260904232555_reposicao_qtde_multiplo_embalagem_portal.sql:495), e ao `recalcularPedido` em [`useDetalhesModal.ts:273`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/useDetalhesModal.ts:273). Não encontrei frete ou desconto externo que devesse entrar nessa fórmula pré-disparo; desconto promocional já é incorporado em `preco_unitario`, e o portal posteriormente substitui o total pelo valor efetivo.

- A edição somente de preço agora é aguardada antes de `aprovarEDisparar` em [`useDetalhesModal.ts:232`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/src/components/reposicao/pedidos/useDetalhesModal.ts:232). A invalidação de cache não precisa terminar antes do disparo, porque a edge relê `preco_unitario` diretamente do banco.

- Sem edição humana, o `ceil` de inicialização é compatível com o `Math.ceil` final do Omie em [`index.ts:984`](/Users/lucassardenberg/Projetos/afiacao-claude-m03-editor-qtd-grava-itens/supabase/functions/disparar-pedidos-aprovados/index.ts:984). E o patch realmente deixou de escrever `num_skus`.

(cópia em /var/folders/cz/94l8x0rn6hqfk080j49r247r0000gn/T/codex-async.XXXXXX.G055ikY3wz)
```

</details>

**Calibração (minha, separada do parecer):** Aplicados no PR (v2): [P1] cardinalidade pelos ITENS (uma query `.in('pedido_id', ids)` no painel — resolve também o [P2] N+1), nunca por `num_skus`; [P1] aprovar FAIL-CLOSED enquanto os itens não chegam/falham/são vazios; [P1] checagem do status do cabeçalho + compare-and-set (`eq/is qtde_final` vista + `.select('id')`, 0 linhas = mudou → aborta) na gravação inline; [P1] o mesmo compare-and-set no modal (a edição só-de-preço não reescreve uma quantidade reduzida em outra aba); [P1] campo mostra o que grava: ceil a cada tecla, múltiplo da embalagem no blur (fator carregado), como o modal do #2198; [P2] a ordem é testada no MESMO log de eventos (o mock do disparo entra no log); [P2] fixture real de primeira compra (preço nulo) e casos de loading/concorrência/fator. Não aplicado: nada — todos os achados tinham reprodução concreta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
