### PR TITLE
sec(authz): as 4 funções da captura entram na vigia de EXECUTE — e a allowlist não aceitava só a entrada

### DIFF
--- a/db/authz-carimbo-prod.json
+++ b/db/authz-carimbo-prod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "medidoEm": "2026-09-07T00:39:47.537Z",
-  "sourceHead": "6f450b941f117003f5779ff705dc0c0f42a6994f",
+  "medidoEm": "2026-09-07T01:05:25.836Z",
+  "sourceHead": "fc2f73de9228689aeaafd4b0e4a21fc8898989be",
   "alvo": {
     "usuario": "claude_ro",
     "servidor": "PostgreSQL 17.6",
@@ -12,9 +12,9 @@
     "funcoes": {
       "script": "authz:funcoes:prod",
       "exit": 0,
-      "resumo": "✅ o EXECUTE de prod bate com o contrato nas 46 função(ões) da allowlist.",
-      "denominador": "🔎 authz:funcoes:prod — 46 definição(ões) lida(s) para 46 chave(s) da allowlist.",
-      "contratoFingerprint": "e7a07836b573c5bcb275928587c03dfa4b568d43135d8e79d23eb9834a8b51c8",
+      "resumo": "✅ o EXECUTE de prod bate com o contrato nas 50 função(ões) da allowlist.",
+      "denominador": "🔎 authz:funcoes:prod — 50 definição(ões) lida(s) para 50 chave(s) da allowlist.",
+      "contratoFingerprint": "4c2ddffc62a49d28fa24579c9a669957d7c6bfdb11df16713dbdb74157076d97",
       "auditorFingerprint": "caabc19be3ea3ea381bc8c37617f9d7c1f0b5491958f5f8ffdc9a9ca851e508e",
       "achados": []
     },

--- a/scripts/authz-funcoes-fechadas.ts
+++ b/scripts/authz-funcoes-fechadas.ts
@@ -43,7 +43,8 @@
  *     CORPO, e o browser precisa alcançá-las;
  *   · 20 das 21 de `ACKNOWLEDGED_SENSITIVE` **não** têm — fecham por PRIVILÉGIO. A 21ª,
  *     `get_carteira_margem_faixa`, tem `authenticated=X` de propósito (fecha por gate de ESCOPO e
- *     PROJEÇÃO, não por privilégio) e é a única exceção; ela está anotada abaixo.
+ *     PROJEÇÃO, não por privilégio) e era, na medição de 2026-08-15, a única exceção; ela está
+ *     anotada abaixo.
  *
  * REMEDIÇÃO 2026-08-18 (após entrarem as 3 de `private`): o conjunto tem **43** funções (19
  * manifest + 24 ACK), 43 de 43 presentes. Enquanto o fecho não for colado no SQL Editor, a
@@ -52,6 +53,24 @@
  * apply o esperado volta a ser `proacl` NULL = 0, `anon` = 0 e `authenticated` = 20 (as 19 do
  * manifest + `get_carteira_margem_faixa`); hoje são 23 porque `proacl` NULL concede a PUBLIC.
  * Este parágrafo é o que impede o bloco acima de virar afirmação falsa — releia-o junto.
