### PR TITLE
test(sonda): o ramo novo era TEXTO, não ramo — a condição sobrevivia a virar `false`

### DIFF
--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -9,8 +9,9 @@
 PEGA      | trava do bloco caro CASE -> WHERE (teatro) | s/CASE WHEN g\.confirmei/WHERE g.confirmei/
 PEGA      | leitura sai da lista canonica (LEFT->JOIN) | s/LEFT JOIN ids i/JOIN ids i/
 PEGA      | resposta ausente vira veredito (LEFT->JOIN)| s/LEFT JOIN net\._http_response/JOIN net._http_response/
-PEGA      | ramo AGUARDE some do veredito              | s/'AGUARDE —/'AGUARDOU —/
-PEGA      | placeholder do bloco que le fica invalido  | s/jsonb_each_text\('\{\}'::jsonb\)/jsonb_each_text('<COLE_AQUI>'::jsonb)/
+PEGA      | ramo AGUARDE some do passo EMBUTIDO        | s/'AGUARDE — o request_id embutido/'AGUARDOU — o request_id embutido/
+PEGA      | ramo AGUARDE some do passo do ECO          | s/'AGUARDE — o request_id colado/'AGUARDOU — o request_id colado/
+PEGA      | placeholder do bloco que le fica invalido  | s/: `'\{\}'::jsonb`;/: `'<COLE_AQUI>'::jsonb`;/
 PEGA      | marcador hardcoded em vez de lido do arquivo | s/lit\(e\.versao\)/lit('v1.0-sensor-inicial')/
 PEGA      | timeout_milliseconds implicito (default 5s) | s/timeout_milliseconds := 20000/-- sem timeout/
 PEGA      | --caro forasteira aceita em silencio       | s/!edges\.includes\(c\)/false/
