### PR TITLE
fix(scoring): margem não fabrica receita 0 para item sem preço — mesma régua do custo no TS; a origem (edge/RPC) vira fatia própria [money-path] (M-04)

### DIFF
--- a/src/lib/scoring/__tests__/margem-sem-preco.test.ts
+++ b/src/lib/scoring/__tests__/margem-sem-preco.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { accumulateMarginFromItems } from '../margin';
+
+const costMap = new Map([['A', 10]]);
+
+describe('accumulateMarginFromItems — item SEM preço não fabrica margem negativa (M-04, ausente ≠ zero)', () => {
+  it('unit_price null/undefined/""/0/"0"/lixo/NaN → item PULADO (receita E custo) e contado em semPreco', () => {
+    for (const unit_price of [null, undefined, '', 0, '0', 'abc', NaN] as const) {
+      const r = accumulateMarginFromItems([{ product_id: 'A', quantity: 2, unit_price: unit_price as never }], costMap);
+      // era o bug: receita 0 + custo 20 = margem NEGATIVA fabricada (custo sem receita)
+      expect(r, `unit_price=${String(unit_price)}`).toEqual({ revenue: 0, cost: 0, semPreco: 1 });
+    }
+  });
+
+  it('preço negativo ou não-finito → pulado (finitude POSITIVA, a mesma régua do custo)', () => {
+    for (const unit_price of [-5, Infinity, -Infinity]) {
+      const r = accumulateMarginFromItems([{ product_id: 'A', quantity: 1, unit_price }], costMap);
+      expect(r, `unit_price=${unit_price}`).toEqual({ revenue: 0, cost: 0, semPreco: 1 });
+    }
+  });
+
+  it('mistura: só o item com preço entra; o sem preço NÃO puxa a margem para baixo', () => {
+    const r = accumulateMarginFromItems(
+      [
+        { product_id: 'A', quantity: 1, unit_price: 100 },
+        { product_id: 'A', quantity: 3, unit_price: null as never },
+      ],
+      costMap,
+    );
+    expect(r).toEqual({ revenue: 100, cost: 10, semPreco: 1 });
+  });
+
+  it('item pt-BR (a forma de produção): valor_unitario ausente idem', () => {
+    const omie = new Map([[7, 'A']]);
+    const r = accumulateMarginFromItems(
+      [
+        { omie_codigo_produto: 7, quantidade: 2, valor_unitario: 50 },
+        { omie_codigo_produto: 7, quantidade: 2 },
+      ],
+      costMap,
+      omie,
+    );
+    expect(r).toEqual({ revenue: 100, cost: 20, semPreco: 1 });
+  });
+
+  it('semPreco NÃO conta item sem custo nem sem product_id — são outras ausências, já excluídas antes', () => {
+    const r = accumulateMarginFromItems(
+      [
+        { product_id: 'SEM-CUSTO', quantity: 1, unit_price: null as never },
+        { quantity: 1, unit_price: null as never },
+      ],
+      costMap,
+    );
+    expect(r).toEqual({ revenue: 0, cost: 0, semPreco: 0 });
+  });
+
+  it('preço válido continua entrando (regressão): string numérica do jsonb inclusive', () => {
+    const r = accumulateMarginFromItems([{ product_id: 'A', quantity: '2', unit_price: '12.5' }], costMap);
+    expect(r).toEqual({ revenue: 25, cost: 20, semPreco: 0 });
+  });
+});
+
+describe('origem — o que este PR NÃO fecha (medido e documentado, não escondido)', () => {
+  // Em prod (psql-ro, 2026-09-05): 70.927 itens em sales_orders.items, 0 sem valor_unitario, 0 com 0.
+  // A ausência que chegaria aqui como 0 nasce em 3 writers (omie-vendas-sync, sync-reprocess e o canon
+  // _shared/omie-pedido.ts) e a RPC criar_pedidos_com_itens ainda faz coalesce(…,0) numa coluna NOT NULL;
+  // os leitores do jsonb (impressão, WhatsApp, orçamento) tratam número, não null. Fechar isso é uma
+  // fatia própria (migration + writers + leitores), não um `|| 0` a menos — Codex xhigh, 6 P1.
+  it('o sentinela `valor_unitario || 0` ainda existe na edge de sync (vigia: se sumir, a fatia de origem entrou e este bloco sai)', () => {
+    const src = readFileSync('supabase/functions/omie-vendas-sync/index.ts', 'utf8');
+    expect(src).toMatch(/valor_unitario\s*\|\|\s*0/);
+  });
+});

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -196,6 +196,12 @@ function resolveProductId(
  * bruta infla silenciosamente (ausente ≠ zero, money-path). O cliente que só compra SKU
  * sem custo fica com receita/custo 0 → margem indefinida (não 100%).
  *
+ * Item sem PREÇO utilizável (ausente/0/lixo) é excluído pela MESMA régua e contado em `semPreco`,
+ * para o caller degradar a confiança. Antes (M-04) ele entrava com receita 0 e custo cheio — margem
+ * NEGATIVA fabricada, que rebaixava o health score do cliente. Espelho SQL: `get_customer_margin_summary`
+ * (`computavel` exige preço E custo — mas a RPC de ingestão ainda coalesce ausência para 0 numa coluna
+ * NOT NULL, e 0 é "computável"; fechar a ORIGEM é fatia própria: migration + writers + leitores).
+ *
  * `omieToProductId` mapeia omie_codigo_produto → UUID; sem ele, itens que só têm o código
  * Omie (a maioria absoluta em produção) são descartados.
  */
@@ -203,20 +209,26 @@ export function accumulateMarginFromItems(
   items: MarginItem[],
   costMap: Map<string, number>,
   omieToProductId?: Map<number, string>,
-): { revenue: number; cost: number } {
+): { revenue: number; cost: number; semPreco: number } {
   let revenue = 0;
   let cost = 0;
+  let semPreco = 0;
   for (const item of items) {
     const productId = resolveProductId(item, omieToProductId);
     if (!productId) continue;
     const c = costMap.get(productId);
     if (c == null) continue;
+    // Finitude POSITIVA, como o custo: ausente/0/negativo/NaN/lixo → item FORA (receita E custo).
+    const price = valorMedido(item.unit_price) ?? valorMedido(item.valor_unitario);
+    if (price === null || !(price > 0)) {
+      semPreco += 1;
+      continue;
+    }
     const qty = Number(item.quantity || item.quantidade || 1);
-    const price = Number(item.unit_price || item.valor_unitario || 0);
     revenue += price * qty;
     cost += c * qty;
   }
-  return { revenue, cost };
+  return { revenue, cost, semPreco };
 }
 
 /**


### PR DESCRIPTION
## O bug (M-04 do plano `docs/superpowers/plans/2026-09-05-plano-melhorias-codebase`, achado A3 do relatório de domínio)

`accumulateMarginFromItems` (`src/lib/scoring/margin.ts`) **pulava** item sem custo, mas incluía item sem preço com `price = … || 0`: receita 0 + custo cheio = **margem negativa fabricada**, que rebaixa o health score do cliente. Na origem, `omie-vendas-sync` gravava `valor_unitario: prod.valor_unitario || 0` no jsonb `sales_orders.items` (e `unit_price: … || 0` no payload da RPC) — a ausência chegava ao TS já como 0, então corrigir só o TS seria inerte.

## Medição (prod, `psql-ro`, 2026-09-05)

`sales_orders.items`: 70.927 itens, **todos** com `valor_unitario`, 0 ausentes, 0 com preço 0. O caminho é **latente** hoje — a correção fecha a porta antes do primeiro pedido sem preço, não conserta dano ativo.

## A correção
- **TS** (`src/lib/scoring/margin.ts`): preço com a MESMA régua do custo (finitude positiva via `valorMedido` + `> 0`); item sem preço utilizável sai da receita **e** do custo e é contado em `semPreco` (novo campo do retorno).
- **A edge NÃO entra neste PR** (recuo deliberado após o Codex, ver calibração): gravar `valor_unitario: null` no jsonb quebraria leitores voltados ao cliente e há outros writers/RPC restaurando o 0. A origem vira a fatia especificada abaixo.

## ⚠️ Pendência que só o founder decide
**Fatia "origem honesta do preço"** (decisão sua — é migration + 3 writers + leitores, não um `|| 0` a menos):
1. `order_items.unit_price` NOT NULL + `coalesce(…,0)` na RPC `criar_pedidos_com_itens` → nullable, sem coalesce; `get_customer_margin_summary` exigindo `preco_unit > 0` no `computavel`.
2. Writers: `omie-vendas-sync` (3 sites: sync, reparo, backfill de cor — este último hoje reconstrói o item a partir da leitura atual do Omie e pode apagar um preço bom), `sync-reprocess/index.ts:261`, canon `_shared/omie-pedido.ts:55,91`.
3. Leitores do jsonb que assumem número: `SalesOrderDetailSheet`, `buildPrintHtml`, `whatsappShare`, `useSalesOrders`, `SalesQuotes.fmt` (crasha em null), `useCrossSellEngine`.
Hoje o caso é latente (0 itens em 70.927). Inventário completo no parecer do Codex abaixo.

## Prova
- `margem-sem-preco.test.ts`: null/undefined/""/0/"0"/lixo/NaN/negativo/Infinity → `{0, 0, semPreco:1}` (era custo 20 com receita 0); mistura; pt-BR; `semPreco` não conta ausências de custo/product_id; regressão de preço válido. **Vigia** da origem: o sentinela `valor_unitario || 0` ainda existe na edge (quando a fatia de origem entrar, este bloco sai).
- RED observado antes do GREEN (8 falhas → verde) — log no comentário; falsificação no comentário.

## Deploy
🖱️ Publish do front. Sem migration, sem edge (a edge saiu deste PR).

## Codex (2ª opinião, gpt-5.6-sol · xhigh) — parecer CRU

<details><summary>saída íntegra do <code>scripts/codex-async.sh</code></summary>

```text
=== PARECER CODEX (modelo gpt-5.6-sol · reasoning xhigh · tentativa 1) ===
## Problemas

- [P1] A correção não alcança o health score real. `accumulateMarginFromItems` não tem caller produtivo; o próprio hook declara que a margem vem da RPC ([useFarmerScoring.ts:434](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/hooks/useFarmerScoring.ts:434)), e o motor server-side chama `get_customer_margin_summary` ([calculate-scores/index.ts:578](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/calculate-scores/index.ts:578)). O transporte `null` volta a `0` na RPC ([20260617160000_criar_pedidos_com_itens.sql:143](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql:143)), e o helper SQL considera `unit_price = 0` computável porque usa `>= 0` ([20260726160000_margem_reconciliacao_universo_unico.sql:118](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql:118)). Exemplo misto: venda de R$100/custo R$60 mais item sem preço/custo R$60 resulta em margem SQL de −20%, não 40%. O M-04 continua inteiro em produção.

- [P1] `semPreco` é telemetria morta e não “degrada a confiança”. Ele só é retornado pelo helper sem caller ([margin.ts:208](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/scoring/margin.ts:208)), enquanto a RPC projeta todo item não computável como `itens_sem_custo` ([20260726160000_margem_reconciliacao_universo_unico.sql:160](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql:160)) e `calculate-scores` persiste apenas essa cobertura ([calculate-scores/index.ts:791](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/calculate-scores/index.ts:791)). O encaixe correto é `private.margem_cliente_agregada` distinguir `sem_preco` de `sem_custo`, projetar isso por `get_customer_margin_summary` e persistir no scoring. `coberturaCustoCliente` sozinho não resolve, porque o `null` já foi apagado antes de chegar nele.

- [P1] Há outro writer ativo que restaura exatamente o sentinel combatido. `sync-reprocess` ainda monta `unit_price: prod.valor_unitario || 0` ([sync-reprocess/index.ts:261](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/sync-reprocess/index.ts:261)); o “canon” compartilhado também usa zero no subtotal e JSON ([omie-pedido.ts:55](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/_shared/omie-pedido.ts:55), [omie-pedido.ts:91](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/_shared/omie-pedido.ts:91)). A reconciliação grava esses valores em `order_items` e substitui `sales_orders.items` ([20260830190000_reconciliar_pedidos_omie.sql:306](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260830190000_reconciliar_pedidos_omie.sql:306), [20260830190000_reconciliar_pedidos_omie.sql:390](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260830190000_reconciliar_pedidos_omie.sql:390)). Um pedido inicialmente gravado com `null` volta a `0` na próxima reconciliação.

- [P1] `subtotal` e `total` continuam publicando uma soma parcial como valor definitivo. Pular a soma ([omie-vendas-sync/index.ts:1295](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:1295)) é numericamente idêntico ao comportamento anterior de somar `qty × 0`; depois esse parcial ocupa os dois campos ([omie-vendas-sync/index.ts:1375](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:1375)). Ele vira faturamento em KPIs ([team-kpis.ts:23](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/dashboard/team-kpis.ts:23), [vendas-kpi-dia.ts:27](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/dashboard/vendas-kpi-dia.ts:27)), spend/M do scoring ([useFarmerScoring.ts:420](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/hooks/useFarmerScoring.ts:420)) e receita do funil WhatsApp ([20260713030000_whatsapp_funil.sql:54](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260713030000_whatsapp_funil.sql:54)). O cabeçalho Omie nem modela um total autoritativo ([omie-vendas-sync/index.ts:110](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:110)). Precisa ser desconhecido ponta a ponta ou carregar um marcador explícito de incompletude; trocar apenas a coluna para `null` não basta, porque consumidores como `somarReceita` convertem `null` novamente em zero ([team-kpis.ts:33](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/dashboard/team-kpis.ts:33)).

- [P1] Os leitores voltados ao cliente fabricam “grátis”. O detalhe converte `null` em R$0,00 ([SalesOrderDetailSheet.tsx:29](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/components/salesOrders/SalesOrderDetailSheet.tsx:29)); a impressão faz o mesmo ([buildPrintHtml.ts:55](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/components/sales/print/buildPrintHtml.ts:55)); e o compartilhamento multiplica `quantidade * null`, que em JavaScript resulta em zero, junto de um total parcial ([whatsappShare.ts:26](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/utils/whatsappShare.ts:26), [useSalesOrders.ts:146](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/components/salesOrders/useSalesOrders.ts:146)). Cenário: o vendedor envia ao cliente um item “R$0,00” e um total menor sem qualquer aviso de preço pendente.

- [P1] O backfill de cor pode destruir um preço histórico bom. Ele reconstrói o item com `valor_unitario: null` a partir da leitura atual do Omie ([omie-vendas-sync/index.ts:2617](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:2617)) e substitui o array inteiro sem mesclar com `bfRow.items` ([omie-vendas-sync/index.ts:2644](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:2644)). Se o pedido já tinha R$100 persistido e a resposta usada somente para enriquecer a cor omite preço, o backfill apaga R$100, grava `null` e mantém o `total` antigo — snapshot internamente contraditório.

- [P2] A tela de orçamentos quebra em vez de degradar. `QuoteItem` continua prometendo `number` ([SalesQuotes.tsx:28](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/pages/SalesQuotes.tsx:28)), mas `fmt` chama `toLocaleString` diretamente ([SalesQuotes.tsx:24](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/pages/SalesQuotes.tsx:24)). Um orçamento com JSON `null` derruba a renderização em [SalesQuotes.tsx:258](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/pages/SalesQuotes.tsx:258), antes de o guard de conversão poder bloqueá-lo.

- [P2] O up-sell perde silenciosamente o SKU. O cross-sell converte `null` em preço zero ([useCrossSellEngine.ts:651](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/hooks/useCrossSellEngine.ts:651)) e depois elimina qualquer compra com preço `<= 0` ([useCrossSellEngine.ts:899](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/hooks/useCrossSellEngine.ts:899)). A identidade continua contando para associações, mas aquele produto desaparece apenas das oportunidades de upgrade, sem indicação de cobertura incompleta.

- [P2] A assimetria de quantidade permanece e é a mesma classe de fabricação. `quantity || quantidade || 1` converte ausente e zero em uma unidade; string inválida vira `NaN` e contamina receita/custo ([margin.ts:227](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/scoring/margin.ts:227)). A edge repete o default no subtotal e RPC ([omie-vendas-sync/index.ts:1297](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:1297), [omie-vendas-sync/index.ts:1358](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:1358)). Não é necessário para fechar M-04, mas precisa de follow-up medido; hoje “Omie não informou quantidade” continua significando “vendeu exatamente 1”.

- [P1] Os pinos aceitam regressões equivalentes e já ficam verdes com o segundo writer errado. Eles examinam apenas `omie-vendas-sync/index.ts`, procuram três grafias literais e exigem somente três ocorrências do helper ([margem-sem-preco.test.ts:64](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/scoring/__tests__/margem-sem-preco.test.ts:64)). `valor_unitario: price ?? 0`, um wrapper alternativo ou o `sync-reprocess` atual passam. Não há teste de integração `Omie ausente → JSON null → RPC → order_items → get_customer_margin_summary`. Os `as never` dos casos nulos ([margem-sem-preco.test.ts:8](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/scoring/__tests__/margem-sem-preco.test.ts:8)) ainda escondem que o próprio `MarginItem` não admite `null` ([margin.ts:165](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/lib/scoring/margin.ts:165)).

## O que eu CONCEDO

- O caso está latente nos dados atuais informados: não há dano ativo enquanto todos os itens têm preço positivo.
- `precoUnitarioOmie` implementa corretamente finitude positiva, e os três testes Deno passaram.
- Não encontrei CHECK, índice ou trigger sensível a `null` versus `0`: `order_items` tem apenas `NOT NULL DEFAULT 0` ([20260225231517…sql:34](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260225231517_06f06d6a-7b38-45f9-90f2-f753bff70026.sql:34)); o índice único usa pedido+SKU ([20260225232831…sql:3](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260225232831_b5de151e-6671-49d0-b5b6-1ea29bc0cbfd.sql:3)); o trigger só ajusta `created_at` ([20260624170000…sql:34](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/migrations/20260624170000_recencia_fonte_trigger_backfill.sql:34)). `sales_price_history` também é `NOT NULL`, mas o payload já omite preços desconhecidos e a RPC exige `> 0`.
- Os leitores de identidade/cor são neutros ao preço: `resolveProductIdsFromItems`/mix, repetição de pedido, bundle, histórico de cores, seleção de cliente e Customer360. O tint gate falha fechado porque o guard geral rejeita `null` antes dele ([omie-vendas-sync/index.ts:1621](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/supabase/functions/omie-vendas-sync/index.ts:1621)).
- Não há ordenação nem `valor_unitario.toFixed()` sobre esse JSON. O crash identificado é o `toLocaleString` de orçamento; os `toFixed` encontrados pertencem ao catálogo ou a `valor_total`.
- A DRE contábil não lê `sales_orders.total`; ela usa `fin_dre_competencia_base` ([financeiroV2Service.ts:578](/Users/lucassardenberg/Projetos/afiacao-claude-m04-margem-sem-preco-nao-fabrica/src/services/financeiroV2Service.ts:578)). O `fin-valor-cockpit`, porém, lê `order_items` e continuará subestimando receita com o sentinel zero.

(cópia em /var/folders/cz/94l8x0rn6hqfk080j49r247r0000gn/T/codex-async.XXXXXX.V0J1XjQk3X)
```

</details>

**Calibração (minha, separada do parecer):** Aceito o veredito e **recuei o escopo**: o PR fica só com o TS (`accumulateMarginFromItems` + `semPreco`) e a medição; **a edge saiu** (`valor_unitario: null` no jsonb quebraria leitores voltados ao cliente — R$ 0,00 na impressão/WhatsApp, `toLocaleString` de orçamento — e há outros writers restaurando o 0: `sync-reprocess` e o canon `_shared/omie-pedido.ts`; a RPC coalesce para 0 numa coluna NOT NULL, então a margem VIVA (SQL) segue fabricando quando o caso acontecer). Concordo que, sem a origem, o TS é inerte para o health score em produção — é exatamente por isso que a fatia de origem está especificada abaixo como pendência com decisão do founder (migration + 3 writers + leitores), e não como `|| 0` a menos. O ‘vigia’ no teste afirma que o sentinela ainda existe, para a fatia futura não passar despercebida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