+ *
+ * REMEDIÇÃO 2026-09-06 (fecho do vetor banco→repo deixado aberto pela captura do #2251): entraram
+ * **4** funções — `get_tint_price`, `get_tint_prices`, `farmer_recomendacoes_substituir` e
+ * `farmer_bundle_recomendacoes_substituir`. O conjunto vai a **50** chaves (20 manifest + 26 ACK +
+ * 4 ACL_ONLY_INTERNAL), `permitido.anon` segue **0** e `permitido.authenticated` sobe de 21 para
+ * **25** (as 20 do manifest + `get_carteira_margem_faixa` + as 4 novas). ACL vivo das 4 MEDIDO por
+ * psql-ro em 2026-09-06, idêntico entre elas e à 5ª da captura (`get_preco_cockpit`, que já estava
+ * aqui): `postgres=X ; authenticated=X ; service_role=X ; sandbox_exec_*=X` — sem `anon`, sem
+ * PUBLIC. As 4 são justamente as que o vetor documentado alcança: o #2251 trouxe o CORPO vivo
+ * delas para o repo, mas o ACL continuava sem vigia, e um `DROP FUNCTION`+`CREATE` as devolveria
+ * ao `anon` pelo default privilege de `public`.
+ *
+ * ⚠️ LIMITE do que a Parte E promete, MEDIDO em contraprova nesta mesma entrega (controle verde na
+ * mesma invocação: `GRANT … TO anon` acusa FUNCAO_REABERTURA): um `GRANT EXECUTE … TO PUBLIC`
+ * pós-âncora **não produz achado nenhum** — o motor casa nomes de role e `public` não está entre
+ * as proibidas, embora privilégio a PUBLIC alcance `anon` na semântica do Postgres. O fecho aqui
+ * cobre o vetor DROP+CREATE, que é a forma documentada neste repo; não cobre essa. Registrado para
+ * entrega própria — quem for corrigir mexe em scripts/lib/authz-funcoes.ts, não nesta lista.
  *
  * `fechadaPor` é a ÂNCORA: a última migration do repo que estabelece o ACL declarado aqui. A
  * vigilância é dela **para a frente, INCLUSIVE** — diferente da Parte C de tabela, que olha só o
@@ -62,7 +81,14 @@
  * Como adicionar uma função: (1) MEÇA o EXECUTE em prod (`has_function_privilege` para `anon` e
  * `authenticated` + o `proacl` cru — `bun run authz:funcoes:prod` faz isso); (2) declare
  * `permitido` a partir do MEDIDO, não do desejado; (3) aponte `fechadaPor` para a migration que
- * estabelece esse ACL, ou `null` enquanto o fecho não estiver no repo (o gate avisa: FECHO_PENDENTE).
+ * estabelece esse ACL, ou `null` enquanto o fecho não estiver no repo (o gate avisa: FECHO_PENDENTE);
+ * (4) CLASSIFIQUE-a num dos três catálogos de scripts/authz-manifest.ts — `AUTHZ_MANIFEST`,
+ * `ACKNOWLEDGED_SENSITIVE` ou `ACL_ONLY_INTERNAL`. Este passo não é opcional nem cosmético: o teste
+ * "não inventa função" reprova chave sem catálogo, e a escolha é DETERMINADA pela medição, não pelo
+ * gosto — SECDEF não cabe em `ACL_ONLY_INTERNAL` (o discriminante dele exige INVOKER), INVOKER não
+ * deve ir para `ACKNOWLEDGED_SENSITIVE` (lá é inerte hoje e suprime amanhã), e o `AUTHZ_MANIFEST`
+ * exige um `requiredGate` de BLOQUEIO — que função fechando só por PROJEÇÃO não tem, e declarar um
+ * fabricaria contrato falso.
  */
 
 /** Roles vigiadas — as duas que o PostgREST expõe ao browser. */
@@ -276,6 +302,38 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
     permitido: PORTA_GATE,
     motivo: 'margem por faixa na carteira — o vendedor no browser alcança; fecha por escopo+projeção',
   },
