### PR TITLE
fix(venda): o cockpit de preço que não foi lido PARA DE afirmar "margem OK" [money-path]

### DIFF
--- a/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
+++ b/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
@@ -107,6 +107,41 @@ perdido é um terço da operação. As telas de cliente têm 5.664 *contas*, e c
 (`fin_ic_matches` = 0), `AdminReposicaoOportunidades:330` (0), `AdminEstoquePicking:371,580,659`
 (0), `WhatsappInbox:110` (0). Corrigir **antes da primeira linha**, porque depois some calado.
 
+## O que considero LEGÍTIMO, e por quê
+
+Sete padrões cobrem a maioria dos 93. Em nenhum deles a ausência afirma segurança:
+
+1. **Campo opcional de um registro já carregado.** `Profile` (telefone/e-mail/horários), `OrderDetail`
+   (previsão, desconto, pagamento), `AdminKnowledgeBaseDetail` (11 `KpiCell` de spec),
+   `RendimentoCalculator` (catalisador/diluente/pot life), `AdminStandardProcessDetail`,
+   `GrupoCliente360`. O `&&` testa **um campo do objeto**, não a leitura: `data` está presente e o
+   campo é nulo. A ausência afirma "não preenchido" — que é verdade.
+2. **Sítio protegido por guard superior.** `PedidoProgramadoDetalhe:274` — o `if (isPending || !data)`
+   da linha 52 torna o `&&` inalcançável com `data` undefined. Falso positivo do detector, que não
+   modela fluxo.
+3. **UI de interação local.** `MapearItemDialog` ("Nada encontrado" de uma busca digitada),
+   `ConsolidarDemandaDialog`, `SubstituicaoModal`, `ImpersonationBanner`, `GovernancePermissions:197‑199`.
+4. **Rodapé de truncamento.** `FollowupsSugeridosCard:95`, `GestorExcecoes:115`,
+   `AdminReposicaoPedidos:681`, `ClientesNaoVinculados:121` — some junto com a lista que qualifica.
+5. **Gráfico/decoração.** `Intelligence*Tab`, `Gamification`, `Training`, `TarefasTemplates`,
+   `MinhasVisitasResultadoCard`, `CustomerProfile360Summary`.
+6. **O `&&` que MOSTRA o aviso de falha.** `ClientesNaoVinculados:80` —
+   `{erro && <Card>A última atualização falhou…}`. É o padrão certo aparecendo na varredura.
+7. **Máquina de estados explícita já no lugar.** `TintPricing:315‑338` —
+   `view.status ∈ {carregando, com-preco, sem-preco}`, e "Sem preço" é **fail-closed por desenho**.
+
+## Sobre gatear a forma
+
+**A decisão de 2026-08-22 continua certa**: `jsx-&&` inteiro no gate faria a baseline crescer por
+motivo benigno em idioma legítimo, e baseline que cresce por motivo benigno ensina a atualizá-la no
+automático. **Nada aqui justifica reverter o filtro de `contarAutoOcultacao`.**
+
+O que a medição sugere é um recorte **menor e diferente**: o sub-tipo que MENTE — default no
+binding (`= []`) + condição `length === 0` + texto afirmativo — tem o mesmo dano da forma já
+gateada e são 16 sítios, não 93. Isso é um PR próprio, com baseline própria e falsificação; e o
+pré-requisito dele é o item 2 acima, porque num hook que engole o erro o gate estaria fiscalizando
+a camada errada.
+
 ## Fatia #1 FECHADA — `usePrecoCockpit` (2026-09-06)
 
 Os dois consumidores (`CartItemList`, `ProductItemForm` — e são **exatamente** dois) passaram a
