### PR TITLE
docs(spec): selo de preço no disparo — "disparado = aprovado" no OMIE [money-path] (DESENHO v11, APROVADO na 6ª rodada Codex)

### DIFF
--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v9)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v10)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -36,7 +36,13 @@
 > É o que fecha a fronteira pré-aprovação sem constranger o motor. ⚠️ **Cria dependência cruzada com o
 > #2187** — ver §2.1.
 >
-> 🔴 **A v9 ainda NÃO foi desafiada.** Rodada 5 é pré-condição da implementação.
+> - **Rodada 5** sobre a v9 (`max · tentativa 1 · 507s · 123.447 tokens`): **corte atômico do §6
+>   confirmado como suficiente**. Mas o token do §2.1 tinha um P1 (a releitura no clique incorpora o
+>   preço adulterado ao próprio token) e o reparo do §5.4 um P2 (produz capturas fictícias no sensor).
+>   Acatados — §9.10.
+>
+> 🔴 **A v10 ainda NÃO foi desafiada.** Rodada 6 é pré-condição da implementação, e não roda nesta
+> sessão (contexto). É a primeira tarefa de quem retomar.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -92,6 +98,17 @@ pela tela, `current_user` é `authenticated`, o mesmo de um UPDATE cru. O trigge
 consegue** separar os dois na fase pré-aprovação (§9.9.2). Quem separa é o token: ele já compara "o que
 você viu" contra "o que está lá" no instante da aprovação, e um campo a mais faz a aprovação recusar o
 caso realista — **a aba velha que grava preço por cima entre a leitura e a aprovação**.
+
+🔴 **E o token tem de vir do snapshot APRESENTADO, não de uma releitura no clique** (§9.10). O spec do
+#2187 manda `PedidoRow`/lote buscarem os itens *imediatamente antes de aprovar* — o que permite
+`tela mostra 10 → outra aba grava 100 → o clique busca 100 → o token contém 100 → aprovação aceita`.
+Os locks protegem **comparação→aprovação**, mas a alteração aconteceu **antes da busca**. O token
+comprova **correspondência com o snapshot**, não procedência nem visualização humana — e isso precisa
+constar expressamente lá.
+Requisito: o token vem do snapshot que foi exibido e confirmado (inline **e** em lote —
+`useCicloHoje.ts:92` aprova os IDs selecionados sem revisão intermediária); releitura divergente
+**interrompe** a aprovação e exige nova revisão. Testar a sequência completa: só testar
+`token=10 × banco=100` **não cobre o furo**.
 
 **Não contradiz a §8.4 do #2187:** lá a decisão foi manter preço fora do **selo**. O token é outra
 coisa — anti-TOCTOU de leitura, não procedência. O selo continua sem preço.
@@ -363,8 +380,19 @@ UPDATE pedido_compra_item SET preco_unitario = :preco_correto  WHERE id = :id;  
 COMMIT;
 ```
 
-O teste é **recusa → reparo → disparo válido**, com o preço final idêntico ao inicial. Sem isso, a
-"recuperação" do §5.3 é promessa não executável.
+🔴 **O reparo tem de ser IDENTIFICÁVEL, senão polui o sensor** (§9.10). Com `owner=postgres`,
+`sucesso_portal` e PO ausente, os dois UPDATEs caem em **`portal_captura`** — que precede `manual_sql`
+na tabela do §4.3 —, e `10→11→10` deixa no log **+10% e −9,09%** como se o portal tivesse mexido no
+custo. Meu comentário "carimba `manual_sql`" **contradizia a minha própria tabela de precedência**.
+
+Correção: `SET LOCAL reposicao.reparo_carimbo = 'on'`, honrado **só** com `current_user = postgres`,
+força a origem `manual_sql`; e o sensor do §4.6 **exclui `manual_sql` da amostra de captura**.
+⚠️ Este GUC é de **ROTULAGEM, nunca de autorização** — é a distinção que o torna aceitável depois de a
+rodada 3 ter derrubado o GUC como mecanismo de autoridade: o pior caso aqui é alguém rotular errado a
+própria escrita no sensor, não obter permissão que não tinha.
+
+O teste é **recusa → reparo → disparo válido**, com o preço final idêntico ao inicial **e** verificando
+origem gravada e efeito no sensor. Sem isso, a "recuperação" do §5.3 é promessa não executável.
 
 ⚠️ Recuperação de preço é **do founder, não do operador**: como `authenticated` não escreve preço
 pós-aprovação, a RPC de 1ª compra só resolve "preço ausente". Preço válido a corrigir é SQL Editor.
@@ -715,6 +743,25 @@ passo 2 do §4.3 restaura os NULLs. A "recuperação" do §5.3 era promessa sem 
   modos.
 - Falta ainda testar UPDATE direto de preço positivo nos dois estados pré-aprovação, inclusive a aba
   antiga após outro preenchimento — depende da decisão §9.9.2.
+
+### 9.10 Quinta rodada (v9) — o corte atômico passou; o token e o reparo, não
+
+`gpt-6-astra · max · tentativa 1 · 507s · 123.447 tokens`. **Confirmado suficiente:** o corte atômico
+do §6 — *"`SHARE ROW EXCLUSIVE` conflita com o `ROW EXCLUSIVE` dos escritores e permanece até o término
+da transação; escritores anteriores terminam antes do corte, os seguintes encontram o ramo ativo"*.
+
+- **[P1] A releitura no clique incorpora o preço adulterado ao PRÓPRIO token.** O #2187 manda buscar os
+  itens imediatamente antes de aprovar ⇒ `tela mostra 10 → outra aba grava 100 → o clique busca 100 →
+  token = 100 → aprovação aceita`. Os locks protegem comparação→aprovação; a alteração é **anterior à
+  busca**. Acatado no §2.1: o token vem do snapshot **apresentado e confirmado**, releitura divergente
+  interrompe. *"Apenas testar `token=10 × banco=100` não cobre o furo."*
+- **[P2] O reparo produz capturas fictícias no sensor.** Acatado no §5.4 (GUC de rotulagem +
+  `manual_sql` fora da amostra).
+- **Risco aceito, a constar expressamente:** *"master deliberado continua passando: pode gravar 100
+  antes da aprovação e apresentar token de 100. Aceitar isso é defensável se quem pode aprovar integra
+  a fronteira de confiança."* — e quem aprova é `master`, a mesma capability de `cap_compras_ler`. **O
+  token comprova correspondência com o snapshot, não procedência nem visualização humana.** Isso não
+  justifica a releitura silenciosa do P1 acima.
 
 ### 9.6 O que o Codex NÃO transformou em achado
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -47,6 +47,12 @@ o Codex reprovou a M1 dele, e a sessão irmã a refez "sobre a main (guard atôm
 §4.5 se enxertam. **Re-conferir §4.5 contra a versão final do guard antes de implementar**; se o
 guard atômico não tiver mais o ponto de enxerto que este spec assume, §4.5 é reescrita, não adaptada.
 
+⚠️ **A classe de SQLSTATE `SA` é do #2187 e está se movendo.** Conferido contra a M1 real em
+2026-09-06: `SA001` e `SA003`–`SA008` já estão ocupados, e o `SA008` de lá é *'Pedido % mudou de
+estado durante a aprovação'* — a v3 deste spec colidia com ele. Por isso os ramos daqui usam a classe
+**`SP`**, mesmo vivendo dentro das funções do #2187. **Ao implementar, re-conferir os códigos livres:
+esta lista envelhece a cada commit de lá.**
+
 Consome, sem reimplementar: a RPC `aprovar_pedido_sugerido` de 3 args, o trigger de
 `pedido_compra_item`, o GUC de bypass (`reposicao.selo_bypass`, honrado só com
 `current_user IN ('postgres','service_role')`), `reposicao_selo_itens`, `aprovacao_selo` e
@@ -489,10 +495,13 @@ PR.
 3. **RPC dedicada para a 1ª compra + UI migra** — o gate sai do cliente, e a regra "só preenche
    ausente" passa a ser servidor.
 4. **Em fila atrás do #2187.** Não standalone (§2).
-5. ~~**Quantidade entra no escopo**~~ 🧭 **REABERTA pelo challenge — §9.2.** Entrou porque parecia
-   "quase de graça"; o Codex mostrou que a recusa de quantidade **não tem recuperação** (cancelar é
-   negado em `sucesso_portal`). Minha recomendação agora é **tirar a quantidade desta fatia** e
-   transformá-la em chip bloqueado no desenho de recuperação de ordem externa.
+5. ~~**Quantidade entra no escopo**~~ → **REVERTIDA na v4 (§9.2).** Entrou porque parecia "quase de
+   graça"; o Codex mostrou que a recusa de quantidade **não tem recuperação** (cancelar é negado em
+   `sucesso_portal`). Sai a conferência de **selo** de quantidade — vira chip bloqueado no desenho de
+   recuperação de ordem externa (§10); fica a de **transporte**, que não tem o beco.
+   ⚠️ Aplicado por recomendação minha, na ausência de decisão contrária: a decisão original foi do
+   founder, e a reversão é trivial (repor os dois motivos de `aprovacao_selo` na tabela do §5.1) —
+   mas então o §9.2 exige desenhar a recuperação de ordem externa junto.
 
 ## 9. Revisão independente — challenge Codex (2026-09-06): **não aprovar**
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -74,8 +74,11 @@ o Codex reprovou a M1 dele, e a sessão irmã a refez "sobre a main (guard atôm
 guard atômico não tiver mais o ponto de enxerto que este spec assume, §4.5 é reescrita, não adaptada.
 
 ⚠️ **A classe de SQLSTATE `SA` é do #2187 e está se movendo.** Conferido contra a M1 real em
-2026-09-06: `SA001` e `SA003`–`SA008` já estão ocupados, e o `SA008` de lá é *'Pedido % mudou de
-estado durante a aprovação'* — a v3 deste spec colidia com ele. Por isso os ramos daqui usam a classe
+2026-09-06 e **re-medido depois da coordenação**: `SA001` e **`SA003`–`SA010`** estão ocupados — o
+`SA008` de lá é *'Pedido % mudou de estado durante a aprovação'*, e a v3 deste spec colidia com ele.
+A sessão irmã confirmou usar `SA008`, `SA009` e `SA010`; quando medi a M1 pela primeira vez só os
+`SA003`–`SA008` existiam. **A lista envelheceu em horas** — é a prova concreta de por que os códigos
+daqui vivem na classe `SP` (conferido: zero `SP00x` no branch de lá). Por isso os ramos daqui usam a classe
 **`SP`**, mesmo vivendo dentro das funções do #2187. **Ao implementar, re-conferir os códigos livres:
 esta lista envelhece a cada commit de lá.**
 
@@ -85,7 +88,13 @@ Consome, sem reimplementar: a RPC `aprovar_pedido_sugerido` de 3 args, o trigger
 `reposicao_pedido_e_portal`. Acrescenta um ramo ao trigger existente — **não cria um segundo trigger
 na mesma tabela**. Se o #2187 for reprovado ou remodelado, este spec é reescrito, não adaptado.
 
-### 2.1 🔴 Requisito que este spec IMPÕE ao #2187 (leitura obrigatória para quem mexe lá)
+### 2.1 ✅ Requisito ACORDADO com o #2187 (coordenado entre sessões em 2026-09-06)
+
+> **Estado:** enviado à sessão que reconstrói o #2187 e **aceito por ela**, textualmente: *"Requisito
+> legítimo e o segundo ponto é um furo real no meu §3.4.3 — vou acatar os dois."* ⚠️ **Isso é aceite em
+> conversa, não código.** A prova é o `p_itens_vistos` do #2187 conter `preco_unitario` **e** o token
+> vir do snapshot apresentado — conferir no branch antes de implementar aqui. Se o aceite não se
+> materializar, o risco pré-aprovação volta a ficar aberto e vira risco aceito nomeado (§9.9.2).
 
 **`preco_unitario` tem de entrar no token `p_itens_vistos`** da RPC `aprovar_pedido_sugerido` de 3 args
 (§3.4.3 do spec do #2187), ao lado de `id`, `sku_codigo_omie`, `qtde_final` e `fator_embalagem_portal`.
@@ -113,8 +122,8 @@ Requisito: o token vem do snapshot que foi exibido e confirmado (inline **e** em
 **Não contradiz a §8.4 do #2187:** lá a decisão foi manter preço fora do **selo**. O token é outra
 coisa — anti-TOCTOU de leitura, não procedência. O selo continua sem preço.
 
-**Se o #2187 recusar este requisito**, o risco pré-aprovação volta a ficar aberto e este spec tem de
-registrá-lo como risco aceito, com o caso da aba velha nomeado.
+**Se o aceite não se materializar em código**, o risco pré-aprovação volta a ficar aberto e este spec
+tem de registrá-lo como risco aceito, com o caso da aba velha nomeado.
 
 ## 3. O que existe hoje (medido em prod via psql-ro, 2026-09-06)
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v1)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v2)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -9,6 +9,15 @@
 > `docs/historico/portal-sayerlack-fator-aprovado-vs-vivo.md`.
 > **Status: desenho aprovado pelo founder em conversa (2026-09-06); implementação EM FILA atrás do
 > #2187, que ainda é DRAFT e do qual esta fatia consome infraestrutura (§2).**
+>
+> 🔴 **REVISÃO INDEPENDENTE PENDENTE.** O challenge do Codex sobre este spec foi disparado em
+> 2026-09-06 e **não rodou**: `scripts/codex-async.sh` saiu com **exit 75 — cota esgotada** (plano
+> declarado `prolite`, que BATE com o ping registrado no cabeçalho do próprio script em 2026-09-05 ⇒
+> limite real, não token velho). Custo do consult: `gpt-6-astra · max · tentativa 1 · —s · tokens ?`
+> (ausente, não zero — o codex não emitiu rodapé). Acionado o **Caminho B** (`money-path.md` §230):
+> validação adversária própria, registrada em §9. **Auto-revisão NÃO substitui revisão
+> independente** — ela cobre o intervalo. **Rodar o Codex retroativamente quando a janela resetar,
+> ANTES de implementar.**
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -291,6 +300,16 @@ portal é terminal ("cancele e aguarde o ciclo"); divergência de preço é **re
 corrige por uma porta autorizada, que re-sela e limpa o motivo, e o reprocesso segue. Sem isso o guard
 brickaria o pedido.
 
+**Mas os dois motivos de selo não têm o mesmo desfecho, e a mensagem tem de dizer qual é qual:**
+
+| motivo | recuperação |
+|---|---|
+| `preco_selo_ausente` / `preco_selo_divergente` / `payload_divergente` (preço) | porta autorizada re-sela e limpa o motivo → reprocessa |
+| `aprovacao_selo_ausente` / `aprovacao_selo_divergente` / `payload_divergente` (qtde) | **não há porta** — o `aprovacao_selo` é imutável por construção no #2187, e assim deve ser. Só sai por **cancelar + o ciclo regravar** |
+
+Sem essa distinção na mensagem o operador reprocessa em círculo achando que é transitório (achado
+B1 do §9).
+
 Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: o fornecedor tem a
 ordem e o Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável
 por conciliação; PO com preço errado é dinheiro saindo errado.
@@ -346,18 +365,28 @@ PR.
   afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica vermelho; remover o
   `SET LOCAL reposicao.selo_bypass='on'` de `sayerlack_aplicar_custo_portal` → a captura legítima toma
   `SA008` (prova que o bypass do §4.4 é necessário, não decorativo).
-- **vitest, gate de forma da edge:** assert **positivo** "o `IncluirPedCompra` é precedido por
-  `reposicao_conferir_disparo_omie`" e assert **negativo** "a conferência não está dentro de um ramo
-  `modo === 'producao'`" — é o segundo que trava o furo do `dry_run`. O gate lê a edge como TEXTO e
-  limpa comentário com o stripper COMPARTILHADO (`removerComentarios` de `@/lib/gates/limpeza-fonte`),
-  nunca regex local.
+- **Gate de forma da edge — REUSA o harness que já existe.**
+  `supabase/functions/_shared/marco-pre-omie_test.ts` já faz exatamente esta forma para o
+  `lerMarcoPreOmie`: assere que a leitura vem **antes** do `IncluirPedCompra`, que existe
+  **exatamente 1** call site, e traz a falsificação embutida (monta a fonte `invertido` e exige
+  vermelho). O novo gate é o **irmão** dele para `reposicao_conferir_disparo_omie`, no mesmo arquivo
+  ou ao lado, com a mesma mecânica — não inventar harness novo.
+  É o assert "exatamente 1 call site" que sustenta a alegação de que a asserção é **inescapável**:
+  sem ele, um segundo `IncluirPedCompra` futuro passaria por fora e nada ficaria vermelho.
+  Acrescenta o assert **negativo** "a conferência não está dentro de um ramo `modo === 'producao'`",
+  **com falsificação própria** (envolver a chamada em `if (modo === 'producao')` e exigir vermelho) —
+  é ele que trava o furo do `dry_run`, e sem falsificar ele é decorativo.
+  O gate lê a edge como TEXTO e limpa comentário com o stripper COMPARTILHADO (`removerComentarios` de
+  `@/lib/gates/limpeza-fonte`), nunca regex local — a edge tem `IncluirPedCompra` em 6 comentários e
+  1 chamada; um stripper local mediria os comentários.
 - **Deno `test:edges`** (`--no-remote`, sem afrouxar o flag), **`edges:typecheck`**, **`sonda:bump`**
   (`VERSAO`) + **`sonda:fingerprint -- --write`** em `disparar-pedidos-aprovados`. Os 5 gates de edge
   não se cobrem.
 - **Manifesto de módulos:** arquivo novo em `src/` ganha dono em `src/lib/modulos/manifesto.ts`.
 - **`bun run psql:errorstop`**, **`shellcheck`** no harness novo.
 - **Codex challenge** (`scripts/codex-async.sh`, background) sobre este spec **antes** de implementar,
-  e sobre o PR depois.
+  e sobre o PR depois. 🔴 **Tentado em 2026-09-06 e barrado por cota (exit 75)** — ver o bloco de
+  status no topo e o Caminho B em §9. É pré-condição da implementação, não do merge deste spec.
 
 ## 8. Decisões do founder (2026-09-06, nesta ordem)
 
@@ -371,7 +400,47 @@ PR.
 4. **Em fila atrás do #2187.** Não standalone (§2).
 5. **Quantidade entra no escopo** (§5.1 item 2): a conferência do disparo cobre os dois selos.
 
-## 9. Fora de escopo (dito, não esquecido)
+## 9. Caminho B — auto-challenge adversário (2026-09-06)
+
+Substitui NADA; cobre o intervalo até o Codex rodar. Os achados abaixo são meus, contra meu próprio
+desenho, e **já estão incorporados no corpo do spec**.
+
+### B1 [P1] Divergência de QUANTIDADE não tem porta de recuperação — e o operador entraria em loop
+
+`preco_selo_divergente` é recuperável: o operador corrige por porta autorizada, que re-sela e limpa o
+motivo (§5.3). **`aprovacao_selo_divergente` não é.** O `aprovacao_selo` é imutável por construção no
+#2187 — não existe, nem deve existir, porta que o re-sele. Um pedido que caia nesse motivo fica em
+`falha_envio` e **nenhuma** ação da tela o destrava; o reprocesso o traz de volta ao mesmo ponto.
+
+Incorporado: §5.3 passa a distinguir os dois desfechos, e a mensagem de recusa tem de dizer qual é
+qual — senão o operador reprocessa em círculo achando que é transitório.
+
+### B2 [P2] `persistir_qtde_inteira` sobrescreve o `valor_total` PROVADO do portal
+
+`sayerlack_aplicar_custo_portal` grava `valor_total` = total provado do Efetivar. Na invocação
+seguinte do disparo, `reposicao_persistir_qtde_inteira` recomputa
+`valor_total = sum(valor_linha)` — descartando o número provado em favor de um derivado. Se o total do
+portal incluir qualquer coisa que não seja `Σ preço×qtde` (frete, arredondamento do fornecedor), o
+provado é perdido em silêncio.
+
+**Fora do escopo desta fatia** (é bug pré-existente, não regressão do selo, e não afeta o `nValUnit`
+que vai ao Omie). Registrado aqui para virar chip. Reforça a §4.1: `valor_linha` e `valor_total` já
+são território de um escritor que os trata como derivados.
+
+### B3 — o que investiguei e NÃO virou achado (medido, não presumido)
+
+- **Outro caminho até o Omie?** Não. `grep -rn IncluirPedCompra supabase/functions/` dá **um** call
+  site executável (`disparar-pedidos-aprovados/index.ts:1057`); o resto é comentário e teste.
+- **Reconciliação cria PO sem passar pela asserção?** Não. Ela **adota** um PO que o Omie diz já
+  existir, via `ConsultarPedCompra` — o PO nasceu de uma invocação anterior que passou pela asserção.
+- **`aplicar_promocoes_no_ciclo` é porta de preço não coberta?** Não. Filtra
+  `status = 'pendente_aprovacao'` (e `IN ('pendente_aprovacao','bloqueado_guardrail')` na reavaliação)
+  — é pré-aprovação.
+- **Duplo envio ao portal na recusa?** Não. Na 1ª invocação o portal devolve `queued` e
+  `processarPedido` retorna **antes** de montar o payload; a asserção só roda na invocação que cria o
+  PO, quando o protocolo já existe.
+
+## 10. Fora de escopo (dito, não esquecido)
 
 - **Teto de valor aprovado** ("o portal cobrou mais do que aprovamos"). É a fatia seguinte, e §4.6 diz
   exatamente qual número a destrava.

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v3)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v4)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -43,7 +43,7 @@ A invariante executável é **procedência**, não igualdade:
 o Codex reprovou a M1 dele, e a sessão irmã a refez "sobre a main (guard atômico)", ainda marcada
 `NÃO PRONTA`. Os cinco símbolos de que esta fatia depende sobrevivem à reconstrução
 (`aprovacao_selo`, `reposicao.selo_bypass`, `reposicao_selar_pedido`, `reposicao_selo_itens`,
-`p_itens_vistos`), mas **a FORMA do guard mudou** — e é dentro dele que os ramos `SA008`/`SA009` do
+`p_itens_vistos`), mas **a FORMA do guard mudou** — e é dentro dele que os ramos `SP006`/`SP007` do
 §4.5 se enxertam. **Re-conferir §4.5 contra a versão final do guard antes de implementar**; se o
 guard atômico não tiver mais o ponto de enxerto que este spec assume, §4.5 é reescrita, não adaptada.
 
@@ -125,7 +125,7 @@ nascimento; SELECT para staff de compras; **nenhum** INSERT/UPDATE/DELETE para `
 
 Classes de SQLSTATE, cada uma do dono da função: `SA00x` = #2187 (selo do portal), `CP00x` =
 `sayerlack_aplicar_custo_portal`, **`SP00x` = este spec**. Os ramos novos dos triggers do #2187 usam
-`SA008` (item) e `SA009` (pedido) porque vivem dentro das funções de lá.
+`SP006` (item) e `SP007` (pedido) porque vivem dentro das funções de lá.
 
 ### 4.3 `reposicao_selar_preco(p_pedido_id bigint, p_origem text)` — o ÚNICO escritor do selo
 
@@ -214,17 +214,23 @@ precisou corrigir preço válido em `falha_envio`; se precisar, é SQL Editor + 
 **UI:** `useDetalhesModal` troca o `update` PostgREST de preço pela RPC.
 `podeEditarPrecoPedido`/`precoEditavelDaLinha` continuam como UX, mas deixam de ser o freio.
 
-### 4.5 Trava — ramo `SA008` no trigger do #2187
+### 4.5 Trava — ramo `SP006` no trigger do #2187
 
 **Em `pedido_compra_item`** — o trigger `BEFORE INSERT/UPDATE/DELETE` do #2187 hoje deixa preço passar
 de propósito (§3.2 de lá). Ganha um segundo ramo: pai **fora** de
-`('pendente_aprovacao','bloqueado_guardrail')` e o UPDATE toca `preco_unitario` → `SA008`, **salvo**
+`('pendente_aprovacao','bloqueado_guardrail')` e o UPDATE toca `preco_unitario` → `SP006`, **salvo**
 sob o bypass `reposicao.selo_bypass` já previsto (GUC **e**
 `current_user IN ('postgres','service_role')` — nunca para `authenticated`).
 
 ⚠️ **`falha_envio` SAIU da lista permissiva** (era o buraco do §9.1). A lista agora é só
 pré-aprovação: depois da aprovação, `authenticated` **não escreve `preco_unitario` em estado nenhum**.
-Quem escreve em `falha_envio` é a RPC de 1ª compra, que é SECDEF e põe o bypass ela mesma (§4.4.1).
+Quem escreve em `falha_envio` é a RPC de 1ª compra, que é SECDEF (§4.4.1).
+
+⚠️ **O ramo de preço autoriza por ESTADO + `current_user`, NÃO por GUC** (mudança da v4). A M1 do
+#2187 declara que *"a M2 autoriza por ESTADO, que é mais forte que um GUC"*, e a v3 daqui dependia do
+`reposicao.selo_bypass`. Alinhar é melhor por si só: para o P0 do §9.1 o que importa é que
+`authenticated` não escreva preço pós-aprovação, e as portas são SECDEF — logo o `current_user` delas
+já é o owner. Um GUC a mais seria uma chave a mais para vazar, e ficaria refém do redesenho do #2187.
 Efeito colateral desejado: a aba velha do §9.4 tem a escrita **recusada no banco** em vez de aceita
 sem selo — o preço continua ≤ 0 e a RPC nova ainda funciona, sem virar intervenção SQL.
 
@@ -237,7 +243,7 @@ seria porta aberta sem dono.
 
 **Em `pedido_compra_sugerido`** — o trigger `BEFORE UPDATE` do #2187 (§3.3 de lá) ganha um ramo:
 `preco_selo` / `preco_selo_em` / `preco_selo_origem` só mudam quando
-`reposicao.selando_preco = NEW.id`, senão `SA009`. É **aqui** que o GUC trabalha. Note a diferença
+`reposicao.selando_preco = NEW.id`, senão `SP007`. É **aqui** que o GUC trabalha. Note a diferença
 para o `aprovacao_selo`, que é imutável depois de gravado: `preco_selo` é *mutável, porém só por uma
 porta*.
 
@@ -281,10 +287,16 @@ do próprio `produtos_incluir`, **não de uma releitura** — e compara em SQL c
 | motivo | condição |
 |---|---|
 | `preco_selo_ausente` | `preco_selo IS NULL` |
-| `aprovacao_selo_ausente` | `aprovacao_selo IS NULL` |
+
 | `preco_selo_divergente` | hash recomputado de `preco_unitario` ≠ `preco_selo` |
-| `aprovacao_selo_divergente` | `reposicao_selo_itens(p_pedido_id)` ≠ `aprovacao_selo` |
-| `payload_divergente` | conjunto de `item_id` ≠ itens do pedido, ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
+
+| `payload_divergente` | correspondência um-para-um quebrada (abaixo), ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
+
+⚠️ **A conferência do `aprovacao_selo` SAIU na v4** (decisão §9.2 aplicada). O que fica de quantidade é
+só **transporte** — `n_qtde` contra a linha do banco — e isso não tem o beco do §9.2: um transporte
+divergente é bug de código da edge, corrigível e reprocessável, não um estado de "fornecedor recebeu e
+não há como voltar". A **prevenção** de quantidade continua sendo do #2187 (selo imutável + trigger);
+o que fica pendente é só a conferência de fronteira dela, agora chip bloqueado (§10).
 
 **Correspondência um-para-um, não igualdade de conjuntos** (§9.5): `p_itens` tem de ser array válido,
 com `item_id` **únicos**, e a **cardinalidade** tem de bater com a contagem de itens do pedido —
