### PR TITLE
docs(sonda): nomeia o limite — sem `--ids`, o sinal da sonda sem identidade dura só a janela de 6h

### DIFF
--- a/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
+++ b/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
@@ -214,6 +214,15 @@ ela: **a ordem da lista que você mandou sondar não é a ordem das respostas qu
 
 ## 5. O que fica para depois (nomeado, não esquecido)
 
+- **O sinal sem `--ids` dura 6h, não é durável.** A resposta sem identidade não entra no ledger (não
+  tem edge), então quando a janela do pg_net expira as mesmas edges voltam a `NUNCA_ATESTADA` e o
+  relatório volta a pedir a 1ª sonda — o founder sonda, recebe a mesma resposta antiga, e a classe
+  reaparece por mais 6h. O laço não é infinito, mas **recomeça**. Quem o corta de vez é o `--ids`:
+  a atribuída vira observação com edge real e entra na fila P1/P2 como qualquer outra. Fechar de
+  vez pede **gravar a atribuída no ledger**, que é escrita — o CLI é read-only, então exigiria o
+  founder colar SQL, ou um caminho de escrita próprio. Entrega própria, com o teste óbvio: atribuir,
+  gravar, deixar a janela expirar e exigir que o veredito por edge SOBREVIVA.
+
 - **Sonda automática segura**: atestação por `OPTIONS` autenticado (bundle pré-sensor devolve só
   CORS) ou credencial exclusiva de probe, com o teste de rollback. Entrega própria.
 - **Fan-out no CI como sinal**: o `sonda:fingerprint` imprimir, no PR, quais consumidores tiveram o

--- a/scripts/lib/pendencias-deploy.ts
+++ b/scripts/lib/pendencias-deploy.ts
@@ -397,6 +397,14 @@ export function lerTolerancia(bruto: string | undefined): boolean {
  * identidade forte é o `request_id` que o PASSO 1 do `sonda:sql` devolve — por isso a atribuição é
  * opcional, explícita e por id. Casar por ORDEM (a i-ésima resposta = a i-ésima edge da lista)
  * seria fabricar: as respostas chegam fora de ordem e nem toda edge da leva responde.
+ *
+ * ⚠️ LIMITE (nomeado, não resolvido): sem `--ids`, o sinal dura só a JANELA de 6h do pg_net. Estas
+ * respostas não entram no ledger — não têm edge, e o §"por que não gravar com edge fictícia" do CLI
+ * explica por que inventar uma é pior. Passadas as 6h, as mesmas edges voltam a `NUNCA_ATESTADA` e
+ * o relatório volta a pedir a 1ª sonda; o founder sonda, recebe a mesma resposta antiga, e a classe
+ * reaparece por mais 6h. O laço não é infinito, mas RECOMEÇA. Quem o corta de vez é o `--ids`: a
+ * atribuída é observação com edge REAL, e a fila P1/P2 dela é durável como qualquer outra. Fechar
+ * o buraco por completo pede gravar a atribuída no ledger — escrita, que este CLI não faz.
  */
 
 /** Uma resposta `probe:true` da janela que não diz de quem é. `versao` é tudo que ela carrega. */


### PR DESCRIPTION
Follow-up do #2221 (já mergeado). **Só comentário e doc — zero mudança de comportamento.**

## O limite que faltava nomear

A classe `SONDA_SEM_IDENTIDADE` corta o laço *"NUNCA atestada → sonde de novo → mesma resposta"* —
mas **só enquanto a resposta está viva em `net._http_response`**. Ela não entra no ledger (não tem
edge, e inventar uma é pior: o `§ por que não gravar com edge fictícia` do CLI explica). Quando o
`pg_net.ttl` de 6h expira, as mesmas edges voltam a `NUNCA_ATESTADA` e o relatório volta a pedir a
1ª sonda. O founder sonda, recebe a mesma resposta antiga, e a classe reaparece por mais 6h.

**O laço não é infinito, mas RECOMEÇA.** Deixar isso implícito seria vender como fechado um buraco
que só está tampado por 6h.

Quem corta de vez é o `--ids`: a atribuída vira observação com **edge real** e entra na fila P1/P2
como qualquer outra — durável. Fechar por completo pede **gravar a atribuída no ledger**, que é
escrita, e o CLI é read-only pelo `psql-ro`. Fica nomeado como entrega própria, com o teste óbvio:
atribuir, gravar, **deixar a janela expirar** e exigir que o veredito por edge SOBREVIVA.

## Evidência

`bunx vitest run scripts/pendencias-deploy.test.ts`: **79/79**. O diff é um bloco de comentário na
lib e um item na lista "o que fica para depois" do doc.

⚠️ **Nota sobre o CI do #2221**: o `validate` passou (e o auto-merge disparou), mas o
`mutation-check` reprovou em **`scripts/mutcheck.d/sonda-versao-sql.mut`** — *"baseline: ✗ VERMELHO —
a suíte já falha sem mutação"*. Aquele contrato mira `scripts/sonda-versao-sql.ts`, arquivo que
nenhum dos dois PRs toca, e **nenhum `.mut` aponta para `pendencias-deploy`**. Está em apuração
local; se se confirmar pré-existente, vira entrega própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
