### PR TITLE
docs(sonda): o mapa `edge→id` do LOTE sai do transporte manual — o passo 1 escreve o passo 2

### DIFF
--- a/.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh
@@ -111,6 +111,10 @@ printf 'export const FONTE_SHA256: Record<string, string> = {\n  "edge-a": "%s",
 ID_SONDA=1000
 
 # gera_sql <dir_do_gerador> — emite o BLOCO DE LEITURA (PASSO 2) com o JSON de ids já colado.
+# ⚠️ O recorte espera o FIM do format() antes de procurar o cabeçalho: desde o #2273 o passo 1
+#    carrega um passo 2 DENTRO de `format($sonda$…$sonda$, m.ids)`, e um `/^-- PASSO 2 /{f=1} f`
+#    cru começaria nele — arrastando o `$sonda$, m.ids) …` para dentro do SQL e emitindo lixo. O
+#    embutido não roda aqui de qualquer forma: ele exige `net.http_post`, que este banco não tem.
 gera_sql() {
   local gdir="$1"
   cat > "$gdir/runner.ts" <<RUNNER
@@ -118,7 +122,7 @@ import { gerarSqlDaLeva } from './sonda-versao-sql';
 process.stdout.write(gerarSqlDaLeva({ raiz: process.argv[2], edges: ['edge-a'] }));
 RUNNER
   bun "$gdir/runner.ts" "$FIX" 2>"$TMP/gen.err" \
-    | awk '/^-- PASSO 2 /{f=1} f' \
+    | awk '/AS passo_2_copie_esta_celula/{visto=1} visto && /^-- PASSO 2 /{f=1} f' \
     | sed "s/jsonb_each_text('{}'::jsonb)/jsonb_each_text('{\"edge-a\": $ID_SONDA}'::jsonb)/"
 }
 
@@ -188,6 +192,11 @@ SQL
       P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
                VALUES ($ID_SONDA, 200,
                  '{\"edge\":\"edge-a\",\"versao\":\"v1.0-alfa\",\"fonte\":\"nao-mapeada\",\"probe\":true}', now());"
+      ;;
+    cron_sem_probe)       # id aponta para a execução REAL da edge (cron): ecoa tudo MENOS `probe`
+      P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
+               VALUES ($ID_SONDA, 200,
+                 '{\"edge\":\"edge-a\",\"versao\":\"v1.0-alfa\",\"fonte\":\"$FP_A\"}', now());"
       ;;
     confirmado)           # eco completo: versao + fonte + probe + edge
       P -q -c "INSERT INTO net._http_response (id, status_code, content, created)
