### PR TITLE
fix(dashboard): o placar de positivação sumia CALADO nos dois "Meu dia" — a ausência AFIRMA que está tudo bem [money-path]

### DIFF
--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -13,6 +13,8 @@ import { FilaDoDia } from '@/components/fila/FilaDoDia';
 import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
 import { useMyPositivacao } from '@/hooks/useMyPositivacao';
 import { useSinalPositivacao } from '@/hooks/useSinalPositivacao';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
 import { AtivarNotificacoesCard } from '@/components/push/AtivarNotificacoesCard';
 import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNudge';
@@ -30,7 +32,9 @@ import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNud
  */
 export function FarmerDashboardV2() {
   const [modoAntigoAberto, setModoAntigoAberto] = useState(false);
-  const { data: positivacao } = useMyPositivacao();
+  const qPositivacao = useMyPositivacao();
+  const { data: positivacao } = qPositivacao;
+  const estadoPositivacao = estadoDeLeitura(qPositivacao);
   useSinalPositivacao(false);
   const onToggleModoAntigo = (open: boolean) => {
     setModoAntigoAberto(open);
@@ -53,7 +57,13 @@ export function FarmerDashboardV2() {
       {/* Receita/positivação vêm de sales_orders, hoje parcial (backfill pendente) → aviso honesto */}
       <DadosVendaParciaisBanner />
 
-      {/* Placar do mês (KPIs da carteira) — o norte da farmer */}
+      {/* Placar do mês (KPIs da carteira) — o norte da farmer.
+          O aviso vem ANTES e FORA do `&&`: sem ele o placar sumia calado no erro/offline, e numa
+          tela que é o norte da vendedora a ausência AFIRMA que está tudo bem. Mesmo desenho de
+          `FarmerCalls`, que hospeda o mesmo hero (#1886). */}
+      {naoConsegui(estadoPositivacao) && (
+        <AvisoLeituraFalhou oque="a positivação da sua carteira" estado={estadoPositivacao} />
+      )}
       {positivacao && <PositivacaoHero kpis={positivacao} isHunter={false} />}
 
       {/* A fila É o dia. */}

--- a/src/components/dashboard/HunterDashboard.tsx
+++ b/src/components/dashboard/HunterDashboard.tsx
@@ -4,6 +4,8 @@ import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNud
 import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
 import { useMyPositivacao } from '@/hooks/useMyPositivacao';
 import { useSinalPositivacao } from '@/hooks/useSinalPositivacao';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
 
 /**
@@ -19,7 +21,9 @@ import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
  * Ver docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md.
  */
 export function HunterDashboard() {
-  const { data: positivacao } = useMyPositivacao();
+  const qPositivacao = useMyPositivacao();
+  const { data: positivacao } = qPositivacao;
+  const estadoPositivacao = estadoDeLeitura(qPositivacao);
   useSinalPositivacao(true);
 
   return (
@@ -34,7 +38,14 @@ export function HunterDashboard() {
       {/* Receita/novos vêm de sales_orders, hoje parcial (backfill pendente) → aviso honesto */}
       <DadosVendaParciaisBanner />
 
-      {/* Placar de aquisição — o norte do hunter (proxy honesto, não-OTE ainda) */}
+      {/* Placar de aquisição — o norte do hunter (proxy honesto, não-OTE ainda).
+          O aviso vem ANTES e FORA do `&&`: sem ele o placar sumia calado no erro/offline, e a
+          ausência numa tela de "norte" AFIRMA que está tudo bem. `oque` fala do PLACAR, e não da
+          "positivação da carteira": é o vocabulário desta tela — nomear o widget errado no aviso
+          é o mesmo silêncio, com mais uma frase. */}
+      {naoConsegui(estadoPositivacao) && (
+        <AvisoLeituraFalhou oque="o seu placar de aquisição" estado={estadoPositivacao} />
+      )}
       {positivacao && <PositivacaoHero kpis={positivacao} isHunter={true} />}
 
       <MinhasTarefasCard />

--- a/src/components/dashboard/__tests__/dashboards-positivacao-nao-some-calada.test.tsx
+++ b/src/components/dashboard/__tests__/dashboards-positivacao-nao-some-calada.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * Guard money-path — o placar do "Meu dia" NÃO PODE sumir calado nos dois dashboards.
+ *
+ * A CLASSE (docs/historico/fase-sem-sinal.md; #1859, #1886 e a revisão retroativa do #1896):
+ * a leitura que falha deixa `data === undefined`, que é a MESMA condição do vazio. Um host que
+ * faz `{positivacao && <PositivacaoHero …/>}` sem ler o ESTADO da query apaga o placar inteiro —
+ * e numa tela que é o NORTE da farmer, a ausência AFIRMA que está tudo bem.
+ *
+ * O defeito vivia em dois hosts ao mesmo tempo:
+ *
+ *     FarmerDashboardV2.tsx:57   {positivacao && <PositivacaoHero kpis={positivacao} isHunter={false} />}
+ *     HunterDashboard.tsx:38     {positivacao && <PositivacaoHero kpis={positivacao} isHunter={true} />}
+ *
+ * enquanto `FarmerCalls` — MESMO hero, MESMO hook, 20 linhas de código ao lado — já montava o
+ * <AvisoLeituraFalhou> desde o #1886. A correção existia; faltava em dois lugares.
+ *
+ * POR QUE O HOST REAL, e não `<PositivacaoHero>` isolado: a lição do #1896 é que o defeito mora na
+ * COMPOSIÇÃO. Um teste do componente é verde num contexto que não existe em produção, e a asserção
+ * NEGATIVA ("a tela não afirma o contrário") sobrevive intacta a um host emudecido — ela passa
+ * exatamente quando a tela some. Por isso aqui só há asserção POSITIVA: o aviso TEM de estar na
+ * tela, com a frase que desarma o "está tudo bem".
+ *
+ * Os hooks rodam de verdade (`useMyPositivacao`, `useSinalPositivacao`, `estadoDeLeitura`); só o
+ * supabase e os IRMÃOS do placar (fila, caça, tarefas, agenda) são dublês — eles são outra
+ * subárvore, e a cadeia que precisa ser provada é "RPC falha → hook lança → `data` undefined →
+ * gate fecha → o host fala mesmo assim".
+ */
+
+const VENDEDOR = 'vendedor-a';
+const ERRO_TIMEOUT = { message: 'canceling statement due to statement timeout' };
+
+type Resposta = { data: unknown; error: { message: string } | null };
+
+/** Payload cru da `get_minha_positivacao` (snake_case), como o PostgREST devolve. */
+const POSITIVACAO = {
+  mes: '2026-08-01',
+  total_eligible: 40,
+  positivados: 10,
+  compradores_mtd: 10,
+  receita_mtd: 50_000,
+  contatados_mtd: 20,
+  recencia_critica: 3,
+  novos_clientes_positivados: 2,
+  a_positivar: [
+    {
+      customer_user_id: 'c9', nome: 'Marcenaria Ômega', revenue_potential: 1000,
+      churn_risk: 70, recover_score: 0.5, days_since_last_purchase: 45, priority_score: 9,
+    },
+  ],
+};
+
+let respostaPositivacao: Resposta = { data: POSITIVACAO, error: null };
+
+function chain(): Record<string, unknown> {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null });
+  return c;
+}
+
+/** Realtime inerte — o `SlaCardMeuDia` assina `whatsapp_messages` no mount (useWhatsappSla.ts:56). */
+function canal(): Record<string, unknown> {
+  const ch: Record<string, unknown> = {};
+  ch.on = () => ch;
+  ch.subscribe = () => ch;
+  ch.unsubscribe = () => Promise.resolve('ok');
+  return ch;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => chain(),
+    channel: () => canal(),
+    removeChannel: () => Promise.resolve('ok'),
+    functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+    rpc: (fn: string) => {
+      const r: Resposta = fn === 'get_minha_positivacao' ? respostaPositivacao : { data: null, error: null };
+      const c: Record<string, unknown> = {
+        order: () => c,
+        range: () => c,
+        then: (resolve: (v: unknown) => void) => resolve(r),
+      };
+      return c;
+    },
+  },
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: VENDEDOR }, isStaff: true, isMaster: false, loading: false }),
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: VENDEDOR }),
+}));
+
+// Irmãos do placar — outra subárvore, nenhum deles participa do defeito. Dublês triviais mantêm o
+// teste preso à COMPOSIÇÃO do host (que é real) em vez da rede inteira do dashboard.
+//
+// Só os do PRÓPRIO módulo (`farmer-inteligencia`): `vi.mock` é lido como ARESTA de import pelo
+// fiscal de fronteiras (src/lib/modulos/imports.ts), então dublar tarefas/whatsapp/push/caça
+// abriria 4 vazamentos de fronteira para baselinar. Esses quatro montam de verdade contra o
+// mesmo dublê de supabase — custam um pouco de tempo e não custam uma exceção arquitetural.
+vi.mock('@/components/fila/FilaDoDia', () => ({ FilaDoDia: () => <div /> }));
+vi.mock('@/components/dashboard/KpisToday', () => ({ KpisToday: () => <div /> }));
+vi.mock('@/components/dashboard/AgendaTodayList', () => ({ AgendaTodayList: () => <div /> }));
+vi.mock('@/components/farmer/ChamadasPendentesNudge', () => ({ ChamadasPendentesNudge: () => <div /> }));
+
+const track = vi.fn();
+vi.mock('@/lib/analytics', () => ({
+  track: (...a: unknown[]) => track(...a),
+  captureException: vi.fn(),
+}));
+
+import { FarmerDashboardV2 } from '../FarmerDashboardV2';
+import { HunterDashboard } from '../HunterDashboard';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+function renderHost(Host: () => JSX.Element) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <TooltipProvider>
+          <Host />
+        </TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * O texto do <AvisoLeituraFalhou> nasce quebrado entre <span> e <strong>, então `findByText` de
+ * string não casa. Ler pelo `role="status"` também é o que um leitor de tela faz.
+ */
+async function textoDosAvisos(): Promise<string> {
+  const avisos = await screen.findAllByRole('status');
+  return avisos.map((a) => a.textContent ?? '').join(' | ');
+}
+
+/** Versão síncrona, para o caso em que a ausência do aviso é o esperado. */
+function textoDeStatus(): string {
+  return screen.queryAllByRole('status').map((a) => a.textContent ?? '').join(' | ');
+}
+
+/** Último payload de um evento, ou undefined se ele nunca saiu. */
+function evento(nome: string): Record<string, unknown> | undefined {
+  const c = [...track.mock.calls].reverse().find((c) => c[0] === nome);
+  return c?.[1] as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+  respostaPositivacao = { data: POSITIVACAO, error: null };
+  track.mockClear();
+});
+
+afterEach(() => {
+  onlineManager.setOnline(true);
+});
+
+const HOSTS = [
+  {
+    nome: 'FarmerDashboardV2',
+    Host: FarmerDashboardV2,
+    kpiDoHero: 'Positivação MTD',
+    oque: 'a positivação da sua carteira',
+    isHunter: false,
+  },
+  {
+    nome: 'HunterDashboard',
+    Host: HunterDashboard,
+    kpiDoHero: 'Novos na carteira (MTD)',
+    oque: 'o seu placar de aquisição',
+    isHunter: true,
+  },
+] as const;
+
+describe.each(HOSTS)('$nome — o placar não some calado', ({ Host, kpiDoHero, oque, isHunter }) => {
+  it('DETECTOR: leitura OK → o hero monta e NÃO há aviso', async () => {
+    // Sem este caso, "o aviso não apareceu" e "o host nem montou" seriam indistinguíveis — que é
+    // exatamente como um teste fica verde por cegueira.
+    renderHost(Host);
+
+    expect(await screen.findByText(kpiDoHero)).toBeTruthy();
+    // Casa a FRASE do aviso, não `role="status"` vazio: o `CacaConteudo` tem um banner de status
+    // próprio (:109) e um "nenhum status na tela" reprovaria por motivo alheio ao que se mede.
+    expect(
+      textoDeStatus(),
+      'aviso na leitura BOA é alarme fabricado (precisão > recall)',
+    ).not.toContain('Isto não quer dizer que está tudo certo');
+  });
+
+  it('a RPC falha → o aviso aparece, dizendo que a informação não chegou', async () => {
+    respostaPositivacao = { data: null, error: ERRO_TIMEOUT };
+
+    renderHost(Host);
+
+    const texto = await textoDosAvisos();
+    expect(
+      texto,
+      'o placar sumiu SEM avisar: numa tela que é o norte do vendedor, a ausência AFIRMA que está tudo bem',
+    ).toContain(`Não foi possível carregar ${oque}`);
+    expect(
+      texto,
+      'sem esta frase o usuário lê "deu erro num widget" e segue decidindo pela tela — o dano da classe',
+    ).toContain('Isto não quer dizer que está tudo certo');
+
+    // O host ESTÁ no estado de falha — o sensor do #1896 é a testemunha disso, e é ele que prova
+    // em prod que este ramo acontece aqui (não é caso hipotético).
+    expect(evento('carteira.positivacao_vista')).toMatchObject({
+      estado: 'erro', pct: null, positivados: null, is_hunter: isHunter,
+    });
+  });
+
+  it('sem rede → o aviso aparece, e fala de CONEXÃO (não culpa o backend)', async () => {
+    // `networkMode: 'online'` (o default) deixa a query em pending+paused: `isLoading` é FALSE,
+    // `data` é undefined e `error` é null. Quem trata só o erro cai no ramo do vazio — num PWA de
+    // campo este é o caso comum, não o raro.
+    onlineManager.setOnline(false);
+
+    renderHost(Host);
+
+    const texto = await textoDosAvisos();
+    expect(
+      texto,
+      'offline é o quarto estado: some calado justamente com o vendedor em campo',
+    ).toContain(`Sem conexão — não foi possível verificar ${oque}`);
+
+    expect(evento('carteira.positivacao_vista')).toMatchObject({
+      estado: 'sem-rede', pct: null, is_hunter: isHunter,
+    });
+  });
+});


