### PR TITLE
docs(deploy): UM prompt por LEVA, não por edge — medido em prod com 8 edges/70 arquivos, 54/54 e zero deploy parcial

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -125,9 +125,14 @@ persiste em disco): a linha pede ao founder para *conferir/criar* pelo nome, e o
 
 ### Passo 3 — Prompt de deploy de edge (se aplicável)
 
-Montar pro founder colar no chat do Lovable (um por edge que o `pendencias:deploy` deu como pendente —
-este passo decide o **conteúdo** do prompt, o closure ∪ {mapa}; ele NÃO decide *se* a edge precisa de
-deploy, e o mapa ter mudado depois do PR não é motivo — ver Passo 2):
+Montar pro founder colar no chat do Lovable, para as edges que o `pendencias:deploy` deu como pendentes
+— este passo decide o **conteúdo** do prompt, o closure ∪ {mapa}; ele NÃO decide *se* a edge precisa de
+deploy, e o mapa ter mudado depois do PR não é motivo (ver Passo 2).
+
+**UMA colagem por LEVA, não por edge (medido 2026-09-06).** Com 2+ edges pendentes, monte um prompt
+único numerando-as, cada uma com a SUA lista de arquivos — a forma exata está no fim deste passo, e a
+medição (8 edges, 70 arquivos, 54/54 depois) no §Estado. O prompt de 1 edge abaixo continua sendo a
+unidade de construção, e é o que você usa quando a leva tem uma só:
 
 > Edit the existing edge function `<nome>` and replace its code with the current contents of
 > `supabase/functions/<nome>/index.ts` from the `main` branch. Deploy it **verbatim** — do NOT modify,
