### PR TITLE
test(sonda): config GLOBAL do hospedeiro deixa de decidir o fixture do gitReal — cada flag provada contra hospedeiro forjado

### DIFF
--- a/docs/historico/teste-que-afirma-o-checkout.md
+++ b/docs/historico/teste-que-afirma-o-checkout.md
@@ -90,3 +90,42 @@ o checkout.
   olho pelo vermelho. Ou conserta ou sai.
 - Vizinho de classe: [teste-que-afirma-o-defeito.md](teste-que-afirma-o-defeito.md) (a suíte verde
   que afirmava o bug) — aqui a suíte vermelha afirmava o clone.
+
+## Adendo (2026-09-06): o fixture ainda herdava a config GLOBAL do hospedeiro
+
+O #2227 tirou do teste a dependência da **ref** do checkout, mas o fixture que entrou no lugar
+deixava a **config global** decidir seu desfecho: `git commit` obedece `commit.gpgsign` e roda os
+hooks de `core.hooksPath`/`init.templateDir` do usuário. Numa máquina com assinatura global ligada,
+o commit do fixture pede passphrase e a suíte INTEIRA (91 testes) fica vermelha por **config**, não
+por comportamento. Mesma classe um nível abaixo: a ref é propriedade do CLONE, a config é da MÁQUINA.
+
+Blindagem: `-c commit.gpgsign=false` + `--no-verify` no commit do fixture. Mora no helper
+COMPARTILHADO `repoGitCru()` (extraído pelo #2243), não em cada chamador — então cobre de uma
+vez os dois fixtures, o COM a `origin/main` e o SEM ela.
+
+**Medido na M2 do founder em 2026-09-06:** `commit.gpgsign`, `core.hooksPath`, `init.templateDir` e
+`tag.gpgsign` globais todos VAZIOS — risco não-materializado. Ficou fora do #2232 de propósito:
+conserto especulativo não entra no mesmo diff que o diferencial medido.
+
+### Como se provou que as duas flags não são decoração
+
+O `mutcheck` mede o **fonte** (`sonda-versao-sql.ts`); flag de fixture vive no **teste**, então o
+contrato não lhe dá dente nenhum — e num hospedeiro limpo as duas são no-op, logo "91/91 verde" é
+**ausência de dado**, não aprovação. A prova exigiu **forjar o hospedeiro** (`GIT_CONFIG_GLOBAL`
+apontando para um `.gitconfig` hostil) e sabotar **uma camada por vez**, com o controle verde na
+MESMA invocação do laço:
+
+| cenário | esperado | medido |
+|---|---|---|
+| variante sabotada / hospedeiro limpo | verde (a sabotagem sozinha não quebra) | verde |
+| fiel / `gpgsign=true` + `gpg.program` inexistente | verde | verde |
+| fiel / `core.hooksPath` com `pre-commit` que reprova | verde | verde |
+| **sem `-c commit.gpgsign=false`** / hostil-gpg | **vermelho** | vermelho: `cannot exec '/nao/existe/este/gpg'` |
+| **sem `--no-verify`** / hostil-hooks | **vermelho** | vermelho: `HOOK-GLOBAL-REPROVOU` |
+
+Cada vermelho casa a **marca própria** da sua camada (não "lançou algo"), e a mensagem de erro
+mostra a OUTRA flag ainda presente no comando — o que prova que o isolamento foi limpo e que
+nenhuma das duas é redundante. Sabotar as duas juntas teria medido UMA coisa, não duas.
+
+**Eco:** contrato de mutação sobre o fonte é cego para o ARNÊS. Blindagem de fixture só se prova
+forjando o ambiente que ela promete neutralizar — senão o verde vem de a hostilidade não existir.

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -955,7 +955,25 @@ function repoGitCru(prefixo: string): { repo: string; git: (...args: string[]) =
   git('init', '-q');
   writeFileSync(join(repo, 'base.txt'), 'base\n');
   git('add', 'base.txt');
-  git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'base');
+  // Config GLOBAL do hospedeiro não decide o veredito do fixture — é a mesma classe que o #2227
+  // tirou daqui (teste afirmando fato do ambiente). `commit.gpgsign=false`: numa máquina com
+  // assinatura global ligada o commit pediria passphrase / não acharia a chave e a suíte INTEIRA
+  // ficaria vermelha por config. `--no-verify`: hook de pre-commit/commit-msg (inclusive via
+  // `core.hooksPath` ou `init.templateDir` globais) não roda no commit do fixture.
+  // Mora aqui, no helper COMPARTILHADO do #2243, e não em cada chamador: blinda de uma vez os
+  // dois fixtures — o COM a `origin/main` e o SEM ela.
+  git(
+    '-c',
+    'user.email=t@t',
+    '-c',
+    'user.name=t',
+    '-c',
+    'commit.gpgsign=false',
+    'commit',
+    '--no-verify',
+    '-qm',
+    'base',
+  );
   return { repo, git };
 }
 