@@ -299,16 +311,14 @@ transporte, e é o contrato que tem de fechar.
 Três coisas numa chamada:
 
 1. **Procedência do preço** (`preco_selo`) — o que esta fatia acrescenta.
-2. **Procedência da quantidade** (`aprovacao_selo`) — o #2187 sela `qtde_final`, mas quem confere é a
-   edge do **portal**, pré-Browserless. O lado Omie mandava `nQtde` sem conferir nada. Custa ~5 linhas
-   de SQL aqui e nenhuma chamada extra.
-3. **Transporte** — o `Number()` do TS colapsa decimais distintos (P2-12 do Codex no #2187). Comparar o
+2. **Transporte** — o `Number()` do TS colapsa decimais distintos (P2-12 do Codex no #2187). Comparar o
    valor **enviado** contra o banco é mais estrito que comparar banco-com-banco: se o `Number()`
    deturpar o preço, o PO sairia deturpado e nós saberíamos.
 
 Sobre `n_qtde`: sob o #2187 a `qtde_final` já é canônica (inteira) na aprovação, então
 `Math.ceil(Number(qtde_final))` é no-op e a comparação estrita `IS DISTINCT FROM qtde_final` é a certa.
-Se **não** for no-op, a recusa é a resposta correta — algo aprovou fração.
+Se **não** for no-op, a recusa é a resposta correta — algo aprovou fração. Isto é conferência de
+TRANSPORTE (payload × banco), não de selo: não depende do `aprovacao_selo` e não herda o beco do §9.2.
 
 ### 5.2 Onde entra na edge
 
@@ -339,9 +349,10 @@ brickaria o pedido.
 | motivo | recuperação |
 |---|---|
 | `preco_selo_ausente` / `preco_selo_divergente` / `payload_divergente` (preço) | porta autorizada re-sela e limpa o motivo → reprocessa |
-| `aprovacao_selo_ausente` / `aprovacao_selo_divergente` / `payload_divergente` (qtde) | 🚧 **NÃO HÁ RECUPERAÇÃO** — ver o beco abaixo |
+| `payload_divergente` (transporte: `n_qtde` ou `n_val_unit` ≠ banco) | bug de código da edge — corrigir, deployar, reprocessar. Nada a re-selar |
 
-⚠️ **O beco da quantidade (§9.2).** A v2 dizia "cancelar + o ciclo regrava". **Isso está bloqueado**:
+⚠️ **Por que a conferência do `aprovacao_selo` NÃO está aqui (§9.2, decidido na v4).** Ela criaria uma
+recusa **sem recuperação**, e essa é a razão de ter saído do escopo. Registrado para quem retomar:
 `cancelar_pedido_sugerido` (na própria M1 do #2187) recusa quando
 `status_envio_portal IN ('enviando_portal','enviado_portal','sucesso_portal','aceito_portal_sem_protocolo','indeterminado_requer_conciliacao')`
 — e `sucesso_portal` é exatamente o estado onde a recusa aconteceria. Resultado: **fornecedor
@@ -354,7 +365,9 @@ existe para evitar. Uma recuperação de verdade precisa tratar a **ordem extern
 confirmado no fornecedor antes de gerar substituto). Preservar a imutabilidade do `aprovacao_selo` é
 compatível com isso; **mudar só a mensagem não é.**
 
-Por isso o escopo da quantidade voltou a ser decisão do founder — §9.2.
+Por isso a conferência de selo de quantidade **saiu desta fatia** e virou chip bloqueado (§10). A
+prevenção do #2187 (selo imutável + trigger) continua cobrindo quantidade; o que falta é a conferência
+de fronteira, e ela não nasce antes da recuperação de ordem externa.
 
 A recuperação do lado do PREÇO também ficou mais estreita na v3, e é honesto dizer: como
 `authenticated` não escreve preço pós-aprovação (§4.5), a RPC de 1ª compra só resolve o caso "preço
@@ -382,15 +395,15 @@ por conciliação; PO com preço errado é dinheiro saindo errado.
 2. **Publish (UI migra para a RPC) + deploy da edge** `disparar-pedidos-aprovados` com a conferência já
    fail-closed. Com M1 aplicada, a edge nova encontra as colunas e a RPC. Com a edge velha ainda no ar
    e M1 aplicada: nada quebra (M1 não recusa nada).
-3. **M2 — ativar.** Ramos `SA008` (item) **e `SA009`** (pedido) nos triggers do #2187 — a v2 agendava
-   só o `SA008` (§9.4). Pré-condição **medida por query**: zero pedidos em `enviando_portal` e a sonda
+3. **M2 — ativar.** Ramos `SP006` (item) **e `SP007`** (pedido) nos triggers do #2187 — a v2 agendava
+   só o `SP006` (§9.4). Pré-condição **medida por query**: zero pedidos em `enviando_portal` e a sonda
    da edge respondendo a versão nova.
 
    ⚠️ **A ordem mudou na v3, e "Publish" não é o marco.** Publish não fecha aba velha — o SW só troca
    de build quando o cliente clica (CLAUDE.md, 4ª camada). Uma aba antiga em `falha_envio` preencheria
    o custo por PostgREST cru, **sem selar**, e a edge nova recusaria; pior, atualizar a UI depois não
    salvaria — o preço já seria positivo e a RPC nova responderia `SP005` (§9.4). Por isso o ramo
-   `SA008` **precisa estar ativo junto com o deploy da edge, não depois dele**: com ele, a escrita da
+   `SP006` **precisa estar ativo junto com o deploy da edge, não depois dele**: com ele, a escrita da
    aba velha é **recusada no banco** (o preço fica ≤ 0 e a RPC nova ainda resolve) em vez de aceita e
    silenciosamente sem selo. Fail-closed contra cliente velho é o ponto — "zero `enviando_portal` +
    sonda nova" não diz nada sobre abas antigas.
@@ -405,34 +418,36 @@ PR.
   positivo de fim; asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos
   sob `SET ROLE authenticated` + GUC do JWT). Cobre:
   🔴 **o teste decisivo do §9.1 — `adulterar → tentar legitimar → conferir disparo`:** como
-  `authenticated`, (a) UPDATE de preço em `falha_envio` → `SA008`; (b) UPDATE de preço → NULL em
-  qualquer status pós-aprovação → `SA008` (fecha a ausência fabricada); (c) chamada direta a
+  `authenticated`, (a) UPDATE de preço em `falha_envio` → `SP006`; (b) UPDATE de preço → NULL em
+  qualquer status pós-aprovação → `SP006` (fecha a ausência fabricada); (c) chamada direta a
   `private.reposicao_selar_preco` → erro de privilégio; (d) adulterar item A + preencher item B pela
   RPC → a RPC recusa (A não estava ≤ 0) e **nada** é selado; (e) em todos, o disparo seguinte recusa.
   Negar INSERT direto no log NÃO é este teste ·
   aprovação sela · captura do portal re-sela e loga o delta · 1ª compra preenche e re-sela · 1ª compra
   **recusa** item com preço > 0 (`SP005`) · payload com NaN/Infinity/≤0 → `SP004` · status fora da
   lista → `SP003` · origem inválida → `SP001` · UPDATE de `preco_unitario` pós-aprovação por
-  `authenticated` → `SA008` · o mesmo UPDATE com `reposicao.selando_preco` posto por `authenticated`
+  `authenticated` → `SP006` · o mesmo UPDATE com `reposicao.selando_preco` posto por `authenticated`
   **não** passa · `reposicao_persistir_qtde_inteira` no disparo **não** quebra o selo (é o teste que
   prova a decisão §4.1) · conferência: `n_val_unit` deturpado → `payload_divergente` · `n_qtde` ≠
-  `qtde_final` → `payload_divergente` · preço alterado sem selar → `preco_selo_divergente` · qtde
-  alterada sem selar → `aprovacao_selo_divergente` · `preco_selo` NULL → `preco_selo_ausente` ·
+  `qtde_final` → `payload_divergente` · preço alterado sem selar → `preco_selo_divergente` ·
+  **payload com `item_id` repetido → `payload_divergente`** (o furo de multiplicidade do §9.5, que a
+  igualdade de conjuntos deixava passar com quantidade dobrada) · `preco_selo` NULL →
+  `preco_selo_ausente` ·
   `preco_recusa_motivo` limpo pelo re-selo · split sela os filhos · hash: ordem por `id`,
-  `0,20 ≡ 0,2`, NULL ≠ vazio · UPDATE direto de `preco_selo` sem o GUC → `SA009` ·
+  `0,20 ≡ 0,2`, NULL ≠ vazio · UPDATE direto de `preco_selo` sem o GUC → `SP007` ·
   `itens_mudados` é `NULL` no primeiro selo e `0` quando o re-selo não muda preço nenhum (é o par que
   prova "ausente ≠ zero" no sensor) · `authenticated` **não** consegue INSERT direto em
   `reposicao_preco_selo_log`, mas a aprovação humana grava lá pela função.
 - **Falsificação uma camada por vez**, com **controle verde na MESMA invocação do laço** (senão a
   suíte sempre-vermelha aprova tudo) e **commit antes** (o `restaurar()` é `git checkout --`):
-  remover o ramo `SA008` → o teste do `authenticated` fica vermelho; neutralizar a comparação de
+  remover o ramo `SP006` → o teste do `authenticated` fica vermelho; neutralizar a comparação de
   `n_val_unit` → o teste de transporte fica vermelho; tirar o re-selo de
   `sayerlack_aplicar_custo_portal` → a conferência acusa divergência num caminho **legítimo**;
   devolver `p_origem` ao chamador (ou reconceder EXECUTE a `authenticated` no selador) → o cenário
   (c) do teste decisivo fica vermelho; repor `falha_envio` na lista permissiva → (a) fica vermelho;
   afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica vermelho; remover o
   `SET LOCAL reposicao.selo_bypass='on'` de `sayerlack_aplicar_custo_portal` → a captura legítima toma
-  `SA008` (prova que o bypass do §4.4 é necessário, não decorativo).
+  `SP006` (prova que o bypass do §4.4 é necessário, não decorativo).
 - **Gate da edge — a v2 afirmava um FATO FALSO aqui, corrigido (§9.5).** Eu escrevi que
   `_shared/marco-pre-omie_test.ts` já assere "exatamente 1 call site de `IncluirPedCompra`". **Não
   assere.** O `G3` conta `atribuicoesDaColuna` — atribuições de `omie_po_inexistente_antes_de` —, e o
@@ -520,17 +535,17 @@ estado onde seria necessária**.
 Meu B1 (§9.3) tinha achado o problema e prescrito a cura errada: **band-aid**. Mudar a mensagem não é
 recuperação.
 
-🧭 **DECISÃO ABERTA.** A quantidade entrou nesta fatia porque parecia "quase de graça" — cinco linhas
-de SQL numa RPC que já ia existir. **Não é de graça**: uma recusa sem recuperação transforma
-"fornecedor recebeu e Omie não" num estado sem saída. Três caminhos:
+✅ **DECIDIDO na v4: a conferência de selo de quantidade SAI desta fatia.** A quantidade entrou porque
+parecia "quase de graça" — cinco linhas de SQL numa RPC que já ia existir. **Não é de graça**: uma
+recusa sem recuperação transforma "fornecedor recebeu e Omie não" num estado sem saída.
 
-1. **Tirar a quantidade desta fatia** (recomendo). A prevenção do #2187 (selo imutável + trigger) já
-   cobre quantidade; o que falta é só a conferência de fronteira, e ela vira chip bloqueado no desenho
-   de recuperação de ordem externa. A fatia volta a ser só preço, que **tem** recuperação.
-2. **Manter, e desenhar a recuperação de ordem externa junto** — cancelamento confirmado no fornecedor
-   antes de gerar substituto. É outra fatia inteira dentro desta.
-3. **Manter como alerta não-bloqueante** — descartado por mim: guard que não recusa, em money-path,
-   é teatro.
+O que sai: a recomputação de `reposicao_selo_itens` contra `aprovacao_selo` (motivos
+`aprovacao_selo_ausente` / `aprovacao_selo_divergente`). **O que FICA: a conferência de transporte**
+`n_qtde` contra a linha do banco — ela não tem o beco, porque divergência ali é bug da edge
+(corrigir → deployar → reprocessar), não estado externo irreversível.
+
+Descartadas: (b) manter e desenhar a recuperação de ordem externa junto — é outra fatia inteira dentro
+desta; (c) manter como alerta não-bloqueante — guard que não recusa, em money-path, é teatro.
 
 ### 9.3 O Caminho B (auto-challenge) — e o que ele subdimensionou
 
@@ -560,10 +575,10 @@ PostgREST cru (`useDetalhesModal.ts:170`, verificado) → nenhum re-selo → edg
 a UI depois **não salvava**: preço já positivo ⇒ a RPC nova responde `SP005`, e a recuperação normal
 vira intervenção SQL.
 
-E a §6 agendava só o `SA008`; o `SA009` não estava em etapa nenhuma.
+E a §6 agendava só o `SP006`; o `SP007` não estava em etapa nenhuma.
 
-**Acatado** em §6: o `SA008` passa a entrar **junto com o deploy da edge**, não depois — assim a
-escrita da aba velha é recusada no banco, o preço fica ≤ 0 e a RPC nova ainda resolve. `SA009`
+**Acatado** em §6: o `SP006` passa a entrar **junto com o deploy da edge**, não depois — assim a
+escrita da aba velha é recusada no banco, o preço fica ≤ 0 e a RPC nova ainda resolve. `SP007`
 agendado explicitamente.
 
 ### 9.5 [P2] Contrato do payload e uma alegação FALSA minha sobre a prova
@@ -597,6 +612,10 @@ falsificação que remove a DECISÃO de recusar.
 
 ## 10. Fora de escopo (dito, não esquecido)
 
+- 🚧 **Conferência de selo de QUANTIDADE no disparo** — tirada na v4 (§9.2). Bloqueada no desenho de
+  **recuperação de ordem externa** (cancelamento confirmado no fornecedor antes de gerar substituto);
+  sem ela, a recusa não tem saída. A prevenção do #2187 segue cobrindo quantidade, e a conferência de
+  transporte (`n_qtde` × banco) fica nesta fatia.
 - **Teto de valor aprovado** ("o portal cobrou mais do que aprovamos"). É a fatia seguinte, e §4.6 diz
   exatamente qual número a destrava.
 - **`valor_linha` e `valor_total`** — §4.1 explica por que ficam fora do hash (separação de efeitos:

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v6)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v7)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -21,10 +21,13 @@
 > - **Rodada 3** sobre a v5 (`max · tentativa 1 · 422s · 164.718 tokens`): a correção de capability
 >   fechou; **mas o "primeiro selo apenas" quebrou a aprovação legítima e o split lava preço** (§9.8).
 >
-> 🛑 **A v6 NÃO remenda os achados da rodada 3 — de propósito.** Três rodadas, três correções minhas na
-> MESMA fronteira, três buracos novos. Isso deixou de ser série de descuidos e virou sinal de que a
-> **FORMA** está errada. §11 apresenta a conclusão estrutural e a alternativa, e é **decisão do
-> founder** — a forma atual foi escolhida por ele na abertura desta fatia.
+> ✅ **A v7 TROCA A FORMA** (decisão do founder, 2026-09-06, §11.2). Sai o hash por pedido com função
+> de selar; entra **procedência POR LINHA, carimbada pelo próprio trigger** no mesmo statement que
+> escreve o preço. Os cinco achados fecham **por construção**, não por remendo — não há selo para
+> forjar, nem selador para chamar, nem "primeiro selo" para disputar, nem GUC, e o carimbo **viaja com
+> a linha** no split. A aprovação, a captura do portal e o split **deixam de ser tocados** por este spec.
+>
+> 🔴 **A v7 ainda NÃO foi desafiada.** Rodada 4 é pré-condição da implementação.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -51,8 +54,8 @@ A invariante executável é **procedência**, não igualdade:
 o Codex reprovou a M1 dele, e a sessão irmã a refez "sobre a main (guard atômico)", ainda marcada
 `NÃO PRONTA`. Os cinco símbolos de que esta fatia depende sobrevivem à reconstrução
 (`aprovacao_selo`, `reposicao.selo_bypass`, `reposicao_selar_pedido`, `reposicao_selo_itens`,
-`p_itens_vistos`), mas **a FORMA do guard mudou** — e é dentro dele que os ramos `SP006`/`SP007` do
-§4.5 se enxertam. **Re-conferir §4.5 contra a versão final do guard antes de implementar**; se o
+`p_itens_vistos`), mas **a FORMA do guard mudou** — e é dentro dele que o ramo `SP006` do
+§4.3 se enxerta. **Re-conferir §4.5 contra a versão final do guard antes de implementar**; se o
 guard atômico não tiver mais o ponto de enxerto que este spec assume, §4.5 é reescrita, não adaptada.
 
 ⚠️ **A classe de SQLSTATE `SA` é do #2187 e está se movendo.** Conferido contra a M1 real em
@@ -102,278 +105,196 @@ na mesma tabela**. Se o #2187 for reprovado ou remodelado, este spec é reescrit
 - **Um único call site chega ao Omie:** `IncluirPedCompra` em `index.ts:1057`. O segundo `select` de
   itens (`index.ts:1761`) é só o e-mail de notificação, pós-PO.
 
-## 4. Forma
+## 4. Forma — procedência POR LINHA, carimbada na escrita
 
-### 4.1 `valor_linha` fica FORA do selo — e por quê
+> **v7.** As v1–v6 usavam um hash por pedido (`preco_selo`) gravado por uma função de selar. Três
+> rodadas de challenge derrubaram essa forma pelo mesmo motivo estrutural (§11): selar era um ato
+> **separável** da escrita, e a autoridade para selar vinha sempre de um proxy fraco. Aqui não há selo,
+> não há função de selar, e não há nada para autorizar a selar.
 
-`reposicao_persistir_qtde_inteira` reescreve `valor_linha` no disparo, em produção, pós-aprovação.
-Selá-lo criaria uma **quarta porta** e quebraria o selo em todo disparo, ou exigiria um bypass novo
-para uma função que não move dinheiro.
+### 4.1 `valor_linha` fica fora — e por quê
 
-E `valor_linha` **nunca chega ao Omie**: o payload é `nValUnit: Number(it.preco_unitario)` e
-`nQtde: Math.ceil(Number(it.qtde_final))` (`index.ts:984-985`). É derivado, alimenta `valor_total`
-(display + guardrail).
+`reposicao_persistir_qtde_inteira` reescreve `valor_linha` no disparo, em produção, pós-aprovação; e
+`valor_linha` **nunca chega ao Omie** (o payload é `nValUnit: Number(preco_unitario)` e
+`nQtde: Math.ceil(Number(qtde_final))`, `index.ts:984-985`). Protegê-lo custaria uma porta a mais por
+nada na fronteira do dinheiro.
 
-**Decisão: o selo e o ramo do trigger cobrem `preco_unitario` apenas.** O sensor (§4.6) calcula total
-por `sum(qtde_final * preco_unitario)`, que não depende de `valor_linha`. Custo aceito: uma escrita
-solta em `valor_linha` desloca `valor_total` sem quebrar o selo — é desvio de relatório, não dinheiro
-saindo, e o disparo o recomputa.
+⚠️ Mas o desvio **não é "só relatório"** (era erro meu, §9.3): o gate de valor mínimo lê
+`pedido.valor_total` (`index.ts:358`) antes da recomputação. Total deslocado flipa um gate de dinheiro.
+Isso vira chip próprio (§10) — e **não** exige `valor_linha` no mecanismo daqui.
 
-### 4.2 Estado novo
+### 4.2 Estado novo — duas colunas na PRÓPRIA linha
 
-Em `pedido_compra_sugerido`: `preco_selo text`, `preco_selo_em timestamptz`, `preco_selo_origem text`,
-`preco_recusa_motivo text`.
+Em `pedido_compra_item`: **`preco_origem text`** e **`preco_gravado_em timestamptz`**.
 
-Tabela append-only `reposicao_preco_selo_log(id bigserial, pedido_id bigint, selo text, origem text,
-selado_em timestamptz default now(), total_anterior numeric, total_novo numeric, itens_mudados int,
-precos jsonb)`.
+`preco_origem ∈ ('motor','primeira_compra','portal_captura','manual_sql','backfill')`.
 
-`precos` guarda o **vetor** `{item_id: preco}` que gerou o selo, não só o hash — sem ele
-`itens_mudados` seria indecidível (não se faz diff contra um sha256). É o vetor da linha anterior deste
-mesmo pedido que dá o "de → para" por item ao sensor.
+Nada em `pedido_compra_sugerido` além de `preco_recusa_motivo text` (§5.3). **Não há `preco_selo`.**
 
-**Um escritor só** (`reposicao_selar_preco`) — sinal de money-path não mora em jsonb multi-writer; aqui
-o jsonb é aceitável exatamente porque o escritor é único e a tabela é append-only. RLS ligada desde o
-nascimento; SELECT para staff de compras; **nenhum** INSERT/UPDATE/DELETE para `anon`/`authenticated`
-(REVOKE **por nome** — `REVOKE FROM PUBLIC` não os tira).
+O sensor (§4.6) deixa de precisar de tabela própria: a procedência e o instante moram na linha, e o
+delta sai de `pedido_compra_item` cruzado com o histórico do próprio carimbo. Uma tabela append-only
+`reposicao_preco_origem_log(item_id, pedido_id, de_preco, para_preco, origem, em)` continua útil como
+série temporal para o teto (§4.6) — **escrita pelo MESMO trigger**, nunca por chamador.
 
-Classes de SQLSTATE, cada uma do dono da função: `SA00x` = #2187 (selo do portal), `CP00x` =
-`sayerlack_aplicar_custo_portal`, **`SP00x` = este spec**. Os ramos novos dos triggers do #2187 usam
-`SP006` (item) e `SP007` (pedido) porque vivem dentro das funções de lá.
+### 4.3 O trigger CARIMBA — e é por isso que não há o que forjar
 
-### 4.3 `reposicao_selar_preco(p_pedido_id bigint, p_origem text)` — o ÚNICO escritor do selo
+Ramo novo no trigger `BEFORE INSERT OR UPDATE ON pedido_compra_item` do #2187. Para cada linha:
 
-**`private.reposicao_selar_preco`** — `SECURITY DEFINER`, `search_path` fixo, **no schema `private`,
-que o PostgREST não expõe**. `REVOKE EXECUTE` de `PUBLIC`, `anon`, `authenticated` **e**
-`service_role`, por nome. Só o OWNER a executa — ou seja, só as funções-porta (SECDEF, mesmo owner)
-do §4.4.
+1. **O carimbo nunca é input.** Se o statement escreve `preco_unitario` (INSERT, ou UPDATE com
+   `NEW.preco_unitario IS DISTINCT FROM OLD.preco_unitario`), o trigger **sobrescreve**
+   `NEW.preco_origem` e `NEW.preco_gravado_em` com valores que ele mesmo calcula. O que o chamador
+   tenha posto nessas colunas é descartado, sempre.
+2. **Se o statement NÃO escreve preço**, o trigger força
+   `NEW.preco_origem := OLD.preco_origem` e `NEW.preco_gravado_em := OLD.preco_gravado_em` — senão
+   alguém reescreveria o carimbo sozinho, que é o mesmo furo por outra porta.
+3. **A autorização e o rótulo saem do MESMO par** `(estado do pai × current_user)`, avaliado do mais
+   específico para o menos. Par não previsto → **`SP006`**, nunca um rótulo adivinhado:
 
-⚠️ **Isto é a correção do P0 do §9.1, e é o coração da v3.** Na v2 ela era chamável por
-`authenticated` com `p_origem` livre, o que permitia:
-`falha_envio → UPDATE preço 10→100 → reposicao_selar_preco(id,'portal_captura') → reprocessar` —
-hash correspondente a 100, recusa limpa, origem falsa, **os dois selos e a comparação do payload
-passando**. O selo era forjável pela própria porta que deveria protegê-lo.
+   | estado do pai | `current_user` | carimbo |
+   |---|---|---|
+   | `pendente_aprovacao` / `bloqueado_guardrail` | qualquer um que a RLS deixe passar | `motor` no INSERT, `primeira_compra` no UPDATE |
+   | `status_envio_portal='sucesso_portal'` **e** `omie_pedido_compra_numero IS NULL` | owner (SECDEF da captura) | `portal_captura` |
+   | `falha_envio` | owner (SECDEF da 1ª compra) | `primeira_compra` |
+   | qualquer | `postgres` (SQL Editor) | `manual_sql` |
+   | resto | — | **`SP006`** |
 
-Por isso, duas mudanças acopladas — nenhuma das duas basta sozinha:
+   Precedência: a linha do portal vem **antes** da de `falha_envio`, porque um pedido pode estar em
+   `status='falha_envio'` com `status_envio_portal='sucesso_portal'`. Ambiguidade resolve para a regra
+   mais específica, e o risco residual é **de RÓTULO** (atribuição no sensor), nunca de autorização —
+   os dois pares são autorizados de qualquer forma.
 
-1. **`p_origem` deixa de ser parâmetro do chamador.** Cada porta passa uma constante que ela própria
-   possui. Como só as portas chamam, a origem não é forjável.
+**`authenticated` não escreve `preco_unitario` em nenhum estado pós-aprovação.** Quem escreve em
+`falha_envio` é a RPC de 1ª compra, que é SECDEF (§4.4). Autorização por **estado + `current_user`**,
+sem GUC — alinhado com a M1 do #2187 (*"a M2 autoriza por ESTADO, que é mais forte que um GUC"*), e
+fechando o P2 da rodada 3: um GUC não autentica quem o definiu.
 
-   ⚠️ **v5 — a aprovação NÃO é SECDEF, e a v4 quebrava por isso.** Conferido na M1 do #2187
-   (l.376): `aprovar_pedido_sugerido` é `SECURITY INVOKER` **por desenho** (as escritas de item vão sob
-   a RLS do aprovador). Logo ela chamaria o selador privado ainda como `authenticated` →
-   *permission denied*, e **a aprovação quebraria inteira**. Privilégio de SECDEF não permanece no
-   chamador depois do retorno.
+### 4.4 As portas — agora elas só ESCREVEM; o carimbo é consequência
 
