### PR TITLE
docs(fecho): o custo no CI era projeção da M2 — o runner mediu 177 s / 710 s

### DIFF
--- a/docs/historico/fecho-nao-lia-o-ledger.md
+++ b/docs/historico/fecho-nao-lia-o-ledger.md
@@ -137,8 +137,12 @@ era mais lenta que a completa.
 |---|---|---|
 | CPU de uma passada da suíte (2 locales) | 16,7 s | 22,7 s |
 | sabotagens | 24 | 33 |
-| projeção do passo `Falsificação` no runner | 125 s (medido) | ~230 s |
-| projeção do job `validate` (teto 15 min) | 671 s (medido) | ~780 s |
+| passo `Falsificação` no runner | 125 s | **177 s** (medido no #2234) |
+| job `validate` (teto 15 min) | 671 s | **710 s** (medido no #2234) |
+
+A projeção feita da M2 dizia ~230 s e ~780 s; o runner entregou **177 s** e **710 s**. O erro é o
+de sempre ao projetar runner a partir da máquina local — e é o motivo de a linha acima citar o
+número MEDIDO, não o estimado. A margem contra o teto ficou em **190 s**, não nos ~120 s temidos.
 
 Duas otimizações entraram por causa disso, e nenhuma reduz cobertura: o `jq` passou de **duas**
 invocações para **uma** (a marca sai na 1ª linha, os vereditos nas seguintes), e a leitura dos
@@ -146,8 +150,9 @@ vereditos ficou **estrita** — `.vereditos[]` sem o `?`, para que `{"formato": 
 "nao-e-lista"}` falhe em vez de virar "zero vereditos", que sairia como o estado LEGÍTIMO "sem
 veredito para esta edge" e esconderia o payload corrompido.
 
-A margem contra o teto de 15 min encolheu de ~230 s para ~120 s. É folga real, mas quem acrescentar
-sabotagem a este arnês daqui em diante deve medir o passo, não presumir.
+A margem contra o teto de 15 min encolheu de ~230 s para **190 s**. É folga real, mas quem
+acrescentar sabotagem a este arnês daqui em diante deve **medir** o passo no runner
+(`gh api repos/{owner}/{repo}/actions/runs/<id>/jobs`), não presumir a partir do relógio local.
 
 ## 6. Limites nomeados
 


### PR DESCRIPTION
Errata datada sobre o [#2234](https://github.com/LucasSardenbergL/afiacao/pull/2234): o doc
registrava a **projeção** feita da M2 do founder (~230 s no passo `Falsificação`, ~780 s no job
`validate`, margem ~120 s). O runner mediu:

| medida | antes | depois (medido) |
|---|---|---|
| passo `Falsificação` | 125 s | **177 s** |
| job `validate` (teto 900 s) | 671 s | **710 s** |

Margem real contra o teto: **190 s**. A regra que fica no doc é a que faltou: medir o passo no
runner (`gh api repos/{owner}/{repo}/actions/runs/<id>/jobs`), não presumir a partir do relógio
local — a M2 com ~22 sessões vivas varia 3× entre execuções do mesmo comando.

Só doc. Gates: `docs:indice docs:links docs:citacoes` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)