### PR DESCRIPTION
## O que

Duas flags no `git commit` do fixture git de `scripts/sonda-versao-sql.test.ts`:
`-c commit.gpgsign=false` e `--no-verify`.

Elas moram no helper **compartilhado** `repoGitCru()` — extraído pelo #2243, que mergeou enquanto
este PR estava draft — e não em cada chamador. Então blindam de uma vez os **dois** fixtures: o COM
a `origin/main` e o SEM ela.

## Por que

O #2227 tirou do teste a dependência da **ref** do checkout, mas o fixture que entrou no lugar
ainda deixava a **config global do hospedeiro** decidir seu desfecho: `git commit` obedece
`commit.gpgsign` e roda os hooks de `core.hooksPath` / `init.templateDir` do usuário. Numa máquina
com assinatura global ligada, o commit do fixture pede passphrase e a suíte **inteira** (91 testes)
fica vermelha por **config**, não por comportamento.

Mesma classe um nível abaixo: a ref é propriedade do **clone**, a config é da **máquina**.

**Medido na M2 em 2026-09-06:** `commit.gpgsign`, `core.hooksPath`, `init.templateDir` e
`tag.gpgsign` globais **todos vazios** — risco não-materializado. Ficou de fora do #2232 de
propósito, para não misturar conserto especulativo com o diferencial medido.

## Por que o verde não bastava como prova

O `mutcheck` muta o **fonte** (`scripts/sonda-versao-sql.ts`), e flag de fixture vive no **teste** —
o contrato é estruturalmente cego a ela. E num hospedeiro limpo as duas flags são **no-op**. Logo
"91/91 verde" aqui é **ausência de dado**, não aprovação.

A prova exigiu **forjar o hospedeiro** (`GIT_CONFIG_GLOBAL` apontando para um `.gitconfig` hostil) e
sabotar **uma camada por vez**, com o controle verde na **mesma invocação** do laço. Rodado duas
vezes: na forma original e de novo na forma pós-#2243, contra o helper compartilhado.

| cenário | esperado | medido |
|---|---|---|
| variante sabotada / hospedeiro **limpo** | verde (a sabotagem sozinha não quebra) | ✅ verde |
| fiel / `gpgsign=true` + `gpg.program` inexistente | verde | ✅ verde |
| fiel / `core.hooksPath` com `pre-commit` que reprova | verde | ✅ verde |
| **sem `-c commit.gpgsign=false`** / hostil-gpg | **vermelho** | ✅ `cannot exec '/nao/existe/este/gpg'` |
| **sem `--no-verify`** / hostil-hooks | **vermelho** | ✅ `HOOK-GLOBAL-REPROVOU` |

Cada vermelho casa a **marca própria** da sua camada (não "lançou algo"), e a mensagem de erro
mostra a **outra** flag ainda presente no comando — isolamento limpo, nenhuma das duas é redundante.
Sabotar as duas juntas teria medido *uma* coisa, não duas. Antes disso, os hospedeiros forjados
foram provados hostis fora do vitest: commit cru sai 128 (gpg) e 1 (hook).

## Evidência (base rebaseada sobre o #2243, exit colado)

| comando | exit | resultado |
|---|---|---|
| `bunx vitest run scripts/sonda-versao-sql.test.ts` | 0 | **91/91** |
| `mutcheck.sh … sonda-versao-sql.mut` | 0 | baseline verde · **45 mutações · 43 pegas · 2 sobreviventes · 0 inválidas · controle+ ✓ (43/43)** |

Os 2 sobreviventes são os mesmos dois cosméticos já documentados no `.mut` (timeout não-pinado e
`ORDER BY` por posição). A contagem subiu de 44 → 45 porque o #2243 acrescentou uma mutação.

## Resíduo

Adendo em [`docs/historico/teste-que-afirma-o-checkout.md`](docs/historico/teste-que-afirma-o-checkout.md)
com a medição, a tabela de falsificação e o eco: **contrato de mutação sobre o fonte é cego para o
arnês; blindagem de fixture só se prova forjando o ambiente que ela promete neutralizar** — senão o
verde vem de a hostilidade não existir.

## Escopo

Só arnês de teste + doc. Nenhuma mudança no fonte, no SQL gerado ou no money-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