@@ -240,6 +245,31 @@ Exercitado no #2009 (`carteira-rebuild`, 3 arquivos de código, 1 deles novo): a
 `probe:true · versao:v1.0-sensor-inicial · edge:carteira-rebuild · fonte:8d2589d0…`, e o `fonte` bateu
 com o `bun run sonda:fingerprint` da main — que é justamente a prova de que o `_shared/` subiu junto, e
 não só o `index.ts` (#2018).
+
+#### A LEVA num prompt só (2 ou mais edges) — a forma medida
+
+Mesmo conteúdo por edge, uma colagem só. O cabeçalho pede o total e proíbe pular; cada edge vira uma
+**seção numerada** com o closure ∪ {mapa} DELA; o fecho pede a confirmação item a item, que é o que
+dá ao founder o relato para comparar com a sonda. Medido em 2026-09-06 com **8 edges / 70 arquivos**:
+as 8 responderam `versao` + `fonte` da main e o `pendencias:deploy` fechou 54/54 (§Estado):
+
+> Edit the following **eight** existing edge functions and update **each** of them from the `main`
+> branch using the current contents of the files listed under it. Deploy all of them **verbatim** —
+> do NOT modify, reinterpret, "improve", or reformat any code. Deploy every function listed; do not
+> skip any.
+>
+> **1. `<nome-1>`**
+> - `supabase/functions/<nome-1>/index.ts`
+> - … (o closure ∪ {mapa} desta edge, um arquivo por linha)
+>
+> **2. `<nome-2>`**
+> - …
+>
+> After deploying, list the eight function names and confirm that **each one** shows **Active**.
+
+⚠️ **O relato do chat não substitui a sonda — ele diz o que perguntar a ela.** Se o Lovable disser que
+pulou alguma, tire-a do bloco de sonda antes de rodar; se disser que deployou todas, a sonda é quem
+confirma. Uma leva = um prompt = **um** bloco de `bun run sonda:sql <edges…>`.
 
 ### Passo 4 — Verificar o frontend pelos bytes (após Publish)
 
@@ -1050,6 +1080,23 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   (rollback pré-sensor dispararia o fluxo real — `monthly-report` = e-mail para a base). Prova:
   `db/test-deploy-atestacoes.sh` (24/24 + 4 sabotagens vermelhas). Detalhe em
   `docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md`.
-- [ ] **Experimento (founder):** um prompt do Lovable com N edges numa leva — mede se ele deploya todas
-  (conveniência: N colagens → 1). Não é prova de deploy; a prova continua sendo o ledger.
+- [x] **UM prompt por LEVA, não por edge (2026-09-06, medido em prod com 8 edges):** o Passo 3 dizia
+  "um por edge tocada" e isso custava N colagens no chat do Lovable. Medido numa leva real — as 8 caras
+  (`calculate-scores`, `carteira-positivacao-snapshot`, `fin-cashflow-engine`, `monthly-report`,
+  `omie-sync-status-produtos`, `scoring-recalc-batch`, `tactical-plans-batch`,
+  `visit-score-recalc-batch`), **70 arquivos** de closure, um único prompt numerando as 8 com a lista
+  de arquivos de cada uma: as 8 responderam a sonda com `versao` **e** `fonte` batendo a main
+  (request_id 70879–70886, lidos um a um), e o `pendencias:deploy` foi de 46/54 para **54/54, exit 0**.
+  **Zero deploy parcial** — nenhuma `SEM_MAPA_NO_BUNDLE` nem `INCOERENTE`, que é o modo de falha
+  temido (o prompt que nomeia poucos arquivos e a função não boota).
+  ⚠️ **O que a medição NÃO prova, e por que o teste era fraco nessa dimensão:** as 8 estavam
+  `NUNCA_ATESTADA` — estado ANTES **desconhecido** —, então "o Lovable deployou as 8" e "deployou
+  algumas e as outras já estavam idênticas à main" produzem o MESMO eco. O que ficou provado é o par
+  que importa para a decisão: o prompt em lote **não** deixa edge pela metade, e depois dele as 8
+  servem o bundle da main. Para fechar a outra metade, repita numa leva com ≥1 edge em `DIVERGE_P1`
+  MEDIDA antes (aí o antes é conhecido e a transição prova o deploy) — enquanto isso não acontecer,
+  a recomendação vale por conveniência com risco medido, não por prova de atomicidade.
+  **Forma do prompt que funcionou** (Passo 3): cabeçalho pedindo as N funções + "Deploy every function
+  listed; do not skip any", uma seção **numerada** por edge com o closure ∪ {mapa} dela, e o fecho
+  "list the N function names and confirm that **each one** shows Active".
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
+++ b/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
@@ -218,8 +218,61 @@ ela: **a ordem da lista que você mandou sondar não é a ordem das respostas qu
   CORS) ou credencial exclusiva de probe, com o teste de rollback. Entrega própria.
 - **Fan-out no CI como sinal**: o `sonda:fingerprint` imprimir, no PR, quais consumidores tiveram o
   `fonte` alterado por `_shared/` e quais bumparam — para o autor decidir P1 ali, não depois.
-- **Experimento do founder**: um prompt do Lovable com N edges (mede conveniência, não prova de
-  deploy — o ledger continua sendo a prova).
+- ~~**Experimento do founder**: um prompt do Lovable com N edges~~ → **FEITO em 2026-09-06, §6.**
 - Limites conhecidos: `fonte` é identidade autorrelatada da FONTE, não hash do bundle; o corpo diz
   qual edge respondeu (o gate de contrato cobre "edge que se identifica errado"); pg_net é UNLOGGED —
   coletor parado por > 6h ou restart perde a janela, e o CLI trata isso como mecânica.