+  // ⚠️ 2026-09-06 — as DUAS abaixo são o mesmo perfil da de cima, e é por isso que estão coladas
+  // nela: SECDEF que `authenticated` alcança de propósito, fechando por PROJEÇÃO (`CASE WHEN
+  // private.cap_custo_ler(auth.uid()) THEN custo ELSE NULL`), sem nenhum RAISE. A `get_carteira_
+  // margem_faixa` deixou de ser exceção única — a fronteira é a mesma, a população é que cresceu.
+  //
+  // O QUE ELAS FECHAM, e o que NÃO fecham: o custo (`custoBase`/`custoCorantes`) sai NULL para
+  // quem não tem cap; `precoFinal` sai para todo `authenticated`, INCLUSIVE customer — é o preço
+  // do balcão. Revogar `authenticated` daqui não é "endurecer": é quebrar a venda. O que a Parte E
+  // protege é o `anon`, que o gate de projeção NÃO segura (sem `auth.uid()` o custo já sai NULL,
+  // mas o PREÇO continuaria saindo — para um anônimo, que não deveria ver tabela de preço alguma).
+  //
+  // Âncora: a captura do #2251, que trouxe para o repo o corpo VIVO das duas (o hardening de
+  // `cap_custo_ler` só existia em prod) e, na mesma migration, reemitiu `REVOKE ALL … FROM PUBLIC,
+  // anon` + `GRANT EXECUTE … TO authenticated, service_role`. É a forma que o cabeçalho descreve:
+  // a migration-âncora é ela mesma uma recriação, e a vigilância vale dela para a frente INCLUSIVE.
+  // ACL vivo MEDIDO por psql-ro em 2026-09-06, idêntico nas duas:
+  //   `postgres=X/postgres ; authenticated=X/postgres ; service_role=X/postgres ; sandbox_exec_*=X`
+  // — `anon` ausente, PUBLIC ausente. Foi o que autorizou `PORTA_GATE` aqui: medido, não desejado.
+  'public.get_tint_price': {
+    fechadaPor: '20260906164001_captura_authz_gate_custo_rpcs_preco.sql',
+    permitido: PORTA_GATE,
+    motivo:
+      'preço de fórmula tintométrica no balcão — todo authenticated (inclusive customer) precisa ' +
+      'do precoFinal; o custo é que sai NULL sem private.cap_custo_ler',
+  },
+  'public.get_tint_prices': {
+    fechadaPor: '20260906164001_captura_authz_gate_custo_rpcs_preco.sql',
+    permitido: PORTA_GATE,
+    motivo:
+      'versão em lote da irmã acima (uuid[]) — mesmo gate de projeção cap_custo_ler, mesma razão ' +
+      'para authenticated alcançar: é o preço da lista do balcão',
+  },
   // ⚠️ REVELADA pelo detector, e baselinada em vez de acomodada (§7 do histórico). Até
   // 20260818121919, a última migration a tocar o ACL desta era a 20260510235956 ("Fatia E3
   // Fase 1"), que revoga de `PUBLIC, anon` e **mantém `GRANT EXECUTE … TO authenticated`** — ou
@@ -397,5 +455,34 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
       'NOME) é a 2ª tranca, e o que a Parte E vigia é um DROP+CREATE futuro devolvendo EXECUTE pelo ' +
       'default privilege de `public` (anon=X, authenticated=X). Medido por psql-ro 2026-09-05 22:41 UTC, ' +
       'após o apply: prosecdef=false, proacl={postgres,service_role,sandbox_exec_*}, anon=NAO, auth=NAO.',
+  },
+
+  // ⚠️ 2026-09-06 — as duas RPCs do farmer, também de `ACL_ONLY_INTERNAL`, mas pelo motivo
+  // OPOSTO ao da vizinha acima: aquela é interna e `authenticated` não a alcança; estas são do
+  // BROWSER e ele as alcança de propósito. O que as põe no mesmo catálogo é só o DISCRIMINANTE —
+  // são SECURITY INVOKER (medido: prosecdef=false) e têm de continuar, porque ESCREVEM sob RLS.
+  // A distinção importa aqui e não lá: `permitido` é ACL, e o ACL delas é `PORTA_GATE`, não
+  // `PORTA_FECHADA`. Ler a categoria como se ditasse o ACL levaria a revogar `authenticated` e
+  // matar o recálculo de recomendações no browser.
+  // Gate no corpo (BLOQUEIO real, com RAISE — ≠ das RPCs de preço, que só projetam):
+  // `p_farmer_id = auth.uid() OR private.cap_carteira_escrever(auth.uid())`, na forma `IS NOT TRUE`
+  // que é fail-closed sob `auth.uid()` NULL. O que a Parte E acrescenta é a tranca de PRIVILÉGIO
+  // contra `anon`: o gate de escopo já o barraria hoje, mas um DROP+CREATE sem REVOKE devolveria a
+  // função ao anônimo e deixaria o gate no corpo como ÚNICA tranca de uma RPC de ESCRITA.
+  // ACL vivo MEDIDO por psql-ro em 2026-09-06, idêntico nas duas:
+  //   `postgres=X/postgres ; authenticated=X/postgres ; service_role=X/postgres ; sandbox_exec_*=X`
+  'public.farmer_recomendacoes_substituir': {
+    fechadaPor: '20260906164002_captura_authz_escopo_carteira_farmer.sql',
+    permitido: PORTA_GATE,
+    motivo:
+      'substitui as recomendações do farmer (RPC de ESCRITA chamada do browser por useCrossSellEngine) ' +
+      '— gate de escopo próprio-farmer OU private.cap_carteira_escrever, INVOKER sob RLS',
+  },
+  'public.farmer_bundle_recomendacoes_substituir': {
+    fechadaPor: '20260906164002_captura_authz_escopo_carteira_farmer.sql',
+    permitido: PORTA_GATE,
+    motivo:
+      'irmã da acima para os bundles (useBundleEngine) — mesmo gate de escopo, mesma assinatura de ' +
+      '8 args, mesma exigência de continuar INVOKER',
   },
 };