@@ -260,6 +269,9 @@ executar_casos() {
     "corpo SEM o campo fonte ⇒ bundle inteiro anterior ao #1998, NUNCA 'parcial'" "DEPLOY PARCIAL"
   caso fonte_nao_mapeada        fonte_nao_mapeada        "DEPLOY PARCIAL" \
     "campo PRESENTE valendo nao-mapeada ⇒ aí sim faltou o mapa no deploy" "PRE_SONDA_FONTE"
+  caso cron_sem_probe           cron_sem_probe           "NAO E RESPOSTA DE SONDA" \
+    "id apontando para o CRON (versao certa, sem probe) NAO pode sair como bundle velho" \
+    "BUNDLE VELHO"
   caso confirmado               confirmado               "DEPLOY CONFIRMADO" \
     "eco completo segue confirmando — o ramo novo não roubou o caminho feliz"
   uma_linha_por_edge confirmado
@@ -268,13 +280,26 @@ executar_casos() {
 if [ "$FALSIFY" = 0 ]; then
   echo "== sonda-veredito-401 — 401 é ambíguo: bundle velho × CRON_SECRET inválido =="
   executar_casos
-  [ "$rc" -eq 0 ] && echo "  tudo bateu: 10 vereditos + cardinalidade" || echo "  ❌ divergência(s) acima"
+  [ "$rc" -eq 0 ] && echo "  tudo bateu: 11 vereditos + cardinalidade" || echo "  ❌ divergência(s) acima"
   exit "$rc"
 fi
 
 # ── falsificação: cada sabotagem precisa deixar ≥1 cenário VERMELHO ──────────────────────────────
 echo "== sonda-veredito-401 --falsify — sabota o gerador e exige vermelho =="
 ORIG=$(cat "$GER/sonda-versao-sql.ts")
+
+# CONTROLE VERDE na MESMA invocacao, ANTES do 1o sed. Sem ele, uma suite sempre-vermelha (Postgres
+# meio subido, fixture quebrada, sabotagem anterior nao restaurada) aprovaria TODAS as sabotagens de
+# uma vez: cada uma "pegaria" um vermelho que ja existia. A suite crua rodada noutra invocacao nao
+# serve — e outro processo e outro tmp. → docs/historico/falsificacao-sem-linha-de-base.md
+executar_casos > "$TMP/controle.out" 2>&1
+if [ "$rc" -ne 0 ]; then
+  echo "  [XX ] CONTROLE VERMELHO com o gerador INTEGRO — nenhuma sabotagem foi tentada:"
+  cat "$TMP/controle.out"
+  exit 1
+fi
+echo "  [ok ] controle: os $(command grep -c '^  \[ok \]' "$TMP/controle.out") cenarios passam com o gerador integro"
+
 cegas=0
 sabotar() { # nome de para
   local nome="$1" de="$2" para="$3"
@@ -316,6 +341,17 @@ sabotar "campo ausente volta a ser lido como DEPLOY PARCIAL (o defeito de 2026-0
         "WHEN NOT (l.corpo ? 'fonte')" "WHEN false"
 sabotar "o COALESCE que fundia ausente com nao-mapeada volta" \
         "WHEN NOT (l.corpo ? 'fonte')" "WHEN COALESCE(l.corpo ->> 'fonte', 'nao-mapeada') = 'nao-mapeada'"
+# O ramo do #2273: id que aponta para a execucao REAL (cron ecoa edge/versao/fonte e nao ecoa
+# probe). Sem ele a linha cai no ELSE e sai 'BUNDLE VELHO' com a versao CERTA — falso NEGATIVO, e o
+# desfecho e redeployar a toa. So aparece EXECUTANDO: a ORDEM dele (antes do `? 'fonte'`) e o que
+# separa "nao e sonda" de "bundle anterior ao #1998".
+sabotar "id de resposta que NAO e sonda volta a virar 'bundle velho' com a versao certa" \
+        "WHEN l.corpo ->> 'probe' IS DISTINCT FROM 'true'" "WHEN false"
+# `IS DISTINCT FROM` -> `<>` e a armadilha NULL-blind: com `probe` AUSENTE (que e exatamente o
+# caso do cron) a comparacao vale NULL, o ramo nao dispara e a linha volta ao ELSE. O ramo continua
+# no arquivo, legivel e inalcancavel — cegueira que so EXECUTANDO se ve.
+sabotar "negacao NULL-blind: o ramo do nao-sonda deixa de alcancar o corpo SEM o campo probe" \
+        "WHEN l.corpo ->> 'probe' IS DISTINCT FROM 'true'" "WHEN l.corpo ->> 'probe' <> 'true'"
 
 echo "--falsify: $cegas cegueira(s) (esperado: 0)"
 [ "$cegas" -eq 0 ] || exit 1

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -211,8 +211,14 @@ TODA resposta — o corpo já cai em `net._http_response`, e o N3 passivo sai de
 #### Sondar VÁRIAS edges numa tacada (leva inteira) — e as 3 armadilhas do SQL Editor
 
 Uma leva tem 5–10 edges, e repetir o par disparo/leitura por edge convida ao erro de trocar o `request_id`
-entre uma e outra. O padrão é disparar todas com `net.http_post` sobre um `VALUES` de nomes e agregar com
-`jsonb_object_agg(edge, request_id)::text` numa **célula única**. Medido 2026-08-24 sondando a oitava leva (#1937).
+entre uma e outra. O padrão é disparar todas com `net.http_post` sobre um `VALUES` de nomes e agregar o par com
+`jsonb_object_agg(edge, request_id)::text` — e, desde 2026-09-06, **esse agregado não é mais ENTREGUE**: ele é
+interpolado por `format()` no texto do passo seguinte, que sai pronto numa **célula única**. Copia-se a célula,
+não o número. É a mesma correção do bloco de UMA edge acima, pela mesma razão
+([sonda-request-id-a-mao.md](../historico/sonda-request-id-a-mao.md)), e os DOIS blocos continuam dois pela
+mesma imposição do `pg_net`: o `http_post` só ENFILEIRA e o worker de fundo só enxerga linha COMMITADA,
+enquanto o SQL Editor roda o batch inteiro como UMA transação. Medido 2026-08-24 sondando a oitava leva
+(#1937); `format()` provado contra prod em 2026-09-06 (#2273).
 
 ⚠️ **A leitura NÃO pede mais o `request_id` colado — ela acha a linha pelo ECO do slug.** A resposta da
 sonda carrega o próprio nome no corpo (`criarRespostaSonda` devolve `{ok, probe, versao, edge, fonte}`),
@@ -220,8 +226,11 @@ então o passo de leitura procura, dentro de uma janela curta, a resposta que di
 colagem à mão era um passo que simplesmente **não acontece**: em 2026-08-30, verificando
 `generate-bundle-argument`, o disparo tinha funcionado (4 respostas HTTP 200 em `net._http_response`) e o
 veredito saiu `SEM ID — esta edge não saiu no JSON colado (bloco errado, ou trava fechada)`. Honesto, e
-ainda assim um round-trip inteiro com o founder por um deploy que já estava no ar. O `jsonb_each_text('{}')`
-sobrevive **opcional**, e só para o que o eco não alcança (ver os dois guards abaixo).
+ainda assim um round-trip inteiro com o founder por um deploy que já estava no ar. O `jsonb_each_text('{}')` VAZIO
+sobrevive no bloco standalone do `--so-leitura` — o caminho do eco, que o agente roda sozinho. No passo que o
+disparo ESCREVE, ele já vem preenchido, e é por isso que esse passo é estritamente melhor: o que o eco não
+alcança (bundle PRE-SENSOR e recusa HTTP, que respondem sem eco do slug) tem id e sai DETERMINADO — em vez de
+cair no INDETERMINADO junto com "não disparou" (ver os dois guards abaixo).
 
 ⚠️ **O casamento exige `probe = 'true'`, não só o slug — senão ele lê a linha do CRON.** Medido em prod
 2026-08-30: a `analytics-outbox-drain` gravou **72** respostas em 6h com `{"edge":…,"versao":…}` e **sem**
@@ -337,12 +346,17 @@ incondicional), não o elimina; na próxima execução dos crons a recusa vira 4
 desqualifica sozinho. Regra prática: **se você acabou de mexer no vault, leia o veredito determinado
 como INDETERMINADO.**
 
-- ⚠️ **O JSON colado aqui é o análogo do `request_id` do bloco de cima — e continua passando pela mão.** A
-  diferença é que o dano já está contido: com `FROM esperado LEFT JOIN ids` (bullet abaixo), colar o blob errado
-  faz **toda** edge esperada aparecer sem id, o que se lê como erro em vez de virar veredito. Ainda assim, o
-  `format()` do bloco de cima **se aplica igual** e é estritamente melhor: o passo 1 pode escrever o passo 2 com o
-  mapa `edge→id` já embutido, e aí não há blob a transportar. Enquanto não for migrado, o `LEFT JOIN` é
-  obrigatório, não opcional — é ele que segura a classe aqui.
+- ⚠️ **O JSON colado aqui era o análogo do `request_id` do bloco de cima — MIGRADO em 2026-09-06 (#2273).** O
+  passo 1 (e o 3) agora terminam em `format($sonda$…$sonda$, m.ids)`: devolvem o passo 2 (e o 4) já escrito, com o
+  mapa `edge→id` dentro, e nenhum identificador passa pela mão. **Mas o `LEFT JOIN` da bullet abaixo continua
+  obrigatório, e por um motivo que a migração NÃO cobre:** a célula é copiada por uma pessoa, e uma célula de
+  OUTRA leva (ou de outra sessão) tem mapa VÁLIDO com os nomes errados. Falsificado contra prod em 2026-09-06
+  trocando o mapa por `{"edge-de-outra-leva": 71275}`: a leitura devolveu **as 2 edges esperadas** com
+  `INDETERMINADO`, não zero linhas. O que a migração fecha é o dígito redigitado; o que o `LEFT JOIN` fecha é o
+  blob inteiro trocado — classes diferentes, guards diferentes. ⚠️ E `format()` obriga a **escapar `%` como
+  `%%`** no corpo embutido (senão `%` vira diretiva) e a conferir o dollar-quoting: o gerador escapa o corpo
+  ANTES de inserir o `%1$L` (na ordem inversa o próprio placeholder viraria `%%1$L`) e ABORTA se o texto contiver
+  a tag `$sonda$`, que encerraria a string no meio e emitiria um passo truncado.
 
 - ⚠️ **A trava do bloco perigoso tem de ser `CASE`, NÃO `WHERE`.** Quando parte da leva só pode ser sondada
   DEPOIS do deploy confirmado (bundle pré-sensor ignora o `probe` e dispara o run), a tentação é
@@ -354,6 +368,14 @@ como INDETERMINADO.**
   é dependente de PLANO: na forma SIMPLES (projeção sem agregação) ele filtra antes e parece proteger —
   quem testar a trava assim lê "seguro" e leva para produção o bloco agregado, que é onde ela falha
   (4 formas medidas em `docs/historico/deploy-no-op-por-desenho.md`).
+- ⚠️ **Id que aponta para resposta que NÃO é sonda sai como "BUNDLE VELHO" com a versão CERTA.** Achado ao
+  falsificar a migração contra prod (2026-09-06): apontado para a resposta 71275 — o cron da
+  `analytics-outbox-drain`, que ecoa `edge`/`versao`/`fonte` e **não** ecoa `probe` —, o `CASE` caía no `ELSE` e
+  imprimia `BUNDLE VELHO — respondeu versao=v1.1-…` com versão e fonte IDÊNTICAS às esperadas. É o falso
+  NEGATIVO da armadilha do casamento só-por-slug, entrando pelo caminho dos `ids` (o `LATERAL` do eco já filtra
+  `probe = 'true'`; o `LEFT JOIN` pelo id não filtrava nada). O ramo `NAO E RESPOSTA DE SONDA` fecha isso, e vem
+  **antes** do `? 'fonte'`: um cron que ecoe `versao` sem `fonte` sairia como `PRE_SONDA_FONTE`, que nomeia
+  "bundle anterior ao #1998" — causa errada, mesma classe.
 - ⚠️ **A leitura tem de partir da lista canônica de edges, não dos ids.** Com `FROM ids JOIN esperado`, colar
   o JSON do bloco errado devolve **zero linhas** — e zero linhas lê-se como "nada a reportar", não como erro.
   Inverta (`FROM esperado LEFT JOIN ids`) e dê um ramo próprio ao id ausente: toda edge esperada aparece
@@ -364,7 +386,10 @@ como INDETERMINADO.**
   só envia após o COMMIT, nada é disparado (confirmado ao vivo em 2026-08-24: `http_request_queue` vazia e
   zero respostas de sonda, com a tabela viva e recebendo cron). Foi o erro que salvou a viagem — mas depender
   disso é depender de o founder colar o arquivo INTEIRO e de o Editor abortar no ponto certo. Use um
-  placeholder VÁLIDO (`'{}'::jsonb`, que cai no ramo "sem id") e ponha a trava real no `CASE` acima.
+  placeholder VÁLIDO (`'{}'::jsonb`, que cai no ramo "sem id") e ponha a trava real no `CASE` acima. Com o mapa
+  embutido o bloco que dispara não tem mais campo de ids nenhum: o **único** campo que o founder toca ali é a
+  trava `'nao'` → `'sim'`, e ela é válida por construção — o `'{}'` continua vivo no bloco standalone do
+  `--so-leitura`, que é onde o placeholder ainda existe.
 - **Distinga rejeição de execução no veredito.** `status_code >= 400` sem `versao` é bundle velho que
   **recusou** o request (401 do gate de JWT na `ai-ops-agent`, 400 do `default` na `sync-reprocess`) —
   nada executou. Só `200` sem `versao` é "ignorou o `probe` e RODOU o fluxo real". Um veredito que junta os

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -218,7 +218,7 @@ não o número. É a mesma correção do bloco de UMA edge acima, pela mesma raz
 ([sonda-request-id-a-mao.md](../historico/sonda-request-id-a-mao.md)), e os DOIS blocos continuam dois pela
 mesma imposição do `pg_net`: o `http_post` só ENFILEIRA e o worker de fundo só enxerga linha COMMITADA,
 enquanto o SQL Editor roda o batch inteiro como UMA transação. Medido 2026-08-24 sondando a oitava leva
-(#1937); `format()` provado contra prod em 2026-09-06 (#2273).
+(#1937); `format()` provado contra prod em 2026-09-06 (#2278).
 
 ⚠️ **A leitura NÃO pede mais o `request_id` colado — ela acha a linha pelo ECO do slug.** A resposta da
 sonda carrega o próprio nome no corpo (`criarRespostaSonda` devolve `{ok, probe, versao, edge, fonte}`),
@@ -346,7 +346,7 @@ incondicional), não o elimina; na próxima execução dos crons a recusa vira 4
 desqualifica sozinho. Regra prática: **se você acabou de mexer no vault, leia o veredito determinado
 como INDETERMINADO.**
 
-- ⚠️ **O JSON colado aqui era o análogo do `request_id` do bloco de cima — MIGRADO em 2026-09-06 (#2273).** O
+- ⚠️ **O JSON colado aqui era o análogo do `request_id` do bloco de cima — MIGRADO em 2026-09-06 (#2278).** O
   passo 1 (e o 3) agora terminam em `format($sonda$…$sonda$, m.ids)`: devolvem o passo 2 (e o 4) já escrito, com o
   mapa `edge→id` dentro, e nenhum identificador passa pela mão. **Mas o `LEFT JOIN` da bullet abaixo continua
   obrigatório, e por um motivo que a migração NÃO cobre:** a célula é copiada por uma pessoa, e uma célula de

--- a/docs/historico/sonda-request-id-a-mao.md
+++ b/docs/historico/sonda-request-id-a-mao.md
@@ -93,7 +93,7 @@ inexistente devolve **uma** linha `AGUARDE` em vez de zero. Os dois corpos de cr
 id vindo do banco, caem em `BUNDLE PRE-SENSOR` — o veredito correto para *aquele request*; lidos com id
 trocado à mão, era o veredito de um request que ninguém fez.
 
-## O mesmo defeito no bloco do LOTE — migrado (2026-09-06, #2273)
+## O mesmo defeito no bloco do LOTE — migrado (2026-09-06, #2278)
 
 A seção irmã do `deploy.md` ("Sondar VÁRIAS edges numa tacada") tinha a variante coletiva: o passo de
 disparo terminava em `SELECT jsonb_object_agg(edge, request_id)::text AS ids_opcionais_passo_2`, e o de

--- a/docs/historico/sonda-request-id-a-mao.md
+++ b/docs/historico/sonda-request-id-a-mao.md
@@ -92,3 +92,53 @@ ponta a ponta no banco de produção em modo leitura: o `format()` produz SQL v�
 inexistente devolve **uma** linha `AGUARDE` em vez de zero. Os dois corpos de cron do incidente, lidos com
 id vindo do banco, caem em `BUNDLE PRE-SENSOR` — o veredito correto para *aquele request*; lidos com id
 trocado à mão, era o veredito de um request que ninguém fez.
+
+## O mesmo defeito no bloco do LOTE — migrado (2026-09-06, #2273)
+
+A seção irmã do `deploy.md` ("Sondar VÁRIAS edges numa tacada") tinha a variante coletiva: o passo de
+disparo terminava em `SELECT jsonb_object_agg(edge, request_id)::text AS ids_opcionais_passo_2`, e o de
+leitura abria com um `jsonb_each_text('{}'::jsonb)` onde alguém colava aquele blob. O SQL do lote não é
+digitado — sai de `bun run sonda:sql` (`scripts/sonda-versao-sql.ts`) —, então a migração é lá, e o
+`deploy.md` a descreve. Hoje o passo 1 (e o 3, das caras) termina em
+`format($sonda$…$sonda$, m.ids)`: **devolve o passo 2 (e o 4) já escrito, com o mapa `edge→id` dentro**.
+Continuam sendo dois blocos pela mesma imposição do `pg_net` verificada acima — nada aqui contorna o
+COMMIT.
+
+**O que a migração fecha e o que ela NÃO fecha.** No bloco de uma edge, o campo desapareceu: não há mais
+nada para o humano preencher. No lote, a **célula** ainda é copiada por uma pessoa — o que sumiu é o
+dígito, não o transporte. Uma célula de OUTRA leva tem mapa sintaticamente VÁLIDO com os nomes errados, e
+contra isso o guard continua sendo o `FROM esperado LEFT JOIN ids` (nunca `FROM ids JOIN esperado`):
+falsificado contra prod trocando o mapa por `{"edge-de-outra-leva": 71275}`, a leitura devolveu **as 2
+edges esperadas** com `INDETERMINADO`, não zero linhas — e zero linhas se leria como "nada a reportar".
+São classes diferentes com guards diferentes; a migração não dispensa o `LEFT JOIN`.
+
+**O que a migração ganha, além da ergonomia:** o mapa embutido é o que o **eco não alcança**. Bundle
+PRE-SENSOR e recusa HTTP respondem sem ecoar o slug e, no caminho do eco, caem em `INDETERMINADO` junto
+com "não disparou"; com o id do próprio disparo em mãos, saem determinados. O `ids` vazio também
+desqualificava o controle de credencial do 401 (o `NOT EXISTS` não excluía a própria leva) — embutido, o
+401 volta a ser determinável.
+
+**Achado da falsificação: um ramo do `CASE` não era disjunto.** Apontado o mapa para a resposta **71275**
+— o cron da `analytics-outbox-drain`, que ecoa `edge`/`versao`/`fonte` e **não** ecoa `probe` —, a
+leitura caía no `ELSE` e imprimia `BUNDLE VELHO — respondeu versao=v1.1-… (esperado v1.1-…)`, com versão
+e fonte **idênticas** às esperadas: o falso negativo da armadilha do casamento só-por-slug, entrando pelo
+caminho dos `ids` (o `LATERAL` do eco já filtra `probe = 'true'`; o `LEFT JOIN` por id não filtrava
+nada). O ramo `NAO E RESPOSTA DE SONDA` fecha isso e vem **antes** do `? 'fonte'` — um cron que ecoe
+`versao` sem `fonte` sairia como `PRE_SONDA_FONTE`, que nomeia "bundle anterior ao #1998": causa errada,
+mesma classe. O defeito era anterior à migração e só aparecia para quem colasse o blob; foi a
+falsificação da migração que o exibiu.
+
+**Duas armadilhas do `format()` que o corpus não exercita.** `%` no corpo vira diretiva, e a tag do
+dollar-quoting dentro do corpo encerraria a string no meio (passo seguinte emitido pela metade, sem erro
+visível). O SQL de hoje não tem nenhum dos dois caracteres — medido —, então um teste que só olhasse o
+SQL emitido ficaria verde por **acidente do corpus** ([gates-textuais-cegos.md](gates-textuais-cegos.md)).
+Daí `escaparParaFormat()` ser exportada e testada direto: escapa `%` **antes** de plantar o `%1$L` (na
+ordem inversa o próprio placeholder viraria `%%1$L` e o mapa sairia literal) e lança quando a tag aparece.
+
+**Falsificação (prod, leitura, `psql-ro -v ON_ERROR_STOP=1`, com as chamadas `net.http_post` trocadas por
+ids literais — `claude_ro` não dispara POST):** o passo 1 rodou no banco e devolveu o passo 2 escrito com
+`jsonb_each_text('{"fin-valor-cockpit": 999999999, "analytics-outbox-drain": 71275}'::jsonb)`; executado,
+devolveu **2 linhas** — id inexistente ⇒ `AGUARDE` (não zero linhas), id de cron ⇒ `NAO E RESPOSTA DE
+SONDA` (antes: `BUNDLE VELHO`). Mapa de outra leva ⇒ 2 linhas `INDETERMINADO`. Passo 3 com a trava
+FECHADA ⇒ mapa `{"fin-valor-cockpit": null}` e **1 linha** dizendo que a trava do passo 3 ficou fechada —
+a trava continua sendo `CASE`, nunca `WHERE`, e nenhum POST sai dela.

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -6,6 +6,7 @@ import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
 import {
+  escaparParaFormat,
   fatiaDaVerdade,
   gerarSqlDaLeva,
   gitReal,
@@ -13,6 +14,7 @@ import {
   main,
   parsearArgs,
   resolverLeva,
+  SENTINELA_MAPA,
   type ExecutorGit,
 } from './sonda-versao-sql';
 
@@ -321,6 +323,7 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os ramos', () 
       'BUNDLE VELHO',
       'PRE-SENSOR',
       'BUNDLE VELHO (pre-sonda)',
+      'NAO E RESPOSTA DE SONDA',
       'INDETERMINADO',
     ]) {
       expect(sql, `ramo ausente: ${ramo}`).toContain(ramo);
@@ -423,9 +426,125 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os ramos', () 
   });
 });
 
+describe('o PASSO 1 ESCREVE o passo 2 — o mapa edge→id não passa pela mão de ninguém', () => {
+  const raiz = () => fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
+
+  // A classe é a do bloco de UMA edge (docs/historico/sonda-request-id-a-mao.md): identificador
+  // transportado à mão troca o alvo em silêncio, e a resposta de cron que ele acerta por acidente
+  // tem a assinatura de "bundle velho". Aqui o transporte era o blob `{"edge": id}` inteiro.
+  it('o disparo termina devolvendo o passo 2 escrito, numa célula única', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('SELECT format($sonda$');
+    expect(sql).toContain('$sonda$, m.ids) AS passo_2_copie_esta_celula');
+    expect(sql).toMatch(/mapa AS \(/);
+  });
+
+  it('o agregado alimenta o format() — deixou de ser coluna ENTREGUE ao operador', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    // O par continua saindo da MESMA execução que disparou (é isso que impede o id de existir
+    // solto); o que sumiu é a coluna que o pedia de volta na mão.
+    expect(sql).toContain('jsonb_object_agg(edge, request_id)::text');
+    expect(sql).not.toContain('ids_opcionais_passo');
+  });
+
+  it('o passo embutido recebe o mapa por %1$L; só o standalone do eco fica com o {}', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const embutido = sql.slice(
+      sql.indexOf('SELECT format($sonda$'),
+      sql.indexOf('AS passo_2_copie_esta_celula'),
+    );
+    expect(embutido).toContain('jsonb_each_text(%1$L::jsonb)');
+    expect(embutido).not.toContain("jsonb_each_text('{}'::jsonb)");
+    expect(sql.slice(sql.indexOf('AS passo_2_copie_esta_celula'))).toContain(
+      "jsonb_each_text('{}'::jsonb)",
+    );
+  });
+
+  it('o bloco CARO escreve o passo 4 e a trava continua sendo CASE, não WHERE', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a', 'edge-b'], caras: ['edge-b'] });
+    expect(sql).toContain('AS passo_4_copie_esta_celula');
+    expect(sql).toContain("CASE WHEN g.confirmei_o_deploy = 'sim'");
+    // O `WHERE guard…` é o teatro que a seção do deploy.md falsificou nos dois sentidos: com a
+    // trava fechada o Postgres avalia a projeção do mesmo jeito e o http_post SAI.
+    expect(sql).not.toMatch(/WHERE\s+g?\.?confirmei_o_deploy/);
+  });
+
+  it('a trava FECHADA embute um mapa de ids NULOS — e isso vira INDETERMINADO, não silêncio', () => {
+    // Provado contra prod em 2026-09-06: o passo 3 travado devolve `{"edge-b": null}` e o passo 4
+    // escrito por ele responde 1 LINHA dizendo que a trava ficou fechada. Zero linhas se leria
+    // como "nada a reportar" — a inversão que o `FROM esperado LEFT JOIN ids` existe para impedir.
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-b'], caras: ['edge-b'] });
+    const embutido = sql.slice(sql.indexOf('SELECT format($sonda$'));
+    expect(embutido).toContain('FROM esperado e');
+    expect(ramoDe(embutido, 'INDETERMINADO —')).toMatch(/trava do passo 3 ficou FECHADA/);
+  });
+
+  it('o passo embutido e o standalone julgam pelos MESMOS ramos — nada de drift entre as duas', () => {
+    // Os dois textos saem da mesma função, mas com variações condicionais (comentários e três
+    // mensagens). Uma variação que apagasse um RAMO deixaria o founder — que recebe o embutido —
+    // com um veredito a menos, e o CI verde: os testes de ramo medem o SQL inteiro, onde a versão
+    // do eco basta para satisfazê-los.
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const emb = sql.slice(
+      sql.indexOf('SELECT format($sonda$'),
+      sql.indexOf('AS passo_2_copie_esta_celula'),
+    );
+    const eco = sql.slice(sql.indexOf('AS passo_2_copie_esta_celula'));
+    for (const ramo of [
+      'INDETERMINADO —',
+      'AGUARDE —',
+      'BUNDLE VELHO (pre-sonda) —',
+      'PRE-SENSOR —',
+      'NAO E RESPOSTA DE SONDA —',
+      'PRE_SONDA_FONTE —',
+      'DEPLOY PARCIAL —',
+      'DEPLOY CONFIRMADO',
+    ]) {
+      expect(emb, `ramo ausente no passo EMBUTIDO: ${ramo}`).toContain(ramo);
+      expect(eco, `ramo ausente no passo do ECO: ${ramo}`).toContain(ramo);
+    }
+  });
+
+  it('o ramo do id que NÃO é sonda vem ANTES do PRE_SONDA_FONTE', () => {
+    // Achado ao falsificar contra prod (resposta 71275, cron da analytics-outbox-drain, que ecoa
+    // edge/versao/fonte e não ecoa probe): sem este ramo a linha cai no ELSE e sai 'BUNDLE VELHO'
+    // com a versão CERTA. E depois do `? 'fonte'` ela sairia como PRE_SONDA_FONTE, que nomeia
+    // "bundle anterior ao #1998" — causa errada, mesma classe de falso negativo.
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const iNaoSonda = sql.indexOf('NAO E RESPOSTA DE SONDA');
+    const iPreFonte = sql.indexOf('PRE_SONDA_FONTE');
+    expect(iNaoSonda).toBeGreaterThan(-1);
+    expect(iNaoSonda).toBeLessThan(iPreFonte);
+    expect(ramoDe(sql, 'NAO E RESPOSTA DE SONDA')).toMatch(/probe:true/);
+  });
+});
+
+describe('escaparParaFormat — as duas armadilhas do format() que o corpus não exercita', () => {
+  // O SQL emitido hoje não tem `%` nem `$` (medido). Sem teste DIRETO, as duas proteções ficariam
+  // verdes por acidente do corpus — a classe de docs/historico/gates-textuais-cegos.md.
+  it('escapa `%` do corpo — senão o format() o lê como diretiva', () => {
+    expect(escaparParaFormat('100% do lote')).toBe('100%% do lote');
+  });
+
+  it('o placeholder entra DEPOIS do escape — na ordem inversa sairia %%1$L', () => {
+    expect(escaparParaFormat(`x ${SENTINELA_MAPA} y`)).toBe('x %1$L y');
+    expect(escaparParaFormat(`50% ${SENTINELA_MAPA}`)).toBe('50%% %1$L');
+  });
+
+  it('corpo que contenha a tag de dollar-quoting falha ALTO — sairia truncado', () => {
+    expect(() => escaparParaFormat('antes $sonda$ depois')).toThrow(/TRUNCADO/);
+  });
+});
+
 describe('PASSO 2 — acha a linha pelo ECO do slug, sem colar request_id nenhum', () => {
   const raiz = () => fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
-  const leitura = (sql: string) => sql.slice(sql.indexOf('-- PASSO 2'));
+  // Desde a migração do #2273 há DOIS textos de passo 2: o que o passo 1 devolve escrito (com o
+  // mapa dentro) e o standalone do `--so-leitura` (o do eco). Ancorar em '-- PASSO 2' pegaria o
+  // primeiro e mediria o embutido achando que media o do eco — o recorte tem de nomear qual.
+  const FIM_DO_FORMAT = 'AS passo_2_copie_esta_celula';
+  const leitura = (sql: string) => sql.slice(sql.indexOf(FIM_DO_FORMAT));
+  const embutida = (sql: string) =>
+    sql.slice(sql.indexOf('SELECT format($sonda$'), sql.indexOf(FIM_DO_FORMAT));
   /** O corpo do `LEFT JOIN LATERAL (…) s ON true` — onde a linha da edge é ESCOLHIDA. */
   const lateral = (sql: string) => {
     const t = leitura(sql);
@@ -525,6 +644,17 @@ describe('PASSO 2 — acha a linha pelo ECO do slug, sem colar request_id nenhum
     expect(ramo).toContain('PRE_SONDA_FONTE');
     expect(ramo).toContain('#1998');
     expect(ramo).not.toContain('DEPLOY PARCIAL');
+  });
+
+  it('o 401 do passo EMBUTIDO não manda colar nada — o mapa já está lá', () => {
+    // O texto do eco manda "cole o JSON no ids para DETERMINAR". Repetido no bloco embutido, ele
+    // mandaria o operador procurar um campo que não existe mais — e a saída certa ali é outra: o
+    // que falta é TRÁFEGO de fundo, não colagem. Provado em prod 2026-09-06 (#2273).
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    const ramo = ramoDe(embutida(sql), 'INDETERMINADO — 401');
+    expect(ramo).not.toMatch(/cole/i);
+    expect(ramo).toMatch(/embutido/);
+    expect(ramo).toMatch(/TRAFEGO/);
   });
 
   it('o 401 sem colagem AUTO-DESQUALIFICA o controle — e a mensagem diz a saída', () => {

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -722,12 +722,28 @@ describe('--janela — o guard temporal é configurável, mas fail-CLOSED', () =
 describe('divisão de trabalho — o founder dispara, o agente lê', () => {
   const raiz = () => fixture({ 'edge-a': 'v1.0-alfa', cara: 'v2.0-beta' });
 
-  it('--so-disparo entrega ao founder SÓ o que precisa de escrita (vault + INSERT)', () => {
+  /** O SQL que fica FORA do `format($sonda$…$sonda$)` — ou seja, o que de fato EXECUTA ali. */
+  const foraDoFormat = (sql: string) =>
+    sql
+      .split('$sonda$')
+      .filter((_, i) => i % 2 === 0)
+      .join('\n');
+
+  it('--so-disparo entrega ao founder SÓ o que EXECUTA escrita — a leitura viaja como TEXTO', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'], soDisparo: true });
     expect(sql).toContain('-- PASSO 1');
     expect(sql).toContain('net.http_post(');
-    expect(sql).not.toContain('-- PASSO 2');
-    expect(sql).not.toContain('net._http_response');
+    // Desde o #2278 o passo 2 vai junto, mas como ARGUMENTO de `format()`: dentro do dollar-quoting
+    // ele é texto, não consulta. O recorte do founder continua sendo só o que precisa dele — o que
+    // não pode aparecer é um bloco de leitura EXECUTÁVEL, fora das aspas.
+    const fora = foraDoFormat(sql);
+    expect(fora).not.toContain('-- PASSO 2');
+    expect(fora).not.toContain('net._http_response');
+    // Controle POSITIVO: sem ele as duas negativas acima passariam medindo um recorte vazio (se o
+    // split mudasse de tag, por exemplo) — a cegueira de `docs/historico/gates-textuais-cegos.md`.
+    expect(sql).toContain('AS passo_2_copie_esta_celula');
+    expect(sql).toContain('net._http_response');
+    expect(fora.length).toBeGreaterThan(200);
   });
 
   it('--so-leitura entrega ao AGENTE só o que roda no psql-ro — nada de vault nem http_post', () => {

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -392,21 +392,55 @@ function httpPost(ref: string, indent: string): string {
 }
 
 /**
+ * De onde o CTE `ids` da leitura tira o mapa `edge → request_id`.
+ *
+ * `eco` é o bloco standalone (`--so-leitura`): o `{}` fica como está e a linha se acha pelo eco do
+ * slug. `embutido` é o passo de leitura que o passo de DISPARO escreve por `format()` — o mapa já
+ * vem dentro, e nenhum identificador passa pela mão de ninguém. Os dois textos saem da MESMA
+ * função de propósito: duas cópias do veredito divergiriam, e a que o founder recebe é a embutida.
+ */
+type FonteDosIds =
+  | { readonly modo: 'eco' }
+  | { readonly modo: 'embutido'; readonly expr: string; readonly passoDisparo: number };
+
+const ECO: FonteDosIds = { modo: 'eco' };
+
+/**
+ * Marcador do lugar do mapa dentro do texto que vira argumento de `format()`.
+ *
+ * Existe para que o escape de `%` (obrigatório: `format()` lê `%` como diretiva) rode sobre o
+ * corpo INTEIRO antes de o placeholder entrar — na ordem inversa, o próprio `%1$L` viraria `%%1$L`
+ * e o mapa sairia literal no passo seguinte. Caractere de controle porque não aparece em SQL.
+ */
+export const SENTINELA_MAPA = '\u0001mapa\u0001';
+
+/** Tag do dollar-quoting que embrulha o passo de leitura dentro do `format()`. */
+const TAG_SONDA = '$sonda$';
+
+/**
  * Bloco de DISPARO — o único que precisa do founder: lê `vault.decrypted_secrets` e faz INSERT via
  * `net.http_post`, e o wrapper read-only recusa os dois (`permission denied for schema vault` e
  * `cannot execute INSERT in a read-only transaction`, provado 2026-08-30).
  *
- * O id e o nome da edge saem agregados na MESMA execução (`jsonb_object_agg`): é o que impede o
- * `request_id` de viajar sozinho e ser copiado para a linha da edge errada. Desde que a leitura
- * casa pelo ECO do slug, esse JSON deixou de ser INSUMO e virou ESCAPE: só quem cai em
- * INDETERMINADO por (c) — PRE-SENSOR ou recusa HTTP, que não ecoam — precisa dele.
+ * O id e o nome da edge saem agregados na MESMA execução (`jsonb_object_agg`), e desde 2026-09-06 o
+ * agregado não é mais ENTREGUE ao operador: ele é interpolado por `format()` no texto do passo
+ * seguinte, que sai pronto numa célula única. O que se copia é a célula, não o número — é a mesma
+ * correção que o bloco de UMA edge recebeu, pela mesma razão (docs/historico/sonda-request-id-a-mao.md):
+ * identificador transportado à mão troca o alvo em silêncio, e a resposta de cron que ele acerta por
+ * acidente tem exatamente a assinatura de "bundle velho".
+ *
+ * São DOIS blocos por imposição do pg_net, não por ergonomia: o `http_post` só ENFILEIRA, e o worker
+ * de fundo enxerga apenas linha COMMITADA — dentro do mesmo batch (o SQL Editor roda tudo como UMA
+ * transação) a requisição ainda não saiu. `pg_sleep`, temp table e `\gset` não contornam isso.
  */
 function blocoDisparo(
   ref: string,
   leva: EdgeSondada[],
-  passoLeitura: number,
+  passoDisparo: number,
+  janelaMin: number,
   comTrava = false,
 ): string {
+  const passoLeitura = passoDisparo + 1;
   const cabeca = comTrava
     ? `WITH guard(confirmei_o_deploy) AS (VALUES ('nao')),  -- ⬅️ 'nao' → 'sim' só DEPOIS do verde\n` +
       `alvos(edge) AS (VALUES\n${valuesAlvos(leva)}\n),\n`
@@ -422,10 +456,67 @@ function blocoDisparo(
     `disparos AS (\n` +
     `  SELECT a.edge,\n` +
     projecao +
+    `),\n` +
+    `mapa AS (\n` +
+    `  -- O par (edge, id) é agregado na MESMA execução que disparou: o request_id nunca existe\n` +
+    `  -- solto, e por isso não há como colá-lo na linha da edge errada.\n` +
+    `  SELECT jsonb_object_agg(edge, request_id)::text AS ids FROM disparos\n` +
     `)\n` +
-    `SELECT jsonb_object_agg(edge, request_id)::text AS ids_opcionais_passo_${passoLeitura}\n` +
-    `FROM disparos;\n`
+    `-- O PASSO ${passoLeitura} sai ESCRITO na célula abaixo, com o mapa já dentro. Copie a célula\n` +
+    `-- INTEIRA e rode/entregue como está: não há número a anotar nem campo a preencher.\n` +
+    `SELECT format(${TAG_SONDA}\n` +
+    corpoDoPassoDeLeitura(leva, janelaMin, passoDisparo) +
+    `${TAG_SONDA}, m.ids) AS passo_${passoLeitura}_copie_esta_celula\n` +
+    `FROM mapa m;\n`
   );
+}
+
+/**
+ * O texto do passo de leitura, pronto para virar o 1º argumento de `format()`.
+ *
+ * Duas conversões, nesta ordem, e a ordem é a correção: (1) todo `%` do corpo vira `%%`, senão
+ * `format()` o interpreta como diretiva e aborta ou corrompe o SQL emitido; (2) só então o
+ * sentinela vira `%1$L`, que interpola o mapa como LITERAL — `%L` cita e escapa sozinho, e devolve
+ * `NULL` sem aspas quando o agregado é nulo (trava fechada), o que o `jsonb_each_text` lê como
+ * zero pares, não como erro. O dollar-quoting é conferido antes: corpo que contenha a tag encerraria
+ * a string no meio e o passo seguinte sairia truncado — fail-CLOSED, com o nome do que colidiu.
+ */
+function corpoDoPassoDeLeitura(
+  leva: EdgeSondada[],
+  janelaMin: number,
+  passoDisparo: number,
+): string {
+  const passoLeitura = passoDisparo + 1;
+  const texto =
+    `-- PASSO ${passoLeitura} — lê e julga. O mapa edge→id já está EMBUTIDO aqui, escrito pelo passo\n` +
+    `--          ${passoDisparo}: nada a colar. Espere ~10s pela resposta HTTP. É SELECT puro —\n` +
+    `--          roda no read-only: cole no chat, ou em ~/.config/afiacao/psql-ro\n` +
+    blocoLeitura(leva, janelaMin, {
+      modo: 'embutido',
+      expr: SENTINELA_MAPA,
+      passoDisparo,
+    });
+  return escaparParaFormat(texto);
+}
+
+/**
+ * Prepara um texto para virar o 1º argumento de `format()`: escapa `%` e planta o `%1$L`.
+ *
+ * Exportada porque é AQUI que as duas armadilhas do `format()` moram, e nenhuma delas aparece no
+ * SQL emitido hoje (o corpo atual não tem `%` nem `$`): sem um teste direto, as duas ficariam
+ * cobertas por acidente do corpus — verdes até o dia em que alguém escrever um `%` num comentário.
+ */
+export function escaparParaFormat(texto: string): string {
+  if (texto.includes(TAG_SONDA)) {
+    throw new Error(
+      `o texto contém a tag de dollar-quoting ${TAG_SONDA} e sairia TRUNCADO dentro do ` +
+        '`format()` — o passo seguinte seria emitido pela metade e ninguém veria. Troque a ' +
+        'TAG_SONDA por uma que não apareça no corpo. Nenhum SQL foi emitido.',
+    );
+  }
+  // A ordem é a correção: escapar DEPOIS de plantar o placeholder transformaria `%1$L` em `%%1$L`,
+  // e o mapa sairia literal — o passo seguinte leria a string "%1$L" como se fosse o JSON.
+  return texto.replaceAll('%', '%%').replaceAll(SENTINELA_MAPA, () => '%1$L');
 }
 
 /**
@@ -525,7 +616,46 @@ const PISO_CONTROLE_CREDENCIAL = 10;
  * colagem é o que UPGRADE um 401 ambíguo a veredito determinado, exatamente como é a saída da
  * causa (c). É por isso que ela sobrevive: deixou de ser INSUMO e virou ESCAPE, nos dois casos.
  */
-function blocoLeitura(leva: EdgeSondada[], janelaMin: number): string {
+function blocoLeitura(leva: EdgeSondada[], janelaMin: number, ids: FonteDosIds = ECO): string {
+  const embutido = ids.modo === 'embutido';
+  const exprIds = embutido ? `${ids.expr}::jsonb` : `'{}'::jsonb`;
+  const passoDisparo = ids.modo === 'embutido' ? ids.passoDisparo : null;
+  const comentarioIds = embutido
+    ? `  -- EMBUTIDO pelo passo ${passoDisparo} — o mapa \`edge → request_id\` foi escrito pelo próprio banco\n` +
+      `  -- no disparo (format()), então aqui não há nada a colar nem a redigitar. É ele que separa a\n` +
+      `  -- causa (c) do INDETERMINADO: PRE-SENSOR e recusa HTTP respondem SEM eco do slug, mas TÊM id.\n`
+    : `  -- OPCIONAL — deixe o {} como está. O eco do slug acha a linha sozinho; colar aqui o JSON do\n` +
+      `  -- disparo só serve para separar a causa (c) do INDETERMINADO (PRE-SENSOR / recusa HTTP).\n`;
+  const comentarioControle = embutido
+    ? `    -- ⚠️ Com o mapa EMBUTIDO o \`ids\` nunca está vazio, e é isso que faz esta exclusão valer: o\n` +
+      `    --    401 desta leva não entra na contagem de recusas contra si mesmo, e o veredito do 401\n` +
+      `    --    pode sair DETERMINADO — o que com o \`ids\` vazio era impossível.\n`
+    : `    -- ⚠️ Com o \`ids\` VAZIO (o padrão desde que a leitura acha pelo eco), esta exclusão não\n` +
+      `    --    exclui nada: um 401 desta leva conta como recusa e o controle se auto-desqualifica.\n` +
+      `    --    É fail-CLOSED — vira INDETERMINADO, nunca veredito confiante. Para DETERMINAR um\n` +
+      `    --    401, cole o JSON do disparo no \`ids\` acima.\n`;
+  const semId = embutido
+    ? `'INDETERMINADO — esta edge não tem request_id no mapa embutido NEM eco de sonda na janela ` +
+      `de ${janelaMin} min. Isto é ausência de dado, não veredito negativo: ou a trava do passo ` +
+      `${passoDisparo} ficou FECHADA e nada foi disparado, ou a célula veio de OUTRA leva — confira ` +
+      `se os nomes das edges batem'`
+    : `'INDETERMINADO — nenhuma resposta de sonda desta edge na janela de ${janelaMin} min. Isto ` +
+      `é ausência de dado, não veredito negativo: pode ser (a) o disparo não ter rodado, (b) a ` +
+      `resposta ainda a caminho (leva ~10s) — rode este passo de novo, ou (c) bundle PRE-SENSOR / ` +
+      `recusa HTTP, que responde SEM eco do slug e é invisível aqui; para separar (c), cole o ` +
+      `request_id do disparo no ids acima'`;
+  const aguarde = embutido
+    ? `'AGUARDE — o request_id embutido pelo passo ${passoDisparo} ainda não tem resposta HTTP ` +
+      `(leva ~10s); rode este passo de novo'`
+    : `'AGUARDE — o request_id colado ainda não tem resposta HTTP (leva ~10s); rode este passo de novo'`;
+  const textoIdDeOutraExecucao = embutido
+    ? `'O mapa veio embutido, logo o id e do disparo desta celula: ou a celula e de OUTRA leva/sessao, ou esta edge respondeu o fluxo real.'`
+    : `'O id colado no ids aponta para outra execucao — foi ele que trocou o alvo.'`;
+  const sufixo401 = embutido
+    ? `                'O mapa embutido ja exclui esta leva do controle, entao o que falta e ' ||\n` +
+      `                'TRAFEGO de fundo: 2xx fora da leva abaixo do piso de ${PISO_CONTROLE_CREDENCIAL} em 6h'\n`
+    : `                'Se o ids acima estiver vazio, o 401 DESTA leva conta como recusa e desqualifica ' ||\n` +
+      `                'o controle: cole o JSON do disparo no ids para DETERMINAR este veredito'\n`;
   return (
     `WITH esperado(edge, versao_esperada, fonte_esperada) AS (VALUES\n${valuesEsperado(leva)}\n),\n` +
     `recentes AS (\n` +
@@ -540,10 +670,9 @@ function blocoLeitura(leva: EdgeSondada[], janelaMin: number): string {
     `    AND left(ltrim(r.content), 1) = '{'\n` +
     `),\n` +
     `ids AS (\n` +
-    `  -- OPCIONAL — deixe o {} como está. O eco do slug acha a linha sozinho; colar aqui o JSON do\n` +
-    `  -- disparo só serve para separar a causa (c) do INDETERMINADO (PRE-SENSOR / recusa HTTP).\n` +
+    comentarioIds +
     `  SELECT chave AS edge, valor::bigint AS request_id\n` +
-    `  FROM jsonb_each_text('{}'::jsonb) AS t(chave, valor)\n` +
+    `  FROM jsonb_each_text(${exprIds}) AS t(chave, valor)\n` +
     `),\n` +
     `controle_credencial AS (\n` +
     `  -- Controle de CREDENCIAL: o 401 acima é ambíguo (bundle velho × CRON_SECRET inválido) e só\n` +
@@ -559,10 +688,7 @@ function blocoLeitura(leva: EdgeSondada[], janelaMin: number): string {
     `    -- contagem de recusas e o controle se auto-envenena (nenhum 401 seria explicável nunca).\n` +
     `    -- NOT EXISTS, não NOT IN: a trava fechada do bloco caro devolve request_id NULL, e\n` +
     `    -- \`NOT IN\` com NULL é NULL-blind — zeraria o controle inteiro em silêncio.\n` +
-    `    -- ⚠️ Com o \`ids\` VAZIO (o padrão desde que a leitura acha pelo eco), esta exclusão não\n` +
-    `    --    exclui nada: um 401 desta leva conta como recusa e o controle se auto-desqualifica.\n` +
-    `    --    É fail-CLOSED — vira INDETERMINADO, nunca veredito confiante. Para DETERMINAR um\n` +
-    `    --    401, cole o JSON do disparo no \`ids\` acima.\n` +
+    comentarioControle +
     `    AND NOT EXISTS (SELECT 1 FROM ids i2 WHERE i2.request_id = r.id)\n` +
     `    -- ⚠️ O que este controle NAO fecha: CRON_SECRET trocado ha poucos minutos E nenhum\n` +
     `    --    cron rodado desde a troca — o trafego 2xx da janela usou o secret ANTIGO e\n` +
@@ -599,13 +725,9 @@ function blocoLeitura(leva: EdgeSondada[], janelaMin: number): string {
     `       l.corpo ->> 'fonte'  AS fonte_respondida,\n` +
     `       CASE\n` +
     `         WHEN l.request_id IS NULL\n` +
-    `           THEN 'INDETERMINADO — nenhuma resposta de sonda desta edge na janela de ` +
-    `${janelaMin} min. Isto é ausência de dado, não veredito negativo: pode ser (a) o disparo não ` +
-    `ter rodado, (b) a resposta ainda a caminho (leva ~10s) — rode este passo de novo, ou (c) ` +
-    `bundle PRE-SENSOR / recusa HTTP, que responde SEM eco do slug e é invisível aqui; para ` +
-    `separar (c), cole o request_id do disparo no ids acima'\n` +
+    `           THEN ` + semId + `\n` +
     `         WHEN l.status_code IS NULL\n` +
-    `           THEN 'AGUARDE — o request_id colado ainda não tem resposta HTTP (leva ~10s); rode este passo de novo'\n` +
+    `           THEN ` + aguarde + `\n` +
     `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code = 401\n` +
     `              AND c.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL} AND c.recusas_recentes = 0\n` +
     `           THEN 'BUNDLE VELHO (pre-sonda) — 401, e o CRON_SECRET esta PROVADO bom agora (' ||\n` +
@@ -616,12 +738,23 @@ function blocoLeitura(leva: EdgeSondada[], janelaMin: number): string {
     `                'controle de credencial NAO foi observado (2xx fora da leva em 6h: ' ||\n` +
     `                c.ok_recentes || ', recusas 401: ' || c.recusas_recentes || '). Confira o ' ||\n` +
     `                'CRON_SECRET no vault ANTES de redeployar — nao ha prova de bundle velho aqui. ' ||\n` +
-    `                'Se o ids acima estiver vazio, o 401 DESTA leva conta como recusa e desqualifica ' ||\n` +
-    `                'o controle: cole o JSON do disparo no ids para DETERMINAR este veredito'\n` +
+    sufixo401 +
     `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code >= 400\n` +
     `           THEN 'BUNDLE VELHO — recusou o request (HTTP ' || l.status_code || '), NADA executou'\n` +
     `         WHEN l.corpo ->> 'versao' IS NULL\n` +
     `           THEN 'PRE-SENSOR — HTTP 200 sem versao: ignorou o probe e RODOU O FLUXO REAL'\n` +
+    // Ramo do id que aponta para uma resposta que NAO e da sonda. So o caminho dos `ids` chega
+    // aqui — o LATERAL do eco ja exige `probe = 'true'` —, e sem este ramo a linha cai no ELSE e
+    // sai 'BUNDLE VELHO' citando a versao CERTA: o falso NEGATIVO que esta secao documenta na
+    // armadilha do casamento so-por-slug. Medido em prod 2026-09-06 apontando o mapa para a
+    // resposta 71275 (cron da analytics-outbox-drain, que ecoa edge/versao/fonte e nao ecoa probe).
+    // Vem ANTES do `? 'fonte'`: cron que ecoa versao sem fonte sairia como PRE_SONDA_FONTE, que
+    // nomeia bundle anterior ao #1998 — causa errada, mesma classe.
+    `         WHEN l.corpo ->> 'probe' IS DISTINCT FROM 'true'\n` +
+    `           THEN 'NAO E RESPOSTA DE SONDA — o corpo tem versao mas NAO tem probe:true, entao ' ||\n` +
+    `                'e a execucao REAL desta edge (cron), nao a sonda: nao ha veredito de deploy ' ||\n` +
+    `                'aqui. ' || ${textoIdDeOutraExecucao} || ' Respondeu versao=' ||\n` +
+    `                COALESCE(l.corpo ->> 'versao', '?') || ' (esperado ' || l.versao_esperada || ')'\n` +
     `         WHEN NOT (l.corpo ? 'fonte')\n` +
     `           THEN 'PRE_SONDA_FONTE — respondeu a sonda (200 + probe) e o corpo NAO TEM o campo ' ||\n` +
     `                'fonte: o bundle no ar e ANTERIOR ao #1998, que criou o campo. E deploy ANTIGO ' ||\n` +
@@ -698,14 +831,17 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
       partes.push(
         `-- PASSO 1 — dispara as ${leva.length} edge(s) baratas da leva. É o bloco do FOUNDER: lê o\n` +
           `--          vault e faz INSERT, e o wrapper read-only recusa os dois.\n` +
-          blocoDisparo(ref, leva, 2),
+          `-- Ele DEVOLVE o passo 2 já escrito, com o mapa edge→id dentro: copie a célula inteira.\n` +
+          blocoDisparo(ref, leva, 1, janelaMin),
       );
     }
     if (querLeitura) {
       partes.push(
-        `-- PASSO 2 — lê e julga. NÃO precisa colar nada: a resposta da sonda ecoa o próprio slug,\n` +
-          `--          e o bloco a encontra na janela de ${janelaMin} min. É SELECT puro — roda no\n` +
-          `--          read-only: bun run sonda:sql --so-leitura <edge>… | ~/.config/afiacao/psql-ro\n` +
+        `-- PASSO 2 — lê e julga SEM mapa nenhum: a resposta da sonda ecoa o próprio slug, e o bloco\n` +
+          `--          a encontra na janela de ${janelaMin} min. É SELECT puro — roda no read-only:\n` +
+          `--          bun run sonda:sql --so-leitura <edge>… | ~/.config/afiacao/psql-ro\n` +
+          `-- ⚠️ Esta é a versão do ECO. A que o passo 1 devolve é ESTRITAMENTE melhor: com o mapa\n` +
+          `--    embutido, PRE-SENSOR e recusa HTTP (que não ecoam) saem determinados, e o 401 também.\n` +
           blocoLeitura(leva, janelaMin),
       );
     }
@@ -723,8 +859,10 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
           `--    docs/agent/deploy.md §"Sondar VÁRIAS edges numa tacada"). E NÃO valide um filtro numa\n` +
           `--    consulta simples para se convencer: lá ele filtra antes e PARECE proteger; é nesta\n` +
           `--    forma, agregada, que ele falha. Trava fechada devolve {"edge": null} e NADA sai —\n` +
-          `--    o passo seguinte não acha eco na janela e responde INDETERMINADO.\n` +
-          blocoDisparo(ref, leva, 4, true),
+          `--    o passo seguinte não acha eco na janela, e o mapa que ele recebe embutido vem com\n` +
+          `--    id nulo — as duas coisas dizem INDETERMINADO, que é o honesto: nada foi disparado.\n` +
+          `-- Ele também DEVOLVE o passo 4 já escrito, com o mapa dentro: copie a célula inteira.\n` +
+          blocoDisparo(ref, leva, 3, janelaMin, true),
       );
     }
     if (querLeitura) {


### PR DESCRIPTION
Continuação direta do #2271, que migrou o bloco de **UMA** edge. A variante coletiva ("Sondar VÁRIAS edges numa tacada") ainda pedia que o founder copiasse o blob `{"edge": id}` de um bloco para o outro — mesma classe: **identificador transportado à mão troca o alvo em silêncio**, e a resposta de cron que ele acerta por acidente tem exatamente a assinatura de "bundle velho".

## Onde a mudança mora

O SQL do lote **não é digitado** — sai de `bun run sonda:sql` (`scripts/sonda-versao-sql.ts`), e o `deploy.md` o descreve ("Não digite esse SQL: gere-o"). Então a migração é no gerador; o doc acompanha.

Antes: `SELECT jsonb_object_agg(edge, request_id)::text AS ids_opcionais_passo_2` → e um `jsonb_each_text('{}'::jsonb)` na leitura, onde alguém colava o blob.
Depois: o passo 1 (e o 3, das caras) termina em `format($sonda$…$sonda$, m.ids)` e **devolve o passo 2 (e o 4) já escrito, com o mapa dentro**. Copia-se a célula, não o número.

Continuam **dois** blocos pela imposição do `pg_net` (o `http_post` só enfileira; o worker de fundo só vê linha COMMITADA, e o SQL Editor roda o batch como UMA transação) — nada aqui tenta fundi-los.

**Preservado:** `timeout_milliseconds` explícito · trava por `CASE`, nunca `WHERE` · `FROM esperado LEFT JOIN ids` · placeholder VÁLIDO no bloco que dispara (o único campo que o founder toca lá é `'nao'` → `'sim'`) · o `COALESCE(content::jsonb->'data', content::jsonb)` do bloco de uma edge, intacto (teste-sentinela).

## Achado da falsificação — um ramo do `CASE` não era disjunto

Apontado o mapa para a resposta **71275** (cron da `analytics-outbox-drain`, que ecoa `edge`/`versao`/`fonte` e **não** ecoa `probe`), a leitura caía no `ELSE` e imprimia `BUNDLE VELHO — respondeu versao=v1.1-…` com versão e fonte **idênticas às esperadas** — falso negativo, desfecho "redeployar à toa". O ramo `NAO E RESPOSTA DE SONDA` fecha isso e vem **antes** do `? 'fonte'` (senão a causa nomeada seria "bundle anterior ao #1998"). O defeito era anterior à migração; foi a falsificação dela que o exibiu.

## Verificação (prod, leitura, `psql-ro -v ON_ERROR_STOP=1`, `net.http_post` trocado por ids literais)

| cenário | resultado |
|---|---|
| passo 1 rodado no banco | devolveu o passo 2 com `jsonb_each_text('{"fin-valor-cockpit": 999999999, "analytics-outbox-drain": 71275}'::jsonb)` |
| id inexistente | **`AGUARDE`**, 1 linha — nunca zero |
| id de cron | **`NAO E RESPOSTA DE SONDA`** (antes: `BUNDLE VELHO`) |
| mapa de OUTRA leva (`{"edge-de-outra-leva": 71275}`) | **2 linhas** `INDETERMINADO` — o `LEFT JOIN` segura |
| passo 3 com a trava FECHADA | mapa `{"fin-valor-cockpit": null}`, **1 linha** nomeando o passo 3 |

Mais: `sonda-veredito-401-eval.sh` (Postgres efêmero, veredito lido do banco) — **11 cenários + cardinalidade**, incluindo o novo `cron_sem_probe`; `--falsify` com **11 sabotagens, 0 cegueiras**, e agora com **CONTROLE VERDE na mesma invocação, antes do 1º sed** (sem ele uma suíte sempre-vermelha aprovaria todas de uma vez).

`escaparParaFormat()` é exportada e testada **direto**: o SQL de hoje não tem `%` nem `$`, então um teste que só olhasse o SQL emitido ficaria verde por **acidente do corpus**. Ela escapa `%` **antes** de plantar o `%1$L` (ordem inversa ⇒ `%%1$L`, mapa literal) e aborta se a tag `$sonda$` aparecer no corpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)