### PR TITLE
fix(captura): a prova sem mudança persiste, o sub-centavo deixa de ser "sem_mudanca" e o sensor enxerga o pedido unitário [money-path]

### DIFF
--- a/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
+++ b/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
@@ -190,8 +190,24 @@ describe('derivarCustos', () => {
     expect(r.updates[0].valor_linha).toBe(1633.45);
     expect(r.updates[0].preco_unitario).toBeCloseTo(408.3625, 4);
   });
-  it('mantém (não sobrescreve) quando o total da linha bate ao centavo', () => {
+  it('mantém (não sobrescreve) quando o total da linha bate DE VERDADE', () => {
     const r = derivarCustos(matchCusto({ qtde: 4, preco_atual: 408.36, total: 1633.44 })); // 4*408.36=1633.44
+    expect(r.updates).toHaveLength(0);
+    expect(r.pulados[0]).toMatchObject({ motivo: 'sem_mudanca' });
+  });
+  // O furo que o Codex achou (2026-09-06): pular por `round2(a) === round2(b)` deixava passar até
+  // ~meio centavo POR ITEM, enquanto o checksum soma o DOM em precisão CHEIA. Com 2 itens assim, o
+  // conjunto PERSISTIDO divergia do DOM acima da tolerância (0,0198 > 0,00515) e o checksum passava
+  // do mesmo jeito — ele valida o DOM, não o que fica gravado. Uma diferença sub-centavo é mudança.
+  it('diferença ABAIXO do centavo NÃO é sem_mudanca — senão o persistido foge do DOM que o checksum validou', () => {
+    const r = derivarCustos(matchCusto({ qtde: 1, preco_atual: 100, total: 100.004 }));
+    expect(r.pulados).toHaveLength(0);
+    expect(r.updates).toHaveLength(1);
+    expect(r.updates[0].valor_linha).toBe(100.004); // precisão cheia, não 100.00
+  });
+  it('ruído binário de `qtde * preco` continua sendo sem_mudanca (não vira escrita inútil)', () => {
+    // 3 * 0.1 = 0.30000000000000004 em double: diferença de ~5.5e-17, quatro ordens abaixo do centavo.
+    const r = derivarCustos(matchCusto({ qtde: 3, preco_atual: 0.1, total: 0.3 }));
     expect(r.updates).toHaveLength(0);
     expect(r.pulados[0]).toMatchObject({ motivo: 'sem_mudanca' });
   });

--- a/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
+++ b/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
@@ -238,6 +238,29 @@ describe('consolidarLinhasPortal (contrato espelhado)', () => {
     expect(c.fonte).toBe('json_total_unico');
     expect(c.linhas[0]).toMatchObject({ sku_portal: 'A', total_linha: 19.6 });
   });
+  // O sensor era CEGO justamente aqui: com 1 item, `total_linha = json.value`, então comparar o
+  // provado com a soma das linhas DEPOIS da gravação dá zero POR CONSTRUÇÃO. O Preço Venda do DOM
+  // já estava parseado e ia para o lixo (`checksum: semChecksum`). Números do #2459: DOM 362,9698
+  // contra JSON 374,77 — R$ 11,80 (3,2510%) cuja origem segue em aberto.
+  it('1 item ⇒ o checksum MEDE a divergência DOM × JSON (sem gatear: tolerancia_abs null)', () => {
+    const c = consolidarLinhasPortal(
+      [dom({ sku_portal: 'A', qtd_un_raw: '2', preco_un_raw: '181,4849', preco_venda_raw: '362,9698' })],
+      { itens: [{ item: 'A', value: 181.4849 }], value: 374.77, ordernum: 1 },
+      [{ sku_portal: 'A', qtde_portal: 2 }],
+    );
+    expect(c.fonte).toBe('json_total_unico');
+    expect(c.linhas[0].total_linha).toBe(374.77); // aceitação inalterada: quem manda é o json.value
+    expect(c.checksum.soma_dom).toBeCloseTo(362.9698, 4);
+    expect(c.checksum.total_json).toBe(374.77);
+    expect(c.checksum.delta_abs).toBeCloseTo(11.8002, 4);
+    expect(c.checksum.delta_rel).toBeCloseTo(0.031486, 5);
+    expect(c.checksum.tolerancia_abs).toBeNull(); // este ramo não tem gate — só medição
+  });
+  it('1 item sem Preço Venda no DOM ⇒ mede null, não fabrica zero', () => {
+    const c = consolidarLinhasPortal([dom({ sku_portal: '', preco_venda_raw: '' })], { itens: [{ item: 'A', value: 12 }], value: 19.6, ordernum: 1 }, [esp[0]]);
+    expect(c.checksum.soma_dom).toBeNull();
+    expect(c.checksum.delta_abs).toBeNull();
+  });
   it('defeito de prod (DOM cego, N itens) ⇒ nenhuma/dom_incompleto e zero custo', () => {
     const c = consolidarLinhasPortal([dom({ sku_portal: '' }), dom({ sku_portal: '' })], json, esp);
     expect(c).toMatchObject({ fonte: 'nenhuma', motivo: 'dom_incompleto' });

--- a/src/lib/reposicao/sayerlack-scraping-pedido.ts
+++ b/src/lib/reposicao/sayerlack-scraping-pedido.ts
@@ -222,9 +222,23 @@ export function consolidarLinhasPortal(dom: LinhaDom[], json: AddJsonPortal | nu
 
   // (3) 1 item ⇒ o total líquido do pedido É o total da linha.
   if (skusJson.length === 1) {
+    // O Preço Venda do DOM JÁ foi parseado acima e era jogado fora aqui — e era isso que tornava a
+    // divergência INVISÍVEL no pedido unitário: com `total_linha = json.value`, comparar depois da
+    // gravação dá delta zero POR CONSTRUÇÃO (Codex 2026-09-06). O #2459 é exatamente este caso —
+    // DOM 362,9698 contra JSON 374,77, R$ 11,80 (3,2510%) de origem ainda não identificada.
+    // Aqui o checksum MEDE, não decide: o pedido de 1 item continua aceito pelo `json.value` como
+    // sempre foi, e `tolerancia_abs: null` marca que não existe gate neste ramo.
+    const somaDom = provadas[0]?.precoVenda ?? null;
+    const deltaAbs = somaDom != null && json.value != null && Number.isFinite(somaDom) && Number.isFinite(json.value)
+      ? Math.abs(json.value - somaDom) : null;
     return {
       linhas: [{ sku_portal: skusJson[0], prz_ent_raw: przDe(skusJson[0]), total_linha: json.value }],
-      fonte: 'json_total_unico', motivo: null, total_pedido: json.value, checksum: semChecksum,
+      fonte: 'json_total_unico', motivo: null, total_pedido: json.value,
+      checksum: {
+        soma_dom: somaDom, total_json: json.value, delta_abs: deltaAbs,
+        delta_rel: deltaAbs != null && json.value ? deltaAbs / json.value : null,
+        tolerancia_abs: null,
+      },
     };
   }
 

--- a/src/lib/reposicao/sayerlack-scraping-pedido.ts
+++ b/src/lib/reposicao/sayerlack-scraping-pedido.ts
@@ -76,7 +76,12 @@ export function derivarCustos(res: ResultadoMatch): { updates: CustoUpdate[]; pu
     if (!Number.isFinite(qtde) || !(qtde > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'qtde_invalida' }); continue; }
     const unit = total / qtde;
     if (!Number.isFinite(unit) || !(unit > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'custo_invalido' }); continue; }
-    if (round2(total) === round2(qtde * c.item.preco_atual)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
+    // Pular por `round2(...) === round2(...)` comparava a CENTAVOS o que o checksum valida em precisão
+    // CHEIA: dois itens pulados podiam carregar ~meio centavo cada, o conjunto PERSISTIDO divergia do
+    // DOM acima da tolerância, e o checksum passava assim mesmo — ele valida o DOM, não o que fica
+    // gravado (Codex 2026-09-06). Só é 'sem_mudanca' o que é igual de verdade; 1e-9 absorve o ruído
+    // binário de `qtde * preco`, quatro ordens de grandeza abaixo do centavo que interessa.
+    if (Math.abs(total - qtde * c.item.preco_atual) < 1e-9) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
     updates.push({ item_id: c.item.item_id, preco_unitario: unit, valor_linha: total }); // precisão cheia
   }
   return { updates, pulados };

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -27,7 +27,7 @@ export const FONTE_SHA256: Record<string, string> = {
   "disparar-pedidos-aprovados": "1885293ff4d579fa780172689fef32cd079aa68eb02a4d3adcb2d96af83be487",
   "dispatch-notifications": "f29d8d0a57a4ccfe8f6fd76645d6c76ad13c891460b6913f24b43ae43cdca114",
   "elevenlabs-transcribe": "6e8f1f351e78f3ab0be470147340f86ce8a3e51d644b5b757f1dd235d9e6a8e2",
-  "enviar-pedido-portal-sayerlack": "9dfbb2adcab0e51a29ea5a8ddb3527800453e2c146d4c5d52a14bfc68f59d215",
+  "enviar-pedido-portal-sayerlack": "348c7eca7894b7d49386605f9b5aef4d5c567288cf5d5d829101427a9e2ff1d9",
   "enviar-push": "38302707026818b24e43f4936dea80f7648c68b2c1351385c7ddd5e396bdd9d5",
   "fin-cashflow-engine": "5327584f8d1bfc36b2f150428575bc459aafd16df4fae37223a20e89425a9a5d",
   "fin-funding": "740615f4f2e2d469bc2e4930dd742e01733ec4b828f16724d3be818a1d4ac32d",

--- a/supabase/functions/enviar-pedido-portal-sayerlack/captura-custo.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/captura-custo.ts
@@ -98,7 +98,12 @@ export function derivarCustos(res: ResultadoMatch): { updates: CustoUpdate[]; pu
     if (!Number.isFinite(qtde) || !(qtde > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'qtde_invalida' }); continue; }
     const unit = total / qtde;
     if (!Number.isFinite(unit) || !(unit > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'custo_invalido' }); continue; }
-    if (round2(total) === round2(qtde * c.item.preco_atual)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
+    // Pular por `round2(...) === round2(...)` comparava a CENTAVOS o que o checksum valida em precisão
+    // CHEIA: dois itens pulados podiam carregar ~meio centavo cada, o conjunto PERSISTIDO divergia do
+    // DOM acima da tolerância, e o checksum passava assim mesmo — ele valida o DOM, não o que fica
+    // gravado (Codex 2026-09-06). Só é 'sem_mudanca' o que é igual de verdade; 1e-9 absorve o ruído
+    // binário de `qtde * preco`, quatro ordens de grandeza abaixo do centavo que interessa.
+    if (Math.abs(total - qtde * c.item.preco_atual) < 1e-9) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
     updates.push({ item_id: c.item.item_id, preco_unitario: unit, valor_linha: total }); // precisão cheia
   }
   return { updates, pulados };

--- a/supabase/functions/enviar-pedido-portal-sayerlack/captura-custo.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/captura-custo.ts
@@ -244,9 +244,23 @@ export function consolidarLinhasPortal(dom: LinhaDom[], json: AddJsonPortal | nu
 
   // (3) 1 item ⇒ o total líquido do pedido É o total da linha.
   if (skusJson.length === 1) {
+    // O Preço Venda do DOM JÁ foi parseado acima e era jogado fora aqui — e era isso que tornava a
+    // divergência INVISÍVEL no pedido unitário: com `total_linha = json.value`, comparar depois da
+    // gravação dá delta zero POR CONSTRUÇÃO (Codex 2026-09-06). O #2459 é exatamente este caso —
+    // DOM 362,9698 contra JSON 374,77, R$ 11,80 (3,2510%) de origem ainda não identificada.
+    // Aqui o checksum MEDE, não decide: o pedido de 1 item continua aceito pelo `json.value` como
+    // sempre foi, e `tolerancia_abs: null` marca que não existe gate neste ramo.
+    const somaDom = provadas[0]?.precoVenda ?? null;
+    const deltaAbs = somaDom != null && json.value != null && Number.isFinite(somaDom) && Number.isFinite(json.value)
+      ? Math.abs(json.value - somaDom) : null;
     return {
       linhas: [{ sku_portal: skusJson[0], prz_ent_raw: przDe(skusJson[0]), total_linha: json.value }],
-      fonte: 'json_total_unico', motivo: null, total_pedido: json.value, checksum: semChecksum,
+      fonte: 'json_total_unico', motivo: null, total_pedido: json.value,
+      checksum: {
+        soma_dom: somaDom, total_json: json.value, delta_abs: deltaAbs,
+        delta_rel: deltaAbs != null && json.value ? deltaAbs / json.value : null,
+        tolerancia_abs: null,
+      },
     };
   }
 

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2150,9 +2150,14 @@ async function processarPedido(
           && match.ambiguos.length === 0 && match.casados.length === itensParaCusto.length && !pulados.some((p) => p.motivo !== 'sem_mudanca');
         if (pedidoInteiroProvado) {
           planejados = derivado.updates.length;
-          // planejados === 0 = todos 'sem_mudanca' (custo já batia): nada a gravar, não é cegueira.
-          if (planejados > 0) {
-            // UMA transação: CAS (omie IS NULL + sucesso_portal) no próprio UPDATE + todos os itens + valor_total.
+          // planejados === 0 = todos 'sem_mudanca' (custo já batia). A RPC é chamada MESMO ASSIM: a
+          // prova do portal vale por si — antes ela era DESCARTADA e as colunas do provado ficavam
+          // nulas apesar de a compra estar comprovada (Codex 2026-09-06). O SQL aceita array vazio
+          // desde 20260906193522; DEPLOYAR ESTA EDGE SÓ DEPOIS DO APPLY dessa migration, senão a
+          // versão anterior da RPC recusa o array vazio com CP001.
+          {
+            // UMA transação: CAS (omie IS NULL + sucesso_portal) no próprio UPDATE + todos os itens +
+            // o total provado em coluna dedicada + o derivado remantido sobre todos os itens.
             // Recusa = SQLSTATE CP00x + ROLLBACK; `data` = nº de itens gravados (== planejados, senão a RPC lançou).
             const { data: gravados, error: eRpc } = await supabase.rpc("sayerlack_aplicar_custo_portal", {
               p_pedido_id: pedido.id,

--- a/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
@@ -22,7 +22,7 @@ export const respostaSonda = criarRespostaSonda("enviar-pedido-portal-sayerlack"
  * v1.7 enviado = aprovado na quantidade (NULL lê-se 1:1; qtde fora do múltiplo recusa; normalização sai) ·
  * v1.8 itens+de-para por caminho único (a RPC inexistente e a instrumentação `[DEBUG_*]` saíram).
  */
-export const VERSAO = "v1.8-itens-caminho-unico";
+export const VERSAO = "v1.9-prova-sem-mudanca-e-sensor-unitario";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
Três defeitos da mesma captura, todos apontados pelo challenge do Codex de 2026-09-06 sobre o achado
B2. Vêm juntos porque moram no mesmo par de gêmeos (`captura-custo.ts` na edge e o espelho em `src`).

## 1. Prova sem mudança de preço era descartada

A edge só chamava a RPC com `planejados > 0`, e o SQL recusava array vazio com CP001. Um envio em
que **nenhum preço mudou** é uma compra comprovada como qualquer outra — mas as colunas do provado
ficavam nulas. Agora a RPC é chamada sempre que `pedidoInteiroProvado`.

⚠️ **Ordem de deploy:** a edge só pode ir ao ar **depois** do apply de
`20260906193522_valor_total_portal_provado.sql` (PR #2267) — a versão anterior da RPC recusa array
vazio.

## 2. `sem_mudanca` comparava a centavos o que o checksum valida em precisão cheia

`derivarCustos` pulava o item por `round2(total) === round2(qtde × preco)`. O checksum, porém, soma o
DOM em precisão **cheia**. Com dois itens pulados, o conjunto **persistido** podia divergir do DOM
acima da tolerância — e o checksum passava assim mesmo, porque ele valida o DOM, **não o que fica
gravado**. O contraexemplo do Codex: 3 itens, DOM 4000,0298, JSON 4000,03, checksum ok, persistido
4000,0102 → erro de 0,0198 contra tolerância de 0,00515.

Agora só é `sem_mudanca` o que é igual de verdade (`< 1e-9`, quatro ordens de grandeza abaixo do
centavo — absorve o ruído binário de `qtde × preco` sem absorver mudança real).

## 3. O sensor de divergência era cego no pedido UNITÁRIO

Este é o mais silencioso. No ramo de 1 item, o `Preço Venda` do DOM **já foi parseado** — e era
descartado (`checksum: semChecksum`), com `total_linha = json.value`. Consequência: comparar as duas
grandezas depois da gravação dá delta zero **por construção**.

O #2459 é exatamente este caso: DOM 362,9698 contra JSON 374,77, **R$ 11,80 (3,2510%)** de origem não
identificada. O número que mede a divergência já estava na memória e ia para o lixo.

Agora o ramo unitário preenche o checksum. Ele **mede, não decide**: o pedido de 1 item continua
aceito pelo `json.value` como sempre foi, e `tolerancia_abs: null` marca que não existe gate ali.

## Prova

Testes novos em `derivarCustos`, porque os 29 existentes passavam **sem alteração alguma** — não
havia cobertura para o furo do sub-centavo:

- diferença abaixo do centavo **não** é `sem_mudanca` (o dente do defeito 2);
- ruído binário (`3 × 0,1`) continua sendo `sem_mudanca` (não vira escrita inútil);
- o ramo unitário passa a carregar `soma_dom`/`delta_abs` (o dente do defeito 3).

Falsificação: revertendo os dois gêmeos para `round2`, os testes novos ficam vermelhos.

O gate `espelho Deno ↔ src` garante que edge e espelho não divirjam.

## ✅ Pré-requisito cumprido — saiu de draft

A migration do #2267 foi **aplicada em produção** e validada por mim via `psql-ro` (segunda
testemunha: outra conexão, depois do commit, não a postcondição de dentro da própria transação).
3 colunas no ar; a função é a NOVA (cita `valor_total_portal_provado` e `CP005`); **nenhum resquício**
do `SET valor_total = p_valor_total` antigo; `SECURITY DEFINER` e `search_path=public` preservados;
`anon`/`authenticated` fechados; `service_role` executa; e o passo (3), o recálculo do derivado,
presente.

A RPC em produção **já aceita array vazio** — a única razão de segurar esta edge.

## Estado da prova quando o PR foi aberto

**Rodaram, verdes:**

| Gate | Resultado |
|---|---|
| `edges:typecheck` | RC=0 — 0 erros de classe-crash |
| `sonda:bump` | RC=0 — `v1.9-prova-sem-mudanca-e-sensor-unitario` |
| `sonda:fingerprint -- --write` | RC=0 — mapa de 55 edges regravado |

**NÃO rodaram** — a máquina local está com **1 slot de `heavy`, ~64MB de RAM livre** e um
`ciclo.sh` de outra worktree segurando o slot há quase 2h (não é órfão: tem pai e filho vivos):

- `bun run test` (vitest) — nunca saiu da fila;
- `bun run test:edges` — **abortou por timeout de fila de 1800s na posição 3**. `RC=1` ali é o
  timeout do `heavy`, **ausência de dado, não reprovação**.

No lugar deles, um probe executando o módulo real (`bun` direto, ~50MB), com os dois lados medidos
na mesma rodada:

```
sabotado (round2):  subcentavo_updates=0
correto  (<1e-9):   subcentavo_updates=1, valor 100.004
ruído binário / igual-de-verdade: 0 nos DOIS lados (não regrediram)
fatia (3): soma_dom=362.9698  total_json=374.77  delta_abs=11.8002
           delta_rel=3,1487%  total_linha=374.77  tolerancia_abs=null
```

Isso prova o **comportamento** e que a asserção `toHaveLength(1)` do teste novo ficaria vermelha com
o código antigo — mas **não** é o vitest executando os testes. **O CI fechou a lacuna**: `validate` passou — o vitest completo e o `test:edges` rodaram lá, e os
testes novos (sub-centavo, ruído binário e o ramo unitário medindo `delta_abs 11,8002`) passaram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