--- a/scripts/authz-funcoes.test.ts
+++ b/scripts/authz-funcoes.test.ts
@@ -82,6 +82,16 @@ describe('AUTHZ_FUNCOES_FECHADAS — sanidade do contrato', () => {
   // A fronteira do cabeçalho de authz-manifest.ts: MANIFEST = alcançável por authenticated (fecha
   // por gate); ACK = fecha por privilégio. `get_carteira_margem_faixa` é a exceção MEDIDA — ACK que
   // authenticated alcança, porque fecha por gate de escopo/projeção, não por privilégio.
+  //
+  // ⚠️ 2026-09-06 — a lista saiu de 1 para 3 nomes, e o que se perde e o que se ganha:
+  // `get_tint_price`/`get_tint_prices` entraram no MESMO perfil medido da carteira (SECDEF que
+  // `authenticated` alcança, fechando por PROJEÇÃO `cap_custo_ler` sem nenhum RAISE — psql-ro
+  // 2026-09-06). NÃO se trocou a lista literal por um invariante do tipo "declarou projeção, então
+  // vale": isso viraria autodeclaração, e cada nome novo deixaria de custar uma revisão. A lista
+  // continua literal DE PROPÓSITO — é o pedágio. Um 4º nome segue falhando aqui até que alguém o
+  // escreva, tendo medido. Quem o fizer: o que sustenta a projeção não é este catálogo, são as
+  // asserções EXECUTADAS (db/test-tint-get-price.sh, db/test-tint-get-prices.sh,
+  // db/test-tint-gate-custo-staff.sh, db/test-carteira-margem-faixa-motivo-gate.sh).
   it('MANIFEST ⇒ authenticated permitido; ACK ⇒ proibido, exceto a exceção medida', () => {
     for (const k of Object.keys(AUTHZ_MANIFEST)) {
       expect(AUTHZ_FUNCOES_FECHADAS[k].permitido.authenticated, k).toBe(true);
@@ -89,7 +99,11 @@ describe('AUTHZ_FUNCOES_FECHADAS — sanidade do contrato', () => {
     const ackComAuth = [...ACKNOWLEDGED_SENSITIVE].filter(
       (k) => AUTHZ_FUNCOES_FECHADAS[k].permitido.authenticated,
     );
-    expect(ackComAuth).toEqual(['public.get_carteira_margem_faixa']);
+    expect(ackComAuth.sort()).toEqual([
+      'public.get_carteira_margem_faixa',
+      'public.get_tint_price',
+      'public.get_tint_prices',
+    ]);
   });
 });
 

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -435,6 +435,36 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   'private.frec_sem_margem',
   'private.fbrec_sem_margem',
   //
+  // ─────────── 2026-09-06 — as 2 RPCs de preço do balcão (captura do #2251) ───────────
+  // MEDIDO em prod (psql-ro, 2026-09-06): as duas são SECURITY DEFINER, STABLE, e o ACL vivo é
+  // `postgres=X ; authenticated=X ; service_role=X ; sandbox_exec_*=X` — sem `anon`, sem PUBLIC.
+  // `authenticated` alcança de PROPÓSITO: são a MESMA exceção medida de `get_carteira_margem_faixa`
+  // no topo desta lista — fecham por PROJEÇÃO, não por privilégio. No corpo VIVO (capturado em
+  // 20260906164001_captura_authz_gate_custo_rpcs_preco.sql) o gate é
+  // `v_is_staff := private.cap_custo_ler(auth.uid())` usado só em
+  // `'custoBase', CASE WHEN v_is_staff THEN v_custo_base ELSE NULL END`: quem não passa recebe
+  // custo NULL, e NADA bloqueia a execução. Por isso NÃO cabem no AUTHZ_MANIFEST — declarar um
+  // `requiredGate` afirmaria um caminho de BLOQUEIO inexistente (o §LIMITE do cabeçalho: mascarar
+  // campo não é expressável em requiredGate), e contrato falso é pior que lacuna.
+  // ⚠️ REVOGAR `authenticated` QUEBRA A VENDA: o customer PRECISA executar para ver `precoFinal`
+  // no balcão — o que ele não vê é o CUSTO. Quem chegar aqui achando que "fechar" é tirar o
+  // EXECUTE está lendo o gate errado. Provado por asserção EXECUTADA em db/test-tint-get-price.sh,
+  // db/test-tint-get-prices.sh e db/test-tint-gate-custo-staff.sh.
+  // ⚠️ Por que a Parte B não as flagrou — o ponto cego LÉXICO já anotado 2× acima, numa 3ª forma:
+  // o corpo delas não cita nenhum token de SENSITIVE_* (fala `valor_unitario`, `volume_total_ml`,
+  // `custoBase`), então `touchesSensitive` volta VAZIO mesmo sendo SECDEF que lê custo. Registro
+  // MANUAL, como a `reposicao_pos_marcador`.
+  // O que esta entrada COMPRA: elas passam a existir na allowlist de EXECUTE
+  // (scripts/authz-funcoes-fechadas.ts), e um DROP+CREATE futuro sem REVOKE — que as devolveria ao
+  // `anon` pelo default privilege de `public` — vira ERRO da Parte E. Era o vetor banco→repo que
+  // a captura do #2251 deixou aberto: o corpo foi capturado, o ACL não estava vigiado.
+  // ⚠️ O que esta entrada CUSTA, e é preciso saber para não se enganar depois: este Set faz a
+  // Parte B PULAR. Se um dia o corpo delas passar a citar `cmc`/`product_costs`, a classificação
+  // preexistente suprime o alarme. O que segura a projeção nesse dia não é este catálogo — são as
+  // asserções executadas acima, e é lá que quem mexer no gate tem de provar.
+  'public.get_tint_price',
+  'public.get_tint_prices',
+  //
   // ⚠️ O fecho por privilégio é estado de PROD, e é a **Parte E** do `authz:check` que o vigia
   // desde 2026-08-15 (scripts/authz-funcoes-fechadas.ts + scripts/lib/authz-funcoes.ts; §9 de
   // docs/historico/sentinela-authz-controle-nao-mencao.md). Toda função desta lista e do
@@ -463,6 +493,14 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
  *
  * Ou seja: não é o teste "não inventa função" afrouxado para ficar verde — é ele partido em duas
  * afirmações mais fortes, cada uma com a checagem que a sustenta.
+ *
+ * ⚠️ AMPLIAÇÃO 2026-09-06 — o nome diz "INTERNOS", mas o que este Set discrimina é SECURITY
+ * INVOKER, e é isso que ele vigia. Entraram duas RPCs chamadas pelo BROWSER (as
+ * `farmer_*_recomendacoes_substituir`), que de interno não têm nada: `authenticated` as executa de
+ * propósito. Elas estão aqui porque o discriminante é exatamente o alarme que se quer armado —
+ * são INVOKER e TÊM de continuar sendo, já que ESCREVEM sob RLS. Ler "interno" como requisito de
+ * entrada faria perder o caso em que o Set é mais útil; o requisito é o INVOKER, e o `motivo` de
+ * cada linha diz quem chama.
  */
 export const ACL_ONLY_INTERNAL = new Set<string>([
   // Helper puro do custo canônico (cost_final → cost_price, finito e > 0, senão NULL). Não lê
@@ -478,6 +516,34 @@ export const ACL_ONLY_INTERNAL = new Set<string>([
   // virar SECDEF, a Parte B acusa e a entrada tem de ser reclassificada, não removida.
   // Fecho: 20260905183314_deploy_atestacoes_ledger_e_sonda_cron.sql (registrada após o apply).
   'public.deploy_atestacoes_colher',
+  // ─────── 2026-09-06 — as 2 RPCs de recomendação do farmer (captura do #2251) ───────
+  // ⚠️ Estas duas NÃO são helper interno: são RPCs do BROWSER, chamadas por `authenticated` em
+  // src/hooks/useCrossSellEngine.ts e src/hooks/useBundleEngine.ts. Entram pelo DISCRIMINANTE, que
+  // é o que este Set tem de próprio: MEDIDO em prod (psql-ro, 2026-09-06) `prosecdef = false`, e
+  // TÊM de continuar INVOKER — elas ESCREVEM em farmer_recommendations /
+  // farmer_bundle_recommendations, e uma versão SECDEF passaria por cima da RLS dessas tabelas
+  // levando junto o gate de escopo. Recriar SECDEF é ERRO da Parte B, com instrução de
+  // reclassificar: é precisamente o alarme que se quer.
+  // ⚠️ LIMITE MEDIDO desse alarme (contraprova 2026-09-06, apontada pelo Codex gpt-6-astra e
+  // confirmada aqui): a Parte B lê DEFINIÇÕES extraídas de `CREATE` — `ALTER FUNCTION … SECURITY
+  // DEFINER` não é lido por ninguém (`grep -c 'ALTER FUNCTION'` = 0 em authz-contract.ts e em
+  // authz-gate-check.ts). O discriminante pega a recriação, que é a forma que este repo usa; não
+  // pega o ALTER isolado. Prometer "tem de continuar INVOKER" sem essa ressalva seria contrato
+  // falso — e contrato falso é o erro que este arquivo inteiro existe para não cometer.
+  // Por que não `ACKNOWLEDGED_SENSITIVE`: seria o modo de falha que o cabeçalho acima documenta —
+  // INVOKER lá é inerte hoje e SUPRIME amanhã a regressão que o gate existe para pegar.
+  // Por que não `AUTHZ_MANIFEST`: ele cataloga SECDEF, e a Parte A mede o gate na definição.
+  // ACL vivo MEDIDO (2026-09-06): `postgres=X ; authenticated=X ; service_role=X ; sandbox_exec_*=X`
+  // — sem `anon`, sem PUBLIC. O fecho por ACL aqui é contra `anon`/PUBLIC, não contra
+  // `authenticated`; o REVOKE nominal está em
+  // 20260906164002_captura_authz_escopo_carteira_farmer.sql, a mesma que capturou o corpo vivo.
+  // O gate no corpo é de ESCOPO e BLOQUEIA de verdade (≠ das irmãs de preço, que só projetam):
+  //   `IF (p_farmer_id = auth.uid() OR coalesce(private.cap_carteira_escrever(auth.uid()), false))
+  //    IS NOT TRUE THEN RAISE EXCEPTION` — `IS NOT TRUE` e não `NOT (...)`: sem JWT `auth.uid()` é
+  //   NULL, a disjunção vira NULL, e `NOT (NULL)` deixaria passar. Provado em
+  //   db/test-farmer-escopo-carteira.sh.
+  'public.farmer_recomendacoes_substituir',
+  'public.farmer_bundle_recomendacoes_substituir',
 ]);
 
 /** chave de lookup a partir de schema+name (case-insensitive, sem assinatura) */


### PR DESCRIPTION
## O que fecha

O #2251 capturou no repo o corpo **vivo** de 5 funções cujo hardening só existia em prod — isso fechou o vetor **repo→banco**. Ficou aberto o **banco→repo**: `DROP FUNCTION` + `CREATE` **reseta o ACL** (só `CREATE OR REPLACE` o preserva), e 4 das 5 não estavam na allowlist de EXECUTE. Nada acusaria se o EXECUTE delas se abrisse para `anon`/PUBLIC.

**ACL vivo medido** por `psql-ro` em 2026-09-06 — idêntico nas 4 (e na 5ª, `get_preco_cockpit`, que já estava lá):

```
postgres=X ; authenticated=X ; service_role=X ; sandbox_exec_*=X   — sem anon, sem PUBLIC
```

## O que a tarefa parecia ser, e o que era

Adicionar as 4 só à allowlist **não passaria no CI**: o teste `não inventa função` exige que toda chave esteja classificada num dos três catálogos de `scripts/authz-manifest.ts`, e nenhuma das 4 estava. A escolha do catálogo foi **determinada por medição**, não por gosto:

| Função | `prosecdef` | Catálogo | Por quê |
|---|---|---|---|
| `get_tint_price`, `get_tint_prices` | `true` | `ACKNOWLEDGED_SENSITIVE` | `ACL_ONLY_INTERNAL` é impossível (o discriminante exige INVOKER); `AUTHZ_MANIFEST` exigiria um `requiredGate` de **bloqueio** que elas não têm — o gate é **projeção pura** (`CASE WHEN cap_custo_ler(...) THEN custo ELSE NULL`), sem nenhum `RAISE`. Mesmo perfil de `get_carteira_margem_faixa`. |
| `farmer_recomendacoes_substituir`, `..._bundle_...` | `false` | `ACL_ONLY_INTERNAL` | O discriminante "tem de continuar INVOKER" é exatamente o alarme desejado: são RPCs de **escrita sob RLS**, e uma versão SECDEF passaria por cima dela levando junto o gate de escopo. ACK está desaconselhado pelo próprio repo para INVOKER. |

⚠️ **`authenticated` precisa executar as duas de preço** — é o `precoFinal` do balcão; o que sai `null` para quem não tem cap é o **custo**. Revogar não é endurecer, é quebrar a venda.

O teste da exceção ACK-com-`authenticated` saiu de 1 para 3 nomes. **Não** virou invariante autodeclarado ("declarou projeção, então vale"): a lista continua literal de propósito — é o pedágio de revisão, e um 4º nome segue falhando até alguém medi-lo.

## Limites registrados (medidos aqui, com controle verde na mesma invocação)

- **`GRANT EXECUTE … TO PUBLIC` pós-âncora não produz achado.** O motor casa nomes de role, e privilégio a PUBLIC alcança `anon`. Controle `GRANT … TO anon` → `FUNCAO_REABERTURA`. Entrega própria (mexe em `scripts/lib/authz-funcoes.ts`, não nesta lista).
- **`ALTER FUNCTION … SECURITY DEFINER` não é lido por ninguém** (`grep -c` = 0 em `authz-contract.ts` e `authz-gate-check.ts`): o discriminante INVOKER pega a **recriação**, não o ALTER isolado. Dito no comentário para não prometer o que o gate não cumpre.

## Evidência

| Comando | Resultado |
|---|---|
| `bun run authz:check` | exit 0 (Partes A–E verdes) |
| `bun run authz:funcoes:prod` | exit 0 — **50/50** batem com prod |
| `bun run authz:carimbo` | exit 0 (o `CARIMBO_ACHADO` de `get_defasagem_cliente` é pré-existente e intocado) |
| `bun run scripts:typecheck` | exit 0 |
| Carimbo regravado | 46 → 50 chaves, `contratoFingerprint` novo, commitado |

**Falsificação** (controle verde antes de qualquer `sed`, restauro reconfirmado):
- âncora de `get_tint_price` → migration inexistente ⇒ `authz:check` **vermelho**
- `farmer_recomendacoes_substituir` declarada `PORTA_FECHADA` ⇒ `authz:funcoes:prod` **vermelho**

A suíte completa (`bun run test`) está enfileirada no semáforo `heavy` local (13ª posição, 13 sessões disputando 1 slot); as 10 assertivas de contrato do arquivo alterado foram reproduzidas fora do vitest e passam. O CI é a medição autoritativa.

**2ª opinião:** Codex `gpt-6-astra` (reasoning `max`, 221s) — challenge sobre a taxonomia. Confirmou o encaixe, recomendou **manter** a lista literal em vez de trocá-la por invariante, e levantou os dois limites acima, verificados por conta própria antes de registrar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