@@ -55,7 +56,8 @@ PEGA      | janela larga: sondagem de ontem vira veredito de hoje | s/interval '
 PEGA      | teto da janela removido (guard do #2079 desligado)    | s/ \|\| janelaMin > JANELA_MAX_MIN//
 PEGA      | LIMIT 1 sem desempate (created EMPATA em prod)        | s/ORDER BY rr\.created DESC, rr\.id DESC/ORDER BY rr.created DESC/
 PEGA      | LATERAL vira INNER: edge sem eco SOME da saida        | s/LEFT JOIN LATERAL \(/JOIN LATERAL (/
-PEGA      | ausencia de linha vira veredito NEGATIVO              | s/THEN 'INDETERMINADO — nenhuma resposta/THEN 'BUNDLE VELHO — nenhuma resposta/
+PEGA      | ausencia de linha vira veredito NEGATIVO (eco)        | s/'INDETERMINADO — nenhuma resposta/'BUNDLE VELHO — nenhuma resposta/
+PEGA      | ausencia de linha vira veredito NEGATIVO (embutido)   | s/'INDETERMINADO — esta edge não tem request_id/'BUNDLE VELHO — esta edge não tem request_id/
 # Cast desprotegido: um corpo nao-JSON alheio na janela aborta a consulta INTEIRA — e a leitura
 # morre no lugar de julgar, que e falha por MECANICA lida como ausencia de resposta.
 PEGA      | cast para jsonb sem o filtro textual antes            | s/AND left\(ltrim\(r\.content\), 1\) = '\{'//
@@ -97,3 +99,27 @@ PEGA      | gitReal ignora a raiz pedida (cwd do processo)        | s/cwd: raiz,
 # — fail-OPEN na dimensão exata do #2227. O caso `em repo git SEM a ref` a mata; esta linha é o que
 # impede a prova de viver só na transcrição de quem mediu (docs/historico/falsificacao-fora-do-ci.md).
 PEGA      | ref ausente (1) traduzida em APROVADO (fail-OPEN)     | s/return \{ status: r\.status \?\? 127,/return { status: (r.status === 1 ? 0 : (r.status ?? 127)),/
+# Os 6 abaixo guardam a MIGRAÇÃO do #2278: o passo de disparo devolve o passo de leitura já ESCRITO
+# (`format($sonda$…$sonda$, m.ids)`), com o mapa `edge→id` embutido. O que se copia é a célula, não o
+# número — a classe de docs/historico/sonda-request-id-a-mao.md, aqui na variante coletiva (o blob
+# `{"edge": id}` inteiro). Sem eles a suíte aceitava o gerador VOLTANDO a entregar o blob.
+PEGA      | passo 1 volta a ENTREGAR o blob de ids                | s/AS passo_\$\{passoLeitura\}_copie_esta_celula/AS ids_opcionais_passo_${passoLeitura}/
+PEGA      | mapa embutido vira {} (o blob faz falta de novo)      | s/embutido \? `\$\{ids\.expr\}::jsonb`/embutido ? `'{}'::jsonb`/
+# As 3 abaixo cobrem as armadilhas do `format()` que o SQL de hoje NÃO exercita (o corpo emitido não
+# tem `%` nem `$`): sem teste DIRETO em `escaparParaFormat` elas ficariam verdes por acidente do
+# corpus — docs/historico/gates-textuais-cegos.md.
+PEGA      | escape de % desligado (o corpo vira diretiva)         | s/\.replaceAll\('%', '%%'\)//
+PEGA      | escape roda DEPOIS do placeholder (vira %%1\$L)       | s/texto\.replaceAll\('%', '%%'\)\.replaceAll\(SENTINELA_MAPA, \(\) => '%1\$L'\)/texto.replaceAll(SENTINELA_MAPA, () => '%1$L').replaceAll('%', '%%')/
+PEGA      | guard do dollar-quoting desligado (passo truncado)    | s/if \(texto\.includes\(TAG_SONDA\)\) \{/if (false) {/
+# O ramo do id que aponta para a execução REAL (cron ecoa edge/versao/fonte e não ecoa probe). Sem
+# ele a linha cai no ELSE e sai 'BUNDLE VELHO' com a versão CERTA — falso NEGATIVO medido em prod
+# 2026-09-06 (resposta 71275).
+PEGA      | ramo do id que NAO e sonda neutralizado               | s/l\.corpo ->> 'probe' IS DISTINCT FROM 'true'/false/
+# A variante NULL-blind do mesmo ramo (`<>` no lugar de `IS DISTINCT FROM`): com `probe` AUSENTE a
+# comparação vale NULL, o ramo não dispara e o texto continua no arquivo — inalcançável. Medido
+# 2026-09-06: as DUAS mutações acima SOBREVIVIAM enquanto a suíte só procurava a string do ramo, que
+# é a cegueira descrita no bloco do `? 'fonte'`. Quem lhes deu dente foi a asserção que cola
+# CONDIÇÃO e RAMO (`WHEN … IS DISTINCT FROM 'true'` seguido do `THEN 'NAO E RESPOSTA DE SONDA`); o
+# veredito EXECUTADO continua provado no cenário `cron_sem_probe` do
+# .claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh.
+PEGA      | negacao NULL-blind no ramo do nao-sonda               | s/IS DISTINCT FROM 'true'/<> 'true'/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -517,6 +517,18 @@ describe('o PASSO 1 ESCREVE o passo 2 — o mapa edge→id não passa pela mão 
     expect(iNaoSonda).toBeLessThan(iPreFonte);
     expect(ramoDe(sql, 'NAO E RESPOSTA DE SONDA')).toMatch(/probe:true/);
   });
+
+  it('a CONDIÇÃO do ramo é NULL-safe e está colada nele — texto presente não é ramo alcançável', () => {
+    // Sem esta asserção o ramo passa a ser texto decorativo: trocar a condição por `false` (ou por
+    // um `<>`, que com `probe` AUSENTE vale NULL e nunca dispara) deixa a string no arquivo e a
+    // suíte VERDE — a cegueira que o próprio .mut descreve e que só EXECUTANDO se vê. Medido: as
+    // duas mutações SOBREVIVIAM antes daqui. `IS DISTINCT FROM` é o operador NULL-safe, e é
+    // exatamente o corpo SEM o campo `probe` (o cron) que o ramo precisa alcançar.
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(
+      /WHEN l\.corpo ->> 'probe' IS DISTINCT FROM 'true'\n\s*THEN 'NAO E RESPOSTA DE SONDA/,
+    );
+  });
 });
 
 describe('escaparParaFormat — as duas armadilhas do format() que o corpus não exercita', () => {


### PR DESCRIPTION
Conserta o `mutation-check` que o #2278 deixou vermelho na main (contrato `scripts/mutcheck.d/sonda-versao-sql.mut`, exit 3). Como o `mutcheck-all` roda os 23 contratos em todo PR, o vermelho aparecia para **todas** as sessões.

## Duas coisas, e a segunda é o achado

**(1) Duas mutações ficaram stale com a migração do #2278** — ausência de medição, não medição:
- `s/'AGUARDE —/…/` passou a casar **2 linhas** (o texto virou dois: o do passo embutido e o do eco) e caiu no guard de substituição única;
- `s/jsonb_each_text('{}'::jsonb)/…/` **não casa mais** — o literal saiu do template do SQL e virou o ramo `eco` do ternário `exprIds`.

Re-ancoradas no texto próprio de cada uma, que é o que o próprio `.mut` já manda fazer para o par de `INDETERMINADO`.

**(2) A mutação que neutraliza o ramo `NAO E RESPOSTA DE SONDA` SOBREVIVIA.** Trocar a condição por `false` deixa a string do ramo no arquivo, e era só a string que a suíte procurava — **texto presente não é ramo alcançável**. É a cegueira que o bloco do `? 'fonte'` já descrevia, repetida um ramo adiante, e ela não apareceu nem no `validate` verde nem no eval (que exercita o veredito por outro caminho): quem a expôs foi o `mutcheck`.

A asserção que cola **condição e ramo** (`WHEN … IS DISTINCT FROM 'true'` seguido do `THEN 'NAO E RESPOSTA DE SONDA`) mata as duas: a `false` e a NULL-blind (`<>`, que com `probe` AUSENTE — o caso do cron, exatamente o que o ramo precisa alcançar — vale NULL e nunca dispara). O veredito EXECUTADO continua provado no cenário `cron_sem_probe` do `sonda-veredito-401-eval.sh`.

## Mais 6 mutações para a migração

O passo 1 voltando a ENTREGAR o blob · o mapa embutido virando `{}` · o escape de `%` desligado · o escape rodando DEPOIS do placeholder (`%%1$L`) · o guard do dollar-quoting desligado · o ramo do não-sonda neutralizado.

## Evidência

`mutcheck`: **54 mutações · 52 pegas · 2 sobreviventes (as declaradas: timeout 20s→30s e `ORDER BY` por posição) · 0 inválidas · controle+ ✓ (52/52) · 0 problemas**, baseline verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)