### PR TITLE
fix(mutcheck): o teste do gitReal media o CHECKOUT, não o executor — baseline vermelho em TODO PR desde ontem

### DIFF
--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -927,11 +927,51 @@ describe('não consigo consultar a origin/main: ausência de dado não é aprova
   });
 });
 
+/**
+ * Repo git DESCARTÁVEL com um commit e, opcionalmente, a ref `refs/remotes/origin/main`.
+ *
+ * Existe porque o teste abaixo mede o EXECUTOR, não o checkout de quem roda a suíte — e a versão
+ * anterior media o checkout sem querer. Ver o comentário do `describe`.
+ */
+function repoDescartavel(comOriginMain: boolean): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sonda-git-real-'));
+  criadas.push(dir);
+  const g = gitReal(dir);
+  g(['init', '--quiet']);
+  g(['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--quiet', '--allow-empty', '-m', 'base']);
+  if (comOriginMain) {
+    const sha = g(['rev-parse', 'HEAD']).stdout.trim();
+    g(['update-ref', 'refs/remotes/origin/main', sha]);
+  }
+  return dir;
+}
+
+/**
+ * O executor de verdade, medido em repo CONTROLADO — nunca no repo de quem roda a suíte.
+ *
+ * 🔴 A versão anterior fazia `gitReal(RAIZ_REPO)(['rev-parse', … 'origin/main'])` e exigia status 0.
+ * Isso não media o executor: media se o CHECKOUT de quem roda a suíte criou `refs/remotes/origin/main`
+ * — e o job `mutation-check` do `ci.yml` usa `actions/checkout` SEM `fetch-depth: 0`, então em PR essa
+ * ref não existe (o `validate`, que a tem, passava). Efeito medido em 2026-09-06: baseline VERMELHO no
+ * contrato `sonda-versao-sql.mut`, e como o baseline aborta o arquivo inteiro, as **43 mutações** dele
+ * paravam de ser medidas — cobertura perdida em silêncio, com o gate gritando o tempo todo (falhou nos
+ * 4 PRs abertos naquela hora e passou na main, que é checkout de branch). Gate que grita sempre é gate
+ * que ninguém lê.
+ *
+ * A régua nova mede a MESMA coisa que importa ao guard — "existindo a ref, devolve 0 e um sha; não
+ * existindo, devolve ≠ 0" — sem herdar o estado do runner. E o caso SEM a ref virou asserção própria:
+ * ele é o ramo fail-CLOSED do guard, e antes ninguém o exercitava com git de verdade.
+ */
 describe('gitReal: o executor de verdade responde o que o guard precisa julgar', () => {
-  it('num repo git, rev-parse da origin/main devolve status 0 e um sha', () => {
-    const r = gitReal(RAIZ_REPO)(['rev-parse', '--verify', '--quiet', 'origin/main']);
+  it('com a ref presente, rev-parse da origin/main devolve status 0 e um sha', () => {
+    const r = gitReal(repoDescartavel(true))(['rev-parse', '--verify', '--quiet', 'origin/main']);
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('em repo git SEM a ref, status ≠ 0 — é o estado do checkout raso, e o guard tem de fechar', () => {
+    const r = gitReal(repoDescartavel(false))(['rev-parse', '--verify', '--quiet', 'origin/main']);
+    expect(r.status).not.toBe(0);
   });
 
   it('fora de um repo git, status ≠ 0 — o guard cai no ramo fail-CLOSED, não no aprovado', () => {


### PR DESCRIPTION
## O bug

`mutation-check` está **vermelho em TODO PR** desde ontem e **verde na main** — medido agora:

| run | branch | mutation-check |
|---|---|---|
| 34039214698 | `main` | ✅ 23 contratos honrados |
| 34038775340 | `main` | ✅ |
| 34038694511 | `claude/prompt-n-edges-lovable` | ❌ |
| 34038651011 | `claude/limite-janela-sem-identidade` | ❌ |
| 34039208756 | `claude/nice-elgamal-77ddd9` | ❌ |
| 34037748722 | `claude/corrige-premissa-2214` | ❌ |

Sempre no mesmo contrato: `scripts/mutcheck.d/sonda-versao-sql.mut` → `baseline: ✗ VERMELHO`.

## A causa (medida, não suposta)

O teste introduzido ontem em `2de0330f6` fazia:

```ts
const r = gitReal(RAIZ_REPO)(['rev-parse', '--verify', '--quiet', 'origin/main']);
expect(r.status).toBe(0);
```

Isso **não mede o executor — mede o checkout de quem roda a suíte.** O job `mutation-check`
(`ci.yml:674`) usa `actions/checkout@v5` **sem `fetch-depth: 0`**, então em `pull_request` a ref
`refs/remotes/origin/main` não existe; o `validate` (`ci.yml:105-107`, com `fetch-depth: 0`) a tem, e
por isso passava. Na main o checkout é de branch e a ref existe — daí verde lá, vermelho em todo PR.

Experimento que fecha a cadeia (repo git limpo, um commit):

```
sem refs remotas   → rev-parse --verify --quiet origin/main → status 1   (a asserção exige 0 ⇒ falha)
com a ref criada   → rev-parse --verify --quiet origin/main → status 0   (passa)
```

**Custo real, e é maior que "um check vermelho":** baseline vermelho **aborta o arquivo inteiro**, então
as **43 mutações** desse contrato pararam de ser medidas — cobertura perdida em silêncio, num contrato
que guarda o veredito de deploy (falso "DEPLOY CONFIRMADO" manda edge de money-path para o ar sem prova).
E um gate que grita em 100% dos PRs é um gate que ninguém lê.

## A correção

O teste passa a montar um **repo git descartável** com (e sem) a ref, medindo o executor e não o runner.
O caso **sem** a ref virou asserção própria: é o ramo fail-CLOSED do guard, que ninguém exercitava com
git de verdade — a suíte ganha um caso em vez de perder.

Não mexi no `ci.yml`: pôr `fetch-depth: 0` no job trataria o sintoma e deixaria de pé um teste que
depende do ambiente. A doutrina do repo é a inversa (verde/vermelho por ambiente é o anti-padrão).

## Evidência

```
bunx vitest run scripts/sonda-versao-sql.test.ts   → 91 passed (era 90; +1 caso)
scripts/mutcheck.sh …/sonda-versao-sql.{ts,test.ts} …/sonda-versao-sql.mut
  → baseline ✓ verde · 43 mutações · 41 pegas · 2 SOBREVIVE (declaradas) · 0 inválidas
    controle+ ✓ (41/41) · 0 problema(s) · exit 0
tsc -p tsconfig.scripts.json → 0    ·    eslint → 0
```

Só teste: sem mudança de produção, sem migration, sem edge, sem Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