### PR DESCRIPTION
Achado da **revisão independente RETROATIVA do #1896** (registro em `docs/historico/fase-sem-sinal.md`; PR do registro: #1933). Dois hosts, a mesma classe do #1859/#1886 viva neles.

## O defeito

`FarmerDashboardV2:57` e `HunterDashboard:38` faziam `{positivacao && <PositivacaoHero …/>}` sem ler o **estado** da query. Quando a `get_minha_positivacao` falha — ou o vendedor está sem sinal — `data` fica `undefined`, a **mesma** condição do vazio, e o placar inteiro desaparece sem uma palavra.

Numa tela que é o **norte** do vendedor, essa ausência não é neutra: ela **afirma** que está tudo bem.

**O gatilho é que isso deixou de ser hipótese.** O #1896 instalou `useSinalPositivacao` nos três hosts — o PostHog agora **recebe** eventos `'erro'`/`'sem-rede'` vindos dos dashboards. O sensor prova que esses estados acontecem lá, com a tela muda.

Pelo inventário de #2273 (`a-forma-que-some-e-a-forma-que-mente.md`), são 2 sítios do sub-tipo que **some** (77 dos 93) — e, ao contrário dos 21 inertes que aquele doc isola, aqui o hook **lança de verdade**: o cenário de erro do guard só fica verde porque `<AvisoLeituraFalhou>` é alcançável. O fix não é inerte, e a execução é a prova.

