### PR TITLE
fix(sonda): a resposta `probe:true` SEM `edge` era lida como "nunca atestada" e mandava re-sondar quem já respondeu [money-path]

### DIFF
--- a/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
+++ b/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
@@ -201,6 +201,17 @@ houver `--ids`.
 - CLI completo contra prod: exit 1 com a classe impressa (7 respostas, 2 versões) e a ressalva na
   lista de sonda. Os 4 caminhos de `--ids` inválido: exit **2**, sem veredito fabricado.
 
+### E a correspondência posicional era mesmo só hipótese
+
+O relato da leva dizia que os 6 ids "casam posição a posição" com a lista `alvos` do PASSO 1. Duas
+medições independentes mostram que isso não se sustenta como dado: (a) a resposta do **70262** disse
+`v1.1-marco-causal`, e não a `v1.0-sensor-inicial` que o relato atribuía a todas; (b) horas depois,
+outra sessão fechou por prova que a **`omie-nfe-recebimento` JÁ está no ar** (#2217) — uma edge no ar
+com o bundle atual responde **com** `edge`, então ela dificilmente é uma das 7 sem identidade.
+
+É por isso que a atribuição é por `request_id` e falha fechada, e por que a classe existe mesmo sem
+ela: **a ordem da lista que você mandou sondar não é a ordem das respostas que voltaram.**
+
 ## 5. O que fica para depois (nomeado, não esquecido)
 
 - **Sonda automática segura**: atestação por `OPTIONS` autenticado (bundle pré-sensor devolve só

--- a/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
+++ b/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
@@ -135,6 +135,72 @@ tem `BYPASSRLS` em prod (`pg_roles`, 2026-09-05), e o default ACL já lhe dá SE
   quem roda; a coerência de `origin/main` (mapa = fonte) é garantida pelo gate `sonda:fingerprint`
   do CI, que todo commit da main passou. O instrumento lê a ref, não a árvore.
 
+## 6. A resposta que prova bundle velho e não diz de QUEM (2026-09-05, mesmo dia)
+
+O bootstrap do ledger produziu o caso na hora seguinte ao apply. O founder colou 30 sondas: **24
+responderam `{ok,probe,versao,edge,fonte}`** e viraram `CONFERE`; **6 responderam a forma ANTERIOR a
+2026-08-28** — `{"ok":true,"probe":true,"versao":"v1.0-sensor-inicial"}`, sem `edge` e sem `fonte`.
+
+`deploy_atestacoes_janela_viva()` exige `edge` string. É o predicado que impede corpo de terceiro de
+virar veredito (§2) — e é exatamente o que torna essas 6 **invisíveis**: não entram no ledger, não
+entram na janela, e o relatório as classificava como `⚪ NUNCA atestada — precisa da 1ª sonda`. O
+founder sondaria de novo e receberia **a mesma resposta**. Um laço em que a prova mais forte de
+deploy pendente se disfarça de ausência de dado.
+
+**A leitura certa: eco sem `edge` não é silêncio, é FORMA.** O commit `069540905` (#2079, 28/08) pôs
+`edge`+`fonte` no eco, em `_shared/sonda-versao.ts` — que está no closure de TODA edge instrumentada.
+Logo, quem responde sem os dois campos serve bundle pré-28/08, e o `fonte` servido diverge do da main
+**com certeza**, sem precisar ser observado. É `DEPLOY PENDENTE` por closure: P2, ou P1 se o `VERSAO`
+da main já for outro.
+
+### O que entrou
+
+- **2ª leitura** (`SQL_SEM_IDENTIDADE`, no CLI): sobre `net._http_response` direto — 200 + `probe`
+  booleano true + `NOT (c ? 'edge')` —, com os mesmos guards da janela viva (`LIKE` textual e cast
+  dentro de `CASE`). Não escreve nada; roda no mesmo `psql-ro`. Produz a classe
+  **`SONDA_SEM_IDENTIDADE`**: contagem, `versao` respondido, `request_id`s e a contra-instrução
+  **"NÃO RE-SONDE"**. E a lista `→ sonda` ganhou a ressalva, para as duas instruções não se
+  contradizerem na mesma tela.
+- **Atribuição OPCIONAL por `request_id`** (`--ids='<json do PASSO 1>'`): casa id→edge e reclassifica
+  em P1/P2 pelo `versao` contra `origin/main`. Fail-closed em JSON inválido, não-objeto, `{}`, valor
+  que não é inteiro positivo, **id repetido** e **edge fora do mapa** — atribuição errada põe o nome
+  de uma edge num veredito que pertence a outra.
+- **Nunca por posição.** É a §7 de [`verificar-sonda-versao.md`](verificar-sonda-versao.md) na veia:
+  `v1.0-sensor-inicial` é a `VERSAO` de 13 edges da main, duas respostas de edges diferentes são
+  idênticas byte a byte, e nem URL, nem fila, nem headers, nem `created` desempatam. O `request_id`
+  do PASSO 1 é a única identidade forte. Sem `--ids`, o relatório dá a contagem — **jamais a edge**.
+- **A atribuída sai da fila de sonda** e vira veredito; a não atribuída **continua pendência**
+  (exit 1) mesmo com `PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1`: a válvula tolera ausência de dado, e
+  isto é prova positiva.
+
+### Por que elas NÃO entram no ledger com `edge = 'desconhecida'` (perguntado, e a resposta é não)
+
+1. O `DISTINCT ON (edge)` do CLI passaria a ver uma edge chamada `desconhecida`, que a main não
+   mapeia ⇒ `🟠 FORA_DO_MAPA` urgente: uma edge **inventada** no relatório de deploy. O slug casa o
+   regex `^[a-z0-9-]{1,80}$` da janela viva e o `NOT NULL` do ledger — **nada no banco a barraria**.
+   A defesa tem de ser não escrever.
+2. O ledger é **eterno** e a janela do pg_net dura 6h: a chance de atribuir a resposta morre com a
+   janela, e ficaria para sempre uma linha que ninguém consegue reinterpretar. Ruído permanente.
+3. `pendencias:deploy` lê pelo `psql-ro`. Gravar exigiria o founder colar SQL — custo humano por um
+   dado que não conclui nada.
+
+A prova não se perde: ela vira **classe** no relatório, e veredito **por edge** quando (e só quando)
+houver `--ids`.
+
+### Evidência
+
+- `bun run test` — 75 casos no arquivo (18 novos): parse da 2ª leitura, os 6 fail-closed do `--ids`,
+  atribuição por id (e a recusa de atribuir sem ele), P1×P2, escalada, marcas do SQL como texto, e o
+  gate de que o CÓDIGO do CLI (sem comentários, pelo stripper compartilhado) não tem `INSERT INTO`
+  nem `desconhecida`.
+- **Prod, 2026-09-05 ~01:40Z** (`psql-ro`, SQL importado do CLI, não copiado): a 2ª leitura devolveu
+  **7** linhas — os 6 ids de 23:35Z (70261, 70262, 70267, 70271, 70281, 70282) e um sétimo às 23:38Z
+  (70287). E **corrigiu o relato**: a resposta do 70262 disse `v1.1-marco-causal`, não
+  `v1.0-sensor-inicial` — ou seja, a atribuição a mudaria de P1 para P2. Medir a leva inteira valeu
+  mais que herdar a suposição.
+- CLI completo contra prod: exit 1 com a classe impressa (7 respostas, 2 versões) e a ressalva na
+  lista de sonda. Os 4 caminhos de `--ids` inválido: exit **2**, sem veredito fabricado.
+
 ## 5. O que fica para depois (nomeado, não esquecido)
 
 - **Sonda automática segura**: atestação por `OPTIONS` autenticado (bundle pré-sensor devolve só

--- a/scripts/lib/pendencias-deploy.ts
+++ b/scripts/lib/pendencias-deploy.ts
@@ -135,6 +135,20 @@ export const SEM_MAPA = 'nao-mapeada';
 /** O que o coletor grava quando o eco não traz `fonte` — ausente ≠ zero, então tem nome. */
 export const SEM_FONTE = 'sem-campo';
 
+/**
+ * O `fonte` de uma sonda que respondeu SEM dizer quem é — atribuída depois, pelo `request_id`.
+ *
+ * Não é `fonte` observado: é a marca de que o bundle NÃO emite `edge`/`fonte`, e portanto é anterior
+ * ao commit 069540905 (2026-08-28, #2079), que pôs os dois campos no eco. Como
+ * `_shared/sonda-versao.ts` está no closure de toda edge instrumentada, o `fonte` servido por esse
+ * bundle diverge do da main com CERTEZA — a divergência é DEDUZIDA do formato da resposta, não
+ * medida. Por isso o ramo dela em `julgar` não consulta `parCoerente`: não há par a casar.
+ */
+export const SEM_IDENTIDADE = 'sem-eco-de-identidade';
+
+/** A data em que `edge`+`fonte` entraram no eco (commit 069540905, #2079) — citada no relatório. */
+export const DATA_ECO_COM_IDENTIDADE = '2026-08-28';
+
 /** P2 mais velha que isto vira urgente: a leva agrupada tem prazo. */
 export const ESCALAR_P2_APOS_DIAS = 7;
 
@@ -238,6 +252,15 @@ export function julgar(
       estado = 'SEM_MAPA_NO_BUNDLE';
     } else if (obs.fonte === SEM_FONTE) {
       estado = 'SEM_FONTE_NO_ECO';
+    } else if (obs.fonte === SEM_IDENTIDADE) {
+      // Sonda ANTIGA atribuída por request_id (armadilha 6). O bundle não emite `edge`, logo é
+      // anterior a 2026-08-28 e o closure JÁ divergiu — nunca CONFERE, nunca "sonde-a". Só o
+      // `versao` decide a fila: bumpado = P1 (mudança declarada), igual = P2 (fan-out de
+      // `_shared/`). `parCoerente` não entra: sem `fonte` observado não existe par para casar, e
+      // consultá-lo devolveria `false` (o sentinela nunca esteve no mapa) ⇒ INCOERENTE fabricado.
+      estado = obs.versao === esp.versao ? 'DIVERGE_P2' : 'DIVERGE_P1';
+      diasPendente = contexto.diasPendente(edge, esp.fonte);
+      escalada = estado === 'DIVERGE_P2' && diasPendente !== null && diasPendente > ESCALAR_P2_APOS_DIAS;
     } else if (obs.fonte === esp.fonte) {
       estado = obs.versao === esp.versao ? 'CONFERE' : 'INCOERENTE';
     } else if (obs.versao !== esp.versao) {
@@ -329,4 +352,191 @@ export function lerTolerancia(bruto: string | undefined): boolean {
   throw new Error(
     `PENDENCIAS_TOLERAR_NUNCA_ATESTADA inválido: ${JSON.stringify(bruto)}. Use 1 ou 0.`,
   );
+}
+
+/**
+ * ARMADILHA 6 — a resposta que prova bundle velho e não diz de QUEM.
+ * ============================================================================================
+ *
+ * Medido no bootstrap do ledger (2026-09-05 23:35Z): das 30 sondas coladas pelo founder, 24
+ * responderam `{ok,probe,versao,edge,fonte}` e viraram CONFERE; 6 responderam a forma ANTERIOR a
+ * 2026-08-28 — `{"ok":true,"probe":true,"versao":"v1.0-sensor-inicial"}` —, sem `edge` e sem
+ * `fonte`. `deploy_atestacoes_janela_viva()` exige `edge` string, então essas 6 nem entram no
+ * ledger: o relatório as classificava como `NUNCA_ATESTADA` e mandava "precisa da 1ª sonda". O
+ * founder sondava de novo e recebia a MESMA resposta — um laço em que a prova mais forte de deploy
+ * pendente se disfarçava de ausência de dado.
+ *
+ * A leitura certa: eco sem `edge` não é silêncio, é FORMA. O `_shared/sonda-versao.ts` que passou a
+ * emitir `edge`+`fonte` (069540905) está no closure de toda edge instrumentada ⇒ quem responde sem
+ * eles serve bundle pré-28/08 ⇒ o `fonte` diverge do da main sem precisar ser observado.
+ *
+ * O QUE ISSO **NÃO** AUTORIZA: dizer QUAL edge respondeu. É a §7 de `verificar-sonda-versao.md` na
+ * veia — `v1.0-sensor-inicial` é a `VERSAO` de 13 edges da main, e duas respostas de edges
+ * diferentes são idênticas byte a byte; `net._http_response` não tem URL, a fila é esvaziada ao
+ * processar, os headers são só Cloudflare e o `created` é o ciclo do worker do pg_net. A ÚNICA
+ * identidade forte é o `request_id` que o PASSO 1 do `sonda:sql` devolve — por isso a atribuição é
+ * opcional, explícita e por id. Casar por ORDEM (a i-ésima resposta = a i-ésima edge da lista)
+ * seria fabricar: as respostas chegam fora de ordem e nem toda edge da leva responde.
+ */
+
+/** Uma resposta `probe:true` da janela que não diz de quem é. `versao` é tudo que ela carrega. */
+export interface SondaSemIdentidade {
+  requestId: number;
+  versao: string;
+  criado: string;
+  idadeHoras: number;
+}
+
+const CAMPOS_SEM_IDENTIDADE = 4;
+
+/**
+ * Faz o parse da 2ª leitura: `request_id|versao|criado|idade_horas`.
+ *
+ * Mesma disciplina de `parsearObservacoes`: linha fora do formato é CONTADA (o CLI a trata como
+ * mecânica, exit 2). O `request_id` tem de ser inteiro positivo — é `net._http_response.id`, e um
+ * id fracionário ou negativo significa que a saída não é a que este parse acha que é.
+ */
+export function parsearSondasSemIdentidade(saida: string): {
+  sondas: SondaSemIdentidade[];
+  linhasIgnoradas: number;
+} {
+  const sondas: SondaSemIdentidade[] = [];
+  let linhasIgnoradas = 0;
+
+  for (const bruta of saida.split('\n')) {
+    const linha = bruta.trim();
+    if (linha === '' || CHATTER.has(linha)) continue;
+
+    const campos = linha.split('|').map((c) => c.trim());
+    if (campos.length !== CAMPOS_SEM_IDENTIDADE || campos.some((c) => c === '')) {
+      linhasIgnoradas += 1;
+      continue;
+    }
+
+    const [idBruto, versao, criado, idadeBruta] = campos;
+    const requestId = Number(idBruto);
+    const idadeHoras = Number(idadeBruta);
+    if (
+      !Number.isInteger(requestId) ||
+      requestId <= 0 ||
+      !Number.isFinite(idadeHoras) ||
+      idadeHoras < 0
+    ) {
+      linhasIgnoradas += 1;
+      continue;
+    }
+    sondas.push({ requestId, versao, criado, idadeHoras });
+  }
+
+  return { sondas, linhasIgnoradas };
+}
+
+/**
+ * Lê o `--ids` — o JSON `{"edge": request_id, …}` que o PASSO 1 do `sonda:sql` devolve — ou LANÇA.
+ *
+ * FAIL-CLOSED em tudo, porque atribuição errada é pior que atribuição nenhuma: ela põe o nome de
+ * uma edge num veredito de deploy que pertence a outra.
+ *
+ *   · id repetido em duas edges — um `request_id` teve UMA resposta; o mapa está errado, e escolher
+ *     uma das duas seria a mesma fabricação que casar por ordem.
+ *   · edge fora do mapa da main — sem `esperado` não há `versao` para comparar, e engolir a entrada
+ *     descartaria em silêncio a resposta que ela identificava.
+ *   · objeto vazio — `--ids={}` é colagem que não atribui nada. Aceitar em silêncio devolveria o
+ *     mesmo relatório de quem não passou a flag, ensinando que a flag "não funcionou".
+ */
+export function parsearIds(bruto: string, esperados: Record<string, Esperado>): Map<number, string> {
+  let cru: unknown;
+  try {
+    cru = JSON.parse(bruto);
+  } catch (e) {
+    throw new Error(
+      `--ids não é JSON: ${(e as Error).message}. Cole o valor de \`ids_opcionais_passo_1\` do \`bun run sonda:sql\`.`,
+    );
+  }
+  if (cru === null || typeof cru !== 'object' || Array.isArray(cru)) {
+    throw new Error('--ids precisa ser um objeto JSON {"edge": request_id, …}, como o PASSO 1 devolve.');
+  }
+
+  const entradas = Object.entries(cru as Record<string, unknown>);
+  if (entradas.length === 0) {
+    throw new Error('--ids veio VAZIO ({}). Sem par edge→request_id não há o que atribuir; omita a flag.');
+  }
+
+  const porId = new Map<number, string>();
+  const foraDoMapa: string[] = [];
+  for (const [edge, valor] of entradas) {
+    if (!(edge in esperados)) {
+      foraDoMapa.push(edge);
+      continue;
+    }
+    if (typeof valor !== 'number' || !Number.isInteger(valor) || valor <= 0) {
+      throw new Error(
+        `--ids: request_id inválido para "${edge}": ${JSON.stringify(valor)}. Esperado inteiro positivo (net._http_response.id).`,
+      );
+    }
+    const jaTem = porId.get(valor);
+    if (jaTem !== undefined) {
+      throw new Error(
+        `--ids: request_id ${valor} aparece em "${jaTem}" E em "${edge}" — um request_id teve UMA resposta. Recole o JSON do PASSO 1.`,
+      );
+    }
+    porId.set(valor, edge);
+  }
+  if (foraDoMapa.length > 0) {
+    throw new Error(
+      `--ids: edge(s) que a main não mapeia: ${foraDoMapa.sort().join(', ')}. ` +
+        'Sem esperado não há veredito — confira o mapa (`bun run sonda:fingerprint`) ou o JSON colado.',
+    );
+  }
+  return porId;
+}
+
+/**
+ * Casa cada resposta sem identidade com a edge do `--ids`, POR request_id.
+ *
+ * O que não casa volta em `naoAtribuidas` — e continua contando como sinal (há bundle velho no ar),
+ * só não vira veredito por edge. Nunca por posição: `[70261, 70262]` não é "a 1ª e a 2ª da lista".
+ */
+export function atribuirSondasSemIdentidade(
+  sondas: SondaSemIdentidade[],
+  idParaEdge: Map<number, string>,
+): { observacoes: Observacao[]; naoAtribuidas: SondaSemIdentidade[] } {
+  const observacoes: Observacao[] = [];
+  const naoAtribuidas: SondaSemIdentidade[] = [];
+
+  for (const s of sondas) {
+    const edge = idParaEdge.get(s.requestId);
+    if (edge === undefined) {
+      naoAtribuidas.push(s);
+      continue;
+    }
+    observacoes.push({
+      edge,
+      versao: s.versao,
+      fonte: SEM_IDENTIDADE,
+      via: 'sonda',
+      criado: s.criado,
+      idadeHoras: s.idadeHoras,
+    });
+  }
+
+  return { observacoes, naoAtribuidas };
+}
+
+/** O que dá para dizer SEM `--ids`: quantas, que `versao` responderam e quais request_ids. */
+export function resumirSemIdentidade(naoAtribuidas: SondaSemIdentidade[]): {
+  total: number;
+  porVersao: { versao: string; n: number }[];
+  requestIds: number[];
+} {
+  const contagem = new Map<string, number>();
+  for (const s of naoAtribuidas) contagem.set(s.versao, (contagem.get(s.versao) ?? 0) + 1);
+  return {
+    total: naoAtribuidas.length,
+    // Mais frequente primeiro; empate pelo nome, para a saída não depender da ordem de chegada.
+    porVersao: [...contagem.entries()]
+      .map(([versao, n]) => ({ versao, n }))
+      .sort((a, b) => b.n - a.n || a.versao.localeCompare(b.versao)),
+    requestIds: naoAtribuidas.map((s) => s.requestId).sort((a, b) => a - b),
+  };
 }

--- a/scripts/lib/pendencias-deploy.ts
+++ b/scripts/lib/pendencias-deploy.ts
@@ -329,6 +329,26 @@ export function julgar(
   };
 }
 
+/**
+ * O exit do CLI: 0 só quando nada pende.
+ *
+ * `tolerarNunca` é a válvula do bootstrap — ela desconta `NUNCA_ATESTADA`, que é AUSÊNCIA de dado.
+ * Resposta `probe:true` sem `edge` é o oposto: prova POSITIVA de bundle pré-2026-08-28 no ar.
+ * Descontá-la junto devolveria exit 0 com o deploy pendente impresso na tela — e um cron que sai 0
+ * ensina o operador a ler silêncio como aprovação, que é o hábito que esta varredura desfaz.
+ */
+export function decidirExit(entrada: {
+  totalPendentes: number;
+  nuncaAtestadas: number;
+  tolerarNunca: boolean;
+  semIdentidade: number;
+}): number {
+  const pendentes = entrada.tolerarNunca
+    ? entrada.totalPendentes - entrada.nuncaAtestadas
+    : entrada.totalPendentes;
+  return pendentes > 0 || entrada.semIdentidade > 0 ? 1 : 0;
+}
+
 /** As edges que precisam de SONDA humana: nunca atestadas, ou cujo eco não traz `fonte`. */
 export function edgesParaSondar(rel: Relatorio): string[] {
   return rel.vereditos

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -8,6 +8,7 @@ import { removerComentarios } from '@/lib/gates/limpeza-fonte';
 import {
   atribuirSondasSemIdentidade,
   DATA_ECO_COM_IDENTIDADE,
+  decidirExit,
   edgesParaSondar,
   ESCALAR_P2_APOS_DIAS,
   julgar,
@@ -725,5 +726,32 @@ describe('o ledger não recebe edge fictícia — o CLI é read-only por constru
   it('nenhuma escrita no ledger, e nenhuma edge fictícia no CÓDIGO', () => {
     expect(codigo).not.toContain('INSERT INTO');
     expect(codigo).not.toContain('desconhecida');
+  });
+});
+
+/**
+ * O EXIT: a válvula do bootstrap tolera AUSÊNCIA de dado, não prova positiva.
+ *
+ * `PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1` existe para a primeira leva, quando nada foi sondado ainda —
+ * ela desconta `NUNCA_ATESTADA`, que é ausência de dado. Resposta `probe:true` sem `edge` é o
+ * oposto: prova POSITIVA de que um bundle pré-2026-08-28 está no ar. Descontá-la junto devolveria
+ * exit 0 com deploy pendente medido na tela.
+ */
+describe('decidirExit', () => {
+  it('nada pendente e nenhuma resposta sem identidade → 0', () => {
+    expect(decidirExit({ totalPendentes: 0, nuncaAtestadas: 0, tolerarNunca: false, semIdentidade: 0 })).toBe(0);
+  });
+
+  it('pendência → 1', () => {
+    expect(decidirExit({ totalPendentes: 3, nuncaAtestadas: 0, tolerarNunca: false, semIdentidade: 0 })).toBe(1);
+  });
+
+  it('a válvula desconta as NUNCA_ATESTADA — é para isso que ela existe', () => {
+    expect(decidirExit({ totalPendentes: 2, nuncaAtestadas: 2, tolerarNunca: true, semIdentidade: 0 })).toBe(0);
+    expect(decidirExit({ totalPendentes: 2, nuncaAtestadas: 2, tolerarNunca: false, semIdentidade: 0 })).toBe(1);
+  });
+
+  it('mas NÃO desconta a resposta sem identidade: exit 1 com a válvula LIGADA', () => {
+    expect(decidirExit({ totalPendentes: 2, nuncaAtestadas: 2, tolerarNunca: true, semIdentidade: 6 })).toBe(1);
   });
 });

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -3,20 +3,37 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+
 import {
+  atribuirSondasSemIdentidade,
+  DATA_ECO_COM_IDENTIDADE,
   edgesParaSondar,
   ESCALAR_P2_APOS_DIAS,
   julgar,
   lerTolerancia,
   LIMITE_FORA_DO_MAPA_HORAS,
+  parsearIds,
   parsearObservacoes,
+  parsearSondasSemIdentidade,
+  resumirSemIdentidade,
   SEM_FONTE,
+  SEM_IDENTIDADE,
   SEM_MAPA,
   type Contexto,
   type Esperado,
   type Observacao,
+  type SondaSemIdentidade,
 } from './lib/pendencias-deploy';
-import { CRON_COLETOR, MIGRATION_LEDGER, SQL, SQL_SAUDE_COLETOR } from './pendencias-deploy';
+import {
+  CRON_COLETOR,
+  formatarSemIdentidade,
+  lerArgIds,
+  MIGRATION_LEDGER,
+  SQL,
+  SQL_SAUDE_COLETOR,
+  SQL_SEM_IDENTIDADE,
+} from './pendencias-deploy';
 
 const ESPERADOS: Record<string, Esperado> = {
   'edge-a': { fonte: 'aaa111', versao: 'v1.0-a' },
@@ -328,5 +345,385 @@ describe('a MIGRATION do ledger — as marcas que o coletor não pode perder', (
 
   it('o cron do coletor tem nome fixo e passa de 15 em 15 min', () => {
     expect(semEspacos).toContain(`'${CRON_COLETOR}', '*/15 * * * *'`);
+  });
+});
+
+/**
+ * A CLASSE `SONDA_SEM_IDENTIDADE` — a resposta que prova bundle velho e não diz de QUEM.
+ *
+ * Caso medido (2026-09-05 23:35Z, bootstrap do ledger): das 30 sondas do founder, 24 responderam
+ * `{ok,probe,versao,edge,fonte}` e viraram CONFERE; 6 responderam a forma ANTERIOR a 2026-08-28
+ * (`{"ok":true,"probe":true,"versao":"v1.0-sensor-inicial"}`), sem `edge` e sem `fonte`. A janela
+ * viva exige `edge` string, então essas 6 ficaram INVISÍVEIS e o relatório disse "NUNCA atestada —
+ * precisa da 1ª sonda": o veredito mandava sondar de novo justamente as que já tinham respondido.
+ *
+ * A resposta sem `edge` não é ausência de dado — é PROVA POSITIVA de bundle anterior ao commit que
+ * pôs `edge`+`fonte` no eco (069540905, 2026-08-28). O `_shared/sonda-versao.ts` está no closure de
+ * toda edge instrumentada ⇒ o `fonte` servido diverge do da main com CERTEZA, sem precisar observá-lo.
+ */
+describe('SONDA_SEM_IDENTIDADE — parse da 2ª leitura', () => {
+  it('parseia `request_id|versao|criado|idade_horas` e ignora o SET do wrapper', () => {
+    const { sondas, linhasIgnoradas } = parsearSondasSemIdentidade(
+      'SET\n70261|v1.0-sensor-inicial|2026-09-05 23:35Z|1.5\n',
+    );
+    expect(sondas).toEqual([
+      { requestId: 70261, versao: 'v1.0-sensor-inicial', criado: '2026-09-05 23:35Z', idadeHoras: 1.5 },
+    ]);
+    expect(linhasIgnoradas).toBe(0);
+  });
+
+  it('CONTA a linha malformada — a descartada pode ser a prova de bundle velho (CLI: exit 2)', () => {
+    const { sondas, linhasIgnoradas } = parsearSondasSemIdentidade(
+      '70261|v1.0|2026-09-05 23:35Z\n70262|v1.0|hoje|2\n',
+    );
+    expect(sondas.map((s) => s.requestId)).toEqual([70262]);
+    expect(linhasIgnoradas).toBe(1);
+  });
+
+  it('id não inteiro e idade não numérica/negativa são IGNORADAS, não interpretadas', () => {
+    const { sondas, linhasIgnoradas } = parsearSondasSemIdentidade(
+      'abc|v1.0|hoje|1\n70261|v1.0|hoje|xyz\n70262|v1.0|hoje|-1\n70263.5|v1.0|hoje|1\n',
+    );
+    expect(sondas).toHaveLength(0);
+    expect(linhasIgnoradas).toBe(4);
+  });
+});
+
+describe('parsearIds — a atribuição por request_id é OPCIONAL e FAIL-CLOSED', () => {
+  it('casa o JSON que o PASSO 1 do `sonda:sql` devolve: id → edge', () => {
+    const m = parsearIds('{"edge-a": 70261, "edge-b": 70262}', ESPERADOS);
+    expect(m.get(70261)).toBe('edge-a');
+    expect(m.get(70262)).toBe('edge-b');
+    expect(m.size).toBe(2);
+  });
+
+  it('JSON inválido LANÇA — atribuição indeterminável não vira atribuição parcial', () => {
+    expect(() => parsearIds('{edge-a: 70261', ESPERADOS)).toThrow(/--ids/);
+  });
+
+  it('o que não é OBJETO de topo LANÇA (array, número, null)', () => {
+    for (const ruim of ['[70261]', '70261', 'null', '"edge-a"']) {
+      expect(() => parsearIds(ruim, ESPERADOS)).toThrow(/objeto/i);
+    }
+  });
+
+  it('valor que não é inteiro positivo LANÇA nomeando a edge — request_id é bigint do pg_net', () => {
+    for (const ruim of ['{"edge-a": "70261"}', '{"edge-a": 0}', '{"edge-a": -1}', '{"edge-a": 1.5}', '{"edge-a": null}']) {
+      expect(() => parsearIds(ruim, ESPERADOS)).toThrow(/edge-a/);
+    }
+  });
+
+  it('id REPETIDO entre duas edges LANÇA nomeando as duas — um request_id teve UMA resposta', () => {
+    expect(() => parsearIds('{"edge-a": 70261, "edge-b": 70261}', ESPERADOS)).toThrow(/70261/);
+    expect(() => parsearIds('{"edge-a": 70261, "edge-b": 70261}', ESPERADOS)).toThrow(/edge-a.*edge-b|edge-b.*edge-a/);
+  });
+
+  it('edge FORA do mapa da main LANÇA — sem esperado não há veredito, e ignorar perderia a resposta', () => {
+    expect(() => parsearIds('{"edge-a": 70261, "fantasma": 70262}', ESPERADOS)).toThrow(/fantasma/);
+  });
+
+  it('objeto VAZIO LANÇA — `--ids={}` é colagem que não atribui nada, não "sem ids"', () => {
+    expect(() => parsearIds('{}', ESPERADOS)).toThrow(/--ids/);
+  });
+});
+
+describe('atribuirSondasSemIdentidade — por request_id, NUNCA por posição', () => {
+  const SONDAS: SondaSemIdentidade[] = [
+    { requestId: 70261, versao: 'v1.0-sensor-inicial', criado: '2026-09-05 23:35Z', idadeHoras: 1 },
+    { requestId: 70262, versao: 'v1.0-sensor-inicial', criado: '2026-09-05 23:35Z', idadeHoras: 1 },
+  ];
+
+  it('casa o id e emite Observacao com o sentinela de fonte e `via: sonda`', () => {
+    const { observacoes, naoAtribuidas } = atribuirSondasSemIdentidade(SONDAS, new Map([[70262, 'edge-b']]));
+    expect(observacoes).toEqual([
+      {
+        edge: 'edge-b',
+        versao: 'v1.0-sensor-inicial',
+        fonte: SEM_IDENTIDADE,
+        via: 'sonda',
+        criado: '2026-09-05 23:35Z',
+        idadeHoras: 1,
+      },
+    ]);
+    expect(naoAtribuidas.map((s) => s.requestId)).toEqual([70261]);
+  });
+
+  it('SEM ids, nada é atribuído — ordem/posição não é identidade (ausente ≠ zero)', () => {
+    const { observacoes, naoAtribuidas } = atribuirSondasSemIdentidade(SONDAS, new Map());
+    expect(observacoes).toEqual([]);
+    expect(naoAtribuidas).toHaveLength(2);
+  });
+
+  it('id do JSON que não casa resposta nenhuma não inventa observação (a leva tem ids das 24 que se identificaram)', () => {
+    const { observacoes } = atribuirSondasSemIdentidade(SONDAS, new Map([[99999, 'edge-a']]));
+    expect(observacoes).toEqual([]);
+  });
+});
+
+describe('julgar — a sonda sem identidade atribuída é DIVERGE, nunca CONFERE nem NUNCA_ATESTADA', () => {
+  const semId = (edge: string, versao: string): Observacao => ({
+    edge,
+    versao,
+    fonte: SEM_IDENTIDADE,
+    via: 'sonda',
+    criado: '2026-09-05 23:35Z',
+    idadeHoras: 1,
+  });
+
+  it('versao IGUAL ao da main é P2 — o closure andou (o `_shared/sonda-versao.ts` de 2026-08-28) sem bump', () => {
+    const r = julgar(ESPERADOS, [semId('edge-a', 'v1.0-a'), obs('edge-b', 'bbb222')], ctx(true, 2));
+    const a = r.vereditos.find((v) => v.edge === 'edge-a');
+    expect(a?.estado).toBe('DIVERGE_P2');
+    expect(a?.diasPendente).toBe(2);
+    expect(r.totalPendentes).toBe(1);
+    expect(r.totalUrgentes).toBe(0);
+  });
+
+  it('versao DIFERENTE é P1 — o autor bumpou, o deploy é do PR', () => {
+    const r = julgar(ESPERADOS, [semId('edge-a', 'v0.9-a'), obs('edge-b', 'bbb222')], ctx(true, 3));
+    const a = r.vereditos.find((v) => v.edge === 'edge-a');
+    expect(a?.estado).toBe('DIVERGE_P1');
+    expect(a?.observado).toBe(SEM_IDENTIDADE);
+    expect(a?.versao).toBe('v0.9-a');
+    expect(r.totalUrgentes).toBe(1);
+  });
+
+  it('NÃO chama `parCoerente` — o par nunca foi observado; a divergência do fonte é DEDUZIDA do bundle', () => {
+    const proibido: Contexto = {
+      parCoerente: () => {
+        throw new Error('parCoerente não deve ser consultado: não há `fonte` observado para casar');
+      },
+      diasPendente: () => 4,
+    };
+    expect(julgar(ESPERADOS, [semId('edge-a', 'v1.0-a'), obs('edge-b', 'bbb222')], proibido).vereditos[0].estado).toBe(
+      'DIVERGE_P2',
+    );
+  });
+
+  it('a P2 sem identidade também ESCALA depois de 7 dias — a fila é a mesma', () => {
+    const r = julgar(ESPERADOS, [semId('edge-a', 'v1.0-a'), obs('edge-b', 'bbb222')], ctx(true, ESCALAR_P2_APOS_DIAS + 1));
+    expect(r.vereditos[0].escalada).toBe(true);
+    expect(r.totalUrgentes).toBe(1);
+  });
+
+  it('SAI da lista da sonda — era o bug: "NUNCA atestada, sonde-a" mandava re-sondar quem já respondeu', () => {
+    const r = julgar(ESPERADOS, [semId('edge-a', 'v1.0-a')], ctx());
+    expect(edgesParaSondar(r)).toEqual(['edge-b']);
+    expect(r.totalObservadas).toBe(1);
+  });
+
+  /**
+   * CASO MEDIDO em prod (2026-09-05 ~01:40Z, `psql-ro`, a 2ª leitura importada do CLI): 7 respostas
+   * `probe:true` sem `edge` — ids 70261/70262/70267/70271/70281/70282 (23:35Z) e 70287 (23:38Z);
+   * seis disseram `v1.0-sensor-inicial` e a do 70262 disse `v1.1-marco-causal`.
+   *
+   * O mapa id→edge abaixo é o que o founder COLARIA do PASSO 1 — ele não é deduzido daqui, e o
+   * teste não afirma quem respondeu o quê: o que ele prende é a MECÂNICA (id casa, `versao` decide
+   * a fila, quem não casa continua sinal). O 70287 fica de fora do mapa de propósito.
+   */
+  it('CASO MEDIDO (2026-09-05): o `versao` de cada uma decide a fila, e a não atribuída sobra como sinal', () => {
+    const mainReal: Record<string, Esperado> = {
+      'conciliar-pedido-portal': { fonte: 'f1', versao: 'v1.0-sensor-inicial' },
+      'disparar-pedidos-aprovados': { fonte: 'f2', versao: 'v1.1-marco-causal' },
+      'gerar-pedidos-diario': { fonte: 'f3', versao: 'v1.0-sensor-inicial' },
+      'omie-nfe-recebimento': { fonte: 'f4', versao: 'v1.1-falha-sai-nao-2xx' },
+      'pedido-programado-enviar': { fonte: 'f5', versao: 'v1.0-sensor-inicial' },
+      'process-nfe': { fonte: 'f6', versao: 'v1.0-sensor-inicial' },
+    };
+    const medido: [number, string][] = [
+      [70261, 'v1.0-sensor-inicial'],
+      [70262, 'v1.1-marco-causal'],
+      [70267, 'v1.0-sensor-inicial'],
+      [70271, 'v1.0-sensor-inicial'],
+      [70281, 'v1.0-sensor-inicial'],
+      [70282, 'v1.0-sensor-inicial'],
+      [70287, 'v1.0-sensor-inicial'],
+    ];
+    const sondas: SondaSemIdentidade[] = medido.map(([requestId, versao]) => ({
+      requestId,
+      versao,
+      criado: '2026-09-05 23:35Z',
+      idadeHoras: 2.2,
+    }));
+    const ids = parsearIds(
+      JSON.stringify({
+        'conciliar-pedido-portal': 70261,
+        'disparar-pedidos-aprovados': 70262,
+        'gerar-pedidos-diario': 70267,
+        'omie-nfe-recebimento': 70271,
+        'pedido-programado-enviar': 70281,
+        'process-nfe': 70282,
+      }),
+      mainReal,
+    );
+    const { observacoes, naoAtribuidas } = atribuirSondasSemIdentidade(sondas, ids);
+    expect(naoAtribuidas.map((s) => s.requestId)).toEqual([70287]);
+
+    const r = julgar(mainReal, observacoes, ctx(true, 1));
+    const porEstado = (e: string) => r.vereditos.filter((v) => v.estado === e).map((v) => v.edge).sort();
+    // Só a `omie-nfe-recebimento` bumpou (a main já está em v1.1-falha-sai-nao-2xx) ⇒ P1.
+    expect(porEstado('DIVERGE_P1')).toEqual(['omie-nfe-recebimento']);
+    expect(porEstado('DIVERGE_P2')).toEqual([
+      'conciliar-pedido-portal',
+      'disparar-pedidos-aprovados',
+      'gerar-pedidos-diario',
+      'pedido-programado-enviar',
+      'process-nfe',
+    ]);
+    expect(porEstado('NUNCA_ATESTADA')).toEqual([]);
+    expect(edgesParaSondar(r)).toEqual([]);
+    expect(r.totalPendentes).toBe(6);
+    expect(r.totalUrgentes).toBe(1);
+  });
+});
+
+describe('resumirSemIdentidade — sem `--ids`, só a CONTAGEM (jamais atribuição por ordem)', () => {
+  it('agrupa por versao respondida e lista os request_ids, ordenados', () => {
+    const resumo = resumirSemIdentidade([
+      { requestId: 70282, versao: 'v1.0-sensor-inicial', criado: 'x', idadeHoras: 1 },
+      { requestId: 70261, versao: 'v1.0-sensor-inicial', criado: 'x', idadeHoras: 1 },
+      { requestId: 70271, versao: 'v0.9-antiga', criado: 'x', idadeHoras: 2 },
+    ]);
+    expect(resumo.total).toBe(3);
+    expect(resumo.porVersao).toEqual([
+      { versao: 'v1.0-sensor-inicial', n: 2 },
+      { versao: 'v0.9-antiga', n: 1 },
+    ]);
+    expect(resumo.requestIds).toEqual([70261, 70271, 70282]);
+  });
+});
+
+/**
+ * A 2ª LEITURA — as respostas que a janela viva não pode enxergar, por construção.
+ *
+ * `deploy_atestacoes_janela_viva()` exige `edge` string: é o que impede corpo alheio de virar
+ * veredito, e é o que torna a sonda pré-28/08 invisível. Consertar isso AFROUXANDO a janela seria
+ * deixar entrar no LEDGER linha sem edge — e o ledger é eterno. Então a correção é uma segunda
+ * consulta, barata, que não escreve nada e cujo produto é uma CLASSE, não uma linha de ledger.
+ */
+describe('SQL_SEM_IDENTIDADE — a 2ª leitura, direto em net._http_response', () => {
+  const s = SQL_SEM_IDENTIDADE.replace(/\s+/g, ' ');
+
+  it('lê net._http_response — a janela viva exige `edge` e por definição não devolve estas linhas', () => {
+    expect(s).toContain('FROM net._http_response');
+    expect(s).toContain('status_code = 200');
+    expect(s).not.toContain('deploy_atestacoes_janela_viva');
+    expect(s).not.toContain('public.deploy_atestacoes');
+  });
+
+  it('é a sonda ATIVA (probe booleano true), não eco: sem o probe, corpo alheio sem `edge` entraria', () => {
+    expect(s).toContain("(r.c -> 'probe') = to_jsonb(true)");
+    expect(s).not.toContain("'probe') = 'true'");
+  });
+
+  it('exige a AUSÊNCIA de `edge` com `NOT (c ? …)` — desigualdade é NULL-blind e devolveria vazio', () => {
+    expect(s).toContain("NOT (r.c ? 'edge')");
+    expect(s).not.toContain("(r.c -> 'edge') <>");
+    expect(s).not.toContain("'edge') IS NULL");
+  });
+
+  it('o cast vive num CASE, com o guard textual antes — corpo truncado não aborta a varredura', () => {
+    expect(s).toContain('CASE WHEN content IS JSON OBJECT THEN content::jsonb END');
+    expect(s).toContain("left(ltrim(content), 1) = '{'");
+    expect(s).toContain('LIKE \'%"probe"%\'');
+  });
+
+  it('exige `versao` string — `probe:true` sem versao é forma que este repo nunca emitiu', () => {
+    expect(s).toContain("jsonb_typeof(r.c -> 'versao') = 'string'");
+  });
+
+  it('ordem estável (created não é ordem total: 64031/64032 empatam ao microssegundo)', () => {
+    expect(s).toContain('ORDER BY r.created DESC, r.id DESC');
+  });
+
+  it('NÃO grava: a 2ª leitura roda no psql-ro e o ledger exige edge REAL', () => {
+    expect(s).not.toContain('INSERT');
+    expect(s).not.toContain('UPDATE');
+  });
+});
+
+describe('--ids — a flag é opcional e o argv também é fail-closed', () => {
+  it('aceita `--ids=<json>` e `--ids <json>`', () => {
+    expect(lerArgIds(['--ids={"edge-a": 1}'])).toBe('{"edge-a": 1}');
+    expect(lerArgIds(['--ids', '{"edge-a": 1}'])).toBe('{"edge-a": 1}');
+  });
+
+  it('ausente devolve null — a atribuição é opcional, o relatório sai do mesmo jeito', () => {
+    expect(lerArgIds([])).toBeNull();
+  });
+
+  it('`--ids` sem valor LANÇA em vez de virar "sem ids"', () => {
+    expect(() => lerArgIds(['--ids'])).toThrow(/--ids/);
+    expect(() => lerArgIds(['--ids='])).toThrow(/--ids/);
+  });
+
+  it('`--ids` repetido LANÇA — dois JSONs são duas levas, e escolher uma é escolher por ordem', () => {
+    expect(() => lerArgIds(['--ids={"edge-a": 1}', '--ids={"edge-b": 2}'])).toThrow(/--ids/);
+  });
+
+  it('argumento desconhecido LANÇA — `--id=` digitado errado sairia como "sem atribuição"', () => {
+    expect(() => lerArgIds(['--id={"edge-a": 1}'])).toThrow(/--id=/);
+  });
+});
+
+describe('o texto da classe — o que impede o founder de sondar de novo', () => {
+  const linhas = formatarSemIdentidade(
+    resumirSemIdentidade([
+      { requestId: 70261, versao: 'v1.0-sensor-inicial', criado: 'x', idadeHoras: 1 },
+      { requestId: 70262, versao: 'v1.0-sensor-inicial', criado: 'x', idadeHoras: 1 },
+    ]),
+  ).join('\n');
+
+  it('nomeia a CLASSE, a contagem, a versao respondida e os request_ids', () => {
+    expect(linhas).toContain('SONDA_SEM_IDENTIDADE');
+    expect(linhas).toContain('2');
+    expect(linhas).toContain('v1.0-sensor-inicial');
+    expect(linhas).toContain('70261');
+    expect(linhas).toContain('70262');
+  });
+
+  it('dá o VEREDITO e a contra-instrução — a resposta é prova de bundle velho, não pedido de sonda', () => {
+    expect(linhas).toContain(DATA_ECO_COM_IDENTIDADE);
+    expect(linhas).toContain('DEPLOY PENDENTE');
+    expect(linhas).toContain('NÃO RE-SONDE');
+  });
+
+  it('ensina a atribuir por request_id, que é a única identidade forte', () => {
+    expect(linhas).toContain('--ids');
+  });
+
+  it('sem nenhuma resposta sem identidade, NÃO imprime seção nenhuma', () => {
+    expect(formatarSemIdentidade(resumirSemIdentidade([]))).toEqual([]);
+  });
+});
+
+/**
+ * ITEM (3) DO PEDIDO, como GATE: a resposta sem identidade NÃO entra no ledger com edge fictícia.
+ *
+ * `edge = 'desconhecida'` casaria o regex de slug da janela viva e o NOT NULL do ledger — nada no
+ * banco a barraria. As razões de não gravar: (a) o `DISTINCT ON (edge)` do CLI passaria a ver uma
+ * "edge" chamada `desconhecida`, que a main não mapeia ⇒ 🟠 FORA_DO_MAPA urgente, uma edge
+ * INVENTADA no relatório de deploy; (b) o ledger é ETERNO e a janela do pg_net dura 6h — a chance
+ * de atribuir a resposta morre com a janela, e ficaria para sempre uma linha que ninguém consegue
+ * reinterpretar; (c) `pendencias:deploy` roda no `psql-ro`: gravar exigiria o founder colar SQL,
+ * custo humano por um dado que não conclui nada. A prova de bundle velho não se perde — ela vira
+ * CLASSE no relatório, e veredito por edge quando (e só quando) houver `--ids`.
+ *
+ * O gate mede o CÓDIGO, nunca o arquivo cru: o parágrafo acima cita as duas strings proibidas, e um
+ * `not.toContain` sobre o arquivo inteiro ficaria vermelho pela PROSA. Stripper compartilhado
+ * (`removerComentarios`), nunca regex local — a lição de `gates-textuais-cegos.md`.
+ */
+describe('o ledger não recebe edge fictícia — o CLI é read-only por construção', () => {
+  const fonteCrua = readFileSync(join(__dirname, 'pendencias-deploy.ts'), 'utf8');
+  const codigo = removerComentarios(fonteCrua);
+
+  it('o stripper deixou código de sobra — gate que mede string vazia é gate cego', () => {
+    expect(codigo.length).toBeGreaterThan(fonteCrua.length * 0.4);
+    expect(codigo).toContain('SQL_SEM_IDENTIDADE');
+  });
+
+  it('nenhuma escrita no ledger, e nenhuma edge fictícia no CÓDIGO', () => {
+    expect(codigo).not.toContain('INSERT INTO');
+    expect(codigo).not.toContain('desconhecida');
   });
 });

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -25,6 +25,29 @@
  * a prova de ontem valia zero hoje. O ledger é alimentado por cron (`deploy-atestacoes-colher`,
  * 15/15 min); a sonda humana passa a ser UMA por deploy (e a 1ª de edge nova), nunca por sessão.
  *
+ * A 2ª LEITURA (`SQL_SEM_IDENTIDADE`, 2026-09-05): `deploy_atestacoes_janela_viva()` exige `edge`
+ * string — é o que impede corpo alheio de virar veredito, e é o que torna a sonda de bundle
+ * pré-28/08 INVISÍVEL: ela responde `{"ok":true,"probe":true,"versao":"…"}` e mais nada. Medido no
+ * bootstrap do ledger: das 30 sondas do founder, 6 vieram assim, ficaram fora do ledger e saíram no
+ * relatório como `NUNCA_ATESTADA — precisa da 1ª sonda`. O founder sondava de novo e recebia a
+ * mesma resposta. Então o CLI faz uma segunda consulta, barata, sobre a MESMA janela: 200 +
+ * `probe` booleano true + SEM a chave `edge`. O produto dela é a classe `SONDA_SEM_IDENTIDADE`.
+ *
+ * ATRIBUIR É OPCIONAL, E SÓ POR `request_id` (`--ids`). `v1.0-sensor-inicial` é a `VERSAO` de 13
+ * edges da main; duas respostas de edges diferentes são idênticas byte a byte, e nem a URL, nem a
+ * fila, nem os headers, nem o `created` desempatam (§7 de `verificar-sonda-versao.md`). A única
+ * identidade forte é o id que o PASSO 1 do `sonda:sql` devolve. Sem `--ids`, o relatório dá a
+ * CONTAGEM, as versões e os ids — nunca a edge. Casar por posição seria fabricar.
+ *
+ * POR QUE ELAS NÃO ENTRAM NO LEDGER COM `edge = 'desconhecida'` (pedido explicitamente, e a
+ * resposta é não): (a) o `DISTINCT ON (edge)` passaria a ver uma edge chamada `desconhecida`, que a
+ * main não mapeia ⇒ 🟠 FORA_DO_MAPA urgente — uma edge INVENTADA no relatório de deploy, e o slug
+ * casa o regex da janela viva, então nada no banco a barraria; (b) o ledger é ETERNO e a janela do
+ * pg_net dura 6h: a chance de atribuir morre com a janela, e a linha ficaria para sempre
+ * impossível de reinterpretar; (c) este CLI lê pelo `psql-ro` — gravar exigiria o founder colar
+ * SQL, custo humano por um dado que não conclui nada. A prova não se perde: ela vira CLASSE no
+ * relatório (exit 1), e veredito por edge quando houver `--ids`.
+ *
  * POR QUE NÃO HÁ CRON DE SONDA ATIVA: o desenho inicial tinha um (6/6h, allowlist das edges que
  * já responderam `probe:true`). O Codex derrubou: rollback pelo Lovable, restauração de projeto
  * ou recriação manual devolvem um bundle PRÉ-sensor, que ignora `probe` e roda o fluxo real — a
@@ -38,13 +61,19 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  atribuirSondasSemIdentidade,
+  DATA_ECO_COM_IDENTIDADE,
   edgesParaSondar,
   julgar,
   lerTolerancia,
+  parsearIds,
   parsearObservacoes,
+  parsearSondasSemIdentidade,
+  resumirSemIdentidade,
   type Contexto,
   type Esperado,
   type Estado,
+  type Observacao,
   type Relatorio,
   type Veredito,
 } from './lib/pendencias-deploy';
@@ -122,6 +151,98 @@ FROM cron.job j
 LEFT JOIN cron.job_run_details d ON d.jobid = j.jobid AND d.status = 'succeeded'
 WHERE j.jobname = '${CRON_COLETOR}';
 `.trim();
+
+/**
+ * A 2ª leitura: sondas que responderam e NÃO disseram quem são.
+ *
+ * Sobre `net._http_response` direto, porque a janela viva as exclui por construção (exige `edge`).
+ * Afrouxar a janela seria deixar entrar no LEDGER — que é eterno — linha sem edge; esta consulta
+ * não escreve nada e roda no mesmo wrapper read-only.
+ *
+ * Os guards são os mesmos da janela viva, pela mesma razão: `LIKE` textual e `left(ltrim(...))`
+ * ANTES do cast, com o cast dentro de um `CASE` (ordem de avaliação é da linguagem, não do plano) —
+ * sem isso, um corpo truncado que começa com `{` aborta a varredura inteira.
+ *
+ * `NOT (r.c ? 'edge')` e não `(r.c ->> 'edge') IS NULL`: a ausência se testa pela CHAVE. E
+ * `probe` tem de ser o BOOLEANO true — sem essa assinatura, qualquer corpo de terceiro sem `edge`
+ * entraria na classe.
+ *
+ * LIMITE conhecido: `probe:true` sem `versao` string fica de fora. Não é forma que este repo já
+ * emitiu (`respostaSonda` sempre recebeu a `VERSAO`), e sem `versao` não há o que comparar com a
+ * main — a linha entraria só para inflar um contador.
+ */
+export const SQL_SEM_IDENTIDADE = `
+SELECT r.id,
+       r.c ->> 'versao',
+       to_char(r.created AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI"Z"'),
+       round((extract(epoch FROM (now() - r.created)) / 3600.0)::numeric, 2)
+FROM (
+  SELECT id, created,
+         CASE WHEN content IS JSON OBJECT THEN content::jsonb END AS c
+  FROM net._http_response
+  WHERE status_code = 200
+    AND id IS NOT NULL
+    AND created IS NOT NULL
+    AND content IS NOT NULL
+    AND left(ltrim(content), 1) = '{'
+    AND content LIKE '%"probe"%'
+    AND content LIKE '%"versao"%'
+) r
+WHERE r.c IS NOT NULL
+  AND (r.c -> 'probe') = to_jsonb(true)
+  AND NOT (r.c ? 'edge')
+  AND jsonb_typeof(r.c -> 'versao') = 'string'
+  AND length(r.c ->> 'versao') BETWEEN 1 AND 120
+ORDER BY r.created DESC, r.id DESC;
+`.trim();
+
+/**
+ * Lê o `--ids` do argv, ou LANÇA (⇒ exit 2). A flag é opcional; o que não é opcional é ela ser
+ * inequívoca — argumento digitado errado que caísse em "sem atribuição" devolveria o relatório
+ * ANTIGO com cara de novo, e o founder concluiria que a atribuição não funciona.
+ */
+export function lerArgIds(argv: string[]): string | null {
+  const USO = 'Uso: bun run pendencias:deploy [--ids=\'{"<edge>": <request_id>, …}\']';
+  let ids: string | null = null;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    let valor: string | undefined;
+
+    if (arg === '--ids') {
+      valor = argv[i + 1];
+      i += 1;
+    } else if (arg.startsWith('--ids=')) {
+      valor = arg.slice('--ids='.length);
+    } else {
+      throw new Error(`argumento desconhecido: ${arg}. ${USO}`);
+    }
+
+    if (valor === undefined || valor.trim() === '') {
+      throw new Error(`--ids veio sem valor. Cole o JSON do PASSO 1 do \`sonda:sql\`. ${USO}`);
+    }
+    if (ids !== null) {
+      throw new Error('--ids repetido: dois JSONs são duas levas, e escolher um deles é escolher por ordem.');
+    }
+    ids = valor;
+  }
+
+  return ids;
+}
+
+/** A seção da classe. Sem resposta sem identidade não há seção — silêncio aqui é o certo. */
+export function formatarSemIdentidade(resumo: ReturnType<typeof resumirSemIdentidade>): string[] {
+  if (resumo.total === 0) return [];
+  return [
+    `\n🔴 SONDA_SEM_IDENTIDADE — ${resumo.total} resposta(s) \`probe:true\` SEM \`edge\` no corpo`,
+    `   versao respondida: ${resumo.porVersao.map((v) => `${v.versao} × ${v.n}`).join(' · ')}`,
+    `   request_id: ${resumo.requestIds.join(', ')}`,
+    `   Bundle anterior a ${DATA_ECO_COM_IDENTIDADE}, quando o eco passou a trazer edge+fonte (069540905).`,
+    '   Isto é DEPLOY PENDENTE por closure, não ausência de dado: NÃO RE-SONDE — a resposta seria a mesma.',
+    '   Para virar veredito POR EDGE, cole o JSON do PASSO 1:',
+    `     bun run sonda:sql --so-disparo <edge>…   →   bun run pendencias:deploy --ids='<json do passo 1>'`,
+  ];
+}
 
 function psql(sql: string): string {
   return execFileSync(PSQL_RO, ['-A', '-F', '|', '-t', '-c', sql], {
@@ -220,7 +341,7 @@ function idade(v: Veredito): string {
   return `há ${Math.round(v.idadeHoras / 24)} d`;
 }
 
-function imprimir(rel: Relatorio): void {
+function imprimir(rel: Relatorio, linhasSemIdentidade: string[]): void {
   // Tipados como `Estado` de propósito: um estado novo na lib sem rótulo aqui — ou um nome
   // digitado errado — vira erro de compilação, não seção que some calada do relatório.
   const ordem: Estado[] = [
@@ -270,12 +391,22 @@ function imprimir(rel: Relatorio): void {
     }
   }
 
+  for (const linha of linhasSemIdentidade) console.log(linha);
+
   const sondar = edgesParaSondar(rel);
   if (sondar.length > 0) {
     console.log(
       `\n   → sonda (founder cola no SQL Editor): bun run sonda:sql ${sondar.join(' ')}` +
         '\n     A resposta entra no ledger em até 15 min (cron deploy-atestacoes-colher) e vale até o fonte da main mudar.',
     );
+    // Sem `--ids` não dá para saber QUAIS destas já responderam — mas dá para não deixar as duas
+    // instruções se contradizerem na mesma tela. A ressalva é o que impede a re-sonda inútil.
+    if (linhasSemIdentidade.length > 0) {
+      console.log(
+        '     ⚠️  Há resposta(s) SEM IDENTIDADE na janela (acima): parte desta lista pode já ter respondido.',
+      );
+      console.log('        Se você acabou de sondar, ATRIBUA com --ids em vez de sondar de novo.');
+    }
   }
 
   console.log(
@@ -288,10 +419,12 @@ function imprimir(rel: Relatorio): void {
   }
 }
 
-export function main(): number {
+export function main(argv: string[] = []): number {
   let tolerarNunca: boolean;
+  let idsBruto: string | null;
   try {
     tolerarNunca = lerTolerancia(process.env.PENDENCIAS_TOLERAR_NUNCA_ATESTADA);
+    idsBruto = lerArgIds(argv);
   } catch (e) {
     console.error(`❌ MECÂNICA: ${(e as Error).message}`);
     return 2;
@@ -309,11 +442,24 @@ export function main(): number {
     return 2;
   }
 
+  // O `--ids` se valida contra o mapa da MAIN, então só aqui: edge fora do mapa é fail-closed.
+  let idParaEdge = new Map<number, string>();
+  if (idsBruto !== null) {
+    try {
+      idParaEdge = parsearIds(idsBruto, esperados);
+    } catch (e) {
+      console.error(`❌ MECÂNICA: ${(e as Error).message}`);
+      return 2;
+    }
+  }
+
   let saudeBruta: string;
   let saida: string;
+  let saidaSemIdentidade: string;
   try {
     saudeBruta = psql(SQL_SAUDE_COLETOR);
     saida = psql(SQL);
+    saidaSemIdentidade = psql(SQL_SEM_IDENTIDADE);
   } catch (e) {
     const err = e as Error & { stderr?: string | Buffer };
     const stderr = String(err.stderr ?? '');
@@ -348,22 +494,33 @@ export function main(): number {
   }
 
   const { observacoes, linhasIgnoradas } = parsearObservacoes(saida);
-  if (linhasIgnoradas > 0) {
+  const { sondas, linhasIgnoradas: ignoradasSemIdentidade } = parsearSondasSemIdentidade(saidaSemIdentidade);
+  const ignoradas = linhasIgnoradas + ignoradasSemIdentidade;
+  if (ignoradas > 0) {
     console.error(
-      `❌ MECÂNICA: ${linhasIgnoradas} linha(s) da saída do psql não casaram o formato — a linha descartada pode ser a divergência.`,
+      `❌ MECÂNICA: ${ignoradas} linha(s) da saída do psql não casaram o formato — a linha descartada pode ser a divergência.`,
     );
     return 2;
   }
 
+  // A atribuída vira observação de primeira classe (id é identidade mais forte que o eco do slug);
+  // a não atribuída continua sendo SINAL, sem virar veredito por edge.
+  const { observacoes: atribuidas, naoAtribuidas } = atribuirSondasSemIdentidade(sondas, idParaEdge);
+  const todas: Observacao[] = [...observacoes, ...atribuidas];
+  const linhasSemIdentidade = formatarSemIdentidade(resumirSemIdentidade(naoAtribuidas));
+
   let rel: Relatorio;
   try {
-    rel = julgar(esperados, observacoes, contextoGit(), linhasIgnoradas);
+    rel = julgar(esperados, todas, contextoGit(), ignoradas);
   } catch (e) {
     console.error(`❌ MECÂNICA: ${(e as Error).message}`);
     return 2;
   }
 
   if (rel.totalObservadas === 0) {
+    // A classe sai ANTES do erro: sem ela, "dispare a 1ª leva" mandaria sondar de novo justamente
+    // quem já respondeu — o laço que esta correção existe para cortar.
+    for (const linha of linhasSemIdentidade) console.error(linha);
     console.error(
       `❌ MECÂNICA: ZERO das ${rel.totalMapeadas} edges mapeadas tem atestação (ledger vazio E janela vazia).`,
     );
@@ -371,14 +528,16 @@ export function main(): number {
     return 2;
   }
 
-  imprimir(rel);
+  imprimir(rel, linhasSemIdentidade);
 
   const nunca = rel.vereditos.filter((v) => v.estado === 'NUNCA_ATESTADA').length;
   const pendentes = tolerarNunca ? rel.totalPendentes - nunca : rel.totalPendentes;
   if (tolerarNunca && nunca > 0) {
     console.log(`\n⚠️  PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1: ${nunca} nunca atestada(s) NÃO contam como pendência nesta execução.`);
   }
-  return pendentes > 0 ? 1 : 0;
+  // A válvula do bootstrap tolera AUSÊNCIA de dado. Resposta sem identidade é o oposto: prova
+  // POSITIVA de que um bundle pré-2026-08-28 está no ar. Ela sai exit 1 mesmo com a válvula ligada.
+  return pendentes > 0 || naoAtribuidas.length > 0 ? 1 : 0;
 }
 
-if (import.meta.main) process.exit(main());
+if (import.meta.main) process.exit(main(process.argv.slice(2)));

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -532,7 +532,6 @@ export function main(argv: string[] = []): number {
   imprimir(rel, linhasSemIdentidade);
 
   const nunca = rel.vereditos.filter((v) => v.estado === 'NUNCA_ATESTADA').length;
-  const pendentes = tolerarNunca ? rel.totalPendentes - nunca : rel.totalPendentes;
   if (tolerarNunca && nunca > 0) {
     console.log(`\n⚠️  PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1: ${nunca} nunca atestada(s) NÃO contam como pendência nesta execução.`);
   }

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -63,6 +63,7 @@ import { join } from 'node:path';
 import {
   atribuirSondasSemIdentidade,
   DATA_ECO_COM_IDENTIDADE,
+  decidirExit,
   edgesParaSondar,
   julgar,
   lerTolerancia,
@@ -535,9 +536,12 @@ export function main(argv: string[] = []): number {
   if (tolerarNunca && nunca > 0) {
     console.log(`\n⚠️  PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1: ${nunca} nunca atestada(s) NÃO contam como pendência nesta execução.`);
   }
-  // A válvula do bootstrap tolera AUSÊNCIA de dado. Resposta sem identidade é o oposto: prova
-  // POSITIVA de que um bundle pré-2026-08-28 está no ar. Ela sai exit 1 mesmo com a válvula ligada.
-  return pendentes > 0 || naoAtribuidas.length > 0 ? 1 : 0;
+  return decidirExit({
+    totalPendentes: rel.totalPendentes,
+    nuncaAtestadas: nunca,
+    tolerarNunca,
+    semIdentidade: naoAtribuidas.length,
+  });
 }
 
 if (import.meta.main) process.exit(main(process.argv.slice(2)));


### PR DESCRIPTION
## O caso, medido no bootstrap do ledger

O founder colou 30 sondas. **24** responderam `{ok,probe,versao,edge,fonte}` e viraram `CONFERE`.
**6** responderam a forma **anterior a 2026-08-28** — `{"ok":true,"probe":true,"versao":"…"}` —, sem
`edge` e sem `fonte`.

`deploy_atestacoes_janela_viva()` exige `edge` string. É o predicado que impede corpo de terceiro de
virar veredito, e é exatamente o que torna essas 6 **invisíveis**: não entram no ledger, não entram
na janela, e o relatório as classificava como `⚪ NUNCA atestada — precisa da 1ª sonda`. O founder
sondaria de novo e receberia **a mesma resposta**. A prova mais forte de deploy pendente se
disfarçava de ausência de dado.

**Eco sem `edge` não é silêncio, é FORMA.** O commit `069540905` (#2079) pôs `edge`+`fonte` no
`_shared/sonda-versao.ts`, que está no closure de toda edge instrumentada. Quem responde sem os dois
serve bundle pré-28/08 ⇒ o `fonte` diverge do da main **com certeza**, sem precisar ser observado.
É deploy pendente por closure: **P2**, ou **P1** se o `VERSAO` da main já for outro.

## O que entrou

- **2ª leitura** (`SQL_SEM_IDENTIDADE`) sobre `net._http_response`: 200 + `probe` booleano true +
  `NOT (c ? 'edge')`, com os mesmos guards da janela viva (`LIKE` textual, cast dentro de `CASE`).
  Não escreve; roda no mesmo `psql-ro`. Produz a classe **`SONDA_SEM_IDENTIDADE`** — contagem,
  `versao` respondido, `request_id`s e a contra-instrução **"NÃO RE-SONDE"**. A lista `→ sonda`
  ganhou a ressalva, para as duas instruções não se contradizerem na mesma tela.
- **Atribuição opcional por `request_id`**: `--ids='<json do PASSO 1>'` casa id→edge e reclassifica
  em P1/P2 pelo `versao` contra `origin/main`. Fail-closed em JSON inválido, não-objeto, `{}`, valor
  que não é inteiro positivo, **id repetido** e **edge fora do mapa**.
- **Nunca por posição.** `v1.0-sensor-inicial` é a `VERSAO` de 13 edges da main e nada no banco
  desempata (§7 de `verificar-sonda-versao.md`). Sem `--ids`, o relatório dá a contagem, as versões e
  os ids — jamais a edge.
- **A não atribuída é pendência mesmo com `PENDENCIAS_TOLERAR_NUNCA_ATESTADA=1`** (`decidirExit`): a
  válvula tolera ausência de dado, e isto é prova positiva.

## Por que NÃO gravar no ledger com `edge = 'desconhecida'`

Foi pedido explicitamente, e a resposta é **não**:

1. O `DISTINCT ON (edge)` passaria a ver uma edge chamada `desconhecida`, que a main não mapeia ⇒
   `🟠 FORA_DO_MAPA` urgente: uma edge **inventada** no relatório de deploy. O slug casa o regex
   `^[a-z0-9-]{1,80}$` da janela viva e o `NOT NULL` do ledger — **nada no banco a barraria**.
2. O ledger é **eterno** e a janela do pg_net dura 6h: a chance de atribuir morre com a janela, e a
   linha ficaria para sempre impossível de reinterpretar.
3. O CLI lê pelo `psql-ro`. Gravar exigiria o founder colar SQL — custo humano por um dado que não
   conclui nada.

Um gate prende a decisão: o **código** do CLI (sem comentários, pelo stripper compartilhado
`removerComentarios`) não pode conter `INSERT INTO` nem `desconhecida`.

## Evidência

- `bun run test` — **79 casos** no arquivo (22 novos); suíte completa **7876 passed / 1 skipped, 765
  arquivos**, exit 0. `typecheck`, `lint`, `sonda:fingerprint`, `sonda:bump`: todos exit 0.
- **Prod** (`psql-ro`, SQL **importado** do CLI, não copiado): a 2ª leitura devolveu **7** linhas —
  os 6 ids de 23:35Z e um sétimo às 23:38Z (70287). O CLI completo saiu **exit 1** com a classe
  impressa; os 4 caminhos de `--ids` inválido saíram **exit 2**, sem veredito fabricado.
- **A medição corrigiu o relato**: a resposta do **70262** disse `v1.1-marco-causal`, não
  `v1.0-sensor-inicial` — a atribuição a moveria de P1 para P2. E outra sessão fechou por prova que
  a `omie-nfe-recebimento` já está no ar (#2217), sendo que edge no ar responde **com** `edge`. A
  correspondência "posição a posição" do relato era hipótese, não dado. É por isso que a atribuição
  é por `request_id` e falha fechada.
- **Falsificação — 10/10 sabotagens VERMELHAS**, cada uma nomeando o assert: as 4 do SQL (ausência
  por desigualdade NULL-blind · `probe` como texto · sem exigir `versao` string · ordem sem
  desempate por id), argumento desconhecido virando silêncio, id repetido aceito, edge fora do mapa
  engolida, `julgar` devolvendo `CONFERE` para sonda sem identidade, atribuição por **posição** em
  vez de id, e a válvula do bootstrap voltando a engolir a prova positiva. Sabotagem **ancorada na
  região do código** — os comentários desta casa citam o código verbatim e vêm antes no arquivo,
  então um `perl -0pi` acertaria a prosa (§10.1 de `sonda-eco-passivo-sem-colagem.md`). Commitado
  antes de falsificar; árvore limpa depois.

Nenhuma edge tocada, nenhuma migration tocada — **nada a deployar por este PR**.

## Como o founder usa

```bash
bun run pendencias:deploy
```

Se a seção `SONDA_SEM_IDENTIDADE` aparecer e você acabou de sondar, **não sonde de novo** — atribua:

```bash
bun run pendencias:deploy --ids='<cole o ids_opcionais_passo_1 que o sonda:sql devolveu>'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