@@ -156,38 +191,3 @@ itens em coluna `items` jsonb (confirmado pelo ESCRITOR, `submitOrder.ts:216`, n
 O limite de 200 nunca foi tocado em 31 mil pedidos. Registrar o zero é o que impede o próximo a
 inflar o argumento — mesma disciplina que separou `orders` (0 linhas) de `sales_orders` (508/30d)
 na medição original, só que agora contra um erro **meu**, plausível e verificável em duas queries.
-
-## O que considero LEGÍTIMO, e por quê
-
-Sete padrões cobrem a maioria dos 93. Em nenhum deles a ausência afirma segurança:
-
-1. **Campo opcional de um registro já carregado.** `Profile` (telefone/e-mail/horários), `OrderDetail`
-   (previsão, desconto, pagamento), `AdminKnowledgeBaseDetail` (11 `KpiCell` de spec),
-   `RendimentoCalculator` (catalisador/diluente/pot life), `AdminStandardProcessDetail`,
-   `GrupoCliente360`. O `&&` testa **um campo do objeto**, não a leitura: `data` está presente e o
-   campo é nulo. A ausência afirma "não preenchido" — que é verdade.
-2. **Sítio protegido por guard superior.** `PedidoProgramadoDetalhe:274` — o `if (isPending || !data)`
-   da linha 52 torna o `&&` inalcançável com `data` undefined. Falso positivo do detector, que não
-   modela fluxo.
-3. **UI de interação local.** `MapearItemDialog` ("Nada encontrado" de uma busca digitada),
-   `ConsolidarDemandaDialog`, `SubstituicaoModal`, `ImpersonationBanner`, `GovernancePermissions:197‑199`.
-4. **Rodapé de truncamento.** `FollowupsSugeridosCard:95`, `GestorExcecoes:115`,
-   `AdminReposicaoPedidos:681`, `ClientesNaoVinculados:121` — some junto com a lista que qualifica.
-5. **Gráfico/decoração.** `Intelligence*Tab`, `Gamification`, `Training`, `TarefasTemplates`,
-   `MinhasVisitasResultadoCard`, `CustomerProfile360Summary`.
-6. **O `&&` que MOSTRA o aviso de falha.** `ClientesNaoVinculados:80` —
-   `{erro && <Card>A última atualização falhou…}`. É o padrão certo aparecendo na varredura.
-7. **Máquina de estados explícita já no lugar.** `TintPricing:315‑338` —
-   `view.status ∈ {carregando, com-preco, sem-preco}`, e "Sem preço" é **fail-closed por desenho**.
-
-## Sobre gatear a forma
-
-**A decisão de 2026-08-22 continua certa**: `jsx-&&` inteiro no gate faria a baseline crescer por
-motivo benigno em idioma legítimo, e baseline que cresce por motivo benigno ensina a atualizá-la no
-automático. **Nada aqui justifica reverter o filtro de `contarAutoOcultacao`.**
-
-O que a medição sugere é um recorte **menor e diferente**: o sub-tipo que MENTE — default no
-binding (`= []`) + condição `length === 0` + texto afirmativo — tem o mesmo dano da forma já
-gateada e são 16 sítios, não 93. Isso é um PR próprio, com baseline própria e falsificação; e o
-pré-requisito dele é o item 2 acima, porque num hook que engole o erro o gate estaria fiscalizando
-a camada errada.

--- a/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
+++ b/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
@@ -107,6 +107,56 @@ perdido é um terço da operação. As telas de cliente têm 5.664 *contas*, e c
 (`fin_ic_matches` = 0), `AdminReposicaoOportunidades:330` (0), `AdminEstoquePicking:371,580,659`
 (0), `WhatsappInbox:110` (0). Corrigir **antes da primeira linha**, porque depois some calado.
 
+## Fatia #1 FECHADA — `usePrecoCockpit` (2026-09-06)
+
+Os dois consumidores (`CartItemList`, `ProductItemForm` — e são **exatamente** dois) passaram a
+ler o estado da query, não só o `data`: `estadoDeLeitura` + `naoConsegui`/`desatualizado` +
+`<AvisoLeituraFalhou>`. O preço continua na tela **com** o aviso — apagar a linha do carrinho
+porque o cockpit falhou trocaria um defeito por outro (`estado-de-leitura.ts`, `desatualizado`).
+
+### 1. A guarda que já existia mockava o hook — e o mock era PARCIAL
+
+O briefing mandou conferir `CartItemList.priceGuard.test.tsx` antes de mexer, contra o risco de
+"tratamento parcial já existente" tornar o fix inerte. O que ele cobre é **nada** desta classe:
+mocka `usePrecoCockpit: () => ({ data: undefined })` — isto é, roda o componente **exatamente no
+estado de falha** — e afirma só o `aria-invalid` do preço. O erro nunca foi olhado.
+
+O achado que vale como regra é o **formato do mock**: `{ data: undefined }` não tem `status` nem
+`fetchStatus`. Depois do fix, `estadoDeLeitura({status: undefined, fetchStatus: undefined})` não
+casa nenhum `if` e cai no `return 'carregando'` — o teste antigo segue verde **por acidente de
+ramo**, não por desenho. Um mock de hook precisa ter a forma que o componente LÊ; mock parcial
+transforma "o componente escolheu este ramo" em "o objeto não tinha o campo". Completado para
+`{ data: undefined, status: 'pending', fetchStatus: 'idle' }` — 'desabilitada', que é o estado
+que aquele teste de fato quer (cockpit indiferente ao guard de preço).
+
+### 2. A RPC lança por DESENHO, não só por acidente de transporte
+
+`get_preco_cockpit` é SECURITY DEFINER e tem dois `RAISE EXCEPTION` no corpo (psql-ro, 2026-09-06):
+
+```
+RAISE EXCEPTION 'forbidden' USING errcode = '42501'
+  IF NOT (auth.uid() IS NOT NULL AND (has_role(auth.uid(),'employee') OR has_role(auth.uid(),'master')))
+RAISE EXCEPTION 'too many items (max 200)' USING errcode = '22023'
+```
+
+ACL: `authenticated=X`, **`anon` sem EXECUTE**. O caminho alcançável não é exótico — é a **aba de
+balcão aberta o dia inteiro**: token expira, `auth.uid()` vira null, a RPC responde 42501, e a
+régua de margem some de um carrinho que continua editável e submetível. A tela do erro era
+byte-a-byte a tela da margem saudável em faixa `neutro`.
+
+### 3. O caminho dos 200 itens NÃO é alcançável — e o zero fica registrado
+
+Antes de usar "carrinho grande derruba a régua" como argumento, medi. `sales_orders` grava os
+itens em coluna `items` jsonb (confirmado pelo ESCRITOR, `submitOrder.ts:216`, não pelo nome):
+
+| pedidos | máx itens | p99 | acima de 200 |
+|---|---|---|---|
+| 31.248 | **28** | 9,0 | **0** |
+
+O limite de 200 nunca foi tocado em 31 mil pedidos. Registrar o zero é o que impede o próximo a
+inflar o argumento — mesma disciplina que separou `orders` (0 linhas) de `sales_orders` (508/30d)
+na medição original, só que agora contra um erro **meu**, plausível e verificável em duas queries.
+
 ## O que considero LEGÍTIMO, e por quê
 
 Sete padrões cobrem a maioria dos 93. Em nenhum deles a ausência afirma segurança:

--- a/src/components/unified-order/CartItemList.tsx
+++ b/src/components/unified-order/CartItemList.tsx
@@ -21,6 +21,8 @@ import { ReguaPrecoSinal } from '@/components/regua-preco/ReguaPrecoSinal';
 import type { ReguaCartItem } from '@/lib/regua-preco/regua-preco-ui';
 import { useReguaPrecoLog } from '@/hooks/useReguaPrecoLog';
 import { isInvalidProductPrice } from '@/services/orderSubmission/priceGuard';
+import { estadoDeLeitura, naoConsegui, desatualizado } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { PriceInput } from './PriceInput';
 
 interface CartItemListProps {
@@ -67,7 +69,18 @@ export function CartItemList({
       .filter(i => i.preco > 0 && Number.isFinite(i.codigo) && i.empresa !== ''),
     [obenProductItems, colacorProductItems, customerUserId],
   );
-  const { data: cockpitList } = usePrecoCockpit(cockpitItens);
+  const cockpit = usePrecoCockpit(cockpitItens);
+  const cockpitList = cockpit.data;
+  // A régua de margem (faixa, markup %, folga em R$) SOME quando `get_preco_cockpit` falha —
+  // e O PREÇO FICA na tela. Sem falar, a ausência afirma "margem OK" exatamente onde o preço é
+  // decidido (money-path §"A leitura que falha e vira silêncio afirmativo"; 508 pedidos/30d em
+  // `sales_orders`). `desatualizado` cobre o dado velho em mãos (refetch que falha, precedência
+  // sem-rede > erro); `naoConsegui` cobre o 1º fetch que não voltou — inclusive o QUARTO ESTADO,
+  // o offline (`pending`+`paused`), em que `isLoading` é FALSE e `error` é null. Carrinho sem
+  // produto deixa a query `enabled:false` ⇒ 'desabilitada' ⇒ sem aviso (a pergunta não foi feita).
+  const estadoCockpit = estadoDeLeitura(cockpit);
+  const avisoCockpit = desatualizado(cockpit, cockpitList !== undefined)
+    ?? (naoConsegui(estadoCockpit) ? estadoCockpit : null);
   const cockpitByKey = useMemo(() => {
     const m = new Map<string, LinhaCockpit>();
     cockpitItens.forEach((inp, i) => {
@@ -251,6 +264,14 @@ export function CartItemList({
           <p className="text-xs text-muted-foreground text-center py-6">Nenhum item adicionado</p>
         ) : (
           <div className="space-y-3">
+            {avisoCockpit && (
+              <AvisoLeituraFalhou
+                oque="a margem dos itens do carrinho"
+                estado={avisoCockpit}
+                testId="aviso-cockpit-carrinho"
+                className="mb-0"
+              />
+            )}
             {obenProductItems.length > 0 && renderProductGroup(obenProductItems, 'Oben', <Building2 className="w-3 h-3 inline mr-1" />)}
 
             {colacorProductItems.length > 0 && (

--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -8,6 +8,8 @@ import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
 import { FichaTecnicaSheet } from '@/components/unified-order/FichaTecnicaSheet';
 import { usePrecoCockpit, type ItemCockpitInput } from '@/hooks/usePrecoCockpit';
 import { FAIXA_UI } from '@/lib/preco/faixa-ui';
+import { estadoDeLeitura, naoConsegui, desatualizado } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { VendaAssistidaSelo } from '@/components/unified-order/VendaAssistidaSelo';
 import type { OpcaoResolvida } from '@/lib/venda-assistida/resolver-opcao';
 import { cn } from '@/lib/utils';
@@ -76,7 +78,14 @@ export function ProductItemForm({
       }))
       .filter(i => i.preco > 0 && Number.isFinite(i.codigo) && i.empresa !== '');
   }, [products, prices, customerPricesLoading, precoLoading, customerUserId, getPrecoNascimento]);
-  const { data: cockpitList } = usePrecoCockpit(cockpitInputs);
+  const cockpit = usePrecoCockpit(cockpitInputs);
+  const cockpitList = cockpit.data;
+  // Mesma classe do carrinho: a faixa some quando a RPC falha e o PREÇO segue exibido, o que
+  // afirma "margem OK" sobre o preço que o item vai NASCER. Enquanto os preços do contrato
+  // carregam, `cockpitInputs` é [] ⇒ query 'desabilitada' ⇒ sem aviso (transitório, não é falha).
+  const estadoCockpit = estadoDeLeitura(cockpit);
+  const avisoCockpit = desatualizado(cockpit, cockpitList !== undefined)
+    ?? (naoConsegui(estadoCockpit) ? estadoCockpit : null);
   // produtos da busca são únicos por código (e tint é filtrado fora) → Map por código.
   const cockpitByCode = useMemo(
     () => new Map((cockpitList ?? []).map(l => [l.codigo, l])),
@@ -111,6 +120,13 @@ export function ProductItemForm({
           <div className="flex items-center gap-1.5 mb-2 text-[11px] text-muted-foreground" role="status">
             <Loader2 className="w-3 h-3 animate-spin" /> Carregando preços do contrato…
           </div>
+        )}
+        {avisoCockpit && (
+          <AvisoLeituraFalhou
+            oque="a margem dos produtos da lista"
+            estado={avisoCockpit}
+            testId="aviso-cockpit-lista"
+          />
         )}
         {loading ? (
           <Loader2 className="w-5 h-5 animate-spin mx-auto" />

--- a/src/components/unified-order/__tests__/CartItemList.priceGuard.test.tsx
+++ b/src/components/unified-order/__tests__/CartItemList.priceGuard.test.tsx
@@ -7,8 +7,12 @@ vi.mock('@/hooks/useUnifiedOrder', () => ({
   fmt: (v: number) => `R$ ${v}`,
   getToolName: () => 'Ferramenta',
 }));
+// Forma COMPLETA do UseQueryResult: o carrinho lê `status`/`fetchStatus` para separar
+// "não há margem a sinalizar" de "não consegui ler o cockpit". Um mock só com `data`
+// cairia num ramo por acidente — aqui o estado declarado é 'desabilitada' (pending+idle),
+// que é o que este teste quer: cockpit indiferente ao guard de preço.
 vi.mock('@/hooks/usePrecoCockpit', () => ({
-  usePrecoCockpit: () => ({ data: undefined }),
+  usePrecoCockpit: () => ({ data: undefined, status: 'pending', fetchStatus: 'idle' }),
   chaveCockpit: (e: string, c: number, t: string | null) => `${e}|${c}|${t ?? ''}`,
 }));
 // Defasagem 2b (T8) puxa useAuth/useQuery — mock vazio isola este teste do guard de preço.

--- a/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
+++ b/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
@@ -31,10 +31,12 @@ vi.mock('@/hooks/useUnifiedOrder', () => ({
   fmt: (v: number) => `R$ ${v}`,
   getToolName: () => 'Ferramenta',
 }));
-// Vizinhos do carrinho que puxam useQuery/useAuth próprios — mock vazio isola ESTA leitura.
-vi.mock('@/hooks/useDefasagemCliente', () => ({
-  useDefasagemCliente: () => ({ defasagemByKey: new Map(), isLoading: false }),
-}));
+// `useDefasagemCliente` NÃO é mockado de propósito: ele só consome `supabase.rpc`, que já
+// está mockado aqui, e a fixture do cockpit não tem `status_defasagem` ⇒ nenhum badge de
+// defasagem nasce. Mockar por caminho custaria uma aresta vendas→farmer-inteligencia no gate
+// de fronteiras por ficção do teste, não por dependência real.
+// Os demais vizinhos são do próprio módulo `vendas` e puxam useQuery próprio — mock vazio
+// (equivalente à flag off) isola ESTA leitura.
 vi.mock('@/hooks/useCustoPrazoRegua', () => ({
   useCustoPrazoRegua: () => ({ prazoDias: null, custoCapitalAnual: null }),
 }));

--- a/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
+++ b/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
@@ -68,12 +68,15 @@ function item(): ProductCartItem {
   return { type: 'product', product: produto, quantity: 1, unit_price: 10 } as unknown as ProductCartItem;
 }
 
-function comQuery(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+function novoQc() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+}
+
+function comQuery(ui: React.ReactElement, qc = novoQc()) {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }
 
-function renderCarrinho() {
+function renderCarrinho(qc?: QueryClient) {
   return comQuery(
     <CartItemList
       cart={{ length: 1 }}
@@ -94,6 +97,7 @@ function renderCarrinho() {
       customerUserId="c1"
       customerName="Cliente"
     />,
+    qc,
   );
 }
 
@@ -136,6 +140,25 @@ describe('CartItemList — cockpit ilegível NÃO pode virar silêncio', () => {
     resposta = { data: [linha()], error: null };
     renderCarrinho();
     expect(await screen.findByText(AVISO)).toBeTruthy();
+  });
+
+  it('DADO EM CACHE + offline no refetch: avisa SEM apagar a régua (o composto)', async () => {
+    // Único ramo que `naoConsegui` não alcança: com dado já respondido o status é
+    // 'success' (⇒ `estadoDeLeitura` = 'pronta') e só o `fetchStatus: 'paused'` denuncia
+    // que a informação na tela é velha. Escolher entre a régua e o aviso seria trocar um
+    // defeito por outro — o desenho mostra os DOIS (`estado-de-leitura.ts`, `desatualizado`).
+    const qc = novoQc();
+    resposta = { data: [linha()], error: null };
+    renderCarrinho(qc);
+    expect(await screen.findByText('Abaixo do custo')).toBeTruthy();
+    expect(screen.queryByText(AVISO)).toBeNull();
+
+    onlineManager.setOnline(false);
+    void qc.invalidateQueries();
+
+    expect(await screen.findByText(AVISO)).toBeTruthy();
+    // e a régua CONTINUA na tela, com o aviso ao lado
+    expect(screen.getByText('Abaixo do custo')).toBeTruthy();
   });
 
   it('erro e faixa-neutra NÃO produzem a mesma tela (o colapso, medido)', async () => {

--- a/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
+++ b/src/components/unified-order/__tests__/cockpit-leitura.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+
+/**
+ * Guard money-path — a RÉGUA DE MARGEM não pode sumir calada quando o cockpit não é lido.
+ *
+ * `usePrecoCockpit` LANÇA quando `get_preco_cockpit` falha (`if (error) throw error`), e os dois
+ * consumidores desestruturavam só o `data`: `const { data: cockpitList } = usePrecoCockpit(...)`.
+ * Com `data === undefined` some o badge de faixa, o `markup %`, a folga em R$ — e O PREÇO FICA
+ * NA TELA. A ausência afirma "margem OK" exatamente onde o preço é decidido: 508 pedidos em 30
+ * dias em `sales_orders` (docs/historico/a-forma-que-some-e-a-forma-que-mente.md, item 1 da ordem
+ * por dano). Classe: docs/agent/money-path.md §"A leitura que falha e vira silêncio afirmativo".
+ *
+ * O HOOK RODA DE VERDADE; só o supabase é mockado. Mockar `usePrecoCockpit` (como faz o
+ * `CartItemList.priceGuard.test.tsx`, que devolve `{ data: undefined }` fixo) provaria apenas que
+ * o componente renderiza um estado montado à mão — e o defeito mora justamente na tradução
+ * "RPC falhou" → "data undefined" → "tela idêntica à da margem saudável".
+ */
+type Resposta = { data: unknown; error: { message: string } | null };
+let resposta: Resposta = { data: [], error: null };
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: () => Promise.resolve(resposta) },
+}));
+// Identidade real do usuário — o cockpit só a usa para isolar o cache por uid.
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+vi.mock('@/hooks/useUnifiedOrder', () => ({
+  fmt: (v: number) => `R$ ${v}`,
+  getToolName: () => 'Ferramenta',
+}));
+// Vizinhos do carrinho que puxam useQuery/useAuth próprios — mock vazio isola ESTA leitura.
+vi.mock('@/hooks/useDefasagemCliente', () => ({
+  useDefasagemCliente: () => ({ defasagemByKey: new Map(), isLoading: false }),
+}));
+vi.mock('@/hooks/useCustoPrazoRegua', () => ({
+  useCustoPrazoRegua: () => ({ prazoDias: null, custoCapitalAnual: null }),
+}));
+vi.mock('@/hooks/useReguaPreco', () => ({
+  useReguaPreco: () => ({ reguaByKey: new Map(), isLoading: false }),
+}));
+vi.mock('@/hooks/useReguaPrecoLog', () => ({
+  useReguaPrecoLog: () => ({ marcarExibido: vi.fn(), marcarAplicado: vi.fn() }),
+}));
+
+import { CartItemList } from '../CartItemList';
+import { ProductItemForm } from '../ProductItemForm';
+import type { Product, ProductCartItem } from '@/hooks/unifiedOrder/types';
+
+/** A frase do aviso — o que separa "não consegui ler" de "a margem está boa". */
+const AVISO = /não quer dizer que está tudo certo/i;
+
+const linha = (over: Record<string, unknown> = {}) => ({
+  codigo: 1, empresa: 'oben', faixa: 'vermelho', motivo: 'abaixo do custo',
+  tem_custo: true, tem_politica: true, calculated_at: '2026-09-06T00:00:00Z', tier: null,
+  cmc: 8, markup_perc: 25, folga_reais: 2, piso_markup: 30, meta_markup: 40,
+  proveniencia: 'cmc', frescor: 'fresco', ...over,
+});
+
+const produto: Product = {
+  id: 'p1', codigo: 'C1', descricao: 'Lixa', unidade: 'UN', valor_unitario: 10,
+  estoque: 5, ativo: true, omie_codigo_produto: 1, account: 'oben', is_tintometric: false,
+};
+
+function item(): ProductCartItem {
+  return { type: 'product', product: produto, quantity: 1, unit_price: 10 } as unknown as ProductCartItem;
+}
+
+function comQuery(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+function renderCarrinho() {
+  return comQuery(
+    <CartItemList
+      cart={{ length: 1 }}
+      obenProductItems={[item()]}
+      colacorProductItems={[]}
+      serviceItems={[]}
+      obenSubtotal={10}
+      colacorProdSubtotal={0}
+      serviceSubtotal={0}
+      totalEstimated={10}
+      deliveryOption="balcao"
+      selectedTimeSlot=""
+      onUpdateQuantity={vi.fn()}
+      onUpdateProductPrice={vi.fn()}
+      onRemoveFromCart={vi.fn()}
+      getServicePrice={() => null}
+      getCartIndex={() => 0}
+      customerUserId="c1"
+      customerName="Cliente"
+    />,
+  );
+}
+
+function renderLista() {
+  return comQuery(
+    <ProductItemForm
+      title="Oben"
+      products={[produto]}
+      prices={{}}
+      loading={false}
+      productSearch=""
+      onSearchChange={vi.fn()}
+      productItems={[]}
+      onAddProduct={vi.fn()}
+      customerUserId="c1"
+    />,
+  );
+}
+
+beforeEach(() => { onlineManager.setOnline(true); });
+afterEach(() => { onlineManager.setOnline(true); });
+
+describe('CartItemList — cockpit ilegível NÃO pode virar silêncio', () => {
+  it('CONTROLE: leitura boa → a régua de margem aparece e NÃO há aviso', async () => {
+    resposta = { data: [linha()], error: null };
+    renderCarrinho();
+    expect(await screen.findByText('Abaixo do custo')).toBeTruthy();
+    expect(await screen.findByText(/25%/)).toBeTruthy();
+    expect(screen.queryByText(AVISO)).toBeNull();
+  });
+
+  it('ERRO de leitura: avisa — este é o defeito da classe (o preço fica, a régua some)', async () => {
+    resposta = { data: null, error: { message: 'permission denied' } };
+    renderCarrinho();
+    expect(await screen.findByText(AVISO)).toBeTruthy();
+  });
+
+  it('OFFLINE (pending+paused): também avisa — isLoading é FALSE e data undefined', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: [linha()], error: null };
+    renderCarrinho();
+    expect(await screen.findByText(AVISO)).toBeTruthy();
+  });
+
+  it('erro e faixa-neutra NÃO produzem a mesma tela (o colapso, medido)', async () => {
+    // `neutro` é o silêncio LEGÍTIMO do cockpit: leu, e não há o que sinalizar.
+    resposta = { data: [linha({ faixa: 'neutro' })], error: null };
+    const neutra = renderCarrinho();
+    await waitFor(() => expect(neutra.container.querySelector('[data-testid="aviso-cockpit-carrinho"]')).toBeNull());
+    const telaNeutra = neutra.container.textContent;
+    neutra.unmount();
+
+    resposta = { data: null, error: { message: 'boom' } };
+    const erro = renderCarrinho();
+    await screen.findByText(AVISO);
+    expect(erro.container.textContent).not.toBe(telaNeutra);
+  });
+});
+
+describe('ProductItemForm — cockpit ilegível NÃO pode virar silêncio', () => {
+  it('CONTROLE: leitura boa → a faixa aparece na lista e NÃO há aviso', async () => {
+    resposta = { data: [linha()], error: null };
+    renderLista();
+    expect(await screen.findByText('Abaixo do custo')).toBeTruthy();
+    expect(screen.queryByText(AVISO)).toBeNull();
+  });
+
+  it('ERRO de leitura: avisa em vez de exibir o preço sem faixa nenhuma', async () => {
+    resposta = { data: null, error: { message: 'permission denied' } };
+    renderLista();
+    expect(await screen.findByText(AVISO)).toBeTruthy();
+  });
+
+  it('OFFLINE (pending+paused): também avisa', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: [linha()], error: null };
+    renderLista();
+    expect(await screen.findByText(AVISO)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fatia #1 do inventário [`a-forma-que-some-e-a-forma-que-mente.md`](docs/historico/a-forma-que-some-e-a-forma-que-mente.md) — o item de **maior dano medido** da classe `{data && <X/>}`.

## O defeito

`usePrecoCockpit` lança quando `get_preco_cockpit` falha (`if (error) throw error`). Os dois — e são **exatamente** dois — consumidores desestruturavam só o `data`. Com `data` undefined somem o badge de faixa, o `markup %`, a folga em R$ e o `<ReguaPrecoSinal>`; **o preço fica na tela**, editável e submetível. A ausência afirma "margem OK" exatamente onde o preço é decidido — `sales_orders` = 31.248 pedidos, **508 em 30 dias**, o maior denominador do inventário.

## O alcance não é hipotético (psql-ro, 2026-09-06)

A RPC é SECURITY DEFINER e tem dois `RAISE EXCEPTION` deliberados:

```
RAISE EXCEPTION 'forbidden' USING errcode = '42501'
  IF NOT (auth.uid() IS NOT NULL AND (has_role(auth.uid(),'employee') OR has_role(auth.uid(),'master')))
RAISE EXCEPTION 'too many items (max 200)' USING errcode = '22023'
```

ACL: `authenticated=X`, **`anon` sem EXECUTE**. O gatilho comum é a aba de balcão aberta o dia inteiro: token expira, `auth.uid()` vira null, 42501, a régua some e o preço fica.

O segundo RAISE eu ia usar como argumento forte — e a medição derrubou. `sales_orders` grava os itens em `items` jsonb (confirmado pelo **escritor**, `submitOrder.ts:216`):

| pedidos | máx itens | p99 | acima de 200 |
|---|---|---|---|
| 31.248 | **28** | 9,0 | **0** |

Nunca aconteceu. **O zero fica registrado** para que ninguém infle o argumento depois.

## A correção

Padrão da casa: `estadoDeLeitura` + `naoConsegui`/`desatualizado` + `<AvisoLeituraFalhou>`. O conteúdo **não some junto com o aviso** — apagar a linha do carrinho porque o cockpit falhou trocaria um defeito por outro. O quarto estado (offline: `pending`+`paused`, `isLoading` FALSE, `error` null) sai como `sem-rede`, com ícone e frase próprios.

## Falsificação (uma camada por vez, com controle verde na mesma invocação)

| sabotagem | resultado | leitura |
|---|---|---|
| versão **pré-fix** | 5 vermelhos, **2 verdes** | não é sempre-vermelho: os 2 sobreviventes são os controles "leitura boa → régua aparece" |
| `naoConsegui` fora (carrinho) | 3 vermelhos / 4 verdes | medida, e isolada por host |
| `naoConsegui` → `=== 'erro'` | **1 vermelho: só o offline** | o quarto estado tem medição **própria** |
| `desatualizado` fora | **verde → camada NÃO medida** | ver abaixo |
| aviso fora do `ProductItemForm` | 2 vermelhos / 5 verdes | os dois hosts medidos separadamente |

**O achado do exercício:** `desatualizado` sobreviveu à sabotagem — eu tinha escrito uma camada que nenhum teste tocava. Não era redundante, era **inalcançada**: é o único ramo que cobre `status:'success'` + `fetchStatus:'paused'` (dado em cache, refetch pausado sem rede), onde `estadoDeLeitura` diz 'pronta' e `naoConsegui` é false. O 8º caso monta exatamente isso e afirma as **duas** coisas — o aviso aparece **e** a régua continua na tela. Re-sabotada depois: **1 vermelho isolado**.

## A guarda que já existia não cobria nada disto

`CartItemList.priceGuard.test.tsx` mocka `usePrecoCockpit` com `{ data: undefined }` — roda o componente **exatamente no estado de falha** e afirma só o `aria-invalid` do preço. Pior: sem `status`/`fetchStatus` o mock faz o componente escolher ramo **por acidente**, não por desenho. Forma do mock completada.

O teste novo monta os dois hosts com o **hook rodando de verdade** e só o supabase mockado (idioma de `DataHealthBanner.estados.test.tsx`).

## Evidência

- alvo **8/8**, gates **47/47** (fronteiras + manifesto + erro-colapsado + unified-order), `typecheck:app` exit 0, `bun lint` exit 0
- O gate de fronteiras **reprovou** a 1ª versão: `vi.mock('@/hooks/useDefasagemCliente')` criava aresta vendas→farmer-inteligencia. Resolvido removendo o mock (aquele hook só usa `supabase.rpc`, já mockado), não com baseline

## Coordenação

O #2283 é a **fatia #2** do mesmo inventário, em outra sessão (draft). Zero sobreposição de código; só o doc colidia, e esta seção foi movida para região disjunta do arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⚠️ Pendências de PRODUÇÃO detectadas no fecho desta sessão (2026-09-07)

Nenhuma é desta entrega — são de **outras sessões** que mergearam na mesma janela. Ficam aqui porque
chip morre com a sessão que o criou, e este corpo é durável (passo 6 da `/fecho`).

### A) 3 migrations MERGEADAS na main e NÃO aplicadas no banco

Medido via `psql-ro` (query que voltou 0 onde deveria voltar N). Migration custom no Lovable não
se auto-aplica e a falha é **silenciosa**.

| migration | evidência de ausência |
|---|---|
| `20260906170000_reposicao_selo_aprovacao_m1_expandir.sql` | `pedido_compra_sugerido` 0/3 colunas · `pedido_compra_item` 0/2 · função `reposicao_pedido_e_portal` ausente |
| `20260906180000_order_items_identidade_linha.sql` | `order_items.omie_codigo_item` ausente · `reconciliar_pedidos_omie` existe mas o `prosrc` **não cita** a coluna ⇒ é a versão velha |
| `20260906180303_deploy_sonda_resultados.sql` | tabela `deploy_sonda_resultados` e função `..._colher` ausentes |

**Já aplicada, não mexer:** `20260906193522_valor_total_portal_provado.sql` (3/3 colunas + função citando a coluna nova).

Caminho: skill `lovable-db-operator` → bloco de handoff → Lucas cola no SQL Editor → **provar de novo no banco**.

### B) 2 edges servindo bundle VELHO (ledger `deploy_atestacoes`, não suspeita)

| edge | veredito |
|---|---|
| `omie-vendas-sync` | `DIVERGE_P2` — prod `v1.2…, fonte 03ac678b…` ≠ main `v1.2…, fonte 5e3a00e7…` (mesma VERSAO, fonte diferente) |
| `sync-reprocess` | `DIVERGE_P1` — prod `v1.3-preco-ausente-nao-e-zero` ≠ main `v1.4-identidade-de-linha-codigo-item` |

⚠️ **Não sondar antes do deploy** — a pendência já está provada, e re-sondar bundle pré-sensor executa o fluxo real.

### C) O acoplamento entre A e B

`sync-reprocess` v1.4 e a migration `order_items_identidade_linha` são a **mesma entrega**, e as duas
estão pendentes. A ordem importa: edge nova contra schema velho pode gravar em coluna inexistente.
Decidir a ordem antes de agir em qualquer um dos dois.

### D) Desta entrega: falta o Publish

Zero edge, zero migration — só `src/`. Precisa apenas do **Publish** no editor do Lovable. E o
service worker só troca de build quando o cliente recarrega: bytes publicados são disponibilidade,
não adoção.