## O conserto

Já existia no repo, 20 linhas ao lado: `FarmerCalls.tsx:450-461` hospeda o **mesmo** hero, com o **mesmo** hook, e monta `<AvisoLeituraFalhou>` nos estados `erro`/`sem-rede`. Faltava em dois lugares.

Os dois hosts passam a derivar o estado do primitivo **compartilhado** (`estadoDeLeitura`/`naoConsegui` de `@/lib/leitura/estado-de-leitura`) — não uma segunda conta, que divergiria no primeiro caso de borda. E a de borda aqui é o **offline**: `networkMode:'online'` deixa a query em `pending`+`paused`, com `isLoading` **falso** e `error` **null** — quem trata só o erro cai no ramo do vazio e continua mudo.

O texto do hunter fala do **placar de aquisição**, não da "positivação da carteira": é o vocabulário daquela tela, e nomear o widget errado no aviso seria o mesmo silêncio com mais uma frase.

## O teste — e por que ele monta o HOST

A lição do #1896 é que **montar o host não basta**. Lá, remover o `AvisoLeituraFalhou` de `FarmerCalls` deixava a suíte em `6 passed` de novo, porque a asserção do caso de erro era **negativa** ("a tela não afirma o contrário") — e asserção negativa sobrevive intacta a um host que voltou a silenciar.

