### PR TITLE
test(sonda): o meio-termo do `gitReal` — repo git VÁLIDO com a `origin/main` AUSENTE, e a falsificação no CI

### DIFF
--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -89,3 +89,11 @@ PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/semRede =
 # valendo o sha DAQUELE repo, ignorar a raiz pedida fica vermelho — e fica nos dois ambientes (com
 # `origin/main` presente volta outro sha; sem ela, o checkout de PR, o `rev-parse` sai 1).
 PEGA      | gitReal ignora a raiz pedida (cwd do processo)        | s/cwd: raiz,/cwd: process.cwd(),/
+# O ramo do MEIO do `gitReal`, irmã da linha acima. Os dois extremos que o describe cobria não
+# exercitam o status 1: repo COM a ref devolve 0, fora de repo devolve 128 — e 1 é justamente o que
+# o git responde quando o repo é VÁLIDO e só a `origin/main` falta, o estado do checkout raso que
+# derrubou o `mutation-check`. MEDIDO 2026-09-06: contra a suíte de então (90 testes) esta mutação
+# SOBREVIVIA, ou seja, o executor podia traduzir "ref ausente" em APROVADO e ninguém ficava vermelho
+# — fail-OPEN na dimensão exata do #2227. O caso `em repo git SEM a ref` a mata; esta linha é o que
+# impede a prova de viver só na transcrição de quem mediu (docs/historico/falsificacao-fora-do-ci.md).
+PEGA      | ref ausente (1) traduzida em APROVADO (fail-OPEN)     | s/return \{ status: r\.status \?\? 127,/return { status: (r.status === 1 ? 0 : (r.status ?? 127)),/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -929,8 +929,8 @@ describe('não consigo consultar a origin/main: ausência de dado não é aprova
 });
 
 /**
- * Repo git de verdade COM `refs/remotes/origin/main` — o chão que o `gitReal` precisa ter sob os
- * pés para devolver o ramo POSITIVO.
+ * Repo git de verdade, base dos fixtures do describe abaixo — cada um decide se a
+ * `refs/remotes/origin/main` existe nele.
  *
  * Construído aqui, e não herdado do checkout da sessão, porque essa ref é propriedade do CLONE e
  * não do código sob teste. MEDIDO no job `mutation-check` (run 34006830215): `actions/checkout@v5`
@@ -944,8 +944,8 @@ describe('não consigo consultar a origin/main: ausência de dado não é aprova
  * `spawnSync` cru de propósito: montar o fixture com o próprio `gitReal` faria o teste do executor
  * depender do executor.
  */
-function repoComOriginMain(): { repo: string; sha: string } {
-  const repo = mkdtempSync(join(tmpdir(), 'sonda-git-'));
+function repoGitCru(prefixo: string): { repo: string; git: (...args: string[]) => string } {
+  const repo = mkdtempSync(join(tmpdir(), prefixo));
   criadas.push(repo);
   const git = (...args: string[]): string => {
     const r = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
@@ -956,9 +956,26 @@ function repoComOriginMain(): { repo: string; sha: string } {
   writeFileSync(join(repo, 'base.txt'), 'base\n');
   git('add', 'base.txt');
   git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'base');
+  return { repo, git };
+}
+
+/** COM a ref: o chão que o `gitReal` precisa ter sob os pés para devolver o ramo POSITIVO. */
+function repoComOriginMain(): { repo: string; sha: string } {
+  const { repo, git } = repoGitCru('sonda-git-');
   git('update-ref', 'refs/remotes/origin/main', 'HEAD');
   // O sha SAI do fixture porque a asserção lá embaixo compara contra ELE — ver o porquê no teste.
   return { repo, sha: git('rev-parse', 'HEAD') };
+}
+
+/**
+ * O MESMO repo, sem o `update-ref` — ou seja, git válido com a `origin/main` AUSENTE. É o estado
+ * literal do runner que quebrou o `mutation-check`: `actions/checkout@v5` sem `fetch-depth: 0` faz
+ * `git init` + `fetch --depth=1 <sha>:refs/remotes/pull/N/merge`, então o repo EXISTE e a ref não.
+ * Fica entre os dois casos que o describe já tinha, e é o único dos três que o `gitFalso` simula
+ * (ramo `opts.main == null`, que devolve status 1).
+ */
+function repoSemOriginMain(): string {
+  return repoGitCru('sonda-git-raso-').repo;
 }
 
 describe('gitReal: o executor de verdade responde o que o guard precisa julgar', () => {
@@ -974,6 +991,20 @@ describe('gitReal: o executor de verdade responde o que o guard precisa julgar',
     // QUALQUER ambiente a volta da ref herdada do checkout — que hoje só ficaria vermelha no job
     // `mutation-check`, silenciosa no local e no `validate`.
     expect(r.stdout.trim()).toBe(sha);
+  });
+
+  it('em repo git SEM a ref, status ≠ 0 — é o estado do checkout raso, e o guard tem de fechar', () => {
+    const r = gitReal(repoSemOriginMain())(['rev-parse', '--verify', '--quiet', 'origin/main']);
+    // O que o `conferirSincronia` lê: `rev.status !== 0` manda no ramo que ABORTA sem emitir SQL.
+    // MEDIDO: sem este caso, um `gitReal` que traduzisse 1 (ref ausente) em 0 passava pelos outros
+    // dois — o de cima devolve 0 de verdade, o de baixo devolve 128 — e o fail-OPEN saía verde.
+    expect(r.status).not.toBe(0);
+    // E a MARCA do ramo, não só "≠ 0": `--verify --quiet` sai 1 e CALADO quando só a ref falta,
+    // contra 128 + "fatal: not a git repository" do caso abaixo. É esse 1 que o `gitFalso` afirma
+    // no ramo `opts.main == null`; sem esta linha o dublê estaria citando o git de memória.
+    expect(r.status).toBe(1);
+    // O guard também recusa por `rev.stdout.trim() === ''`: aqui não há sha nenhum para inventar.
+    expect(r.stdout.trim()).toBe('');
   });
 
   it('fora de um repo git, status ≠ 0 — o guard cai no ramo fail-CLOSED, não no aprovado', () => {


### PR DESCRIPTION
Acréscimo sobre o #2227 (que tirou do teste a asserção que media o CHECKOUT) e o #2232 (que pôs no `.mut` a mutação que transformou aquele conserto em cobertura vigiada). Terceiro passo da mesma sequência.

## O que faltava

O describe `gitReal: o executor de verdade responde o que o guard precisa julgar` cobria os dois **extremos**:

| estado | `rev-parse --verify --quiet origin/main` |
|---|---|
| repo COM a ref | status **0** + o sha daquele repo |
| fora de um repo git | status **128** + `fatal: not a git repository` |
| **repo git VÁLIDO, ref AUSENTE** | **status 1, calado** ← não era coberto |

O terceiro é justamente o estado que quebrou o `mutation-check`: `actions/checkout@v5` sem `fetch-depth: 0` faz `git init` + `fetch --depth=1 <sha>:refs/remotes/pull/N/merge`, então o repo **existe** e a `origin/main` não.

## Por que não é cobertura cosmética — medido ANTES de escrever

Mutação candidata: o `gitReal` traduzindo status 1 (ref ausente) em 0 (aprovado) — o fail-OPEN da própria classe do #2227.

- Contra a suíte de **90** testes: **SOBREVIVE**, verde. Nenhum dos dois extremos exercita o 1 (um devolve 0 de verdade, o outro 128).
- Contra a suíte de **91**: vermelha, e derruba **exatamente** o teste novo.

Falsificação conduzida com controle verde na **mesma invocação** do laço, abortando antes do primeiro `sed` se o controle não fechasse — e com o caso já commitado, porque a restauração é `git checkout --`.

## As duas asserções

`expect(r.status).not.toBe(0)` é o que o `conferirSincronia` lê (`rev.status !== 0` manda no ramo que aborta sem emitir SQL). `expect(r.status).toBe(1)` é a **marca do ramo**: é o valor que o dublê `gitFalso` afirma em `opts.main == null` — até aqui o dublê citava o git de memória, sem nada que o desmentisse.

Fixture montado com `spawnSync` cru pela mesma razão do #2227: montá-lo com o próprio `gitReal` faria o teste do executor depender do executor. O construtor comum saiu para `repoGitCru`; cada fixture decide se cria a ref.

## A linha no `.mut`

A prova acima rodou **à mão**, uma vez — que é a classe de `docs/historico/falsificacao-fora-do-ci.md` ("teste que existe e não roda é ausência de dado"). O cabeçalho do próprio `.mut` já manda a falsificação viver lá. A linha nova faz o CI vigiar esse dente.

## Provas

| comando | resultado |
|---|---|
| `bunx vitest run scripts/sonda-versao-sql.test.ts` | **91/91**, exit 0 |
| `bun run typecheck` (src + scripts) | exit 0 |
| `bunx eslint scripts/sonda-versao-sql.test.ts` | exit 0 |
| `mutcheck.sh` **antes** da linha nova | 44 · 42 pegas · 2 sobreviventes · 0 problemas · exit 0 |
| `mutcheck.sh` **com** a linha nova | **45 · 43 pegas · 2 sobreviventes · 0 inválidas · controle+ ✓ (43/43) · 0 problemas · exit 0** |

O `✓ PEGA` da linha nova prova de uma vez que o padrão casa uma única vez, que o mutante compila, e que quem o mata é o **teste** — não o compilador (que viraria falso-PEGA e inflaria o poder aparente da suíte).

> Nota de contagem: o contrato tinha **43** mutações antes do #2227; a 44ª entrou pelo #2232 (`gitReal ignora a raiz pedida`). A base correta hoje é 44, e este PR leva a 45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)