-   Solução: uma entrada SECDEF **estreita**, `public.reposicao_selar_preco_na_aprovacao(p_pedido_id)`,
-   com EXECUTE para `authenticated` — e que **não pode lavar nada**, porque:
-   - exige `preco_selo IS NULL` ⇒ **só o PRIMEIRO selo**; re-selar é impossível por ela. Lavar exige
-     re-selar um pedido JÁ selado, e é exatamente isso que ela recusa;
-   - exige `aprovacao_selo IS NOT NULL` e o pedido já em `aprovado_aguardando_disparo` ⇒ ela só age no
-     instante em que o preço ainda é, por definição, o legítimo da fase pré-aprovação;
-   - **preserva a capability da RLS** (abaixo) — não amplia quem pode.
-
-   Não reconceder EXECUTE no selador genérico: era isso que abria o P0.
-2. **Selar e escrever deixam de ser atos separáveis.** Não existe "selar o que já está lá": toda
-   porta escreve e sela na MESMA função, na MESMA transação. É o que fecha a variante do Codex
-   "`UPDATE preço 10→NULL` e chamar a RPC de 1ª compra com 100" — sem escrita crua não há NULL
-   fabricado (§4.5).
-
-Espelha o idioma do `reposicao_selo_itens` do #2187, sobre vetor **disjunto** do dele:
-
-```
-encode(sha256(convert_to(jsonb_agg(jsonb_build_array(
-  id, trim_scale(preco_unitario)::text
-) ORDER BY id)::text, 'UTF8')), 'hex')
-```
-
-`jsonb_agg` remove ambiguidade de separador; `NULL` vira `null`; `trim_scale` faz `0,20 ≡ 0,2`.
-**Uma implementação, em SQL** — nenhum espelho TS do hash.
-
-Em ordem, numa transação:
-
-1. `p_origem` ∈ `('aprovacao','primeira_compra','portal_captura','backfill_m1','manual_sql')`, senão
-   `SP001`.
-2. Pedido existe e tem ≥ 1 item, senão `SP002`.
-3. Calcula `total_novo = sum(qtde_final * preco_unitario)` e lê `total_anterior` da última linha do log
-   (NULL na primeira vez — **ausente ≠ zero**, e o sensor filtra `total_anterior > 0`).
-4. `itens_mudados` = itens cujo `trim_scale(preco_unitario)` difere do `precos` da **última linha do
-   log deste pedido**; `NULL` quando não há linha anterior (ausente ≠ zero: `NULL` diz "não havia com
-   o que comparar", `0` diria "comparei e nada mudou").
-5. Grava `preco_selo`, `preco_selo_em = now()`, `preco_selo_origem = p_origem`, e
-   **`preco_recusa_motivo = NULL`** (§5.3), sob `SET LOCAL reposicao.selando_preco = <pedido_id>`.
-6. `INSERT` no log, com `precos` = o vetor recém-selado.
-
-### 4.4 As três portas — cada uma re-sela na PRÓPRIA transação
-
-| Porta | Quando | Como |
+| Porta | Quando | Muda o quê |
 |---|---|---|
-| `aprovar_pedido_sugerido` (3 args, do #2187) | aprovação | `PERFORM reposicao_selar_preco(id,'aprovacao')` logo após `reposicao_selar_pedido` |
-| `reposicao_definir_custo_primeira_compra(p_pedido_id bigint, p_itens jsonb)` **nova** | `pendente_aprovacao` / `bloqueado_guardrail` / `falha_envio` | valida **no servidor**; re-sela com `'primeira_compra'` |
-| `sayerlack_aplicar_custo_portal` | pós-`sucesso_portal`, pré-PO | `SET LOCAL reposicao.selo_bypass='on'` no topo (ela escreve item com o pai em `aprovado_aguardando_disparo`, fora da lista permissiva do §4.5 — e o bypass do #2187 exige o GUC **além** do papel), e `reposicao_selar_preco(id,'portal_captura')` antes do `RETURN`, dentro do CAS que já existe |
+| motor (`gerar_pedidos_*`, `aplicar_promocoes_no_ciclo`) | INSERT, pedido nasce `pendente_aprovacao` | **nada** — já passa, e ganha carimbo `motor` de graça |
+| `reposicao_definir_custo_primeira_compra` **nova** | `pendente_aprovacao` / `bloqueado_guardrail` / `falha_envio` | escreve preço; o trigger carimba |
+| `sayerlack_aplicar_custo_portal` | pós-`sucesso_portal`, pré-PO | **nada** — a RPC não muda; o trigger carimba |
+| `aprovar_pedido_sugerido` (#2187) | aprovação | **nada. A aprovação NÃO é tocada por este spec** |
+| `pedido_compra_split` | disparo | **nada** — ver §4.4.2 |
 
-`pedido_compra_split` sela os filhos com `reposicao_selar_preco(filho,'aprovacao')` sob o bypass,
-junto do que o #2187 §3.5 já faz.
+🔴 **Isto é o ganho central da v7, e cada linha "nada" fecha um achado:**
+a aprovação não chama selador nenhum (fecha o P1 da rodada 2 — ela é `SECURITY INVOKER` e não teria
+privilégio); não existe "primeiro selo" para a 1ª compra disputar com a aprovação (fecha o P1 da
+rodada 3); e o `sayerlack_aplicar_custo_portal` volta a ser exatamente o que já está em produção.
 
-**A 4ª via — founder consertando pelo SQL Editor — não ganha função.** Roda como `postgres`, que o
-bypass do #2187 §3.2 já honra, e chama `reposicao_selar_preco(id,'manual_sql')` explicitamente.
-Fica no runbook `docs/runbooks/lovable-supabase.md`, não no código.
+#### 4.4.1 `reposicao_definir_custo_primeira_compra(p_pedido_id, p_itens)`
 
-#### 4.4.1 `reposicao_definir_custo_primeira_compra`
+`SECURITY DEFINER`, `search_path` fixo. `p_itens = [{item_id, preco_unitario}]`.
 
-**`SECURITY DEFINER`**, `search_path` fixo — porque depois da v3 `authenticated` não escreve preço em
-NENHUM status pós-aprovação (§4.5), nem em `falha_envio`.
-
-🔴 **v5 — o gate NÃO é "staff". Isso era escalada de privilégio que EU introduzi** (§9.7). A v4
-copiou o gate do `sayerlack_aplicar_custo_portal` (`employee OR master`). Mas a RLS que o SECDEF
-substitui é `cap_compras_ler`, e **conferido em prod ela é
-`has_role(_uid,'master')` — SÓ MASTER**. Com o gate frouxo, um `employee` ganharia por esta porta uma
-escrita que a RLS reservava a `master`: pedido em `falha_envio` com custo ausente → preço arbitrário
-positivo → o owner grava **e sela** → reprocessamento manda ao Omie. Sem forjar nada.
-
-**Regra da v5, e vale para TODA porta humana SECDEF deste spec** (inclusive a
-`reposicao_selar_preco_na_aprovacao` do §4.3): o gate é **exatamente a capability que a RLS exigia** —
-`private.cap_compras_ler(auth.uid())`, senão `42501`. E **`auth.uid() IS NULL` NÃO passa**: ausência de
-identidade não é autorização (a expressão `auth.uid() IS NOT NULL AND NOT staff` do
-`sayerlack_aplicar_custo_portal` deixa NULL passar **de propósito**, porque lá quem chama é a edge com
-`service_role` — copiá-la para uma porta humana inverte o sentido). `REVOKE EXECUTE` de `PUBLIC` e
+🔴 **O gate é a capability EXATA que a RLS exigia** — `private.cap_compras_ler(auth.uid())`, senão
+`42501` —, e **`auth.uid() IS NULL` NÃO passa**. Conferido em prod: `cap_compras_ler` é
+`has_role(_uid,'master')`, **só master**. A v4 copiou o gate do `sayerlack_aplicar_custo_portal`
+(`employee OR master`), o que dava a `employee` uma escrita reservada a `master` (§9.7). E a expressão
+de lá deixa `auth.uid() IS NULL` passar **de propósito**, porque quem chama é a edge com
+`service_role` — copiá-la para porta humana inverte o sentido. Não trocar por `cap_compras_escrever`:
+ela nasceu para a telemetria do motor, outra superfície (rodada 3). `REVOKE EXECUTE` de `PUBLIC` e
 `anon` por nome.
 
-`p_itens = [{item_id, preco_unitario}]`.
-
-1. Pedido `FOR UPDATE`; status ∈ `('pendente_aprovacao','bloqueado_guardrail','falha_envio')`, senão
-   `SP003`.
+1. Pedido `FOR UPDATE`; status ∈ `('pendente_aprovacao','bloqueado_guardrail','falha_envio')`, senão `SP003`.
 2. Payload: array não vazio, `item_id` inteiro, `preco_unitario` **NOT NULL**, `<> 'NaN'::numeric`,
-   `> 0` e `< 'Infinity'::numeric` — os três lados (`'NaN'::numeric` e `'Infinity'::numeric` **passam**
-   em `> 0`). Senão `SP004`.
+   `> 0`, `< 'Infinity'::numeric` — os três lados (`'NaN'` e `'Infinity'` **passam** em `> 0`). Senão `SP004`.
 3. Cada item pertence ao pedido **e tem `coalesce(preco_unitario,0) <= 0` agora** — só PREENCHE, nunca
-   troca preço bom. `ROW_COUNT <> n` → `SP005` e ROLLBACK de tudo.
-4. `valor_linha = ceil(qtde_final) * preco_unitario` para as linhas tocadas, e `valor_total` recomputado.
-5. `PERFORM reposicao_selar_preco(p_pedido_id, 'primeira_compra')`.
+   troca preço bom. `ROW_COUNT <> n` → `SP005`, ROLLBACK de tudo.
+4. `valor_linha = ceil(qtde_final) * preco_unitario` nas linhas tocadas; `valor_total` recomputado.
 
-**Mais estrito que a tela de hoje**, de propósito: hoje uma aba velha em `falha_envio` reescreve
-*qualquer* preço; a RPC só deixa preencher ausente. O founder confirmou (2026-09-06) que nunca
-precisou corrigir preço válido em `falha_envio`; se precisar, é SQL Editor + `'manual_sql'`.
+Não há passo 5: o carimbo é do trigger.
 
-**UI:** `useDetalhesModal` troca o `update` PostgREST de preço pela RPC.
-`podeEditarPrecoPedido`/`precoEditavelDaLinha` continuam como UX, mas deixam de ser o freio.
+**UI:** `useDetalhesModal` troca o `update` PostgREST de preço (`useDetalhesModal.ts:170`) pela RPC.
 
-### 4.5 Trava — ramo `SP006` no trigger do #2187
+#### 4.4.2 Split — o carimbo VIAJA COM A LINHA
 
-**Em `pedido_compra_item`** — o trigger `BEFORE INSERT/UPDATE/DELETE` do #2187 hoje deixa preço passar
-de propósito (§3.2 de lá). Ganha um segundo ramo: pai **fora** de
-`('pendente_aprovacao','bloqueado_guardrail')` e o UPDATE toca `preco_unitario` → `SP006`, **salvo**
-sob o bypass `reposicao.selo_bypass` já previsto (GUC **e**
-`current_user IN ('postgres','service_role')` — nunca para `authenticated`).
+`pedido_compra_split` move `pedido_id` das linhas. `preco_origem` e `preco_gravado_em` **vão junto,
+porque são colunas da linha** — o filho herda a procedência do item, e não ganha procedência nova por
+ser um pedido novo.
 
-⚠️ **`falha_envio` SAIU da lista permissiva** (era o buraco do §9.1). A lista agora é só
-pré-aprovação: depois da aprovação, `authenticated` **não escreve `preco_unitario` em estado nenhum**.
-Quem escreve em `falha_envio` é a RPC de 1ª compra, que é SECDEF (§4.4.1).
+🔴 É isto que fecha o P1 da rodada 3, e por construção: lá, o split criava o **primeiro selo** dos
+filhos e assim lavava um preço divergente do pai *sem nunca chamar a entrada pública*. Aqui não há
+selo de pedido para nascer — não há o que lavar. O split não precisa conferir o pai, e **não é
+alterado por este spec**.
 
-⚠️ **O ramo de preço autoriza por ESTADO + `current_user`, NÃO por GUC** (mudança da v4). A M1 do
-#2187 declara que *"a M2 autoriza por ESTADO, que é mais forte que um GUC"*, e a v3 daqui dependia do
-`reposicao.selo_bypass`. Alinhar é melhor por si só: para o P0 do §9.1 o que importa é que
-`authenticated` não escreva preço pós-aprovação, e as portas são SECDEF — logo o `current_user` delas
-já é o owner. Um GUC a mais seria uma chave a mais para vazar, e ficaria refém do redesenho do #2187.
-Efeito colateral desejado: a aba velha do §9.4 tem a escrita **recusada no banco** em vez de aceita
-sem selo — o preço continua ≤ 0 e a RPC nova ainda funciona, sem virar intervenção SQL.
+Cuidado que fica: o trigger vê o UPDATE de `pedido_id`. Como ele **não** toca `preco_unitario`, cai no
+passo 2 do §4.3 (preserva o carimbo) e não em `SP006`.
 
-O GUC `reposicao.selando_preco` **não** aparece aqui, e isso é desenho: `reposicao_selar_preco` escreve
-só em `pedido_compra_sugerido`, nunca em `pedido_compra_item`. Uma exceção para ele no trigger de item
-seria porta aberta sem dono.
+### 4.5 O que continua guardado no pedido
 
-`reposicao_persistir_qtde_inteira` não toca `preco_unitario`, então não interage com este ramo.
-*(A v4 deixou aqui uma frase morta dizendo que `falha_envio` seguia permissivo — contradizia a própria
-mudança logo acima. Removida na v5, §9.7.)*
-
-**Em `pedido_compra_sugerido`** — o trigger `BEFORE UPDATE` do #2187 (§3.3 de lá) ganha um ramo:
-`preco_selo` / `preco_selo_em` / `preco_selo_origem` só mudam quando
-`reposicao.selando_preco = NEW.id`, senão `SP007`. É **aqui** que o GUC trabalha. Note a diferença
-para o `aprovacao_selo`, que é imutável depois de gravado: `preco_selo` é *mutável, porém só por uma
-porta*.
-
-`preco_recusa_motivo` fica sem guard: quem o grava é a edge (`service_role`) e quem o limpa é
-`reposicao_selar_preco`. Um guard ali só criaria uma trava a mais para o mesmo efeito.
-
-**O trigger continua guardando, nunca escrevendo** — a forma que a v2 do #2187 adotou depois do P0 do
-Codex.
+Nada de selo. O #2187 segue dono das transições de status e da imutabilidade do `aprovacao_selo`; este
+spec não acrescenta ramo em `pedido_compra_sugerido`. **`SP007` deixou de existir** — era o ramo do
+GUC, e o GUC saiu (rodada 3, P2).
 
 ### 4.6 O sensor — é ele que decide o teto depois
 
-O founder decidiu (2026-09-06): **procedência agora, teto depois, com número medido.** Um limiar hoje
-seria chutado — a captura tem 1 pedido de sinal.
+Procedência agora, teto depois com número medido (decisão §8.2). Com o carimbo na linha o sensor fica
+mais fino do que era com o hash por pedido — o delta é **por item**:
 
 ```sql
 SELECT origem,
-       count(*) AS reselos,
-       count(*) FILTER (WHERE itens_mudados > 0) AS mudou,
-       round(percentile_cont(0.5) WITHIN GROUP (ORDER BY (total_novo-total_anterior)/total_anterior*100)::numeric, 2) AS p50_delta_perc,
-       round(max((total_novo-total_anterior)/total_anterior*100)::numeric, 2) AS max_delta_perc
-  FROM reposicao_preco_selo_log
- WHERE selado_em > now() - interval '30 days' AND total_anterior > 0
+       count(*) AS escritas,
+       round(percentile_cont(0.5) WITHIN GROUP (ORDER BY (para_preco-de_preco)/de_preco*100)::numeric, 2) AS p50_delta_perc,
+       round(max((para_preco-de_preco)/de_preco*100)::numeric, 2) AS max_delta_perc
+  FROM reposicao_preco_origem_log
+ WHERE em > now() - interval '30 days' AND de_preco > 0
  GROUP BY 1;
 ```
 
-Denominador ao lado: `sucesso_portal` por semana (hoje ~10). A fatia seguinte ("teto de valor
-aprovado") **só nasce com esse número na mão**, com ≥ 4 semanas de `origem='portal_captura'` e
-`mudou > 0` — "está no ar e ninguém reclamou" é ausência de dado.
+Denominador ao lado: `sucesso_portal` por semana (hoje ~10). A fatia do teto **só nasce** com ≥ 4
+semanas de `origem='portal_captura'` e escritas > 0 — "está no ar e ninguém reclamou" é ausência de
+dado.
 
 ## 5. A fronteira: asserção antes do `IncluirPedCompra`
 
 ### 5.1 `reposicao_conferir_disparo_omie(p_pedido_id bigint, p_itens jsonb)`
 
 `RETURNS TABLE(ok boolean, motivo text, divergencias jsonb)`. `STABLE`, `SECURITY INVOKER`,
-`search_path` fixo. EXECUTE só para `service_role` (a edge).
+`search_path` fixo, EXECUTE só para `service_role`.
 
 Recebe **exatamente o que a edge está prestes a mandar** — `[{item_id, n_val_unit, n_qtde}]`, derivado
-do próprio `produtos_incluir`, **não de uma releitura** — e compara em SQL com `IS DISTINCT FROM` sobre
-`numeric`. Motivos, em ordem de avaliação (o primeiro que casa vence):
+do próprio `produtos_incluir`, **não de uma releitura**. Motivos, na ordem de avaliação:
 
 | motivo | condição |
 |---|---|
-| `preco_selo_ausente` | `preco_selo IS NULL` |
-
-| `preco_selo_divergente` | hash recomputado de `preco_unitario` ≠ `preco_selo` |
-
-| `payload_divergente` | correspondência um-para-um quebrada (abaixo), ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
-
-⚠️ **A conferência do `aprovacao_selo` SAIU na v4** (decisão §9.2 aplicada). O que fica de quantidade é
-só **transporte** — `n_qtde` contra a linha do banco — e isso não tem o beco do §9.2: um transporte
-divergente é bug de código da edge, corrigível e reprocessável, não um estado de "fornecedor recebeu e
-não há como voltar". A **prevenção** de quantidade continua sendo do #2187 (selo imutável + trigger);
-o que fica pendente é só a conferência de fronteira dela, agora chip bloqueado (§10).
+| `preco_origem_ausente` | alguma linha com `preco_origem IS NULL` ou `preco_gravado_em IS NULL` |
+| `preco_origem_invalida` | alguma linha com `preco_origem` fora do conjunto permitido |
+| `payload_divergente` | correspondência um-para-um quebrada, ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
 
 **Correspondência um-para-um, não igualdade de conjuntos** (§9.5): `p_itens` tem de ser array válido,
-com `item_id` **únicos**, e a **cardinalidade** tem de bater com a contagem de itens do pedido —
-`count(*) = count(DISTINCT item_id) = (SELECT count(*) FROM pedido_compra_item WHERE pedido_id = ...)`.
-Sem isso, um payload que repete `{id:7, preço:10, qtde:2}` duas vezes mantém o mesmo CONJUNTO de ids,
-satisfaz toda comparação individual, e passaria com **quantidade total dobrada**. Não há produtor
-dessas duplicatas hoje (o `.map` parte das linhas do banco) — é defeito do CONTRATO da proteção de
-transporte, e é o contrato que tem de fechar.
+com `item_id` **únicos**, e cardinalidade igual à contagem de itens do pedido —
+`count(*) = count(DISTINCT item_id) = (SELECT count(*) FROM pedido_compra_item WHERE pedido_id = …)`.
+Sem isso, um payload que repete `{id:7, preço:10, qtde:2}` mantém o mesmo CONJUNTO de ids, satisfaz
+toda comparação individual, e passaria com **quantidade total dobrada**. Não há produtor disso hoje
+(o `.map` parte das linhas do banco) — é defeito de CONTRATO, e contrato se fecha no contrato.
 
-`divergencias` traz o recorte por item, para o log e para o operador.
+Comparação de `numeric` em SQL com `IS DISTINCT FROM`: o `Number()` do TS colapsa decimais distintos
+(P2-12 do Codex no #2187). Comparar o valor **enviado** contra o banco é mais estrito que
+banco-contra-banco — se o `Number()` deturpar o preço, o PO sairia deturpado e nós saberíamos.
 
-Três coisas numa chamada:
+⚠️ **Honestidade sobre o que esta conferência prova.** A **prevenção** mora no trigger (§4.3), que é
+`BEFORE … FOR EACH ROW` e sobrescreve o carimbo: enquanto ele existir, não há como escrever preço sem
+ser carimbado. A conferência é **defesa em profundidade** contra linha **não carimbada** — legado,
+backfill incompleto, ou uma janela em que o trigger não estivesse ativo. Ela **não** detecta uma
+escrita crua feita com o trigger desabilitado, e nenhum esquema puramente-em-banco detectaria: quem
+escreve controla todas as colunas. O hash das v1–v6 tinha a mesma limitação — só que com uma função de
+selar a mais para abusar.
 
-1. **Procedência do preço** (`preco_selo`) — o que esta fatia acrescenta.
-2. **Transporte** — o `Number()` do TS colapsa decimais distintos (P2-12 do Codex no #2187). Comparar o
-   valor **enviado** contra o banco é mais estrito que comparar banco-com-banco: se o `Number()`
-   deturpar o preço, o PO sairia deturpado e nós saberíamos.
-
-Sobre `n_qtde`: sob o #2187 a `qtde_final` já é canônica (inteira) na aprovação, então
-`Math.ceil(Number(qtde_final))` é no-op e a comparação estrita `IS DISTINCT FROM qtde_final` é a certa.
-Se **não** for no-op, a recusa é a resposta correta — algo aprovou fração. Isto é conferência de
-TRANSPORTE (payload × banco), não de selo: não depende do `aprovacao_selo` e não herda o beco do §9.2.
+⚠️ **A conferência de SELO de quantidade não está aqui** (decisão §9.2): ela criava recusa **sem
+recuperação**. O que fica de quantidade é **transporte** — `n_qtde` contra a linha do banco —, e isso
+não tem o beco: transporte divergente é bug de código da edge, corrigível e reprocessável. A prevenção
+de quantidade segue sendo do #2187.
 
 ### 5.2 Onde entra na edge
 
-Colada no único call site (`index.ts:1057`), depois de montar `produtos_incluir`, ao lado do
-`lerMarcoPreOmie` que já tem essa disciplina — **com o sinal invertido, e o comentário tem que dizer
-por quê**: `lerMarcoPreOmie` é fail-**open** de propósito (perder o marco é melhor que perder o PO);
-esta é fail-**closed** — erro da RPC, `ok=false`, ou resposta sem forma esperada = recusa. Degradar é
-certo no sensor, errado no que move dinheiro.
+Colada no único call site (`index.ts:1057` — verificado: é o único `IncluirPedCompra` executável),
+depois de montar `produtos_incluir`, ao lado do `lerMarcoPreOmie`, que já tem essa disciplina — **com o
+sinal invertido, e o comentário tem de dizer por quê**: `lerMarcoPreOmie` é fail-**open** de propósito
+(perder o marco é melhor que perder o PO); esta é fail-**closed** — erro da RPC, `ok=false`, resposta
+vazia ou fora de forma = recusa. Degradar é certo no sensor, errado no que move dinheiro.
 
-O `select` de itens (`index.ts:842`) passa a trazer `id`, para o `item_id` do payload.
+O `select` de itens (`index.ts:842`) passa a trazer `id`.
 
 **Roda nos DOIS modos.** `dry_run` chama `IncluirPedCompra` incondicionalmente e **cria PO real no
 Omie** (`index.ts:454-457`); pular a conferência lá seria o mesmo furo com outro nome.
@@ -381,159 +302,119 @@ Omie** (`index.ts:454-457`); pular a conferência lá seria o mesmo furo com out
 ### 5.3 Na recusa
 
 `throw` com o motivo → o `catch` que já existe grava `falha_envio` (`index.ts:1163`). **Nenhum estado
-terminal novo, nenhuma máquina de estados nova.** `preco_recusa_motivo` guarda o motivo.
-
-**Assimetria deliberada em relação ao `portal_recusa_motivo` do #2187, que é imutável:**
-`preco_recusa_motivo` é **limpo pelo `reposicao_selar_preco`** (§4.3 passo 5). Divergência de selo do
-portal é terminal ("cancele e aguarde o ciclo"); divergência de preço é **recuperável** — o operador
-corrige por uma porta autorizada, que re-sela e limpa o motivo, e o reprocesso segue. Sem isso o guard
-brickaria o pedido.
-
-**Mas os dois motivos de selo não têm o mesmo desfecho, e a mensagem tem de dizer qual é qual:**
+terminal novo, nenhuma máquina de estados nova.** `preco_recusa_motivo` guarda o motivo, e é limpo na
+próxima escrita autorizada de preço (o mesmo trigger que carimba).
 
 | motivo | recuperação |
 |---|---|
-| `preco_selo_ausente` / `preco_selo_divergente` / `payload_divergente` (preço) | porta autorizada re-sela e limpa o motivo → reprocessa |
-| `payload_divergente` (transporte: `n_qtde` ou `n_val_unit` ≠ banco) | bug de código da edge — corrigir, deployar, reprocessar. Nada a re-selar |
+| `preco_origem_ausente` / `preco_origem_invalida` | escrita por porta autorizada recarimba a linha → reprocessa. Se o preço já é válido e só falta carimbo, é SQL Editor (`manual_sql`) |
+| `payload_divergente` (transporte) | bug de código da edge — corrigir, deployar, reprocessar. Nada a recarimbar |
 
-⚠️ **Por que a conferência do `aprovacao_selo` NÃO está aqui (§9.2, decidido na v4).** Ela criaria uma
-recusa **sem recuperação**, e essa é a razão de ter saído do escopo. Registrado para quem retomar:
-`cancelar_pedido_sugerido` (na própria M1 do #2187) recusa quando
-`status_envio_portal IN ('enviando_portal','enviado_portal','sucesso_portal','aceito_portal_sem_protocolo','indeterminado_requer_conciliacao')`
-— e `sucesso_portal` é exatamente o estado onde a recusa aconteceria. Resultado: **fornecedor
-recebeu, Omie não recebeu, reprocessar repete a recusa, cancelar é negado.** A conciliação também não
-reconstrói o selo.
+Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: fornecedor tem a
+ordem, Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável por
+conciliação; PO com preço errado é dinheiro saindo errado.
 
-E afrouxar o cancelamento local **seria pior**: ele não cancela a ordem no fornecedor, e um ciclo novo
-geraria uma segunda compra com outro identificador — compra em dobro, que é o dano que este spec
-existe para evitar. Uma recuperação de verdade precisa tratar a **ordem externa** (cancelamento
-confirmado no fornecedor antes de gerar substituto). Preservar a imutabilidade do `aprovacao_selo` é
-compatível com isso; **mudar só a mensagem não é.**
-
-Por isso a conferência de selo de quantidade **saiu desta fatia** e virou chip bloqueado (§10). A
-prevenção do #2187 (selo imutável + trigger) continua cobrindo quantidade; o que falta é a conferência
-de fronteira, e ela não nasce antes da recuperação de ordem externa.
-
-A recuperação do lado do PREÇO também ficou mais estreita na v3, e é honesto dizer: como
-`authenticated` não escreve preço pós-aprovação (§4.5), a RPC de 1ª compra só resolve o caso "preço
-ausente". Preço válido adulterado só se corrige pelo **SQL Editor** (`postgres`, com o re-selo
-explícito). É recuperável pelo founder, não pelo operador.
-
-Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: o fornecedor tem a
-ordem e o Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável
-por conciliação; PO com preço errado é dinheiro saindo errado.
+⚠️ Recuperação de preço é **do founder, não do operador**: como `authenticated` não escreve preço
+pós-aprovação, a RPC de 1ª compra só resolve "preço ausente". Preço válido a corrigir é SQL Editor.
 
 ## 6. Rollout expandir → ativar (3 camadas manuais; a ordem é a diferença entre nada quebrar e fila presa)
 
-1. **M1 — expandir (nada recusa escrita).** Colunas, `reposicao_preco_selo_log` + RLS,
-   `reposicao_selar_preco`, `reposicao_conferir_disparo_omie`,
-   `reposicao_definir_custo_primeira_compra`, re-selo dentro de `sayerlack_aplicar_custo_portal`, da
-   RPC de aprovação do #2187 e do split. `NOTIFY pgrst, 'reload schema'`; regenerar
-   `src/integrations/supabase/types.ts`. `DO $post$` relê o catálogo (existência, SECDEF onde previsto,
-   `search_path` preso, `anon`/`authenticated` sem EXECUTE onde previsto).
-   **Backfill** de `preco_selo` para pedidos em estado não-terminal, com `origem='backfill_m1'` — hoje
-   1 pedido em `aprovado_aguardando_disparo`. Sela o preço que estiver lá: não há como saber se foi
-   adulterado, e recusar toda a fila em voo seria pior. A origem `backfill_m1` deixa isso visível no
-   log. **Depois do backfill, `NULL` significa "alguém zerou" — e recusar é correto.**
-   Pré-voo `pg_get_functiondef` da PROD para toda função recriada (apply manual diverge do repo; a
-   última a recriar vence). `CREATE OR REPLACE` preserva ACL; `REVOKE`/`GRANT` reafirmados por nome.
-2. **Publish (UI migra para a RPC) + deploy da edge** `disparar-pedidos-aprovados` com a conferência já
-   fail-closed. Com M1 aplicada, a edge nova encontra as colunas e a RPC. Com a edge velha ainda no ar
-   e M1 aplicada: nada quebra (M1 não recusa nada).
-3. **M2 — ativar.** Ramos `SP006` (item) **e `SP007`** (pedido) nos triggers do #2187 — a v2 agendava
-   só o `SP006` (§9.4). Pré-condição **medida por query**: zero pedidos em `enviando_portal` e a sonda
-   da edge respondendo a versão nova.
-
-   ⚠️ **A ordem mudou na v3, e "Publish" não é o marco.** Publish não fecha aba velha — o SW só troca
-   de build quando o cliente clica (CLAUDE.md, 4ª camada). Uma aba antiga em `falha_envio` preencheria
-   o custo por PostgREST cru, **sem selar**, e a edge nova recusaria; pior, atualizar a UI depois não
-   salvaria — o preço já seria positivo e a RPC nova responderia `SP005` (§9.4). Por isso o ramo
-   `SP006` **precisa estar ativo junto com o deploy da edge, não depois dele**: com ele, a escrita da
-   aba velha é **recusada no banco** (o preço fica ≤ 0 e a RPC nova ainda resolve) em vez de aceita e
-   silenciosamente sem selo. Fail-closed contra cliente velho é o ponto — "zero `enviando_portal` +
-   sonda nova" não diz nada sobre abas antigas.
-4. **Sensor da fase seguinte:** §4.6.
+1. **M1 — expandir (nada recusa escrita).** Colunas `preco_origem`/`preco_gravado_em` em
+   `pedido_compra_item`, `preco_recusa_motivo` no pedido, `reposicao_preco_origem_log` + RLS,
+   `reposicao_conferir_disparo_omie`, `reposicao_definir_custo_primeira_compra`. `NOTIFY pgrst,
+   'reload schema'`; regenerar `src/integrations/supabase/types.ts`. `DO $post$` relê o catálogo
+   (existência, SECDEF onde previsto, `search_path` preso, `anon`/`authenticated` sem EXECUTE onde
+   previsto, **e que `cap_compras_ler` é a capability usada na porta humana**).
+   **Backfill** de `preco_origem='backfill'` + `preco_gravado_em=now()` para itens de pedidos em estado
+   não-terminal. Carimba o que estiver lá: não há como saber se foi adulterado, e recusar toda a fila
+   em voo seria pior. `backfill` fica visível como origem própria. **Depois disso, `NULL` significa
+   "linha que ninguém carimbou" — e recusar é correto.**
+   Nem `aprovar_pedido_sugerido`, nem `sayerlack_aplicar_custo_portal`, nem `pedido_compra_split` são
+   recriadas — a v7 não as toca (§4.4). Isso encolhe a M1 e elimina o pré-voo `pg_get_functiondef`
+   sobre três funções que outra sessão está reconstruindo.
+2. **Ramo do trigger + deploy da edge + Publish, na MESMA leva.** Publish não fecha aba antiga (o SW só
+   troca de build quando o cliente clica) — uma aba velha em `falha_envio` gravaria preço por PostgREST
+   cru **sem carimbo**, e a edge nova recusaria; pior, atualizar a UI depois não salvaria, porque o
+   preço já seria positivo e a RPC nova responderia `SP005` (§9.4). Com o ramo `SP006` ativo **junto**,
+   a escrita da aba velha é **recusada no banco**: o preço fica ≤ 0 e a RPC nova ainda resolve.
+   Pré-condição medida por query: zero pedidos em `enviando_portal`.
+3. **Sensor da fase seguinte:** §4.6.
 
 Deploy da edge decidido por `bun run pendencias:deploy` (ledger `deploy_atestacoes`), não pelo diff do
 PR.
 
 ## 7. Prova
 
-- **PG17 `db/test-reposicao-preco-selo.sh`** (padrão dos harnesses; `-v ON_ERROR_STOP=1` + marcador
-  positivo de fim; asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos
-  sob `SET ROLE authenticated` + GUC do JWT). Cobre:
-  🔴 **o teste decisivo do §9.1 — `adulterar → tentar legitimar → conferir disparo`.** Cada cenário
-  tem DUAS asserções, e a v4 errava a segunda (§9.7): o ataque é **recusado** *e* **o estado fica
-  intacto**, portanto **o disparo legítimo seguinte PASSA**. "Em todos o disparo recusa" estava errado
-  — se o `UPDATE 10→100` foi barrado, banco e selo seguem em 10, e recusar o disparo de 10 seria
-  quebrar o fluxo real, não protegê-lo. O disparo só recusa onde a adulteração **conseguiu** passar —
-  e o teste existe para provar que nenhuma consegue.
-  Como `authenticated`: (a) UPDATE de preço em `falha_envio` → `SP006`, preço segue 10, disparo passa;
-  (b) UPDATE de preço → NULL pós-aprovação → `SP006` (fecha a ausência fabricada), disparo passa;
-  (c) chamada direta a `private.reposicao_selar_preco` → erro de privilégio; (d) chamada a
-  `reposicao_selar_preco_na_aprovacao` num pedido **já selado** → recusa (só primeiro selo);
+- **PG17 `db/test-reposicao-preco-origem.sh`** (`-v ON_ERROR_STOP=1` + marcador positivo de fim;
+  asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos sob
+  `SET ROLE authenticated` + GUC do JWT).
+
+  🔴 **O teste decisivo — `adulterar → tentar carimbar → conferir disparo`.** Cada cenário tem **DUAS**
+  asserções, e a v4 errava a segunda (§9.7): o ataque é **recusado** *e* **o estado fica intacto**,
+  portanto **o disparo legítimo seguinte PASSA**. "Em todos o disparo recusa" estava errado — se o
+  `UPDATE 10→100` foi barrado, banco e carimbo seguem em 10, e recusar o disparo de 10 quebraria o
+  fluxo real em vez de protegê-lo.
+
+  Como `authenticated`: (a) UPDATE de preço em `falha_envio` → `SP006`, preço segue 10, **disparo
+  passa**; (b) UPDATE de preço → NULL pós-aprovação → `SP006`, **disparo passa** (fecha a ausência
+  fabricada); (c) UPDATE que muda **só** `preco_origem`/`preco_gravado_em`, sem tocar preço → o
+  carimbo antigo é preservado (passo 2 do §4.3), nada muda; (d) INSERT/UPDATE passando `preco_origem`
+  escolhido pelo chamador → o trigger **sobrescreve**, e o valor gravado é o que ele calculou;
   (e) variante A/B: a adulteração de A é barrada em (a); a RPC de 1ª compra recebe **só B** (que está
   ≤ 0) e **deve SUCEDER** — recusar B por causa de A, que nem está no payload, mudaria o ataque
-  testado; (f) 🔴 **capability**: `employee` na RPC de 1ª compra → `42501`; **`master` → autorizado**;
-  `auth.uid() IS NULL` → `42501`. (g) 🔴 **a aprovação real roda como `authenticated`, com as duas
-  migrations integradas, e SELA** — é o cenário que a v4 quebrava (§9.7).
-  Negar INSERT direto no log NÃO é este teste ·
-  aprovação sela · captura do portal re-sela e loga o delta · 1ª compra preenche e re-sela · 1ª compra
-  **recusa** item com preço > 0 (`SP005`) · payload com NaN/Infinity/≤0 → `SP004` · status fora da
-  lista → `SP003` · origem inválida → `SP001` · UPDATE de `preco_unitario` pós-aprovação por
-  `authenticated` → `SP006` · o mesmo UPDATE com `reposicao.selando_preco` posto por `authenticated`
-  **não** passa · `reposicao_persistir_qtde_inteira` no disparo **não** quebra o selo (é o teste que
-  prova a decisão §4.1) · conferência: `n_val_unit` deturpado → `payload_divergente` · `n_qtde` ≠
-  `qtde_final` → `payload_divergente` · preço alterado sem selar → `preco_selo_divergente` ·
-  **payload com `item_id` repetido → `payload_divergente`** (o furo de multiplicidade do §9.5, que a
-  igualdade de conjuntos deixava passar com quantidade dobrada) · `preco_selo` NULL →
-  `preco_selo_ausente` ·
-  `preco_recusa_motivo` limpo pelo re-selo · split sela os filhos · hash: ordem por `id`,
-  `0,20 ≡ 0,2`, NULL ≠ vazio · UPDATE direto de `preco_selo` sem o GUC → `SP007` ·
-  `itens_mudados` é `NULL` no primeiro selo e `0` quando o re-selo não muda preço nenhum (é o par que
-  prova "ausente ≠ zero" no sensor) · `authenticated` **não** consegue INSERT direto em
-  `reposicao_preco_selo_log`, mas a aprovação humana grava lá pela função.
+  testado.
+
+  🔴 **Os fluxos legítimos que as v5/v6 quebravam, agora como teste** (§9.8): (f) `1ª compra →
+  aprovação` como master autenticado, **sucesso**; (g) `backfill de pendente → aprovação`,
+  **sucesso**; (h) **split de pai com preço divergente**: os filhos herdam `preco_origem` e
+  `preco_gravado_em` **da linha**, e o disparo do filho não vê procedência nova — é o teste que prova a
+  §4.4.2 e que a forma antiga reprovava.
+
+  🔴 **Capability** (§9.7): (i) `employee` na RPC de 1ª compra → `42501`; (j) **`master` → autorizado**;
+  (k) `auth.uid() IS NULL` → `42501`.
+
+  Mais: payload NaN/Infinity/≤0 → `SP004` · status fora da lista → `SP003` · a 1ª compra **recusa** item
+  com preço > 0 → `SP005` · `reposicao_persistir_qtde_inteira` no disparo **não** altera carimbo (é o
+  teste que prova a decisão §4.1) · conferência: `n_val_unit` deturpado e `n_qtde` ≠ `qtde_final` →
+  `payload_divergente` · **payload com `item_id` repetido → `payload_divergente`** (o furo de
+  multiplicidade do §9.5, que a igualdade de conjuntos deixava passar com quantidade dobrada) ·
+  `preco_origem` NULL → `preco_origem_ausente` · `preco_recusa_motivo` limpo na próxima escrita
+  autorizada.
+
 - **Falsificação uma camada por vez**, com **controle verde na MESMA invocação do laço** (senão a
   suíte sempre-vermelha aprova tudo) e **commit antes** (o `restaurar()` é `git checkout --`):
-  remover o ramo `SP006` → o teste do `authenticated` fica vermelho; neutralizar a comparação de
-  `n_val_unit` → o teste de transporte fica vermelho; tirar o re-selo de
-  `sayerlack_aplicar_custo_portal` → a conferência acusa divergência num caminho **legítimo**;
-  devolver `p_origem` ao chamador (ou reconceder EXECUTE a `authenticated` no selador) → o cenário
-  (c) fica vermelho; repor `falha_envio` na lista permissiva → (a) fica vermelho; **trocar
-  `cap_compras_ler` por `employee OR master` na RPC de 1ª compra → (f) fica vermelho** (é a
-  falsificação da escalada que eu mesmo introduzi na v4); tirar o `preco_selo IS NULL` da entrada de
-  aprovação → (d) fica vermelho; afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom"
-  fica vermelho.
+  fazer o trigger **aceitar** `NEW.preco_origem` do chamador em vez de sobrescrever → (d) fica
+  vermelho; remover o passo 2 (preservar carimbo quando o preço não muda) → (c) fica vermelho; repor
+  `falha_envio` como estado de escrita livre → (a) fica vermelho; **trocar `cap_compras_ler` por
+  `employee OR master` na RPC de 1ª compra → (i) fica vermelho** — é a falsificação da escalada que eu
+  mesmo introduzi na v4; afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica
+  vermelho.
+
 - **Gate da edge — a v2 afirmava um FATO FALSO aqui, corrigido (§9.5).** Eu escrevi que
-  `_shared/marco-pre-omie_test.ts` já assere "exatamente 1 call site de `IncluirPedCompra`". **Não
-  assere.** O `G3` conta `atribuicoesDaColuna` — atribuições de `omie_po_inexistente_antes_de` —, e o
-  Codex executou os 7 testes com um segundo call site inserido: **7/7 verde nos dois casos**. Eu
-  afirmei sobre um arquivo que só tinha visto por `grep`. O harness é bom **modelo de estilo** (o `G2`
-  tem falsificação embutida), não uma garantia pronta.
+  `_shared/marco-pre-omie_test.ts` já asserta "exatamente 1 call site de `IncluirPedCompra`". **Não
+  assere**: o `G3` conta `atribuicoesDaColuna` — atribuições de `omie_po_inexistente_antes_de` —, e o
+  Codex executou os 7 testes com um segundo call site inserido, **7/7 verde nos dois casos**. Eu
+  afirmei sobre um arquivo que só tinha visto por `grep`. Ele é bom **modelo de estilo** (o `G2` traz
+  falsificação embutida), não garantia pronta.
 
   Então o gate **é novo**, e forma sozinha não basta: presença + ordem + ausência de
-  `if (modo === 'producao')` são satisfeitas por uma chamada **cuja resposta é ignorada**. O que prova
+  `if (modo === 'producao')` são satisfeitas por **uma chamada cuja resposta é ignorada**. O que prova
   a asserção é COMPORTAMENTO:
-
   - **zero chamadas ao Omie** quando a RPC (a) erra, (b) devolve `ok=false`, (c) devolve vazio,
     (d) devolve formato inválido — **nos DOIS modos** (`producao` e `dry_run`), 8 casos;
-  - assert de **contagem** de call sites de `IncluirPedCompra` (que não existia) — é ele, e só ele,
-    que sustenta "inescapável";
+  - assert de **contagem** de call sites de `IncluirPedCompra` (que não existia) — é ele, e só ele, que
+    sustenta "inescapável";
   - **falsificação removendo a DECISÃO de recusar** (manter a chamada, ignorar o resultado): tem de
-    ficar vermelho. Sem essa falsificação o gate é decorativo — é exatamente o defeito que o Codex
-    demonstrou executando.
+    ficar vermelho. Sem ela o gate é decorativo — o defeito que o Codex demonstrou executando.
 
-  Onde o gate lê a edge como TEXTO, limpa comentário com o stripper COMPARTILHADO
-  (`removerComentarios` de `@/lib/gates/limpeza-fonte`), nunca regex local — a edge tem
-  `IncluirPedCompra` em 6 comentários e 1 chamada; um stripper local mediria os comentários.
-- **Deno `test:edges`** (`--no-remote`, sem afrouxar o flag), **`edges:typecheck`**, **`sonda:bump`**
-  (`VERSAO`) + **`sonda:fingerprint -- --write`** em `disparar-pedidos-aprovados`. Os 5 gates de edge
-  não se cobrem.
-- **Manifesto de módulos:** arquivo novo em `src/` ganha dono em `src/lib/modulos/manifesto.ts`.
-- **`bun run psql:errorstop`**, **`shellcheck`** no harness novo.
-- **Codex challenge** (`scripts/codex-async.sh`, background) sobre este spec **antes** de implementar,
-  e sobre o PR depois. 🔴 **Tentado em 2026-09-06 e barrado por cota (exit 75)** — ver o bloco de
-  status no topo e o Caminho B em §9. É pré-condição da implementação, não do merge deste spec.
+  Onde lê a edge como TEXTO, limpa comentário com o stripper COMPARTILHADO (`removerComentarios` de
+  `@/lib/gates/limpeza-fonte`), nunca regex local — a edge tem `IncluirPedCompra` em 6 comentários e 1
+  chamada.
+
+- **Deno `test:edges`** (`--no-remote`, sem afrouxar o flag), **`edges:typecheck`**, **`sonda:bump`** +
+  **`sonda:fingerprint -- --write`** em `disparar-pedidos-aprovados`. Os 5 gates de edge não se cobrem.
+- **Manifesto de módulos** para arquivo novo em `src/`; **`bun run psql:errorstop`**; **`shellcheck`**.
+- **Codex challenge** sobre esta v7 **antes** de implementar — as v2/v4/v5 foram reprovadas (§9).
 
 ## 8. Decisões do founder (2026-09-06, nesta ordem)
 
@@ -552,6 +433,9 @@ PR.
    ⚠️ Aplicado por recomendação minha, na ausência de decisão contrária: a decisão original foi do
    founder, e a reversão é trivial (repor os dois motivos de `aprovacao_selo` na tabela do §5.1) —
    mas então o §9.2 exige desenhar a recuperação de ordem externa junto.
+
+6. **Trocar a forma: procedência por LINHA** (2026-09-06, §11) — depois de três rodadas de challenge
+   reprovando o hash-por-pedido pelo mesmo motivo estrutural.
 
 ## 9. Revisão independente — challenge Codex (2026-09-06): **não aprovar**
 
@@ -634,7 +518,8 @@ PostgREST cru (`useDetalhesModal.ts:170`, verificado) → nenhum re-selo → edg
 a UI depois **não salvava**: preço já positivo ⇒ a RPC nova responde `SP005`, e a recuperação normal
 vira intervenção SQL.
 
-E a §6 agendava só o `SP006`; o `SP007` não estava em etapa nenhuma.
+E a §6 agendava só o `SP006`; o `SP007` não estava em etapa nenhuma. *(Na v7 o `SP007` deixou de
+existir — era o ramo do GUC, e a forma nova não tem GUC nem selo de pedido.)*
 
 **Acatado** em §6: o `SP006` passa a entrar **junto com o deploy da edge**, não depois — assim a
 escrita da aba velha é recusada no banco, o preço fica ≤ 0 e a RPC nova ainda resolve. `SP007`
@@ -793,9 +678,15 @@ hoje o delta é por pedido); e a §5.1 deixa de comparar hash, o que **enfraquec
 "conjunto de itens mudou" — que, no entanto, já é coberta pelo trigger do #2187 e pela cardinalidade
 um-para-um do payload.
 
-### 11.2 🧭 Decisão do founder
+### 11.2 ✅ Decisão do founder: TROCAR (2026-09-06)
 
 A forma "selo próprio + re-selo por porta" foi **escolha sua** na abertura desta fatia, com a
 alternativa de então sendo "trigger sem hash". A informação nova é que essa forma custou três rodadas
-sem convergir. Recomendo **trocar para 11.1** e reescrever o spec sobre ela, aproveitando tudo o que
-foi medido (§3), o escopo (§9.2) e a prova comportamental da edge (§7) — que não dependem da forma.
+sem convergir. **Decidido: trocar para 11.1**, e é o que a §4 desta v7 implementa. Aproveitados sem
+mudança: a medição (§3), o escopo (§9.2) e a prova comportamental da edge (§7) — nenhum deles dependia
+da forma.
+
+**O que a troca também comprou, e não estava no argumento original:** a M1 encolheu. A v6 recriava
+`aprovar_pedido_sugerido`, `sayerlack_aplicar_custo_portal` e `pedido_compra_split` — três funções que
+outra sessão está reconstruindo agora no #2187, cada uma exigindo pré-voo `pg_get_functiondef` contra
+a PROD e sujeitas à regra "a última a recriar vence". A v7 **não toca nenhuma das três**.

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v7)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v8)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -27,7 +27,13 @@
 > forjar, nem selador para chamar, nem "primeiro selo" para disputar, nem GUC, e o carimbo **viaja com
 > a linha** no split. A aprovação, a captura do portal e o split **deixam de ser tocados** por este spec.
 >
-> 🔴 **A v7 ainda NÃO foi desafiada.** Rodada 4 é pré-condição da implementação.
+> - **Rodada 4** sobre a v7 (`max · tentativa 1 · 425s · 161.439 tokens`): *"as regressões anteriores
+>   de aprovação, capability e GUC **não se reabrem** pela forma descrita"* — a troca de forma
+>   funcionou. Mas **não aprovar**: o próprio ROLLOUT fabricava procedência válida para preço
+>   adulterado, e a fronteira pré-aprovação continuava aberta (§9.9).
+>
+> 🔴 **A v8 ainda NÃO foi desafiada.** E ela carrega **uma decisão do founder em aberto (§9.9.2)** que
+> toca o #2187.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -162,6 +168,10 @@ Ramo novo no trigger `BEFORE INSERT OR UPDATE ON pedido_compra_item` do #2187. P
    `status='falha_envio'` com `status_envio_portal='sucesso_portal'`. Ambiguidade resolve para a regra
    mais específica, e o risco residual é **de RÓTULO** (atribuição no sensor), nunca de autorização —
    os dois pares são autorizados de qualquer forma.
+
+🔴 **O trigger NÃO pode ser `SECURITY DEFINER`** — ele decide sobre a identidade do executor, e
+SECDEF trocaria justamente essa identidade, tornando a decisão circular. Verificar no catálogo
+(`prosecdef = false`) na postcondição da migration e nos testes (§9.9).
 
 **`authenticated` não escreve `preco_unitario` em nenhum estado pós-aprovação.** Quem escreve em
 `falha_envio` é a RPC de 1ª compra, que é SECDEF (§4.4). Autorização por **estado + `current_user`**,
@@ -307,12 +317,31 @@ próxima escrita autorizada de preço (o mesmo trigger que carimba).
 
 | motivo | recuperação |
 |---|---|
-| `preco_origem_ausente` / `preco_origem_invalida` | escrita por porta autorizada recarimba a linha → reprocessa. Se o preço já é válido e só falta carimbo, é SQL Editor (`manual_sql`) |
+| `preco_origem_ausente` / `preco_origem_invalida` | **procedimento de reparo do §5.4** — reescrever o mesmo preço NÃO recarimba |
 | `payload_divergente` (transporte) | bug de código da edge — corrigir, deployar, reprocessar. Nada a recarimbar |
 
 Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: fornecedor tem a
 ordem, Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável por
 conciliação; PO com preço errado é dinheiro saindo errado.
+
+### 5.4 Reparo de carimbo ausente — e por que o óbvio não funciona
+
+🔴 `UPDATE ... SET preco_unitario = 10` numa linha que **já** vale 10 **não entra no ramo de
+carimbar**: o gatilho é `NEW.preco_unitario IS DISTINCT FROM OLD.preco_unitario`, e não há distinção.
+Pior: o passo 2 do §4.3 então **restaura os NULLs antigos**. Passar `preco_origem` no UPDATE não ajuda
+— o trigger descarta input. A captura do portal escrevendo os mesmos 10 dá no mesmo (§9.9.3).
+
+Procedimento (SQL Editor, `postgres`, **uma transação**), a ser testado como parte da prova:
+
+```sql
+BEGIN;
+UPDATE pedido_compra_item SET preco_unitario = preco_unitario + 1 WHERE id = :id;  -- entra no ramo
+UPDATE pedido_compra_item SET preco_unitario = :preco_correto  WHERE id = :id;     -- carimba manual_sql
+COMMIT;
+```
+
+O teste é **recusa → reparo → disparo válido**, com o preço final idêntico ao inicial. Sem isso, a
+"recuperação" do §5.3 é promessa não executável.
 
 ⚠️ Recuperação de preço é **do founder, não do operador**: como `authenticated` não escreve preço
 pós-aprovação, a RPC de 1ª compra só resolve "preço ausente". Preço válido a corrigir é SQL Editor.
@@ -325,19 +354,29 @@ pós-aprovação, a RPC de 1ª compra só resolve "preço ausente". Preço váli
    'reload schema'`; regenerar `src/integrations/supabase/types.ts`. `DO $post$` relê o catálogo
    (existência, SECDEF onde previsto, `search_path` preso, `anon`/`authenticated` sem EXECUTE onde
    previsto, **e que `cap_compras_ler` é a capability usada na porta humana**).
-   **Backfill** de `preco_origem='backfill'` + `preco_gravado_em=now()` para itens de pedidos em estado
-   não-terminal. Carimba o que estiver lá: não há como saber se foi adulterado, e recusar toda a fila
-   em voo seria pior. `backfill` fica visível como origem própria. **Depois disso, `NULL` significa
+   🔴 **CORTE ATÔMICO: o backfill e a ativação do ramo são a MESMA transação** (§9.9.1). A v7 punha o
+   backfill na M1 e o ramo na leva seguinte, e **o próprio rollout fabricava procedência válida para
+   preço adulterado**: entre um e outro, um `master` fazia `UPDATE preco_unitario=100` sem tocar o
+   carimbo, e o carimbo de 10 ficava **colado ao preço 100** — a conferência depois passava (origem
+   presente, permitida, transporte batendo) e o Omie recebia 100. *"Mesma leva" não define ordem entre
+   operações manuais.*
+   Portanto, numa transação só: `LOCK TABLE pedido_compra_item IN SHARE ROW EXCLUSIVE MODE` →
+   backfill (`preco_origem='backfill'`, `preco_gravado_em=now()`) para itens de pedidos em estado
+   não-terminal → **criar o ramo do trigger** → commit. Sem janela para escrita concorrente.
+   O backfill carimba o que estiver lá — não há como saber se foi adulterado, e recusar toda a fila em
+   voo seria pior; `backfill` fica visível como origem própria. **Depois do commit, `NULL` significa
    "linha que ninguém carimbou" — e recusar é correto.**
    Nem `aprovar_pedido_sugerido`, nem `sayerlack_aplicar_custo_portal`, nem `pedido_compra_split` são
    recriadas — a v7 não as toca (§4.4). Isso encolhe a M1 e elimina o pré-voo `pg_get_functiondef`
    sobre três funções que outra sessão está reconstruindo.
-2. **Ramo do trigger + deploy da edge + Publish, na MESMA leva.** Publish não fecha aba antiga (o SW só
+2. **Deploy da edge + Publish — DEPOIS do commit da M1** (o ramo já está ativo; a edge nova depende
+   dele). Publish não fecha aba antiga (o SW só
    troca de build quando o cliente clica) — uma aba velha em `falha_envio` gravaria preço por PostgREST
    cru **sem carimbo**, e a edge nova recusaria; pior, atualizar a UI depois não salvaria, porque o
    preço já seria positivo e a RPC nova responderia `SP005` (§9.4). Com o ramo `SP006` ativo **junto**,
    a escrita da aba velha é **recusada no banco**: o preço fica ≤ 0 e a RPC nova ainda resolve.
-   Pré-condição medida por query: zero pedidos em `enviando_portal`.
+   ⚠️ Uma query de "zero pedidos em `enviando_portal`" **não fecha a janela de UPDATE dos itens** — foi
+   por isso que o corte virou transacional no passo 1, e não uma pré-condição medida (§9.9.1).
 3. **Sensor da fase seguinte:** §4.6.
 
 Deploy da edge decidido por `bun run pendencias:deploy` (ledger `deploy_atestacoes`), não pelo diff do
@@ -402,6 +441,9 @@ PR.
   a asserção é COMPORTAMENTO:
   - **zero chamadas ao Omie** quando a RPC (a) erra, (b) devolve `ok=false`, (c) devolve vazio,
     (d) devolve formato inválido — **nos DOIS modos** (`producao` e `dry_run`), 8 casos;
+  - 🔴 **e os CONTROLES POSITIVOS desses oito** (§9.9): RPC válida → **exatamente UMA** chamada ao
+    Omie, nos dois modos. Sem eles, *"uma edge que recusa tudo satisfaz os oito casos negativos"* — é a
+    mesma armadilha de sabotar sem linha de base verde, agora dentro do meu próprio gate;
   - assert de **contagem** de call sites de `IncluirPedCompra` (que não existia) — é ele, e só ele, que
     sustenta "inescapável";
   - **falsificação removendo a DECISÃO de recusar** (manter a chamada, ignorar o resultado): tem de
@@ -580,6 +622,77 @@ O que **não** fechou — três achados, nenhum remendado nesta v6 (ver §11):
 
 Ressalva do parecer: revisão de desenho contra o código disponível; as migrations novas não foram
 executadas e o `psql-ro` dele falhou por DNS (as medições são minhas, §3).
+
+### 9.9 Quarta rodada (v7) — a troca de forma FUNCIONOU, mas ainda **não aprovar**
+
+`gpt-6-astra · max · tentativa 1 · 425s · 161.439 tokens`. Palavras do parecer: *"as regressões
+anteriores de aprovação, capability e GUC **não se reabrem** pela forma descrita"*, e nenhum escape
+adicional por `ON CONFLICT`, UPDATE em massa, `COPY` ou `DELETE+INSERT` com o ramo ativo. A forma nova
+resistiu. O que não resistiu:
+
+#### 9.9.1 [P1] O próprio ROLLOUT fabricava procedência válida para preço adulterado
+
+```
+M1: item aprovado com preço=10, origem=backfill, instante=t0
+authenticated/master: UPDATE preco_unitario=100   ← ramo do trigger AINDA não existe
+ativação do ramo + edge nova
+conferência: origem presente, permitida, transporte bate → PASSA → nValUnit=100
+```
+
+A escrita **não precisa tocar o carimbo**: o carimbo de 10 fica colado ao preço 100. E *"mesma leva"
+não define ordem entre operações manuais*. Isso **reabre o efeito financeiro do achado da rodada 3
+sem precisar de split nem de selo novo**. Acatado no §6: backfill e criação do ramo na **mesma
+transação**, sob `LOCK TABLE`, e a edge só depois do commit.
+
+⚠️ E o Codex corrigiu a minha "honestidade" do §5.1: eu equiparei "não detecta escrita crua com trigger
+desabilitado" a "não resiste a administrador malicioso". **Não são equivalentes** — um hash protegido
+detectaria uma escrita que altera *somente o preço*. Não impedir um admin de adulterar tudo não torna
+as duas propriedades iguais. A forma por linha realmente perde essa detecção; o que a compensa é o
+corte atômico + o trigger sempre ativo, não uma nota de rodapé.
+
+#### 9.9.2 [P1] A fronteira PRÉ-aprovação — 🧭 decisão em aberto
+
+Com o mecanismo inteiro ativo: `pendente_aprovacao, preço=10 → master faz UPDATE cru para 100 → o
+trigger permite e carimba `primeira_compra` → aprovação ocorre → a conferência aceita 100`. A RPC
+responderia `SP005` para essa troca; o UPDATE direto obtém a **mesma procedência sem satisfazer o
+predicado**. Variante acidental, mais provável: duas abas com custo ausente, uma preenche 10, a **aba
+velha grava 100** com o pedido ainda pendente.
+
+🔴 **E o conserto óbvio não existe.** Medido em prod (2026-09-06): `gerar_pedidos_sugeridos_ciclo`,
+`gerar_pedidos_oportunidade_ciclo`, `aplicar_promocoes_no_ciclo` e `remover_itens_pedido_sugerido` são
+**todas INVOKER e todas executáveis por `authenticated`**. Quando um humano roda o ciclo pela tela,
+`current_user` **é** `authenticated` — indistinguível de um UPDATE cru dele. Então "recusar escrita de
+`authenticated`" quebraria o motor, e "exigir preço anterior ausente em todo UPDATE" barraria promoção
+legítima, que muda preço positivo. **O par `(estado × current_user)` não separa isto.** É limitação da
+forma, não descuido.
+
+**Minha recomendação, aplicada provisoriamente e reversível:** não constranger o motor. Fechar pelo
+lado da APROVAÇÃO — **incluir `preco_unitario` no token `p_itens_vistos` do #2187** (§3.4.3 de lá).
+O token já existe e já compara "o que você viu" contra "o que está lá"; acrescentar um campo faz a
+aprovação recusar exatamente o caso da aba velha, que é o realista. Isso **não contradiz a §8.4 do
+#2187**: lá a decisão foi manter preço fora do **selo**; o token é outra coisa — é anti-TOCTOU de
+leitura, não procedência.
+
+⚠️ **Mas toca o #2187**, que está em reconstrução — por isso é decisão do founder, não minha. Se ele
+preferir não tocar, a alternativa é aceitar o risco pré-aprovação como coberto pelo próprio ato de
+aprovar (o aprovador vê os números que aprova) e registrar isso como risco aceito.
+
+#### 9.9.3 [P2] A recuperação prometida não era executável
+
+`UPDATE SET preco_unitario = 10` numa linha que já vale 10 não entra no ramo (`IS DISTINCT FROM`), e o
+passo 2 do §4.3 restaura os NULLs. A "recuperação" do §5.3 era promessa sem procedimento. Acatado:
+§5.4 traz o reparo atômico e o teste **recusa → reparo → disparo válido** com preço final idêntico.
+
+#### 9.9.4 Duas notas de prova e de catálogo
+
+- **O trigger não pode ser `SECURITY DEFINER`**: ele decide sobre a identidade do executor, e SECDEF
+  trocaria essa identidade. Verificar `prosecdef = false` na postcondição. Acatado no §4.3.
+- 🔴 **Os oito casos negativos do gate da edge precisam de CONTROLES POSITIVOS** — *"uma edge que
+  recusa tudo também satisfaz aqueles oito casos"*. É a armadilha de sabotar sem linha de base verde,
+  dentro do meu próprio gate. Acatado no §7: RPC válida → **exatamente uma** chamada ao Omie, nos dois
+  modos.
+- Falta ainda testar UPDATE direto de preço positivo nos dois estados pré-aprovação, inclusive a aba
+  antiga após outro preenchimento — depende da decisão §9.9.2.
 
 ### 9.6 O que o Codex NÃO transformou em achado
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -40,6 +40,14 @@ A invariante executável é **procedência**, não igualdade:
 
 ## 2. Dependência do #2187 (esta fatia NÃO é standalone)
 
+⚠️ **O #2187 está EM RECONSTRUÇÃO** (conferido em 2026-09-06, imediatamente antes de abrir este PR):
+o Codex reprovou a M1 dele, e a sessão irmã a refez "sobre a main (guard atômico)", ainda marcada
+`NÃO PRONTA`. Os cinco símbolos de que esta fatia depende sobrevivem à reconstrução
+(`aprovacao_selo`, `reposicao.selo_bypass`, `reposicao_selar_pedido`, `reposicao_selo_itens`,
+`p_itens_vistos`), mas **a FORMA do guard mudou** — e é dentro dele que os ramos `SA008`/`SA009` do
+§4.5 se enxertam. **Re-conferir §4.5 contra a versão final do guard antes de implementar**; se o
+guard atômico não tiver mais o ponto de enxerto que este spec assume, §4.5 é reescrita, não adaptada.
+
 Consome, sem reimplementar: a RPC `aprovar_pedido_sugerido` de 3 args, o trigger de
 `pedido_compra_item`, o GUC de bypass (`reposicao.selo_bypass`, honrado só com
 `current_user IN ('postgres','service_role')`), `reposicao_selo_itens`, `aprovacao_selo` e

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v8)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v9)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -32,8 +32,11 @@
 >   funcionou. Mas **não aprovar**: o próprio ROLLOUT fabricava procedência válida para preço
 >   adulterado, e a fronteira pré-aprovação continuava aberta (§9.9).
 >
-> 🔴 **A v8 ainda NÃO foi desafiada.** E ela carrega **uma decisão do founder em aberto (§9.9.2)** que
-> toca o #2187.
+> ✅ **Decisão do founder (§9.9.2): `preco_unitario` entra no token `p_itens_vistos` do #2187.**
+> É o que fecha a fronteira pré-aprovação sem constranger o motor. ⚠️ **Cria dependência cruzada com o
+> #2187** — ver §2.1.
+>
+> 🔴 **A v9 ainda NÃO foi desafiada.** Rodada 5 é pré-condição da implementação.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -75,6 +78,26 @@ Consome, sem reimplementar: a RPC `aprovar_pedido_sugerido` de 3 args, o trigger
 `current_user IN ('postgres','service_role')`), `reposicao_selo_itens`, `aprovacao_selo` e
 `reposicao_pedido_e_portal`. Acrescenta um ramo ao trigger existente — **não cria um segundo trigger
 na mesma tabela**. Se o #2187 for reprovado ou remodelado, este spec é reescrito, não adaptado.
+
+### 2.1 🔴 Requisito que este spec IMPÕE ao #2187 (leitura obrigatória para quem mexe lá)
+
+**`preco_unitario` tem de entrar no token `p_itens_vistos`** da RPC `aprovar_pedido_sugerido` de 3 args
+(§3.4.3 do spec do #2187), ao lado de `id`, `sku_codigo_omie`, `qtde_final` e `fator_embalagem_portal`.
+Comparação com `trim_scale` + `IS DISTINCT FROM`, como os demais campos numéricos.
+
+**Por quê:** medido em prod (2026-09-06), `gerar_pedidos_sugeridos_ciclo`,
+`gerar_pedidos_oportunidade_ciclo`, `aplicar_promocoes_no_ciclo` e `remover_itens_pedido_sugerido` são
+**todas `SECURITY INVOKER` e executáveis por `authenticated`** — logo, com um humano rodando o ciclo
+pela tela, `current_user` é `authenticated`, o mesmo de um UPDATE cru. O trigger deste spec **não
+consegue** separar os dois na fase pré-aprovação (§9.9.2). Quem separa é o token: ele já compara "o que
+você viu" contra "o que está lá" no instante da aprovação, e um campo a mais faz a aprovação recusar o
+caso realista — **a aba velha que grava preço por cima entre a leitura e a aprovação**.
+
+**Não contradiz a §8.4 do #2187:** lá a decisão foi manter preço fora do **selo**. O token é outra
+coisa — anti-TOCTOU de leitura, não procedência. O selo continua sem preço.
+
+**Se o #2187 recusar este requisito**, o risco pré-aprovação volta a ficar aberto e este spec tem de
+registrá-lo como risco aceito, com o caso da aba velha nomeado.
 
 ## 3. O que existe hoje (medido em prod via psql-ro, 2026-09-06)
 
@@ -650,7 +673,7 @@ detectaria uma escrita que altera *somente o preço*. Não impedir um admin de a
 as duas propriedades iguais. A forma por linha realmente perde essa detecção; o que a compensa é o
 corte atômico + o trigger sempre ativo, não uma nota de rodapé.
 
-#### 9.9.2 [P1] A fronteira PRÉ-aprovação — 🧭 decisão em aberto
+#### 9.9.2 [P1] A fronteira PRÉ-aprovação — ✅ decidido: preço entra no token do #2187
 
 Com o mecanismo inteiro ativo: `pendente_aprovacao, preço=10 → master faz UPDATE cru para 100 → o
 trigger permite e carimba `primeira_compra` → aprovação ocorre → a conferência aceita 100`. A RPC
@@ -666,16 +689,15 @@ velha grava 100** com o pedido ainda pendente.
 legítima, que muda preço positivo. **O par `(estado × current_user)` não separa isto.** É limitação da
 forma, não descuido.
 
-**Minha recomendação, aplicada provisoriamente e reversível:** não constranger o motor. Fechar pelo
-lado da APROVAÇÃO — **incluir `preco_unitario` no token `p_itens_vistos` do #2187** (§3.4.3 de lá).
+**✅ Decidido pelo founder (2026-09-06):** não constranger o motor. Fechar pelo lado da APROVAÇÃO —
+**incluir `preco_unitario` no token `p_itens_vistos` do #2187** (§3.4.3 de lá).
 O token já existe e já compara "o que você viu" contra "o que está lá"; acrescentar um campo faz a
 aprovação recusar exatamente o caso da aba velha, que é o realista. Isso **não contradiz a §8.4 do
 #2187**: lá a decisão foi manter preço fora do **selo**; o token é outra coisa — é anti-TOCTOU de
 leitura, não procedência.
 
-⚠️ **Mas toca o #2187**, que está em reconstrução — por isso é decisão do founder, não minha. Se ele
-preferir não tocar, a alternativa é aceitar o risco pré-aprovação como coberto pelo próprio ato de
-aprovar (o aprovador vê os números que aprova) e registrar isso como risco aceito.
+⚠️ **Toca o #2187**, que está em reconstrução ⇒ o requisito está isolado na **§2.1** para que a sessão
+irmã o encontre sem ler este spec inteiro. Descartada a alternativa de aceitar como risco.
 
 #### 9.9.3 [P2] A recuperação prometida não era executável
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v5)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v6)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -18,9 +18,13 @@
 >   fechados, mas **a minha correção do P0 introduziu duas regressões** — escalada de privilégio na
 >   porta humana e quebra da aprovação (§9.7).
 >
-> **Esta v5 acata tudo e ainda NÃO foi desafiada.** Rodada 3 é pré-condição da implementação.
-> As duas rodadas acharam furo na **fronteira de autorização**, nunca na criptografia do selo — é onde
-> o risco deste desenho mora (§9.7).
+> - **Rodada 3** sobre a v5 (`max · tentativa 1 · 422s · 164.718 tokens`): a correção de capability
+>   fechou; **mas o "primeiro selo apenas" quebrou a aprovação legítima e o split lava preço** (§9.8).
+>
+> 🛑 **A v6 NÃO remenda os achados da rodada 3 — de propósito.** Três rodadas, três correções minhas na
+> MESMA fronteira, três buracos novos. Isso deixou de ser série de descuidos e virou sinal de que a
+> **FORMA** está errada. §11 apresenta a conclusão estrutural e a alternativa, e é **decisão do
+> founder** — a forma atual foi escolhida por ele na abertura desta fatia.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -656,6 +660,42 @@ satisfeitas por **uma chamada cuja resposta é ignorada**. Acatado em §7: teste
 exigindo **zero chamadas ao Omie** em erro/`ok=false`/vazio/formato inválido, **nos dois modos**, mais
 falsificação que remove a DECISÃO de recusar.
 
+### 9.8 Terceira rodada (v5) — **não aprovar**: o conserto do P0 quebrou a aprovação, e o split lava
+
+`gpt-6-astra · max · tentativa 1 · 422s · 164.718 tokens`. O que **fechou**: a capability nas duas
+portas humanas (`cap_compras_ler(auth.uid())` + rejeição de UID nulo reproduz a RLS dos itens). O Codex
+acrescentou que **não** se deve trocar por `cap_compras_escrever` — ela nasceu para outra superfície
+(telemetria do motor) — e que portal e split precisam preservar o caminho de máquina com
+`service_role`.
+
+O que **não** fechou — três achados, nenhum remendado nesta v6 (ver §11):
+
+- **[P1] O "primeiro selo apenas" impede aprovação legítima. Regressão da v5.**
+  `pendente_aprovacao + custo ausente → RPC de 1ª compra (que sela) → aprovar → a entrada nova recusa`,
+  porque ela exige `preco_selo IS NULL` e a 1ª compra já selou. O **backfill** de estados não-terminais
+  produz o mesmo bloqueio para pendentes. E a 1ª compra é comum: **152 itens em 72 pedidos/120d**
+  (§3). *"Apenas remover o `IS NULL` reabre a porta anterior"* — é o pêndulo entre o P0 e esta
+  regressão que motiva o §11.
+- **[P1, 9/10] O split lava preço criando o PRIMEIRO selo dos filhos.** Pai aprovado com preço 100 e
+  selo de 10 (origem concreta: escrita crua entre M1 e M2, depois do backfill). O §4.4 manda selar os
+  filhos mas **não** exige conferir o selo do pai antes de mover os itens; o split roda na edge antes
+  de processar (`index.ts:1688`). Os filhos nascem com preço 100 e um **primeiro selo válido de 100**,
+  origem `aprovacao`. A entrada pública nova nem é chamada.
+  ⚠️ **Isto refuta a tese central da v5** — *"lavar exige re-selar um pedido já selado"*. Não exige:
+  **troca-se o pedido que recebe o selo.**
+- **[P2] O GUC do `SP007` não autentica quem o definiu.** O ramo exige só igualdade com `NEW.id`; no
+  modelo SQL, `set_config('reposicao.selando_preco', id)` + `UPDATE preco_selo = NULL` o satisfaz.
+  Não é explorável por HTTP hoje (o wrapper público de `set_config` restringe a `fin.%`), por isso P2 —
+  mas a garantia de "um escritor só" precisa de contexto de execução no `SP007`, e a falsificação tem
+  de **tentar zerar o selo**. (Eu havia movido o ramo de ITEM para estado+`current_user` na v4 e deixei
+  o de PEDIDO no GUC — incoerência minha.)
+- Sobre a prova: o cenário (g) segue incompatível com a integração prescrita e precisa cobrir também os
+  selos pré-aprovação; e o (f) de capability está só na 1ª compra — tem de ser replicado na entrada
+  pública de aprovação.
+
+Ressalva do parecer: revisão de desenho contra o código disponível; as migrations novas não foram
+executadas e o `psql-ro` dele falhou por DNS (as medições são minhas, §3).
+
 ### 9.6 O que o Codex NÃO transformou em achado
 
 - **Hash:** sem colisão estrutural. JSON preserva fronteiras, `ORDER BY id` estabiliza, `trim_scale`
@@ -711,3 +751,51 @@ correção minha mexeu exatamente aí e criou a regressão seguinte.
 - **Auditoria de `pedido_compra_item`** (não há `atualizado_em` nem tabela de histórico). O log do selo
   cobre o que importa para esta invariante; auditoria geral da tabela é outra decisão.
 - **`conciliar-pedido-portal`** — o #2187 já mexe nela; esta fatia não acrescenta nada lá.
+
+## 11. A conclusão estrutural — e a decisão que ela força
+
+Três rodadas de challenge. Em cada uma, a correção que eu fiz na fronteira de autorização abriu um
+buraco novo **na mesma fronteira**:
+
+| Rodada | O que eu consertei | O que a correção abriu |
+|---|---|---|
+| 1 → v3 | selador chamável por `authenticated` com origem livre | porta humana SECDEF com gate mais frouxo que a RLS **e** aprovação INVOKER sem acesso ao selador |
+| 2 → v5 | capability exata + entrada de "primeiro selo apenas" | "primeiro selo" **bloqueia aprovação legítima**; e o split lava trocando o pedido que recebe o selo |
+| 3 → ? | (não remendado) | — |
+
+Isso deixou de ser série de descuidos. O que se repete é a **forma**: o selo é um ato **separável** da
+escrita, e a autoridade para selar vem sempre de um proxy fraco — o papel do chamador, um GUC, a
+ausência de selo anterior, ou qual pedido está sendo selado. Todo proxy fraco tem um caminho que o
+satisfaz sem a intenção que ele representa. Remendar o proxy da vez apenas move o furo.
+
+### 11.1 A alternativa: procedência POR LINHA, carimbada na escrita
+
+Em vez de um hash por pedido que alguém precisa **autorizar a gravar**, gravar a procedência **na
+própria linha do item, no mesmo statement que escreve o preço**:
+`pedido_compra_item.preco_origem` + `preco_gravado_em`, e o trigger **carimba ele mesmo** a partir do
+contexto de execução (`current_user` + estado do pai), recusando escrita de contexto não autorizado.
+
+O disparo deixa de recomputar hash: confere que **toda linha** tem `preco_origem` no conjunto
+permitido para o estado do pedido.
+
+Por que isto fecha os cinco achados **por construção**, não por remendo:
+
+- **R1/P0 (forjar re-selando):** não há selo para regravar — o carimbo é escrito pelo trigger, nunca
+  pelo chamador.
+- **R2/P1 (aprovação INVOKER):** não há selador para chamar. A aprovação não muda.
+- **R3/P1 (primeiro selo):** o conceito não existe; 1ª compra e aprovação não disputam nada.
+- **R3/P1 (split lava):** o carimbo **viaja com a linha**. O filho herda a procedência do item, não
+  ganha uma nova por ser um pedido novo.
+- **R3/P2 (GUC):** não há GUC.
+
+Custo honesto: uma coluna a mais por item; o sensor do §4.6 passa a ler por linha (fica **melhor** —
+hoje o delta é por pedido); e a §5.1 deixa de comparar hash, o que **enfraquece** a detecção de
+"conjunto de itens mudou" — que, no entanto, já é coberta pelo trigger do #2187 e pela cardinalidade
+um-para-um do payload.
+
+### 11.2 🧭 Decisão do founder
+
+A forma "selo próprio + re-selo por porta" foi **escolha sua** na abertura desta fatia, com a
+alternativa de então sendo "trigger sem hash". A informação nova é que essa forma custou três rodadas
+sem convergir. Recomendo **trocar para 11.1** e reescrever o spec sobre ela, aproveitando tudo o que
+foi medido (§3), o escopo (§9.2) e a prova comportamental da edge (§7) — que não dependem da forma.

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v10)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v11 — APROVADO)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -41,8 +41,10 @@
 >   preço adulterado ao próprio token) e o reparo do §5.4 um P2 (produz capturas fictícias no sensor).
 >   Acatados — §9.10.
 >
-> 🔴 **A v10 ainda NÃO foi desafiada.** Rodada 6 é pré-condição da implementação, e não roda nesta
-> sessão (contexto). É a primeira tarefa de quem retomar.
+> ✅ **Rodada 6 sobre a v10: APROVAR** (`max · tentativa 1 · 295s · 74.423 tokens`) — *"não encontrei
+> achado novo P0/P1/P2 nos deltas examinados"*. **Seis rodadas, cinco reprovações.** As duas condições
+> da aprovação e a lista de riscos aceitos estão na **§9.11** — e elas são parte do contrato, não
+> observações.
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -771,6 +773,65 @@ da transação; escritores anteriores terminam antes do corte, os seguintes enco
   a fronteira de confiança."* — e quem aprova é `master`, a mesma capability de `cap_compras_ler`. **O
   token comprova correspondência com o snapshot, não procedência nem visualização humana.** Isso não
   justifica a releitura silenciosa do P1 acima.
+
+### 9.11 Sexta rodada (v10) — ✅ **APROVAR**, com duas condições
+
+`gpt-6-astra · max · tentativa 1 · 295s · 74.423 tokens`. *"Não encontrei achado novo P0/P1/P2 nos
+deltas examinados da v10."* Parecer sobre o DESENHO — as provas acompanham a implementação.
+
+#### 9.11.1 As duas condições (fazem parte da aprovação)
+
+1. **Não omitir o requisito do snapshot no #2187** (§2.1). A aprovação não vale sem ele.
+2. **Não substituir os testes comportamentais por testes só do comparador.** Testar o comparador SQL
+   não prova que a UI não reaproveita a confirmação antiga.
+
+#### 9.11.2 A propriedade decisiva do token é TEMPORAL — e o teste tem de atravessar a UI real
+
+*"A UI pode reapresentar 100. **Ela não pode reutilizar a confirmação de 10 para aprovar 100.**"*
+Releitura divergente invalida aquela tentativa; apresentar outro snapshot exige **nova ação explícita**.
+
+Protocolo do teste, em ordem: renderizar e confirmar que o snapshot apresentado contém 10 → alterar o
+banco para 100 → clicar em aprovar e **resolver releituras, cache e efeitos pendentes** → exigir que,
+**sem outra ação do usuário**, não haja aprovação bem-sucedida nem disparo. Enviar token 10 e receber
+recusa **é válido**; enviar token 100 automaticamente **é falha**. Só depois de apresentar a revisão
+atualizada e receber nova confirmação é que aprovar 100 pode passar. Repetir em **inline, modal e
+lote** — no lote a asserção acompanha o pedido divergente, sem exigir atomicidade global que este spec
+não promete.
+
+🔴 **Falsificação indispensável:** trocar a implementação por *"reler 100 → renderizar 100 → aprovar
+100 na continuação do mesmo clique"*. O teste tem de ficar **vermelho mesmo que 100 tenha aparecido no
+DOM**.
+
+⚠️ E verificar os **valores efetivamente apresentados**, não uma variável chamada `snapshot`: hoje a
+célula de preço do cockpit (`PedidoRowCells.tsx:8`) exibe `row.valor_total` — isso **não** demonstra
+apresentação dos preços dos ITENS que compõem o token.
+
+#### 9.11.3 O GUC de rotulagem: a distinção se sustenta, mas ele não autentica o autor
+
+Confirmado que o override **não concede escrita** (`postgres` já está autorizado pela tabela do §4.3, e
+o GUC não dispensa predicado de RPC nenhum). Mas `current_user` **muda** dentro de uma função SECDEF,
+então ele não identifica quem definiu o GUC. Cadeia possível, condicionada a acesso SQL e EXECUTE na
+captura: `ligar reposicao.reparo_carimbo → chamar sayerlack_aplicar_custo_portal → SECDEF executa como
+postgres → captura REAL recebe manual_sql → evento fica FORA da amostra`.
+
+**É omissão no sensor, não escrita indevida** — envenena o teto por falta em vez de por excesso. Não
+alcançável pelo HTTP existente (o wrapper público de `set_config` restringe a `fin.%`). Fica como
+risco aceito nomeado, e o teste do §5.4 deve verificar a origem gravada **e** o efeito no sensor.
+
+#### 9.11.4 Riscos aceitos, na íntegra do parecer
+
+- **Master deliberado passa**: grava 100 antes de aprovar e apresenta token de 100. O banco não
+  distingue um frontend deliberadamente falso de um master chamando a RPC direto com token
+  correspondente. Defensável porque quem aprova **é** master, a mesma capability de `cap_compras_ler`.
+- **O sensor pode não ser representativo**: *"quantidade de sinal não garante cobertura ou
+  representatividade para decidir o teto"*.
+- **O backfill aceita os valores existentes sem provar seu histórico**; escrita com trigger desativado
+  pode conservar um carimbo aparentemente válido.
+- **`valor_linha`/`valor_total` seguem fora** — inclusive o efeito no gate de valor mínimo (§10).
+- **Quantidade** depende da prevenção do #2187 e da conferência de transporte; a reconferência de selo
+  fica fora (§9.2).
+- **Recusa depois de o portal receber a ordem** deixa fornecedor com pedido e Omie sem PO; correção de
+  preço positivo pode exigir intervenção do founder.
 
 ### 9.6 O que o Codex NÃO transformou em achado
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v2)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v3)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -10,14 +10,13 @@
 > **Status: desenho aprovado pelo founder em conversa (2026-09-06); implementação EM FILA atrás do
 > #2187, que ainda é DRAFT e do qual esta fatia consome infraestrutura (§2).**
 >
-> 🔴 **REVISÃO INDEPENDENTE PENDENTE.** O challenge do Codex sobre este spec foi disparado em
-> 2026-09-06 e **não rodou**: `scripts/codex-async.sh` saiu com **exit 75 — cota esgotada** (plano
-> declarado `prolite`, que BATE com o ping registrado no cabeçalho do próprio script em 2026-09-05 ⇒
-> limite real, não token velho). Custo do consult: `gpt-6-astra · max · tentativa 1 · —s · tokens ?`
-> (ausente, não zero — o codex não emitiu rodapé). Acionado o **Caminho B** (`money-path.md` §230):
-> validação adversária própria, registrada em §9. **Auto-revisão NÃO substitui revisão
-> independente** — ela cobre o intervalo. **Rodar o Codex retroativamente quando a janela resetar,
-> ANTES de implementar.**
+> 🔴 **CHALLENGE CODEX: "não aprovar"** (2026-09-06). A 1ª tentativa foi barrada por cota (exit 75);
+> a janela resetou e a 2ª rodou. Custo: `gpt-6-astra · max · tentativa 2 · 908s · 165.313 tokens`.
+> Dois P1 bloqueantes — e o primeiro eu classifico como **P0**, porque derrota o mecanismo por dentro.
+> Achados, verificação e o que mudou nesta v3: **§9**. O Caminho B (auto-challenge) que cobria o
+> intervalo virou §9.3 — ele tinha achado B1/B2, mas **subdimensionou os dois**.
+>
+> Esta v3 acata os cinco achados. **Uma decisão do founder segue aberta (§9.2): escopo da quantidade.**
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -130,15 +129,25 @@ Classes de SQLSTATE, cada uma do dono da função: `SA00x` = #2187 (selo do port
 
 ### 4.3 `reposicao_selar_preco(p_pedido_id bigint, p_origem text)` — o ÚNICO escritor do selo
 
-**`SECURITY DEFINER`**, `search_path` fixo. Definer e não invoker por uma razão concreta: o log é
-fechado a `authenticated` (§4.2), então uma função invoker chamada pela aprovação humana não
-conseguiria inserir nele. Definer + EXECUTE gateado é o que mantém "um escritor só" com a tabela
-trancada para escrita direta.
+**`private.reposicao_selar_preco`** — `SECURITY DEFINER`, `search_path` fixo, **no schema `private`,
+que o PostgREST não expõe**. `REVOKE EXECUTE` de `PUBLIC`, `anon`, `authenticated` **e**
+`service_role`, por nome. Só o OWNER a executa — ou seja, só as funções-porta (SECDEF, mesmo owner)
+do §4.4.
 
-Gate de papel na entrada, espelhando `sayerlack_aplicar_custo_portal`:
-`auth.uid() IS NOT NULL AND NOT staff` → `42501` (com `service_role` o uid é NULL e passa). O fecho
-REAL é o privilégio: `REVOKE EXECUTE` de `anon` **por nome**; `authenticated` mantém EXECUTE (a
-aprovação humana precisa), `service_role` também.
+⚠️ **Isto é a correção do P0 do §9.1, e é o coração da v3.** Na v2 ela era chamável por
+`authenticated` com `p_origem` livre, o que permitia:
+`falha_envio → UPDATE preço 10→100 → reposicao_selar_preco(id,'portal_captura') → reprocessar` —
+hash correspondente a 100, recusa limpa, origem falsa, **os dois selos e a comparação do payload
+passando**. O selo era forjável pela própria porta que deveria protegê-lo.
+
+Por isso, duas mudanças acopladas — nenhuma das duas basta sozinha:
+
+1. **`p_origem` deixa de ser parâmetro do chamador.** Cada porta passa uma constante que ela própria
+   possui. Como só as portas chamam, a origem não é forjável.
+2. **Selar e escrever deixam de ser atos separáveis.** Não existe "selar o que já está lá": toda
+   porta escreve e sela na MESMA função, na MESMA transação. É o que fecha a variante do Codex
+   "`UPDATE preço 10→NULL` e chamar a RPC de 1ª compra com 100" — sem escrita crua não há NULL
+   fabricado (§4.5).
 
 Espelha o idioma do `reposicao_selo_itens` do #2187, sobre vetor **disjunto** do dele:
 
@@ -182,7 +191,10 @@ Fica no runbook `docs/runbooks/lovable-supabase.md`, não no código.
 
 #### 4.4.1 `reposicao_definir_custo_primeira_compra`
 
-`SECURITY INVOKER` (a escrita vai sob a RLS do operador, `cap_compras_ler`), `search_path` fixo.
+**`SECURITY DEFINER`**, `search_path` fixo, e **põe `SET LOCAL reposicao.selo_bypass='on'` ela
+mesma** — porque depois da v3 `authenticated` não escreve preço em NENHUM status pós-aprovação
+(§4.5), nem em `falha_envio`. Definer com gate de papel na entrada (`auth.uid() IS NOT NULL AND NOT
+staff` → `42501`) substitui a RLS que o invoker daria.
 `p_itens = [{item_id, preco_unitario}]`.
 
 1. Pedido `FOR UPDATE`; status ∈ `('pendente_aprovacao','bloqueado_guardrail','falha_envio')`, senão
@@ -206,9 +218,15 @@ precisou corrigir preço válido em `falha_envio`; se precisar, é SQL Editor + 
 
 **Em `pedido_compra_item`** — o trigger `BEFORE INSERT/UPDATE/DELETE` do #2187 hoje deixa preço passar
 de propósito (§3.2 de lá). Ganha um segundo ramo: pai **fora** de
-`('pendente_aprovacao','bloqueado_guardrail','falha_envio')` e o UPDATE toca `preco_unitario` →
-`SA008`, **salvo** sob o bypass `reposicao.selo_bypass` já previsto (GUC **e**
+`('pendente_aprovacao','bloqueado_guardrail')` e o UPDATE toca `preco_unitario` → `SA008`, **salvo**
+sob o bypass `reposicao.selo_bypass` já previsto (GUC **e**
 `current_user IN ('postgres','service_role')` — nunca para `authenticated`).
+
+⚠️ **`falha_envio` SAIU da lista permissiva** (era o buraco do §9.1). A lista agora é só
+pré-aprovação: depois da aprovação, `authenticated` **não escreve `preco_unitario` em estado nenhum**.
+Quem escreve em `falha_envio` é a RPC de 1ª compra, que é SECDEF e põe o bypass ela mesma (§4.4.1).
+Efeito colateral desejado: a aba velha do §9.4 tem a escrita **recusada no banco** em vez de aceita
+sem selo — o preço continua ≤ 0 e a RPC nova ainda funciona, sem virar intervenção SQL.
 
 O GUC `reposicao.selando_preco` **não** aparece aqui, e isso é desenho: `reposicao_selar_preco` escreve
 só em `pedido_compra_sugerido`, nunca em `pedido_compra_item`. Uma exceção para ele no trigger de item
@@ -268,6 +286,14 @@ do próprio `produtos_incluir`, **não de uma releitura** — e compara em SQL c
 | `aprovacao_selo_divergente` | `reposicao_selo_itens(p_pedido_id)` ≠ `aprovacao_selo` |
 | `payload_divergente` | conjunto de `item_id` ≠ itens do pedido, ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
 
+**Correspondência um-para-um, não igualdade de conjuntos** (§9.5): `p_itens` tem de ser array válido,
+com `item_id` **únicos**, e a **cardinalidade** tem de bater com a contagem de itens do pedido —
+`count(*) = count(DISTINCT item_id) = (SELECT count(*) FROM pedido_compra_item WHERE pedido_id = ...)`.
+Sem isso, um payload que repete `{id:7, preço:10, qtde:2}` duas vezes mantém o mesmo CONJUNTO de ids,
+satisfaz toda comparação individual, e passaria com **quantidade total dobrada**. Não há produtor
+dessas duplicatas hoje (o `.map` parte das linhas do banco) — é defeito do CONTRATO da proteção de
+transporte, e é o contrato que tem de fechar.
+
 `divergencias` traz o recorte por item, para o log e para o operador.
 
 Três coisas numa chamada:
@@ -313,10 +339,27 @@ brickaria o pedido.
 | motivo | recuperação |
 |---|---|
 | `preco_selo_ausente` / `preco_selo_divergente` / `payload_divergente` (preço) | porta autorizada re-sela e limpa o motivo → reprocessa |
-| `aprovacao_selo_ausente` / `aprovacao_selo_divergente` / `payload_divergente` (qtde) | **não há porta** — o `aprovacao_selo` é imutável por construção no #2187, e assim deve ser. Só sai por **cancelar + o ciclo regravar** |
+| `aprovacao_selo_ausente` / `aprovacao_selo_divergente` / `payload_divergente` (qtde) | 🚧 **NÃO HÁ RECUPERAÇÃO** — ver o beco abaixo |
 
-Sem essa distinção na mensagem o operador reprocessa em círculo achando que é transitório (achado
-B1 do §9).
+⚠️ **O beco da quantidade (§9.2).** A v2 dizia "cancelar + o ciclo regrava". **Isso está bloqueado**:
+`cancelar_pedido_sugerido` (na própria M1 do #2187) recusa quando
+`status_envio_portal IN ('enviando_portal','enviado_portal','sucesso_portal','aceito_portal_sem_protocolo','indeterminado_requer_conciliacao')`
+— e `sucesso_portal` é exatamente o estado onde a recusa aconteceria. Resultado: **fornecedor
+recebeu, Omie não recebeu, reprocessar repete a recusa, cancelar é negado.** A conciliação também não
+reconstrói o selo.
+
+E afrouxar o cancelamento local **seria pior**: ele não cancela a ordem no fornecedor, e um ciclo novo
+geraria uma segunda compra com outro identificador — compra em dobro, que é o dano que este spec
+existe para evitar. Uma recuperação de verdade precisa tratar a **ordem externa** (cancelamento
+confirmado no fornecedor antes de gerar substituto). Preservar a imutabilidade do `aprovacao_selo` é
+compatível com isso; **mudar só a mensagem não é.**
+
+Por isso o escopo da quantidade voltou a ser decisão do founder — §9.2.
+
+A recuperação do lado do PREÇO também ficou mais estreita na v3, e é honesto dizer: como
+`authenticated` não escreve preço pós-aprovação (§4.5), a RPC de 1ª compra só resolve o caso "preço
+ausente". Preço válido adulterado só se corrige pelo **SQL Editor** (`postgres`, com o re-selo
+explícito). É recuperável pelo founder, não pelo operador.
 
 Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: o fornecedor tem a
 ordem e o Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável
@@ -339,9 +382,18 @@ por conciliação; PO com preço errado é dinheiro saindo errado.
 2. **Publish (UI migra para a RPC) + deploy da edge** `disparar-pedidos-aprovados` com a conferência já
    fail-closed. Com M1 aplicada, a edge nova encontra as colunas e a RPC. Com a edge velha ainda no ar
    e M1 aplicada: nada quebra (M1 não recusa nada).
-3. **M2 — ativar.** Ramo `SA008` no trigger do #2187. Pré-condição **medida por query**: zero pedidos
-   em `enviando_portal` e a sonda da edge respondendo a versão nova. M2 é a última — aplicá-la com a
-   edge velha no ar poria um pedido em `falha_envio` sem motivo legível.
+3. **M2 — ativar.** Ramos `SA008` (item) **e `SA009`** (pedido) nos triggers do #2187 — a v2 agendava
+   só o `SA008` (§9.4). Pré-condição **medida por query**: zero pedidos em `enviando_portal` e a sonda
+   da edge respondendo a versão nova.
+
+   ⚠️ **A ordem mudou na v3, e "Publish" não é o marco.** Publish não fecha aba velha — o SW só troca
+   de build quando o cliente clica (CLAUDE.md, 4ª camada). Uma aba antiga em `falha_envio` preencheria
+   o custo por PostgREST cru, **sem selar**, e a edge nova recusaria; pior, atualizar a UI depois não
+   salvaria — o preço já seria positivo e a RPC nova responderia `SP005` (§9.4). Por isso o ramo
+   `SA008` **precisa estar ativo junto com o deploy da edge, não depois dele**: com ele, a escrita da
+   aba velha é **recusada no banco** (o preço fica ≤ 0 e a RPC nova ainda resolve) em vez de aceita e
+   silenciosamente sem selo. Fail-closed contra cliente velho é o ponto — "zero `enviando_portal` +
+   sonda nova" não diz nada sobre abas antigas.
 4. **Sensor da fase seguinte:** §4.6.
 
 Deploy da edge decidido por `bun run pendencias:deploy` (ledger `deploy_atestacoes`), não pelo diff do
@@ -352,6 +404,12 @@ PR.
 - **PG17 `db/test-reposicao-preco-selo.sh`** (padrão dos harnesses; `-v ON_ERROR_STOP=1` + marcador
   positivo de fim; asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos
   sob `SET ROLE authenticated` + GUC do JWT). Cobre:
+  🔴 **o teste decisivo do §9.1 — `adulterar → tentar legitimar → conferir disparo`:** como
+  `authenticated`, (a) UPDATE de preço em `falha_envio` → `SA008`; (b) UPDATE de preço → NULL em
+  qualquer status pós-aprovação → `SA008` (fecha a ausência fabricada); (c) chamada direta a
+  `private.reposicao_selar_preco` → erro de privilégio; (d) adulterar item A + preencher item B pela
+  RPC → a RPC recusa (A não estava ≤ 0) e **nada** é selado; (e) em todos, o disparo seguinte recusa.
+  Negar INSERT direto no log NÃO é este teste ·
   aprovação sela · captura do portal re-sela e loga o delta · 1ª compra preenche e re-sela · 1ª compra
   **recusa** item com preço > 0 (`SP005`) · payload com NaN/Infinity/≤0 → `SP004` · status fora da
   lista → `SP003` · origem inválida → `SP001` · UPDATE de `preco_unitario` pós-aprovação por
@@ -370,23 +428,33 @@ PR.
   remover o ramo `SA008` → o teste do `authenticated` fica vermelho; neutralizar a comparação de
   `n_val_unit` → o teste de transporte fica vermelho; tirar o re-selo de
   `sayerlack_aplicar_custo_portal` → a conferência acusa divergência num caminho **legítimo**;
+  devolver `p_origem` ao chamador (ou reconceder EXECUTE a `authenticated` no selador) → o cenário
+  (c) do teste decisivo fica vermelho; repor `falha_envio` na lista permissiva → (a) fica vermelho;
   afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica vermelho; remover o
   `SET LOCAL reposicao.selo_bypass='on'` de `sayerlack_aplicar_custo_portal` → a captura legítima toma
   `SA008` (prova que o bypass do §4.4 é necessário, não decorativo).
-- **Gate de forma da edge — REUSA o harness que já existe.**
-  `supabase/functions/_shared/marco-pre-omie_test.ts` já faz exatamente esta forma para o
-  `lerMarcoPreOmie`: assere que a leitura vem **antes** do `IncluirPedCompra`, que existe
-  **exatamente 1** call site, e traz a falsificação embutida (monta a fonte `invertido` e exige
-  vermelho). O novo gate é o **irmão** dele para `reposicao_conferir_disparo_omie`, no mesmo arquivo
-  ou ao lado, com a mesma mecânica — não inventar harness novo.
-  É o assert "exatamente 1 call site" que sustenta a alegação de que a asserção é **inescapável**:
-  sem ele, um segundo `IncluirPedCompra` futuro passaria por fora e nada ficaria vermelho.
-  Acrescenta o assert **negativo** "a conferência não está dentro de um ramo `modo === 'producao'`",
-  **com falsificação própria** (envolver a chamada em `if (modo === 'producao')` e exigir vermelho) —
-  é ele que trava o furo do `dry_run`, e sem falsificar ele é decorativo.
-  O gate lê a edge como TEXTO e limpa comentário com o stripper COMPARTILHADO (`removerComentarios` de
-  `@/lib/gates/limpeza-fonte`), nunca regex local — a edge tem `IncluirPedCompra` em 6 comentários e
-  1 chamada; um stripper local mediria os comentários.
+- **Gate da edge — a v2 afirmava um FATO FALSO aqui, corrigido (§9.5).** Eu escrevi que
+  `_shared/marco-pre-omie_test.ts` já assere "exatamente 1 call site de `IncluirPedCompra`". **Não
+  assere.** O `G3` conta `atribuicoesDaColuna` — atribuições de `omie_po_inexistente_antes_de` —, e o
+  Codex executou os 7 testes com um segundo call site inserido: **7/7 verde nos dois casos**. Eu
+  afirmei sobre um arquivo que só tinha visto por `grep`. O harness é bom **modelo de estilo** (o `G2`
+  tem falsificação embutida), não uma garantia pronta.
+
+  Então o gate **é novo**, e forma sozinha não basta: presença + ordem + ausência de
+  `if (modo === 'producao')` são satisfeitas por uma chamada **cuja resposta é ignorada**. O que prova
+  a asserção é COMPORTAMENTO:
+
+  - **zero chamadas ao Omie** quando a RPC (a) erra, (b) devolve `ok=false`, (c) devolve vazio,
+    (d) devolve formato inválido — **nos DOIS modos** (`producao` e `dry_run`), 8 casos;
+  - assert de **contagem** de call sites de `IncluirPedCompra` (que não existia) — é ele, e só ele,
+    que sustenta "inescapável";
+  - **falsificação removendo a DECISÃO de recusar** (manter a chamada, ignorar o resultado): tem de
+    ficar vermelho. Sem essa falsificação o gate é decorativo — é exatamente o defeito que o Codex
+    demonstrou executando.
+
+  Onde o gate lê a edge como TEXTO, limpa comentário com o stripper COMPARTILHADO
+  (`removerComentarios` de `@/lib/gates/limpeza-fonte`), nunca regex local — a edge tem
+  `IncluirPedCompra` em 6 comentários e 1 chamada; um stripper local mediria os comentários.
 - **Deno `test:edges`** (`--no-remote`, sem afrouxar o flag), **`edges:typecheck`**, **`sonda:bump`**
   (`VERSAO`) + **`sonda:fingerprint -- --write`** em `disparar-pedidos-aprovados`. Os 5 gates de edge
   não se cobrem.
@@ -406,53 +474,136 @@ PR.
 3. **RPC dedicada para a 1ª compra + UI migra** — o gate sai do cliente, e a regra "só preenche
    ausente" passa a ser servidor.
 4. **Em fila atrás do #2187.** Não standalone (§2).
-5. **Quantidade entra no escopo** (§5.1 item 2): a conferência do disparo cobre os dois selos.
+5. ~~**Quantidade entra no escopo**~~ 🧭 **REABERTA pelo challenge — §9.2.** Entrou porque parecia
+   "quase de graça"; o Codex mostrou que a recusa de quantidade **não tem recuperação** (cancelar é
+   negado em `sucesso_portal`). Minha recomendação agora é **tirar a quantidade desta fatia** e
+   transformá-la em chip bloqueado no desenho de recuperação de ordem externa.
 
-## 9. Caminho B — auto-challenge adversário (2026-09-06)
+## 9. Revisão independente — challenge Codex (2026-09-06): **não aprovar**
 
-Substitui NADA; cobre o intervalo até o Codex rodar. Os achados abaixo são meus, contra meu próprio
-desenho, e **já estão incorporados no corpo do spec**.
+`gpt-6-astra · reasoning max · tentativa 2 · 908s · 165.313 tokens`. A 1ª tentativa saiu com exit 75
+(cota); a janela resetou e a 2ª rodou. **Toda alegação factual do parecer foi conferida contra o
+código antes de entrar aqui** — parecer de agente não vira spec sem verificação. As cinco estão
+acatadas no corpo.
 
-### B1 [P1] Divergência de QUANTIDADE não tem porta de recuperação — e o operador entraria em loop
+### 9.1 [P0 — eu subo de P1] O re-selo legitimava uma alteração proibida
 
-`preco_selo_divergente` é recuperável: o operador corrige por porta autorizada, que re-sela e limpa o
-motivo (§5.3). **`aprovacao_selo_divergente` não é.** O `aprovacao_selo` é imutável por construção no
-#2187 — não existe, nem deve existir, porta que o re-sele. Um pedido que caia nesse motivo fica em
-`falha_envio` e **nenhuma** ação da tela o destrava; o reprocesso o traz de volta ao mesmo ponto.
+Como staff `authenticated`:
+`falha_envio → UPDATE preço 10→100 → reposicao_selar_preco(id,'portal_captura') → reprocessar`.
+O UPDATE passava pela lista permissiva; o selador aceitava chamador e origem sem exigir o CAS da
+captura; gravava o hash de 100, limpava a recusa e registrava origem falsa. A quantidade ficava
+intacta ⇒ **os dois selos e a comparação do payload passavam**.
 
-Incorporado: §5.3 passa a distinguir os dois desfechos, e a mensagem de recusa tem de dizer qual é
-qual — senão o operador reprocessa em círculo achando que é transitório.
+Classifico como **P0, não P1**: o mecanismo não era contornado por fora, era **derrotado pela própria
+porta que deveria protegê-lo**. Um guard que o atacante pode re-selar não é guard.
 
-### B2 [P2] `persistir_qtde_inteira` sobrescreve o `valor_total` PROVADO do portal
+E o Codex antecipou a correção incompleta: revogar só a chamada direta não bastaria — sobraria
+`UPDATE preço → NULL` + RPC de 1ª compra com o valor novo, porque o `<= 0` validaria a **ausência
+fabricada**; e adulterar o item A enquanto se preenche legitimamente o item B faria o re-selo do
+pedido inteiro incorporar A.
 
-`sayerlack_aplicar_custo_portal` grava `valor_total` = total provado do Efetivar. Na invocação
-seguinte do disparo, `reposicao_persistir_qtde_inteira` recomputa
-`valor_total = sum(valor_linha)` — descartando o número provado em favor de um derivado. Se o total do
-portal incluir qualquer coisa que não seja `Σ preço×qtde` (frete, arredondamento do fornecedor), o
-provado é perdido em silêncio.
+**Acatado** em §4.3 (selador vai para `private`, sem EXECUTE para ninguém além do owner; `p_origem`
+deixa de ser do chamador), §4.4.1 (RPC de 1ª compra vira SECDEF e põe o bypass ela mesma) e §4.5
+(`falha_envio` **sai** da lista permissiva — pós-aprovação `authenticated` não escreve preço em estado
+nenhum). As três são acopladas; nenhuma resolve sozinha.
 
-**Fora do escopo desta fatia** (é bug pré-existente, não regressão do selo, e não afeta o `nValUnit`
-que vai ao Omie). Registrado aqui para virar chip. Reforça a §4.1: `valor_linha` e `valor_total` já
-são território de um escritor que os trata como derivados.
+**Teste decisivo** (§7): *adulterar → tentar legitimar → conferir disparo*. Negar INSERT direto no log
+não prova nada.
 
-### B3 — o que investiguei e NÃO virou achado (medido, não presumido)
+### 9.2 [P1] O beco da quantidade — e a decisão que volta para o founder
 
-- **Outro caminho até o Omie?** Não. `grep -rn IncluirPedCompra supabase/functions/` dá **um** call
-  site executável (`disparar-pedidos-aprovados/index.ts:1057`); o resto é comentário e teste.
-- **Reconciliação cria PO sem passar pela asserção?** Não. Ela **adota** um PO que o Omie diz já
-  existir, via `ConsultarPedCompra` — o PO nasceu de uma invocação anterior que passou pela asserção.
-- **`aplicar_promocoes_no_ciclo` é porta de preço não coberta?** Não. Filtra
-  `status = 'pendente_aprovacao'` (e `IN ('pendente_aprovacao','bloqueado_guardrail')` na reavaliação)
-  — é pré-aprovação.
-- **Duplo envio ao portal na recusa?** Não. Na 1ª invocação o portal devolve `queued` e
-  `processarPedido` retorna **antes** de montar o payload; a asserção só roda na invocação que cria o
-  PO, quando o protocolo já existe.
+**Verificado no código:** `cancelar_pedido_sugerido`, na própria M1 do #2187, recusa quando
+`status_envio_portal IN ('enviando_portal','enviado_portal','sucesso_portal','aceito_portal_sem_protocolo','indeterminado_requer_conciliacao')`.
+A recuperação que a v2 prescrevia ("cancelar + o ciclo regrava") está **bloqueada exatamente no
+estado onde seria necessária**.
+
+Meu B1 (§9.3) tinha achado o problema e prescrito a cura errada: **band-aid**. Mudar a mensagem não é
+recuperação.
+
+🧭 **DECISÃO ABERTA.** A quantidade entrou nesta fatia porque parecia "quase de graça" — cinco linhas
+de SQL numa RPC que já ia existir. **Não é de graça**: uma recusa sem recuperação transforma
+"fornecedor recebeu e Omie não" num estado sem saída. Três caminhos:
+
+1. **Tirar a quantidade desta fatia** (recomendo). A prevenção do #2187 (selo imutável + trigger) já
+   cobre quantidade; o que falta é só a conferência de fronteira, e ela vira chip bloqueado no desenho
+   de recuperação de ordem externa. A fatia volta a ser só preço, que **tem** recuperação.
+2. **Manter, e desenhar a recuperação de ordem externa junto** — cancelamento confirmado no fornecedor
+   antes de gerar substituto. É outra fatia inteira dentro desta.
+3. **Manter como alerta não-bloqueante** — descartado por mim: guard que não recusa, em money-path,
+   é teatro.
+
+### 9.3 O Caminho B (auto-challenge) — e o que ele subdimensionou
+
+Enquanto a cota estava esgotada, auto-desafiei o desenho. Achei **B1** (quantidade sem recuperação) e
+**B2** (`valor_total` provado sobrescrito). **Subdimensionei os dois**, e o registro importa mais que
+o acerto:
+
+- **B1** eu prescrevi "distinguir na mensagem" — band-aid, porque não conferi se o cancelamento era
+  possível (§9.2).
+- **B2** eu chamei de "desvio de relatório, não dinheiro". **Errado, e verificado:** o gate de valor
+  mínimo lê `pedido.valor_total` (`disparar-pedidos-aprovados/index.ts:358`) **antes** de
+  `processarPedido` recomputar. Total adulterado **flipa um gate de dinheiro**. Continua fora de
+  escopo — mas pelo motivo CERTO (separação de efeitos: não afeta `nValUnit`/`nQtde`, e não exige
+  `valor_linha` no hash), não pelo motivo errado que eu tinha dado. Vira chip com essa nota.
+- **B3** (meus descartes) o Codex confirmou: um call site atual, promoção pré-aprovação, sem reenvio
+  com protocolo. Mas registrou o que eu não tinha visto: **descarte correto não é recuperação** — nada
+  disso destrava o §9.2.
+
+Isto é a evidência de que **auto-revisão não substitui revisão independente**: ela encontrou os dois
+sintomas certos e errou o tamanho dos dois.
+
+### 9.4 [P2] O rollout deixava a aba velha de fora, e agendava só metade dos ramos
+
+Publish não fecha aba antiga (o SW só troca de build quando o cliente clica). Sequência furada:
+pedido selado com custo ausente → `falha_envio` → **aba velha preenche o custo corretamente** por
+PostgREST cru (`useDetalhesModal.ts:170`, verificado) → nenhum re-selo → edge nova recusa. E atualizar
+a UI depois **não salvava**: preço já positivo ⇒ a RPC nova responde `SP005`, e a recuperação normal
+vira intervenção SQL.
+
+E a §6 agendava só o `SA008`; o `SA009` não estava em etapa nenhuma.
+
+**Acatado** em §6: o `SA008` passa a entrar **junto com o deploy da edge**, não depois — assim a
+escrita da aba velha é recusada no banco, o preço fica ≤ 0 e a RPC nova ainda resolve. `SA009`
+agendado explicitamente.
+
+### 9.5 [P2] Contrato do payload e uma alegação FALSA minha sobre a prova
+
+**Multiplicidade.** A §5.1 comparava conjuntos de `item_id`. Um payload que repete
+`{id:7, preço:10, qtde:2}` mantém o mesmo conjunto e satisfaz toda comparação individual — passaria com
+**quantidade total dobrada**. Não há produtor hoje (o `.map` parte das linhas do banco), mas é defeito
+do **contrato**, e contrato se fecha no contrato. Acatado em §5.1: array válido, ids únicos,
+cardinalidade igual, correspondência um-para-um.
+
+**A alegação falsa.** A v2 dizia que `_shared/marco-pre-omie_test.ts` já asserta "exatamente 1 call
+site de `IncluirPedCompra`", e eu usei isso para sustentar que a asserção seria "inescapável".
+**Verificado: é falso.** O `G3` conta `atribuicoesDaColuna` — atribuições de
+`omie_po_inexistente_antes_de`. O Codex executou os 7 testes com um segundo call site inserido:
+**7/7 verde nos dois casos**. Eu afirmei sobre um arquivo que só tinha lido por `grep` — a armadilha
+de sempre: recorte não é leitura.
+
+E mesmo com a contagem acrescentada, presença + ordem + ausência de `if (modo === 'producao')` são
+satisfeitas por **uma chamada cuja resposta é ignorada**. Acatado em §7: testes comportamentais
+exigindo **zero chamadas ao Omie** em erro/`ok=false`/vazio/formato inválido, **nos dois modos**, mais
+falsificação que remove a DECISÃO de recusar.
+
+### 9.6 O que o Codex NÃO transformou em achado
+
+- **Hash:** sem colisão estrutural. JSON preserva fronteiras, `ORDER BY id` estabiliza, `trim_scale`
+  normaliza escala, NULL ≠ zero, inserção/remoção mudam o vetor. *"O furo principal está em quem pode
+  autenticar esse vetor"* — que é o §9.1.
+- Ressalva do próprio parecer: a análise das RPCs novas é **de desenho** (elas não existem), e a
+  consulta SQL read-only dele falhou por DNS — ele manteve as medições do prompt como fatos. As
+  medições são minhas, via `psql-ro`, e estão na §3.
 
 ## 10. Fora de escopo (dito, não esquecido)
 
 - **Teto de valor aprovado** ("o portal cobrou mais do que aprovamos"). É a fatia seguinte, e §4.6 diz
   exatamente qual número a destrava.
-- **`valor_linha`** — §4.1 explica por que fica fora e qual desvio isso aceita.
+- **`valor_linha` e `valor_total`** — §4.1 explica por que ficam fora do hash (separação de efeitos:
+  não alcançam `nValUnit`/`nQtde`). ⚠️ **Mas o desvio NÃO é "só relatório"**, como a v2 dizia: o gate
+  de valor mínimo lê `pedido.valor_total` (`index.ts:358`) antes da recomputação, então total
+  adulterado flipa um gate de dinheiro (§9.3). Vira chip próprio, com essa nota — e o chip **não**
+  precisa de `valor_linha` no hash.
 - **Auditoria de `pedido_compra_item`** (não há `atualizado_em` nem tabela de histórico). O log do selo
   cobre o que importa para esta invariante; auditoria geral da tabela é outra decisão.
 - **`conciliar-pedido-portal`** — o #2187 já mexe nela; esta fatia não acrescenta nada lá.

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,4 +1,4 @@
-# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v4)
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v5)
 
 > Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
 > `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
@@ -10,13 +10,17 @@
 > **Status: desenho aprovado pelo founder em conversa (2026-09-06); implementação EM FILA atrás do
 > #2187, que ainda é DRAFT e do qual esta fatia consome infraestrutura (§2).**
 >
-> 🔴 **CHALLENGE CODEX: "não aprovar"** (2026-09-06). A 1ª tentativa foi barrada por cota (exit 75);
-> a janela resetou e a 2ª rodou. Custo: `gpt-6-astra · max · tentativa 2 · 908s · 165.313 tokens`.
-> Dois P1 bloqueantes — e o primeiro eu classifico como **P0**, porque derrota o mecanismo por dentro.
-> Achados, verificação e o que mudou nesta v3: **§9**. O Caminho B (auto-challenge) que cobria o
-> intervalo virou §9.3 — ele tinha achado B1/B2, mas **subdimensionou os dois**.
+> 🔴 **DUAS RODADAS DE CHALLENGE CODEX, as duas "não aprovar".** Toda alegação factual foi conferida
+> por mim contra o código antes de entrar no spec.
+> - **Rodada 1** sobre a v2 (`max · tentativa 2 · 908s · 165.313 tokens`; a 1ª tentativa caiu por cota
+>   e a janela resetou): 5 achados, um deles **P0** — o selo era forjável pela própria porta (§9.1).
+> - **Rodada 2** sobre a v4 (`max · tentativa 1 · 401s · 156.347 tokens`): os ataques antigos estavam
+>   fechados, mas **a minha correção do P0 introduziu duas regressões** — escalada de privilégio na
+>   porta humana e quebra da aprovação (§9.7).
 >
-> Esta v3 acata os cinco achados. **Uma decisão do founder segue aberta (§9.2): escopo da quantidade.**
+> **Esta v5 acata tudo e ainda NÃO foi desafiada.** Rodada 3 é pré-condição da implementação.
+> As duas rodadas acharam furo na **fronteira de autorização**, nunca na criptografia do selo — é onde
+> o risco deste desenho mora (§9.7).
 
 ## 1. A invariante — e por que NÃO é igualdade
 
@@ -150,6 +154,22 @@ Por isso, duas mudanças acopladas — nenhuma das duas basta sozinha:
 
 1. **`p_origem` deixa de ser parâmetro do chamador.** Cada porta passa uma constante que ela própria
    possui. Como só as portas chamam, a origem não é forjável.
+
+   ⚠️ **v5 — a aprovação NÃO é SECDEF, e a v4 quebrava por isso.** Conferido na M1 do #2187
+   (l.376): `aprovar_pedido_sugerido` é `SECURITY INVOKER` **por desenho** (as escritas de item vão sob
+   a RLS do aprovador). Logo ela chamaria o selador privado ainda como `authenticated` →
+   *permission denied*, e **a aprovação quebraria inteira**. Privilégio de SECDEF não permanece no
+   chamador depois do retorno.
+
+   Solução: uma entrada SECDEF **estreita**, `public.reposicao_selar_preco_na_aprovacao(p_pedido_id)`,
+   com EXECUTE para `authenticated` — e que **não pode lavar nada**, porque:
+   - exige `preco_selo IS NULL` ⇒ **só o PRIMEIRO selo**; re-selar é impossível por ela. Lavar exige
+     re-selar um pedido JÁ selado, e é exatamente isso que ela recusa;
+   - exige `aprovacao_selo IS NOT NULL` e o pedido já em `aprovado_aguardando_disparo` ⇒ ela só age no
+     instante em que o preço ainda é, por definição, o legítimo da fase pré-aprovação;
+   - **preserva a capability da RLS** (abaixo) — não amplia quem pode.
+
+   Não reconceder EXECUTE no selador genérico: era isso que abria o P0.
 2. **Selar e escrever deixam de ser atos separáveis.** Não existe "selar o que já está lá": toda
    porta escreve e sela na MESMA função, na MESMA transação. É o que fecha a variante do Codex
    "`UPDATE preço 10→NULL` e chamar a RPC de 1ª compra com 100" — sem escrita crua não há NULL
@@ -197,10 +217,24 @@ Fica no runbook `docs/runbooks/lovable-supabase.md`, não no código.
 
 #### 4.4.1 `reposicao_definir_custo_primeira_compra`
 
-**`SECURITY DEFINER`**, `search_path` fixo, e **põe `SET LOCAL reposicao.selo_bypass='on'` ela
-mesma** — porque depois da v3 `authenticated` não escreve preço em NENHUM status pós-aprovação
-(§4.5), nem em `falha_envio`. Definer com gate de papel na entrada (`auth.uid() IS NOT NULL AND NOT
-staff` → `42501`) substitui a RLS que o invoker daria.
+**`SECURITY DEFINER`**, `search_path` fixo — porque depois da v3 `authenticated` não escreve preço em
+NENHUM status pós-aprovação (§4.5), nem em `falha_envio`.
+
+🔴 **v5 — o gate NÃO é "staff". Isso era escalada de privilégio que EU introduzi** (§9.7). A v4
+copiou o gate do `sayerlack_aplicar_custo_portal` (`employee OR master`). Mas a RLS que o SECDEF
+substitui é `cap_compras_ler`, e **conferido em prod ela é
+`has_role(_uid,'master')` — SÓ MASTER**. Com o gate frouxo, um `employee` ganharia por esta porta uma
+escrita que a RLS reservava a `master`: pedido em `falha_envio` com custo ausente → preço arbitrário
+positivo → o owner grava **e sela** → reprocessamento manda ao Omie. Sem forjar nada.
+
+**Regra da v5, e vale para TODA porta humana SECDEF deste spec** (inclusive a
+`reposicao_selar_preco_na_aprovacao` do §4.3): o gate é **exatamente a capability que a RLS exigia** —
+`private.cap_compras_ler(auth.uid())`, senão `42501`. E **`auth.uid() IS NULL` NÃO passa**: ausência de
+identidade não é autorização (a expressão `auth.uid() IS NOT NULL AND NOT staff` do
+`sayerlack_aplicar_custo_portal` deixa NULL passar **de propósito**, porque lá quem chama é a edge com
+`service_role` — copiá-la para uma porta humana inverte o sentido). `REVOKE EXECUTE` de `PUBLIC` e
+`anon` por nome.
+
 `p_itens = [{item_id, preco_unitario}]`.
 
 1. Pedido `FOR UPDATE`; status ∈ `('pendente_aprovacao','bloqueado_guardrail','falha_envio')`, senão
@@ -244,8 +278,9 @@ O GUC `reposicao.selando_preco` **não** aparece aqui, e isso é desenho: `repos
 só em `pedido_compra_sugerido`, nunca em `pedido_compra_item`. Uma exceção para ele no trigger de item
 seria porta aberta sem dono.
 
-`falha_envio` fica na lista permissiva porque a RPC de 1ª compra é quem escreve lá — e ela sela.
 `reposicao_persistir_qtde_inteira` não toca `preco_unitario`, então não interage com este ramo.
+*(A v4 deixou aqui uma frase morta dizendo que `falha_envio` seguia permissivo — contradizia a própria
+mudança logo acima. Removida na v5, §9.7.)*
 
 **Em `pedido_compra_sugerido`** — o trigger `BEFORE UPDATE` do #2187 (§3.3 de lá) ganha um ramo:
 `preco_selo` / `preco_selo_em` / `preco_selo_origem` só mudam quando
@@ -423,11 +458,21 @@ PR.
 - **PG17 `db/test-reposicao-preco-selo.sh`** (padrão dos harnesses; `-v ON_ERROR_STOP=1` + marcador
   positivo de fim; asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos
   sob `SET ROLE authenticated` + GUC do JWT). Cobre:
-  🔴 **o teste decisivo do §9.1 — `adulterar → tentar legitimar → conferir disparo`:** como
-  `authenticated`, (a) UPDATE de preço em `falha_envio` → `SP006`; (b) UPDATE de preço → NULL em
-  qualquer status pós-aprovação → `SP006` (fecha a ausência fabricada); (c) chamada direta a
-  `private.reposicao_selar_preco` → erro de privilégio; (d) adulterar item A + preencher item B pela
-  RPC → a RPC recusa (A não estava ≤ 0) e **nada** é selado; (e) em todos, o disparo seguinte recusa.
+  🔴 **o teste decisivo do §9.1 — `adulterar → tentar legitimar → conferir disparo`.** Cada cenário
+  tem DUAS asserções, e a v4 errava a segunda (§9.7): o ataque é **recusado** *e* **o estado fica
+  intacto**, portanto **o disparo legítimo seguinte PASSA**. "Em todos o disparo recusa" estava errado
+  — se o `UPDATE 10→100` foi barrado, banco e selo seguem em 10, e recusar o disparo de 10 seria
+  quebrar o fluxo real, não protegê-lo. O disparo só recusa onde a adulteração **conseguiu** passar —
+  e o teste existe para provar que nenhuma consegue.
+  Como `authenticated`: (a) UPDATE de preço em `falha_envio` → `SP006`, preço segue 10, disparo passa;
+  (b) UPDATE de preço → NULL pós-aprovação → `SP006` (fecha a ausência fabricada), disparo passa;
+  (c) chamada direta a `private.reposicao_selar_preco` → erro de privilégio; (d) chamada a
+  `reposicao_selar_preco_na_aprovacao` num pedido **já selado** → recusa (só primeiro selo);
+  (e) variante A/B: a adulteração de A é barrada em (a); a RPC de 1ª compra recebe **só B** (que está
+  ≤ 0) e **deve SUCEDER** — recusar B por causa de A, que nem está no payload, mudaria o ataque
+  testado; (f) 🔴 **capability**: `employee` na RPC de 1ª compra → `42501`; **`master` → autorizado**;
+  `auth.uid() IS NULL` → `42501`. (g) 🔴 **a aprovação real roda como `authenticated`, com as duas
+  migrations integradas, e SELA** — é o cenário que a v4 quebrava (§9.7).
   Negar INSERT direto no log NÃO é este teste ·
   aprovação sela · captura do portal re-sela e loga o delta · 1ª compra preenche e re-sela · 1ª compra
   **recusa** item com preço > 0 (`SP005`) · payload com NaN/Infinity/≤0 → `SP004` · status fora da
@@ -450,10 +495,11 @@ PR.
   `n_val_unit` → o teste de transporte fica vermelho; tirar o re-selo de
   `sayerlack_aplicar_custo_portal` → a conferência acusa divergência num caminho **legítimo**;
   devolver `p_origem` ao chamador (ou reconceder EXECUTE a `authenticated` no selador) → o cenário
-  (c) do teste decisivo fica vermelho; repor `falha_envio` na lista permissiva → (a) fica vermelho;
-  afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica vermelho; remover o
-  `SET LOCAL reposicao.selo_bypass='on'` de `sayerlack_aplicar_custo_portal` → a captura legítima toma
-  `SP006` (prova que o bypass do §4.4 é necessário, não decorativo).
+  (c) fica vermelho; repor `falha_envio` na lista permissiva → (a) fica vermelho; **trocar
+  `cap_compras_ler` por `employee OR master` na RPC de 1ª compra → (f) fica vermelho** (é a
+  falsificação da escalada que eu mesmo introduzi na v4); tirar o `preco_selo IS NULL` da entrada de
+  aprovação → (d) fica vermelho; afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom"
+  fica vermelho.
 - **Gate da edge — a v2 afirmava um FATO FALSO aqui, corrigido (§9.5).** Eu escrevi que
   `_shared/marco-pre-omie_test.ts` já assere "exatamente 1 call site de `IncluirPedCompra`". **Não
   assere.** O `G3` conta `atribuicoesDaColuna` — atribuições de `omie_po_inexistente_antes_de` —, e o
@@ -618,6 +664,36 @@ falsificação que remove a DECISÃO de recusar.
 - Ressalva do próprio parecer: a análise das RPCs novas é **de desenho** (elas não existem), e a
   consulta SQL read-only dele falhou por DNS — ele manteve as medições do prompt como fatos. As
   medições são minhas, via `psql-ro`, e estão na §3.
+
+### 9.7 Segunda rodada do challenge (v4) — **não aprovar**, e os dois P1 são MEUS
+
+`gpt-6-astra · max · tentativa 1 · 401s · 156.347 tokens`. O Codex confirmou que os ataques de escrita
+crua foram fechados **na regra pretendida** — e achou que **a própria correção do P0 introduziu duas
+regressões**. As duas verificadas por mim antes de entrar aqui.
+
+- **[P1] Escalada de privilégio na porta humana.** Verificado em prod: `private.cap_compras_ler` é
+  `has_role(_uid,'master')` — **só master**. Meu gate da v4 copiou o do
+  `sayerlack_aplicar_custo_portal` (`employee OR master`), e com SECDEF isso daria a `employee` uma
+  escrita que a RLS reservava a `master`: `falha_envio` com custo ausente → preço arbitrário positivo →
+  o owner grava e sela → reprocessamento manda ao Omie. **Sem forjar nada.** Trocar RLS por SECDEF sem
+  reproduzir a capability **exata** é escalada silenciosa — a lição está agora como regra no §4.4.1, e
+  vale para toda porta humana deste spec.
+- **[P1] A premissa "as portas são SECDEF" é falsa para a aprovação.** Verificado na M1 do #2187
+  (l.376): `aprovar_pedido_sugerido` é `SECURITY INVOKER` **por desenho**. Privilégio de SECDEF não
+  permanece no chamador, então a aprovação chamaria o selador privado ainda como `authenticated` e
+  tomaria *permission denied*: **a v4 quebrava a aprovação inteira**. Corrigido no §4.3 com uma entrada
+  SECDEF estreita de **primeiro selo apenas** — que não pode lavar nada, porque lavar exige re-selar um
+  pedido já selado, e é isso que ela recusa.
+- **[P2] O meu teste decisivo exigia resultado impossível.** Eu escrevia "em todos, o disparo seguinte
+  recusa". Errado: se o ataque foi barrado, o estado ficou intacto e **o disparo legítimo tem de
+  passar**. Também: na variante A/B a RPC recebe só B e **deve suceder**; e a falsificação ainda citava
+  um GUC que a v4 tinha removido. Um spec com teste contraditório produz implementação que passa no
+  teste errado. Corrigido no §7.
+
+**Padrão que se repete e vale registrar:** as duas rodadas acharam furos na *fronteira de
+autorização*, não na criptografia do selo. Hash, ordenação, escala e NULL passaram limpos nas duas. O
+risco deste desenho nunca esteve em "o hash colide" — está em **quem pode autenticar o vetor**, e cada
+correção minha mexeu exatamente aí e criou a regressão seguinte.
 
 ## 10. Fora de escopo (dito, não esquecido)
 

--- a/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
+++ b/docs/superpowers/specs/2026-09-06-selo-preco-disparo-omie-design.md
@@ -1,0 +1,381 @@
+# Selo de preço no disparo — "disparado = aprovado" no OMIE (2026-09-06, v1)
+
+> Money-path de compras. Origem: decisão **§8.4 do PR #2187** (spec
+> `2026-09-05-selo-aprovacao-pedido-sayerlack-design.md`, branch `claude/frosty-goodall-f12941`), que
+> deixou `preco_unitario`/`valor_linha` **fora** das colunas seladas de propósito — o selo de lá
+> protege o que o PORTAL recebe. Esta é a outra metade: o que o **Omie** recebe. O Codex registrou o
+> desacordo como P2-13 no challenge do desenho v1 do #2187.
+> Contexto vivo: `docs/agent/reposicao.md` §Portal Sayerlack, `docs/agent/money-path.md`,
+> `docs/historico/portal-sayerlack-fator-aprovado-vs-vivo.md`.
+> **Status: desenho aprovado pelo founder em conversa (2026-09-06); implementação EM FILA atrás do
+> #2187, que ainda é DRAFT e do qual esta fatia consome infraestrutura (§2).**
+
+## 1. A invariante — e por que NÃO é igualdade
+
+O enunciado ingênuo — "o preço no PO é o preço da aprovação" — é **literalmente falso no único fluxo
+que existe em produção**, e implementá-lo recusaria todo pedido Sayerlack cuja captura de custo
+funcionasse.
+
+`sayerlack_aplicar_custo_portal` (migration `20260905090000`) só grava sob CAS
+`omie_pedido_compra_numero IS NULL AND status_envio_portal = 'sucesso_portal'`: **por desenho ela roda
+depois da aprovação e antes do PO**, trocando a estimativa do motor pelo custo PROVADO do portal. A
+ordem real é `aprovar → portal (async) → sucesso_portal → captura de custo → conciliação →
+IncluirPedCompra lendo preço fresco`.
+
+A invariante executável é **procedência**, não igualdade:
+
+> Todo `nValUnit` e todo `nQtde` que chegam ao `IncluirPedCompra` foram escritos por uma porta
+> **autorizada naquele momento** — motor (pré-aprovação), humano preenchendo custo de 1ª compra
+> (preço ausente), ou captura do portal (pós-`sucesso_portal`, pré-PO). Nunca por um UPDATE sem
+> procedência. Divergência é recusa do pedido **antes de qualquer efeito no Omie**.
+
+## 2. Dependência do #2187 (esta fatia NÃO é standalone)
+
+Consome, sem reimplementar: a RPC `aprovar_pedido_sugerido` de 3 args, o trigger de
+`pedido_compra_item`, o GUC de bypass (`reposicao.selo_bypass`, honrado só com
+`current_user IN ('postgres','service_role')`), `reposicao_selo_itens`, `aprovacao_selo` e
+`reposicao_pedido_e_portal`. Acrescenta um ramo ao trigger existente — **não cria um segundo trigger
+na mesma tabela**. Se o #2187 for reprovado ou remodelado, este spec é reescrito, não adaptado.
+
+## 3. O que existe hoje (medido em prod via psql-ro, 2026-09-06)
+
+- **Nada do #2187 está aplicado.** `aprovacao_selo` / `portal_recusa_motivo`: 0 colunas.
+  `pedido_compra_item`: **0 triggers**. Os 3 triggers de `pedido_compra_sugerido` são outros
+  (`trg_analytics_outbox_pedido_compra`, `trg_po_inexistente_antes_de_guard`,
+  `trg_set_status_envio_portal`).
+- **A janela é 100% Sayerlack.** Dos pedidos com PO no Omie em 120 dias, **123 de 123** são
+  OBEN/Sayerlack. Aprovação → PO: p50 **1 min**, p90 **28 min**, máx **20.032 min (~14 dias)**. Não
+  existe disparo não-portal nesse recorte — mas o guard é desenhado no `IncluirPedCompra`, que é
+  universal, e não no predicado de portal: escopá-lo a Sayerlack deixaria o buraco aberto no dia em
+  que um fornecedor não-portal entrar.
+- **Escritores de `preco_unitario` / `valor_linha`, auditados:**
+
+  | Writer | Quando | Papel | Freio hoje |
+  |---|---|---|---|
+  | motor (`gerar_pedidos_sugeridos_ciclo`, `gerar_pedidos_oportunidade_ciclo`, `aplicar_promocoes_no_ciclo`) | INSERT; pedido nasce `pendente_aprovacao` | invoker | pré-aprovação |
+  | UI de 1ª compra (`preco-edit.ts` → PostgREST cru) | `pendente_aprovacao` / `bloqueado_guardrail` / `falha_envio`, só se preço ≤ 0 | `authenticated` + `cap_compras_ler` | **só o cliente** |
+  | `sayerlack_aplicar_custo_portal` | pós-`sucesso_portal`, pré-PO | `service_role`, CAS no banco | ok, sem rastro selável |
+  | `reposicao_persistir_qtde_inteira` | **no disparo, em produção** | SECDEF | reescreve **só `valor_linha`** (`ceil(qtde_final) * preco_unitario`) |
+
+- **Policies de `pedido_compra_item`:** `staff_pedido_compra_item_{select,insert,update,delete}` são
+  `cap_compras_ler` por linha, em qualquer status do pai. Qualquer staff de compras altera item por
+  `id`. Aba velha fura.
+- **`falha_envio` é caminho vivo, não hipótese.** A edge grava em qualquer throw de `processarPedido`
+  (`index.ts:1163`), inclusive no guard "SKU(s) sem custo"; o reprocesso aceita
+  `["aprovado_aguardando_disparo","falha_envio"]` (`index.ts:1578`). Zero linhas nesse status **hoje**
+  é medida de status atual, não de histórico — é estado transitório. **152 itens sem custo em 72
+  pedidos** nos últimos 120d: a 1ª compra é comum.
+- **A captura de custo está sem sinal.** Deployada em 05/09. Denominador ~10 `sucesso_portal`/semana;
+  **1 pedido** com `captura_custo`, e nele `atualizados = 0`. **Não existe tabela de auditoria de
+  `pedido_compra_item` nem coluna `atualizado_em`** — não dá para medir retroativamente se algum preço
+  já mudou pós-aprovação. Ausência de dado, não aprovação.
+- **Um único call site chega ao Omie:** `IncluirPedCompra` em `index.ts:1057`. O segundo `select` de
+  itens (`index.ts:1761`) é só o e-mail de notificação, pós-PO.
+
+## 4. Forma
+
+### 4.1 `valor_linha` fica FORA do selo — e por quê
+
+`reposicao_persistir_qtde_inteira` reescreve `valor_linha` no disparo, em produção, pós-aprovação.
+Selá-lo criaria uma **quarta porta** e quebraria o selo em todo disparo, ou exigiria um bypass novo
+para uma função que não move dinheiro.
+
+E `valor_linha` **nunca chega ao Omie**: o payload é `nValUnit: Number(it.preco_unitario)` e
+`nQtde: Math.ceil(Number(it.qtde_final))` (`index.ts:984-985`). É derivado, alimenta `valor_total`
+(display + guardrail).
+
+**Decisão: o selo e o ramo do trigger cobrem `preco_unitario` apenas.** O sensor (§4.6) calcula total
+por `sum(qtde_final * preco_unitario)`, que não depende de `valor_linha`. Custo aceito: uma escrita
+solta em `valor_linha` desloca `valor_total` sem quebrar o selo — é desvio de relatório, não dinheiro
+saindo, e o disparo o recomputa.
+
+### 4.2 Estado novo
+
+Em `pedido_compra_sugerido`: `preco_selo text`, `preco_selo_em timestamptz`, `preco_selo_origem text`,
+`preco_recusa_motivo text`.
+
+Tabela append-only `reposicao_preco_selo_log(id bigserial, pedido_id bigint, selo text, origem text,
+selado_em timestamptz default now(), total_anterior numeric, total_novo numeric, itens_mudados int,
+precos jsonb)`.
+
+`precos` guarda o **vetor** `{item_id: preco}` que gerou o selo, não só o hash — sem ele
+`itens_mudados` seria indecidível (não se faz diff contra um sha256). É o vetor da linha anterior deste
+mesmo pedido que dá o "de → para" por item ao sensor.
+
+**Um escritor só** (`reposicao_selar_preco`) — sinal de money-path não mora em jsonb multi-writer; aqui
+o jsonb é aceitável exatamente porque o escritor é único e a tabela é append-only. RLS ligada desde o
+nascimento; SELECT para staff de compras; **nenhum** INSERT/UPDATE/DELETE para `anon`/`authenticated`
+(REVOKE **por nome** — `REVOKE FROM PUBLIC` não os tira).
+
+Classes de SQLSTATE, cada uma do dono da função: `SA00x` = #2187 (selo do portal), `CP00x` =
+`sayerlack_aplicar_custo_portal`, **`SP00x` = este spec**. Os ramos novos dos triggers do #2187 usam
+`SA008` (item) e `SA009` (pedido) porque vivem dentro das funções de lá.
+
+### 4.3 `reposicao_selar_preco(p_pedido_id bigint, p_origem text)` — o ÚNICO escritor do selo
+
+**`SECURITY DEFINER`**, `search_path` fixo. Definer e não invoker por uma razão concreta: o log é
+fechado a `authenticated` (§4.2), então uma função invoker chamada pela aprovação humana não
+conseguiria inserir nele. Definer + EXECUTE gateado é o que mantém "um escritor só" com a tabela
+trancada para escrita direta.
+
+Gate de papel na entrada, espelhando `sayerlack_aplicar_custo_portal`:
+`auth.uid() IS NOT NULL AND NOT staff` → `42501` (com `service_role` o uid é NULL e passa). O fecho
+REAL é o privilégio: `REVOKE EXECUTE` de `anon` **por nome**; `authenticated` mantém EXECUTE (a
+aprovação humana precisa), `service_role` também.
+
+Espelha o idioma do `reposicao_selo_itens` do #2187, sobre vetor **disjunto** do dele:
+
+```
+encode(sha256(convert_to(jsonb_agg(jsonb_build_array(
+  id, trim_scale(preco_unitario)::text
+) ORDER BY id)::text, 'UTF8')), 'hex')
+```
+
+`jsonb_agg` remove ambiguidade de separador; `NULL` vira `null`; `trim_scale` faz `0,20 ≡ 0,2`.
+**Uma implementação, em SQL** — nenhum espelho TS do hash.
+
+Em ordem, numa transação:
+
+1. `p_origem` ∈ `('aprovacao','primeira_compra','portal_captura','backfill_m1','manual_sql')`, senão
+   `SP001`.
+2. Pedido existe e tem ≥ 1 item, senão `SP002`.
+3. Calcula `total_novo = sum(qtde_final * preco_unitario)` e lê `total_anterior` da última linha do log
+   (NULL na primeira vez — **ausente ≠ zero**, e o sensor filtra `total_anterior > 0`).
+4. `itens_mudados` = itens cujo `trim_scale(preco_unitario)` difere do `precos` da **última linha do
+   log deste pedido**; `NULL` quando não há linha anterior (ausente ≠ zero: `NULL` diz "não havia com
+   o que comparar", `0` diria "comparei e nada mudou").
+5. Grava `preco_selo`, `preco_selo_em = now()`, `preco_selo_origem = p_origem`, e
+   **`preco_recusa_motivo = NULL`** (§5.3), sob `SET LOCAL reposicao.selando_preco = <pedido_id>`.
+6. `INSERT` no log, com `precos` = o vetor recém-selado.
+
+### 4.4 As três portas — cada uma re-sela na PRÓPRIA transação
+
+| Porta | Quando | Como |
+|---|---|---|
+| `aprovar_pedido_sugerido` (3 args, do #2187) | aprovação | `PERFORM reposicao_selar_preco(id,'aprovacao')` logo após `reposicao_selar_pedido` |
+| `reposicao_definir_custo_primeira_compra(p_pedido_id bigint, p_itens jsonb)` **nova** | `pendente_aprovacao` / `bloqueado_guardrail` / `falha_envio` | valida **no servidor**; re-sela com `'primeira_compra'` |
+| `sayerlack_aplicar_custo_portal` | pós-`sucesso_portal`, pré-PO | `SET LOCAL reposicao.selo_bypass='on'` no topo (ela escreve item com o pai em `aprovado_aguardando_disparo`, fora da lista permissiva do §4.5 — e o bypass do #2187 exige o GUC **além** do papel), e `reposicao_selar_preco(id,'portal_captura')` antes do `RETURN`, dentro do CAS que já existe |
+
+`pedido_compra_split` sela os filhos com `reposicao_selar_preco(filho,'aprovacao')` sob o bypass,
+junto do que o #2187 §3.5 já faz.
+
+**A 4ª via — founder consertando pelo SQL Editor — não ganha função.** Roda como `postgres`, que o
+bypass do #2187 §3.2 já honra, e chama `reposicao_selar_preco(id,'manual_sql')` explicitamente.
+Fica no runbook `docs/runbooks/lovable-supabase.md`, não no código.
+
+#### 4.4.1 `reposicao_definir_custo_primeira_compra`
+
+`SECURITY INVOKER` (a escrita vai sob a RLS do operador, `cap_compras_ler`), `search_path` fixo.
+`p_itens = [{item_id, preco_unitario}]`.
+
+1. Pedido `FOR UPDATE`; status ∈ `('pendente_aprovacao','bloqueado_guardrail','falha_envio')`, senão
+   `SP003`.
+2. Payload: array não vazio, `item_id` inteiro, `preco_unitario` **NOT NULL**, `<> 'NaN'::numeric`,
+   `> 0` e `< 'Infinity'::numeric` — os três lados (`'NaN'::numeric` e `'Infinity'::numeric` **passam**
+   em `> 0`). Senão `SP004`.
+3. Cada item pertence ao pedido **e tem `coalesce(preco_unitario,0) <= 0` agora** — só PREENCHE, nunca
+   troca preço bom. `ROW_COUNT <> n` → `SP005` e ROLLBACK de tudo.
+4. `valor_linha = ceil(qtde_final) * preco_unitario` para as linhas tocadas, e `valor_total` recomputado.
+5. `PERFORM reposicao_selar_preco(p_pedido_id, 'primeira_compra')`.
+
+**Mais estrito que a tela de hoje**, de propósito: hoje uma aba velha em `falha_envio` reescreve
+*qualquer* preço; a RPC só deixa preencher ausente. O founder confirmou (2026-09-06) que nunca
+precisou corrigir preço válido em `falha_envio`; se precisar, é SQL Editor + `'manual_sql'`.
+
+**UI:** `useDetalhesModal` troca o `update` PostgREST de preço pela RPC.
+`podeEditarPrecoPedido`/`precoEditavelDaLinha` continuam como UX, mas deixam de ser o freio.
+
+### 4.5 Trava — ramo `SA008` no trigger do #2187
+
+**Em `pedido_compra_item`** — o trigger `BEFORE INSERT/UPDATE/DELETE` do #2187 hoje deixa preço passar
+de propósito (§3.2 de lá). Ganha um segundo ramo: pai **fora** de
+`('pendente_aprovacao','bloqueado_guardrail','falha_envio')` e o UPDATE toca `preco_unitario` →
+`SA008`, **salvo** sob o bypass `reposicao.selo_bypass` já previsto (GUC **e**
+`current_user IN ('postgres','service_role')` — nunca para `authenticated`).
+
+O GUC `reposicao.selando_preco` **não** aparece aqui, e isso é desenho: `reposicao_selar_preco` escreve
+só em `pedido_compra_sugerido`, nunca em `pedido_compra_item`. Uma exceção para ele no trigger de item
+seria porta aberta sem dono.
+
+`falha_envio` fica na lista permissiva porque a RPC de 1ª compra é quem escreve lá — e ela sela.
+`reposicao_persistir_qtde_inteira` não toca `preco_unitario`, então não interage com este ramo.
+
+**Em `pedido_compra_sugerido`** — o trigger `BEFORE UPDATE` do #2187 (§3.3 de lá) ganha um ramo:
+`preco_selo` / `preco_selo_em` / `preco_selo_origem` só mudam quando
+`reposicao.selando_preco = NEW.id`, senão `SA009`. É **aqui** que o GUC trabalha. Note a diferença
+para o `aprovacao_selo`, que é imutável depois de gravado: `preco_selo` é *mutável, porém só por uma
+porta*.
+
+`preco_recusa_motivo` fica sem guard: quem o grava é a edge (`service_role`) e quem o limpa é
+`reposicao_selar_preco`. Um guard ali só criaria uma trava a mais para o mesmo efeito.
+
+**O trigger continua guardando, nunca escrevendo** — a forma que a v2 do #2187 adotou depois do P0 do
+Codex.
+
+### 4.6 O sensor — é ele que decide o teto depois
+
+O founder decidiu (2026-09-06): **procedência agora, teto depois, com número medido.** Um limiar hoje
+seria chutado — a captura tem 1 pedido de sinal.
+
+```sql
+SELECT origem,
+       count(*) AS reselos,
+       count(*) FILTER (WHERE itens_mudados > 0) AS mudou,
+       round(percentile_cont(0.5) WITHIN GROUP (ORDER BY (total_novo-total_anterior)/total_anterior*100)::numeric, 2) AS p50_delta_perc,
+       round(max((total_novo-total_anterior)/total_anterior*100)::numeric, 2) AS max_delta_perc
+  FROM reposicao_preco_selo_log
+ WHERE selado_em > now() - interval '30 days' AND total_anterior > 0
+ GROUP BY 1;
+```
+
+Denominador ao lado: `sucesso_portal` por semana (hoje ~10). A fatia seguinte ("teto de valor
+aprovado") **só nasce com esse número na mão**, com ≥ 4 semanas de `origem='portal_captura'` e
+`mudou > 0` — "está no ar e ninguém reclamou" é ausência de dado.
+
+## 5. A fronteira: asserção antes do `IncluirPedCompra`
+
+### 5.1 `reposicao_conferir_disparo_omie(p_pedido_id bigint, p_itens jsonb)`
+
+`RETURNS TABLE(ok boolean, motivo text, divergencias jsonb)`. `STABLE`, `SECURITY INVOKER`,
+`search_path` fixo. EXECUTE só para `service_role` (a edge).
+
+Recebe **exatamente o que a edge está prestes a mandar** — `[{item_id, n_val_unit, n_qtde}]`, derivado
+do próprio `produtos_incluir`, **não de uma releitura** — e compara em SQL com `IS DISTINCT FROM` sobre
+`numeric`. Motivos, em ordem de avaliação (o primeiro que casa vence):
+
+| motivo | condição |
+|---|---|
+| `preco_selo_ausente` | `preco_selo IS NULL` |
+| `aprovacao_selo_ausente` | `aprovacao_selo IS NULL` |
+| `preco_selo_divergente` | hash recomputado de `preco_unitario` ≠ `preco_selo` |
+| `aprovacao_selo_divergente` | `reposicao_selo_itens(p_pedido_id)` ≠ `aprovacao_selo` |
+| `payload_divergente` | conjunto de `item_id` ≠ itens do pedido, ou `n_val_unit IS DISTINCT FROM preco_unitario`, ou `n_qtde IS DISTINCT FROM qtde_final` |
+
+`divergencias` traz o recorte por item, para o log e para o operador.
+
+Três coisas numa chamada:
+
+1. **Procedência do preço** (`preco_selo`) — o que esta fatia acrescenta.
+2. **Procedência da quantidade** (`aprovacao_selo`) — o #2187 sela `qtde_final`, mas quem confere é a
+   edge do **portal**, pré-Browserless. O lado Omie mandava `nQtde` sem conferir nada. Custa ~5 linhas
+   de SQL aqui e nenhuma chamada extra.
+3. **Transporte** — o `Number()` do TS colapsa decimais distintos (P2-12 do Codex no #2187). Comparar o
+   valor **enviado** contra o banco é mais estrito que comparar banco-com-banco: se o `Number()`
+   deturpar o preço, o PO sairia deturpado e nós saberíamos.
+
+Sobre `n_qtde`: sob o #2187 a `qtde_final` já é canônica (inteira) na aprovação, então
+`Math.ceil(Number(qtde_final))` é no-op e a comparação estrita `IS DISTINCT FROM qtde_final` é a certa.
+Se **não** for no-op, a recusa é a resposta correta — algo aprovou fração.
+
+### 5.2 Onde entra na edge
+
+Colada no único call site (`index.ts:1057`), depois de montar `produtos_incluir`, ao lado do
+`lerMarcoPreOmie` que já tem essa disciplina — **com o sinal invertido, e o comentário tem que dizer
+por quê**: `lerMarcoPreOmie` é fail-**open** de propósito (perder o marco é melhor que perder o PO);
+esta é fail-**closed** — erro da RPC, `ok=false`, ou resposta sem forma esperada = recusa. Degradar é
+certo no sensor, errado no que move dinheiro.
+
+O `select` de itens (`index.ts:842`) passa a trazer `id`, para o `item_id` do payload.
+
+**Roda nos DOIS modos.** `dry_run` chama `IncluirPedCompra` incondicionalmente e **cria PO real no
+Omie** (`index.ts:454-457`); pular a conferência lá seria o mesmo furo com outro nome.
+
+### 5.3 Na recusa
+
+`throw` com o motivo → o `catch` que já existe grava `falha_envio` (`index.ts:1163`). **Nenhum estado
+terminal novo, nenhuma máquina de estados nova.** `preco_recusa_motivo` guarda o motivo.
+
+**Assimetria deliberada em relação ao `portal_recusa_motivo` do #2187, que é imutável:**
+`preco_recusa_motivo` é **limpo pelo `reposicao_selar_preco`** (§4.3 passo 5). Divergência de selo do
+portal é terminal ("cancele e aguarde o ciclo"); divergência de preço é **recuperável** — o operador
+corrige por uma porta autorizada, que re-sela e limpa o motivo, e o reprocesso segue. Sem isso o guard
+brickaria o pedido.
+
+Para Sayerlack a recusa acontece **depois** de o portal já ter recebido o pedido: o fornecedor tem a
+ordem e o Omie não tem o PO. É estado operacional real, e é o **correto** — PO faltando é recuperável
+por conciliação; PO com preço errado é dinheiro saindo errado.
+
+## 6. Rollout expandir → ativar (3 camadas manuais; a ordem é a diferença entre nada quebrar e fila presa)
+
+1. **M1 — expandir (nada recusa escrita).** Colunas, `reposicao_preco_selo_log` + RLS,
+   `reposicao_selar_preco`, `reposicao_conferir_disparo_omie`,
+   `reposicao_definir_custo_primeira_compra`, re-selo dentro de `sayerlack_aplicar_custo_portal`, da
+   RPC de aprovação do #2187 e do split. `NOTIFY pgrst, 'reload schema'`; regenerar
+   `src/integrations/supabase/types.ts`. `DO $post$` relê o catálogo (existência, SECDEF onde previsto,
+   `search_path` preso, `anon`/`authenticated` sem EXECUTE onde previsto).
+   **Backfill** de `preco_selo` para pedidos em estado não-terminal, com `origem='backfill_m1'` — hoje
+   1 pedido em `aprovado_aguardando_disparo`. Sela o preço que estiver lá: não há como saber se foi
+   adulterado, e recusar toda a fila em voo seria pior. A origem `backfill_m1` deixa isso visível no
+   log. **Depois do backfill, `NULL` significa "alguém zerou" — e recusar é correto.**
+   Pré-voo `pg_get_functiondef` da PROD para toda função recriada (apply manual diverge do repo; a
+   última a recriar vence). `CREATE OR REPLACE` preserva ACL; `REVOKE`/`GRANT` reafirmados por nome.
+2. **Publish (UI migra para a RPC) + deploy da edge** `disparar-pedidos-aprovados` com a conferência já
+   fail-closed. Com M1 aplicada, a edge nova encontra as colunas e a RPC. Com a edge velha ainda no ar
+   e M1 aplicada: nada quebra (M1 não recusa nada).
+3. **M2 — ativar.** Ramo `SA008` no trigger do #2187. Pré-condição **medida por query**: zero pedidos
+   em `enviando_portal` e a sonda da edge respondendo a versão nova. M2 é a última — aplicá-la com a
+   edge velha no ar poria um pedido em `falha_envio` sem motivo legível.
+4. **Sensor da fase seguinte:** §4.6.
+
+Deploy da edge decidido por `bun run pendencias:deploy` (ledger `deploy_atestacoes`), não pelo diff do
+PR.
+
+## 7. Prova
+
+- **PG17 `db/test-reposicao-preco-selo.sh`** (padrão dos harnesses; `-v ON_ERROR_STOP=1` + marcador
+  positivo de fim; asserts negativos casam a **SQLSTATE exata** e re-lançam o resto; cenários humanos
+  sob `SET ROLE authenticated` + GUC do JWT). Cobre:
+  aprovação sela · captura do portal re-sela e loga o delta · 1ª compra preenche e re-sela · 1ª compra
+  **recusa** item com preço > 0 (`SP005`) · payload com NaN/Infinity/≤0 → `SP004` · status fora da
+  lista → `SP003` · origem inválida → `SP001` · UPDATE de `preco_unitario` pós-aprovação por
+  `authenticated` → `SA008` · o mesmo UPDATE com `reposicao.selando_preco` posto por `authenticated`
+  **não** passa · `reposicao_persistir_qtde_inteira` no disparo **não** quebra o selo (é o teste que
+  prova a decisão §4.1) · conferência: `n_val_unit` deturpado → `payload_divergente` · `n_qtde` ≠
+  `qtde_final` → `payload_divergente` · preço alterado sem selar → `preco_selo_divergente` · qtde
+  alterada sem selar → `aprovacao_selo_divergente` · `preco_selo` NULL → `preco_selo_ausente` ·
+  `preco_recusa_motivo` limpo pelo re-selo · split sela os filhos · hash: ordem por `id`,
+  `0,20 ≡ 0,2`, NULL ≠ vazio · UPDATE direto de `preco_selo` sem o GUC → `SA009` ·
+  `itens_mudados` é `NULL` no primeiro selo e `0` quando o re-selo não muda preço nenhum (é o par que
+  prova "ausente ≠ zero" no sensor) · `authenticated` **não** consegue INSERT direto em
+  `reposicao_preco_selo_log`, mas a aprovação humana grava lá pela função.
+- **Falsificação uma camada por vez**, com **controle verde na MESMA invocação do laço** (senão a
+  suíte sempre-vermelha aprova tudo) e **commit antes** (o `restaurar()` é `git checkout --`):
+  remover o ramo `SA008` → o teste do `authenticated` fica vermelho; neutralizar a comparação de
+  `n_val_unit` → o teste de transporte fica vermelho; tirar o re-selo de
+  `sayerlack_aplicar_custo_portal` → a conferência acusa divergência num caminho **legítimo**;
+  afrouxar o `<= 0` da 1ª compra → o teste de "não troca preço bom" fica vermelho; remover o
+  `SET LOCAL reposicao.selo_bypass='on'` de `sayerlack_aplicar_custo_portal` → a captura legítima toma
+  `SA008` (prova que o bypass do §4.4 é necessário, não decorativo).
+- **vitest, gate de forma da edge:** assert **positivo** "o `IncluirPedCompra` é precedido por
+  `reposicao_conferir_disparo_omie`" e assert **negativo** "a conferência não está dentro de um ramo
+  `modo === 'producao'`" — é o segundo que trava o furo do `dry_run`. O gate lê a edge como TEXTO e
+  limpa comentário com o stripper COMPARTILHADO (`removerComentarios` de `@/lib/gates/limpeza-fonte`),
+  nunca regex local.
+- **Deno `test:edges`** (`--no-remote`, sem afrouxar o flag), **`edges:typecheck`**, **`sonda:bump`**
+  (`VERSAO`) + **`sonda:fingerprint -- --write`** em `disparar-pedidos-aprovados`. Os 5 gates de edge
+  não se cobrem.
+- **Manifesto de módulos:** arquivo novo em `src/` ganha dono em `src/lib/modulos/manifesto.ts`.
+- **`bun run psql:errorstop`**, **`shellcheck`** no harness novo.
+- **Codex challenge** (`scripts/codex-async.sh`, background) sobre este spec **antes** de implementar,
+  e sobre o PR depois.
+
+## 8. Decisões do founder (2026-09-06, nesta ordem)
+
+1. **Selo próprio + re-selo por porta**, não o selo do #2187 estendido. O selo de lá é imutável por
+   construção; este precisa ser reescrito legitimamente até 2x. Fundi-los tornaria mutável o selo cuja
+   propriedade central é a imutabilidade. **A §8.4 do #2187 fica intacta — não foi reaberta.**
+2. **Procedência agora, teto depois**, com o sensor do §4.6 produzindo o número. Evita a armadilha
+   "fase N+1 sem sinal da fase N".
+3. **RPC dedicada para a 1ª compra + UI migra** — o gate sai do cliente, e a regra "só preenche
+   ausente" passa a ser servidor.
+4. **Em fila atrás do #2187.** Não standalone (§2).
+5. **Quantidade entra no escopo** (§5.1 item 2): a conferência do disparo cobre os dois selos.
+
+## 9. Fora de escopo (dito, não esquecido)
+
+- **Teto de valor aprovado** ("o portal cobrou mais do que aprovamos"). É a fatia seguinte, e §4.6 diz
+  exatamente qual número a destrava.
+- **`valor_linha`** — §4.1 explica por que fica fora e qual desvio isso aceita.
+- **Auditoria de `pedido_compra_item`** (não há `atualizado_em` nem tabela de histórico). O log do selo
+  cobre o que importa para esta invariante; auditoria geral da tabela é outra decisão.
+- **`conciliar-pedido-portal`** — o #2187 já mexe nela; esta fatia não acrescenta nada lá.


### PR DESCRIPTION
**DRAFT.** Desenho aprovado; implementação bloqueada pelo #2187. Fecha a outra metade da decisão **§8.4 do #2187**: o selo de lá protege o que o **portal** recebe; este, o que o **Omie** recebe.

## ✅ Aprovado na 6ª rodada — cinco reprovações antes

| # | Sobre | Custo | Resultado |
|---|---|---|---|
| 1 | v2 | `908s · 165k` | 5 achados, um **P0**: o selo era forjável pela própria porta |
| 2 | v4 | `401s · 156k` | 2 P1 — **regressões da minha correção** |
| 3 | v5 | `422s · 165k` | 2 P1 — "primeiro selo" travava aprovação; **split lavava preço** |
| 4 | v7 | `425s · 161k` | *"as regressões anteriores não se reabrem"* — **a troca de forma funcionou** |
| 5 | v9 | `507s · 123k` | corte atômico confirmado; caem token e reparo |
| 6 | v10 | `295s · 74k` | ✅ **APROVAR** — *"não encontrei achado novo P0/P1/P2"* |

## O achado que mudou a premissa

"Preço no PO == preço na aprovação" é **literalmente falso no único fluxo que existe**: `sayerlack_aplicar_custo_portal` roda, por desenho, entre a aprovação e o PO. Um selo de igualdade recusaria todo pedido Sayerlack cuja captura funcionasse. A invariante executável é **procedência**.

Medido em prod: **123/123** dos POs em 120d são OBEN/Sayerlack; `pedido_compra_item` sem trigger, sem `atualizado_em`, sem auditoria; captura de custo com **1 pedido de sinal** em ~10 `sucesso_portal`/semana.

## A forma final

Três rodadas na mesma fronteira levaram à **troca de forma** (decisão do founder): saiu o hash por pedido com função de selar; entrou **procedência POR LINHA** — `preco_origem` + `preco_gravado_em` carimbados pelo **próprio trigger** no statement que escreve o preço. Carimbo nunca é input; preservado quando o preço não muda. Fecha os achados **por construção**, e o carimbo **viaja com a linha** no split.

Colateral: a M1 encolheu — a forma antiga recriava três funções que a sessão irmã está reconstruindo; **a v11 não toca nenhuma**.

## 🔴 As duas condições da aprovação

1. **Não omitir o requisito do snapshot no #2187** (§2.1) — a aprovação não vale sem ele.
2. **Não substituir os testes comportamentais por testes só do comparador.**

E a propriedade decisiva do token é **temporal**: a UI pode reapresentar 100, mas **não pode reutilizar a confirmação de 10 para aprovar 100**. O teste atravessa a UI real (inline, modal, lote), e a falsificação obrigatória — *"reler 100 → renderizar 100 → aprovar 100 no mesmo clique"* — tem de ficar **vermelha mesmo com 100 no DOM**.

## Coordenação com o #2187 — requisito aceito

Enviei a §2.1 à sessão que reconstrói o #2187. Resposta: *"Requisito legítimo e o segundo ponto é um furo real no meu §3.4.3 — vou acatar os dois."* ⚠️ **Aceite em conversa não é código** — a prova é o `p_itens_vistos` conter `preco_unitario` e o token vir do snapshot apresentado.

Efeito colateral medido: a classe `SA` saiu de `SA003–SA008` para **`SA003–SA010`** em poucas horas. É a prova concreta de por que os códigos daqui vivem na classe `SP`.

## Riscos aceitos (§9.11.4)

`master` deliberado passa · representatividade do sensor não garantida · backfill aceita valores sem provar histórico · `valor_linha`/`valor_total` fora, **inclusive o efeito no gate de valor mínimo** · quantidade depende do #2187 · recusa pós-portal deixa fornecedor com pedido e Omie sem PO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 🔘 Backup durável de chip (ritual `/fecho`, 2026-09-06)

Chip é destino **perecível** — morre com a sessão. O conteúdo fica aqui para sobreviver ao arquivamento.

**Chip "Deployar as 4 edges de IA que ganharam sonda"** — pendência de TERCEIRO na janela desta sessão (esta sessão não tocou edge nenhuma).

Commit `302c753ba` — *"feat(sonda): as 4 edges de IA saem da classe cega"*. Medido pelo `edges-pendentes.sh --desde 599fc4fde`: as 4 saíram `SEM_PROVA` com ledger `NUNCA_ATESTADA` (nunca vistas em prod ⇒ a 1ª sonda é humana).

Arquivos — **nomear TODOS** ao pedir deploy (prompt que nomeia um só deixa a edge sem bootar, #2020):
`analyze-services/{index,versao}.ts` · `copilot-analyze/{index,versao}.ts` · `elevenlabs-transcribe/{index,versao}.ts` · `identify-tool/{index,versao}.ts` · `_shared/sonda-fingerprints.ts` · `_shared/sonda-versao-contrato_test.ts`

**Antes de pedir qualquer deploy, rodar `bun run pendencias:deploy`** — quem decide é o ledger `deploy_atestacoes`, não o diff. A sessão dona do `302c753ba` pode já ter pedido.

⚠️ São edges de **IA** (chamam LLM): tratar como **caras** até a triagem de `docs/agent/deploy.md` dizer o contrário. Em edge cara a ordem é **deploy antes, sonda depois só para confirmar** — bundle pré-sensor ignora o `probe` e executa o fluxo real.