`dashboards-positivacao-nao-some-calada.test.tsx` monta os hosts **reais** e assevera **positivamente** a fala do aviso (inclusive a frase que desarma o "deu erro num widget"), com dois **detectores** provando que o host montou — senão "aviso ausente" e "host mudo" seriam indistinguíveis. Cada caso confere também o evento do sensor (`estado`, `pct: null`, `is_hunter`), amarrando a tela ao que o PostHog já registra.

**Falsificação (sabotando o HOST, não o componente):**

| passo | resultado |
|---|---|
| verde | `6 passed` |
| **commit** (antes de sabotar) | `4207c18` |
| aviso removido dos **dois** hosts | **`4 failed \| 2 passed`** — os 2 detectores seguem verdes, provando que o host montou e mesmo assim emudeceu |
| restaurado | `6 passed` |

Dublês só do **próprio módulo**: `vi.mock` é lido como aresta de import pelo fiscal de fronteiras (`src/lib/modulos/imports.ts:41`), então dublar tarefas/whatsapp/push/caça abriria 4 vazamentos para baselinar. Esses quatro montam de verdade contra o mesmo dublê de supabase.

## Validação

- `bun run typecheck` — **exit 0**
- `bunx eslint` nos 3 arquivos — **exit 0**
- `bun run test` (suíte inteira) — 769 arquivos, **7944 testes**, com **1** vermelho: `erro-colapsado-em-vazio-gate` em `Test timed out in 20000ms` (durou 21754ms). Vale a pena dizer o que ele é e o que ele não é:
  - **não é asserção** — o gate tem mensagens próprias (`Arquivos (baseline→medido): …`); nenhuma apareceu;
  - o arquivo de teste novo **não entra** na varredura dele: `IGNORAR = /(\.test\.|_test\.|\.d\.ts$|__tests__|\.stories\.)/` casa duas vezes ⇒ zero fontes a mais para ler;
  - rodando o **próprio detector do gate** sobre os 2 hosts, antes vs. depois deste commit: `contarAutoOcultacao` = **0 → 0** nos dois, `DELTA_AUTO_OCULTACAO=0`. A forma fiscalizada é `return-null`/`ternario-null`; `jsx-&&` está fora de propósito, com sentinela;
  - a mesma árvore, antes do rebase, passou o gate (730/730). O que mudou foi o denominador (+39 arquivos vindos da main) e a máquina — o `heavy` estava com **11 na fila e 77 min de espera**.

  Ou seja: **21.7s contra teto de 20s**, num gate que varre ~1.500 fontes e cresce com o repo. Não é deste PR, mas vai reprovar sozinho cada vez mais — e como *timeout*, que não aponta para causa nenhuma. Deixo o CI numa máquina não-saturada ser o juiz aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
