### PR TITLE
test(mutcheck): "40 hex" não distingue o fixture do ambiente — a asserção vira o sha, e o `.mut` vigia

### DIFF
--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -83,3 +83,9 @@ PEGA      | fatia perde o mapa (so o versao.ts e conferido)        | s/, ARQ_MAP
 PEGA      | fetch some: compara contra retrato velho por padrao    | s/const f = git\(\['fetch', REMOTO, RAMO_DEPLOYADO\]\);/const f = { status: 0, stdout: '', stderr: '' };/
 PEGA      | fetch que falha degrada em vez de abortar              | s/if \(f\.status !== 0\) \{/if (false) {/
 PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/semRede === true/true/
+# O `cwd` do `gitReal`. O #2227 tirou a ref `origin/main` herdada do checkout (a causa do
+# `mutation-check` vermelho em todo PR — docs/historico/teste-que-afirma-o-checkout.md) e pôs um
+# repo fixture no lugar. Esta linha é o que transforma esse conserto em COBERTURA: com a asserção
+# valendo o sha DAQUELE repo, ignorar a raiz pedida fica vermelho — e fica nos dois ambientes (com
+# `origin/main` presente volta outro sha; sem ela, o checkout de PR, o `rev-parse` sai 1).
+PEGA      | gitReal ignora a raiz pedida (cwd do processo)        | s/cwd: raiz,/cwd: process.cwd(),/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -944,26 +944,36 @@ describe('não consigo consultar a origin/main: ausência de dado não é aprova
  * `spawnSync` cru de propósito: montar o fixture com o próprio `gitReal` faria o teste do executor
  * depender do executor.
  */
-function repoComOriginMain(): string {
+function repoComOriginMain(): { repo: string; sha: string } {
   const repo = mkdtempSync(join(tmpdir(), 'sonda-git-'));
   criadas.push(repo);
-  const git = (...args: string[]) => {
+  const git = (...args: string[]): string => {
     const r = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
     if (r.status !== 0) throw new Error(`fixture: git ${args.join(' ')} falhou: ${r.stderr}`);
+    return (r.stdout ?? '').trim();
   };
   git('init', '-q');
   writeFileSync(join(repo, 'base.txt'), 'base\n');
   git('add', 'base.txt');
   git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'base');
   git('update-ref', 'refs/remotes/origin/main', 'HEAD');
-  return repo;
+  // O sha SAI do fixture porque a asserção lá embaixo compara contra ELE — ver o porquê no teste.
+  return { repo, sha: git('rev-parse', 'HEAD') };
 }
 
 describe('gitReal: o executor de verdade responde o que o guard precisa julgar', () => {
-  it('num repo git, rev-parse da origin/main devolve status 0 e um sha', () => {
-    const r = gitReal(repoComOriginMain())(['rev-parse', '--verify', '--quiet', 'origin/main']);
+  it('num repo git, rev-parse da origin/main devolve status 0 e o sha DAQUELE repo', () => {
+    const { repo, sha } = repoComOriginMain();
+    const r = gitReal(repo)(['rev-parse', '--verify', '--quiet', 'origin/main']);
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+    // "40 hex" sozinho não distingue o repo do FIXTURE de qualquer outro que tenha `origin/main` —
+    // e o `gitReal(RAIZ_REPO)` que ficava vermelho em todo PR passa nessa forma frouxa. Comparar
+    // com o sha do fixture (a) prova que `cwd: raiz` é honrado no ramo APROVADO, coisa que só o
+    // caso "fora de um repo git" abaixo cobria, pelo lado negativo, e (b) deixa VERMELHA em
+    // QUALQUER ambiente a volta da ref herdada do checkout — que hoje só ficaria vermelha no job
+    // `mutation-check`, silenciosa no local e no `validate`.
+    expect(r.stdout.trim()).toBe(sha);
   });
 
   it('fora de um repo git, status ≠ 0 — o guard cai no ramo fail-CLOSED, não no aprovado', () => {


### PR DESCRIPTION
Segue o #2227 (mergeado), que tirou do teste do `gitReal` a ref `origin/main` herdada do checkout — a causa do `mutation-check` ficar **vermelho em TODO PR e verde na main** — e pôs um repo fixture no lugar. O conserto está certo. O que falta é ele virar **cobertura**.

## O buraco que sobrou

```ts
expect(r.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
```

Isso é satisfeito por **qualquer** repo que tenha `origin/main` — inclusive a raiz do checkout. Então voltar ao `gitReal(RAIZ_REPO)` continua **VERDE** no worktree do dev e no job `validate` (que tem `fetch-depth: 0`), e vermelho **só** no `mutation-check`. O mesmo bug volta pela mesma porta, silencioso exatamente onde se olha.

Colateral: o lado **aprovado** da aferição nunca provou que `gitReal` honra a raiz pedida. Antes do #2227 a raiz do teste era a mesma do processo — indistinguíveis. Só o caso "fora de um repo git" cobria isso, pelo lado negativo.

## Duas mudanças, uma ideia

1. **O fixture devolve o sha, e a asserção compara com ELE.** Deixa vermelha em qualquer ambiente a volta da ref herdada, e prova `cwd: raiz` honrado no ramo aprovado.
2. **`s/cwd: raiz,/cwd: process.cwd(),/` entra no contrato `.mut`.** Falsificação que só roda à mão é ausência de dado — é o que o cabeçalho deste mesmo `.mut` já diz. A mutação fica vermelha nos **dois** ambientes: com `origin/main` presente volta outro sha; sem ela (o checkout de PR) o `rev-parse` sai 1.

## Evidência

| gate | resultado |
|---|---|
| `bunx vitest run scripts/sonda-versao-sql.test.ts` | **90/90** (mesma contagem da main) |
| `tsc --noEmit -p tsconfig.scripts.json` | **rc=0** |
| `eslint scripts/sonda-versao-sql.test.ts` | **rc=0** |
| contrato `sonda-versao-sql.mut` | baseline **VERDE** · **44 mutações · 42 pegas · 2 sobreviventes esperados · 0 inválidas · controle+ ✓ (42/42)** |

O `controle+ ✓` é o controle verde na **mesma invocação do laço** que sabota — sem ele, sempre-vermelha aprovaria tudo.

## Não incluído de propósito

O helper do fixture roda `git commit` sem `-c commit.gpgsign=false` nem `--no-verify`. Numa máquina com assinatura de commit global ligada a suíte quebraria — **mesma classe** deste PR (config do ambiente vazando pra dentro do teste), mas **não medida**: `git config --get commit.gpgsign` está vazio aqui. Fica como follow-up em vez de conserto especulativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