+
+## 6. O prompt de N edges — medido (2026-09-06), e o que ele NÃO prova
+
+O item "um prompt do Lovable com N edges" estava aberto no §5 e na skill. Fechado com medição, não
+com opinião — e a leva foi escolhida para que o teste tivesse **valor além do experimento**: as 8
+edges CARAS eram exatamente as que sobraram sem prova do bootstrap (a trava do bloco perigoso ficou
+fechada, como devia), então deployá-las da main converte `NUNCA_ATESTADA` em atestação e ainda fecha
+a cobertura. Experimento que não deixa trabalho feito é experimento caro.
+
+**O artefato:** UM prompt no chat do Lovable com as 8 numeradas — `calculate-scores`,
+`carteira-positivacao-snapshot`, `fin-cashflow-engine`, `monthly-report`, `omie-sync-status-produtos`,
+`scoring-recalc-batch`, `tactical-plans-batch`, `visit-score-recalc-batch` —, cada uma com o **seu**
+closure ∪ {mapa} lido de `origin/main` (10 a 13 arquivos por edge, **70** no total), cabeçalho pedindo
+as oito e proibindo pular, fecho pedindo `Active` item a item.
+
+**O desfecho, lido no banco por `request_id` (nunca pelo último id da tabela):**
+
+| edge | request_id | `versao` respondido | `fonte` (12) | bate a main? |
+|---|---|---|---|---|
+| `calculate-scores` | 70879 | v1.0-sensor-inicial | 9d7a3da6c615 | sim |
+| `carteira-positivacao-snapshot` | 70880 | v1.1-pedidos-do-mes-keyset | be7d1152c411 | sim |
+| `fin-cashflow-engine` | 70881 | v1.1-paginacao-eof-vazio | 5327584f8d1b | sim |
+| `monthly-report` | 70882 | v1.0-sensor-inicial | 29e973d17ece | sim |
+| `omie-sync-status-produtos` | 70883 | v1.0-sensor-inicial | 9ad6546de095 | sim |
+| `scoring-recalc-batch` | 70884 | v1.0-sensor-inicial | 3899eef2be43 | sim |
+| `tactical-plans-batch` | 70885 | v1.0-sensor-inicial | 6d882834d7ce | sim |
+| `visit-score-recalc-batch` | 70886 | v1.0-sensor-inicial | fc6e87d83a3d | sim |
+
+`bun run pendencias:deploy` foi de **46/54** para **54/54, exit 0** — e repetido contra a main que
+andou no meio-tempo, continuou 54/54.
+
+**O que isto autoriza:** trocar "um prompt por edge" por **um prompt por LEVA** no Passo 3 da skill.
+O ganho é direto (8 colagens → 1), e o modo de falha temido não apareceu: **zero deploy parcial**,
+nenhuma `SEM_MAPA_NO_BUNDLE` nem `INCOERENTE` — que é como se manifestaria o prompt em lote que
+subisse o `index.ts` de uma edge e esquecesse o `_shared/` dela (o furo do #2020, visto do outro lado).
+
+**O que NÃO prova, e o teste era fraco nessa dimensão por construção.** As 8 estavam
+`NUNCA_ATESTADA`: o estado ANTES era **desconhecido**. Logo "o Lovable deployou as 8" e "deployou
+algumas, e as outras já estavam idênticas à main" produzem eco IDÊNTICO — a mesma classe de
+ambiguidade que o `fonte` existe para resolver, aqui aplicada ao *evento* em vez do *estado*. Três
+das 8 (`calculate-scores`, `monthly-report`, `tactical-plans-batch`) têm `fonte` que entrou na main
+em 30/08, então algumas plausivelmente já estavam no ar. Reconhecer isso é o ponto: um teste cujo
+lado positivo é indistinguível do no-op não vira "confirmado" por ter dado verde.
+
+**Como fechar a outra metade, quando aparecer a leva certa:** repetir o prompt único numa leva com
+**≥1 edge em `DIVERGE_P1` MEDIDA antes** (fonte servido ≠ main, com o par lido do ledger). Aí o antes
+é conhecido, e a transição de `DIVERGE_P1` para `CONFERE` prova o deploy pelo *evento*, não só pelo
+estado. Até lá a recomendação vale por **conveniência com risco medido** — não por prova de
+atomicidade, e a skill diz isso em voz alta.
+
+**Método, de brinde:** o relato do chat ("deployei as oito") não entrou como evidência em lugar
+nenhum — é ele que a `verificar-sonda-versao.md` chama de relato, e o repo inteiro é construído sobre
+"relato de veredito não é veredito". O que ele serve é para *estreitar a pergunta*: se o Lovable
+disser que pulou alguma, tire-a do bloco de sonda antes de rodar. A prova continua sendo o `fonte`.


### PR DESCRIPTION
## O que este PR fecha

O item **"Experimento (founder): um prompt do Lovable com N edges numa leva"** estava aberto no
`Estado / pendências` da skill `lovable-deploy-verify` e no §5 de
`docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md`. Fechado com **medição em produção**.

## O experimento

A leva foi escolhida para deixar trabalho feito, não só resultado: as **8 edges CARAS** eram as que
sobraram sem prova do bootstrap do ledger (a trava do bloco perigoso ficou fechada, como devia).
UM prompt no chat do Lovable, as 8 numeradas, cada uma com o **seu** closure ∪ {mapa} lido de
`origin/main` — **70 arquivos** no total.

Desfecho lido no banco **por `request_id`** (nunca pelo último id da tabela):

| edge | request_id | `versao` | `fonte` (12) | bate a main? |
|---|---|---|---|---|
| `calculate-scores` | 70879 | v1.0-sensor-inicial | 9d7a3da6c615 | sim |
| `carteira-positivacao-snapshot` | 70880 | v1.1-pedidos-do-mes-keyset | be7d1152c411 | sim |
| `fin-cashflow-engine` | 70881 | v1.1-paginacao-eof-vazio | 5327584f8d1b | sim |
| `monthly-report` | 70882 | v1.0-sensor-inicial | 29e973d17ece | sim |
| `omie-sync-status-produtos` | 70883 | v1.0-sensor-inicial | 9ad6546de095 | sim |
| `scoring-recalc-batch` | 70884 | v1.0-sensor-inicial | 3899eef2be43 | sim |
| `tactical-plans-batch` | 70885 | v1.0-sensor-inicial | 6d882834d7ce | sim |
| `visit-score-recalc-batch` | 70886 | v1.0-sensor-inicial | fc6e87d83a3d | sim |

`bun run pendencias:deploy`: **46/54 → 54/54, exit 0** (repetido contra a main que andou no meio-tempo,
continuou 54/54).

## O que muda na skill

Passo 3: de *"um prompt por edge tocada"* para **um prompt por LEVA**, com a forma exata que funcionou
(cabeçalho pedindo as N + "do not skip any", seção numerada por edge com o closure dela, fecho pedindo
`Active` item a item). O prompt de 1 edge continua sendo a unidade de construção. Ganho: 8 colagens → 1.

O modo de falha temido **não apareceu**: zero deploy parcial, nenhuma `SEM_MAPA_NO_BUNDLE` nem
`INCOERENTE` — que é como se manifestaria o prompt em lote que sobe o `index.ts` e esquece o
`_shared/` (o furo do #2020, visto do outro lado).

## ⚠️ O que a medição NÃO prova (está escrito na skill, não só aqui)

As 8 estavam `NUNCA_ATESTADA` — o estado **ANTES era desconhecido**. Logo *"o Lovable deployou as 8"* e
*"deployou algumas, e as outras já estavam idênticas à main"* produzem eco **idêntico**; três delas têm
`fonte` que entrou na main em 30/08, então algumas plausivelmente já estavam no ar. Um teste cujo lado
positivo é indistinguível do no-op não vira "confirmado" por ter dado verde.

**Como fechar a outra metade:** repetir numa leva com **≥1 edge em `DIVERGE_P1` MEDIDA antes** — aí o
antes é conhecido e a transição `DIVERGE_P1 → CONFERE` prova o deploy pelo *evento*, não só pelo estado.
Até lá a recomendação vale por **conveniência com risco medido**, não por prova de atomicidade.

## Evidência

- `bash .claude/skills/lovable-deploy-verify/evals/run.sh` ✅ (o harness da skill, que sabota o próprio
  `SKILL.md` no eval `criterio-caro` — o edit não quebrou a âncora que ele extrai)
- `docs:indice` ✅ · `docs:links` ✅ · `docs:citacoes` ✅ · `claude:size` ✅
- Só docs e skill: sem código, sem migration, sem edge, sem Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
