### PR TITLE
fix(leitura): "não encontrado" para de ser o que a falha diz — os 6 sítios de fonte VIVA do 3º front

### DIFF
--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -140,14 +140,15 @@ const BASELINE_AFIRMATIVO = new Map<string, number>([
   ["src/components/customer/CustomerVisitsTab.tsx", 1],
   ["src/components/knowledge-base/CompletudeSection.tsx", 1],
   ["src/components/tarefas/ProvasParaAuditar.tsx", 1],
-  ["src/pages/AdminKnowledgeBaseDetail.tsx", 1],
-  ["src/pages/AdminReposicaoPromocaoDetail.tsx", 1],
   ["src/pages/AdminStandardProcessDetail.tsx", 1],
   ["src/pages/GrupoCliente360.tsx", 1],
   ["src/pages/OrderDetail.tsx", 1],
-  ["src/pages/RecebimentoConferencia.tsx", 1],
+  // Resíduo MEDIDO, não fix pela metade: a leitura de `user_tools` já ramifica
+  // (`estadoDeRegistro`), mas o guard é `!tool || !healthMetrics` e `healthMetrics` deriva
+  // de `useToolEvents` — a query IRMÃ, que ainda engole o erro no default `= []` do binding.
+  // `tool_events` é uma das fontes ZERADAS (0 linhas) que a medição de 2026-09-06 separou
+  // para depois; quando ela for tratada, estes dois zeram e saem daqui.
   ["src/pages/ToolHistory.tsx", 1],
-  ["src/pages/ToolPublicHistory.tsx", 1],
   ["src/pages/ToolReports.tsx", 1],
 ]);
 

--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -105,8 +105,6 @@ const BASELINE = new Map<string, number>([
   ["src/pages/GovernancePermissions.tsx", 1],
   ["src/pages/RotaPropostas.tsx", 1],
   ["src/pages/SalesPrintDashboard.tsx", 6],
-  ["src/pages/ToolHistory.tsx", 1],
-  ["src/pages/ToolReports.tsx", 1],
   ["src/pages/Training.tsx", 2],
 ]);
 

--- a/src/lib/__tests__/estado-de-leitura.test.ts
+++ b/src/lib/__tests__/estado-de-leitura.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { estadoDeLeitura, naoConsegui, desatualizado, type EstadoLeitura, type FatiaDeQuery } from '../leitura/estado-de-leitura';
+import {
+  estadoDeLeitura,
+  naoConsegui,
+  desatualizado,
+  estadoDeRegistro,
+  ehNaoEncontrado,
+  PGRST_NENHUMA_LINHA,
+  type EstadoLeitura,
+  type FatiaDeQuery,
+} from '../leitura/estado-de-leitura';
 
 /**
  * O mapeamento (status × fetchStatus) → estado é EXAUSTIVO de propósito: estado sem nome
@@ -82,5 +91,117 @@ describe('desatualizado — dado em mãos + leitura falha = mostre os DOIS', () 
   it('leitura boa não inventa aviso', () => {
     expect(desatualizado({ status: 'success', fetchStatus: 'idle' }, true)).toBeNull();
     expect(desatualizado({ status: 'success', fetchStatus: 'fetching' }, true)).toBeNull();
+  });
+});
+
+/**
+ * ── LEITURA DE UM REGISTRO POR ID — os dois terminadores, dois mecanismos ─────────────
+ *
+ * `estadoDeLeitura` responde "a leitura aconteceu?". Não responde "esta linha existe?",
+ * e é essa segunda pergunta que as telas de detalhe respondem ERRADO: `if (!registro)`
+ * → "não encontrado" cobre também "o banco caiu" (achado 3 de
+ * docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * O eixo que separa as duas NÃO é o mesmo nos dois terminadores do PostgREST, e é por isso
+ * que um fix só não serve aos dois:
+ *
+ *   `.maybeSingle()` → a distinção EXISTE no dado: sucesso com `data === null` é
+ *                      "não existe"; `undefined` só sai de loading ou erro. O componente
+ *                      que escreve `if (!x)` DESCARTA o que o hook preservou.
+ *   `.single()`      → a distinção NÃO existe sem ler o erro: 0 linhas LANÇA PGRST116,
+ *                      e chega ao componente idêntico a uma queda de rede.
+ *
+ * Os dois casos abaixo são enumerados separados de propósito: uma implementação que
+ * cubra só o `data === null` passa no primeiro bloco e reprova no segundo.
+ */
+describe('ehNaoEncontrado — só o código do PostgREST para "0 linhas" conta', () => {
+  it('PGRST116 (o `.single()` que não achou a linha) é não-encontrado', () => {
+    expect(ehNaoEncontrado({ code: PGRST_NENHUMA_LINHA })).toBe(true);
+    expect(PGRST_NENHUMA_LINHA).toBe('PGRST116');
+  });
+
+  it('outro erro do PostgREST NÃO é não-encontrado — inclusive os plausíveis', () => {
+    // PGRST301 = JWT expirado; 42501 = permissão negada por RLS. Ambos são falha de
+    // leitura com cara de "sumiu", e é exatamente aí que a tela mentiria.
+    expect(ehNaoEncontrado({ code: 'PGRST301' })).toBe(false);
+    expect(ehNaoEncontrado({ code: '42501' })).toBe(false);
+  });
+
+  it('erro de rede (Error sem `code`) NÃO é não-encontrado', () => {
+    expect(ehNaoEncontrado(new Error('Failed to fetch'))).toBe(false);
+  });
+
+  it('ausência de erro não é não-encontrado', () => {
+    expect(ehNaoEncontrado(null)).toBe(false);
+    expect(ehNaoEncontrado(undefined)).toBe(false);
+  });
+
+  it('a string solta não passa por erro — o eixo é `error.code`, não o texto', () => {
+    // Um `includes('PGRST116')` sobre a mensagem passaria aqui e casaria também a
+    // mensagem de UM erro embrulhado por outro. O contrato é o campo.
+    expect(ehNaoEncontrado('PGRST116')).toBe(false);
+    expect(ehNaoEncontrado(new Error('PGRST116: no rows'))).toBe(false);
+  });
+});
+
+describe('estadoDeRegistro — `.maybeSingle()`: a distinção vem do DADO', () => {
+  const ok = { status: 'success', fetchStatus: 'idle' } as const;
+
+  it('respondeu e veio linha → pronta', () => {
+    expect(estadoDeRegistro({ ...ok, error: null }, true)).toBe('pronta');
+  });
+
+  it('respondeu e veio null → inexistente (o hook sabia; o componente jogava fora)', () => {
+    expect(estadoDeRegistro({ ...ok, error: null }, false)).toBe('inexistente');
+  });
+
+  it('LANÇOU sem registro → erro, NUNCA inexistente', () => {
+    expect(estadoDeRegistro({ status: 'error', fetchStatus: 'idle', error: new Error('boom') }, false)).toBe('erro');
+  });
+});
+
+describe('estadoDeRegistro — `.single()`: a distinção vem do CÓDIGO DO ERRO', () => {
+  it('PGRST116 → inexistente (0 linhas, não falha)', () => {
+    expect(
+      estadoDeRegistro({ status: 'error', fetchStatus: 'idle', error: { code: PGRST_NENHUMA_LINHA } }, false),
+    ).toBe('inexistente');
+  });
+
+  it('qualquer outro erro → erro, mesmo sem registro em mãos', () => {
+    expect(
+      estadoDeRegistro({ status: 'error', fetchStatus: 'idle', error: { code: 'PGRST301' } }, false),
+    ).toBe('erro');
+  });
+});
+
+describe('estadoDeRegistro — o 4º estado (offline) NÃO pode virar "inexistente"', () => {
+  it('pending + paused → sem-rede, mesmo sem registro em mãos', () => {
+    // `networkMode:'online'` sem rede: `isLoading` é FALSE e `data` é `undefined`. Quem
+    // ramifica só por `isLoading`/`error` cai no ramo do "não encontrado" — o offline é o
+    // estado que engana quem "já trata erro" (#1874).
+    expect(estadoDeRegistro({ status: 'pending', fetchStatus: 'paused', error: null }, false)).toBe('sem-rede');
+  });
+
+  it('pending + fetching → carregando · pending + idle → desabilitada', () => {
+    expect(estadoDeRegistro({ status: 'pending', fetchStatus: 'fetching', error: null }, false)).toBe('carregando');
+    expect(estadoDeRegistro({ status: 'pending', fetchStatus: 'idle', error: null }, false)).toBe('desabilitada');
+  });
+
+  it('nenhum estado de pendência consulta `temRegistro` — não há dado para consultar', () => {
+    for (const fetchStatus of ['fetching', 'paused', 'idle'] as const) {
+      const q = { status: 'pending', fetchStatus, error: null } as const;
+      expect(estadoDeRegistro(q, false)).toBe(estadoDeRegistro(q, true));
+    }
+  });
+});
+
+describe('naoConsegui — "inexistente" é resposta, não falha', () => {
+  it('não aciona o aviso de leitura falhada', () => {
+    expect(naoConsegui('inexistente')).toBe(false);
+  });
+
+  it('erro e sem-rede continuam acionando', () => {
+    expect(naoConsegui('erro')).toBe(true);
+    expect(naoConsegui('sem-rede')).toBe(true);
   });
 });

--- a/src/lib/leitura/estado-de-leitura.ts
+++ b/src/lib/leitura/estado-de-leitura.ts
@@ -65,8 +65,74 @@ export function estadoDeLeitura(q: FatiaDeQuery): EstadoLeitura {
  * a re-afirmar o tipo na unha — e um `as` reintroduziria, por cast, exatamente a confusão
  * de estados que este módulo existe para impedir.
  */
-export function naoConsegui(e: EstadoLeitura): e is EstadoSemLeitura {
+export function naoConsegui(e: EstadoDeRegistro): e is EstadoSemLeitura {
   return e === 'erro' || e === 'sem-rede';
+}
+
+// ─── LEITURA DE UM REGISTRO POR ID ──────────────────────────────────────────────────
+//
+// `estadoDeLeitura` responde "a leitura aconteceu?". Uma tela de DETALHE precisa de uma
+// segunda resposta — "esta linha existe?" — e é ela que o front do `return` afirmativo
+// erra: `if (!registro) return <p>não encontrado</p>` cobre também "o banco caiu"
+// (docs/historico/o-check-verde-que-a-falha-acende.md, achado 3). O usuário sai procurar
+// um documento que existe.
+//
+// O eixo que separa as duas NÃO é o mesmo nos dois terminadores do PostgREST, e é por isso
+// que um fix só não serve aos dois:
+//
+//   `.maybeSingle()` → a distinção EXISTE no dado. Em SUCESSO, `null` é "não existe";
+//                      `undefined` só sai de loading ou erro. O componente que escreve
+//                      `if (!x)` DESCARTA o que o hook preservou.
+//   `.single()`      → a distinção NÃO existe sem ler o erro: 0 linhas LANÇA, e chega
+//                      idêntico a uma queda de rede.
+
+/**
+ * O código que o PostgREST devolve quando não pôde coagir o resultado a UM objeto.
+ *
+ * ⚠️ RESTRIÇÃO DE USO: `PGRST116` é "não deu UMA linha" — 0 linhas **ou mais de uma**
+ * (o comentário de `useKbProductSpecs.ts` documenta o caso >1 no repo). Tratá-lo como
+ * "não existe" só é correto quando o filtro é por CHAVE ÚNICA, onde >1 é impossível;
+ * sobre filtro não-único ele também significa "há linhas demais", que é defeito de dado
+ * — e aí "não encontrado" volta a mentir, só que na direção oposta.
+ */
+export const PGRST_NENHUMA_LINHA = 'PGRST116';
+
+/**
+ * O erro que chegou é "não achei a linha"? Casa o CAMPO `code`, nunca o texto.
+ *
+ * Casar a mensagem (`includes('PGRST116')`) casaria também um erro EMBRULHADO por outro,
+ * e a mensagem é do servidor: muda sem aviso.
+ */
+export function ehNaoEncontrado(erro: unknown): boolean {
+  return (
+    typeof erro === 'object' &&
+    erro !== null &&
+    (erro as { code?: unknown }).code === PGRST_NENHUMA_LINHA
+  );
+}
+
+/** `EstadoLeitura` mais o único estado que só uma leitura POR ID tem: a linha não existe. */
+export type EstadoDeRegistro = EstadoLeitura | 'inexistente';
+
+/**
+ * Os 6 estados de uma leitura de UM registro — com "não existe" separado de "não consegui".
+ *
+ * `temRegistro` só é consultado quando a query RESPONDEU: nos estados de pendência não há
+ * dado para consultar, e é justamente aí que mora o offline (`pending` + `paused`, com
+ * `isLoading` FALSE e `data` `undefined`) que faz o `if (!registro)` mentir sem que erro
+ * nenhum tenha acontecido.
+ *
+ * Serve aos dois terminadores porque lê os DOIS eixos: o dado em mãos e o código do erro.
+ * Quem passar só o primeiro (`.single()` sem `error`) recebe `'erro'` no não-achado — que
+ * é conservador e honesto, nunca "inexistente" fabricado.
+ */
+export function estadoDeRegistro(
+  q: FatiaDeQuery & { error?: unknown },
+  temRegistro: boolean,
+): EstadoDeRegistro {
+  if (q.status === 'error') return ehNaoEncontrado(q.error) ? 'inexistente' : 'erro';
+  if (q.status === 'success') return temRegistro ? 'pronta' : 'inexistente';
+  return estadoDeLeitura(q);
 }
 
 /**

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -58,7 +58,10 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/useGamificationScore.ts",
       "src/hooks/useSharpeningSuggestions.ts",
     ],
-    testes: ["src/pages/__tests__/CentralFerramenta.test.tsx"],
+    testes: [
+      "src/pages/__tests__/CentralFerramenta.test.tsx",
+      "src/pages/__tests__/ToolDetalhe.estados.test.tsx",
+    ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },
   {
@@ -439,7 +442,10 @@ export const MODULOS: ModuloApp[] = [
       "src/queries/usePedidosASeparar.ts",
       "src/hooks/useEstoqueValor.ts",
     ],
-    testes: ["src/services/__tests__/picking-confirm.test.ts"],
+    testes: [
+      "src/services/__tests__/picking-confirm.test.ts",
+      "src/pages/__tests__/RecebimentoConferencia.estados.test.tsx",
+    ],
     risco: { moneyPath: true, offlineFirst: true, authSensitive: false },
   },
   {
@@ -468,6 +474,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useReposicaoSessao.test.ts",
       "src/pages/__tests__/AdminReposicaoPromocaoDetail.test.tsx",
       "src/pages/__tests__/AdminReposicaoPedidos.alertas-erro-honesto.test.tsx",
+      "src/pages/__tests__/AdminReposicaoPromocaoDetail.estados.test.tsx",
     ],
     risco: { moneyPath: true, offlineFirst: false, authSensitive: false },
   },
@@ -562,6 +569,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/hooks/__tests__/useExtractSpecs.test.tsx",
       "src/hooks/__tests__/useKnowledgeBaseList.test.tsx",
+      "src/pages/__tests__/AdminKnowledgeBaseDetail.estados.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -24,7 +24,7 @@ import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 export default function AdminKnowledgeBaseDetail() {
   const { id } = useParams<{ id: string }>();
 
-  const qDoc = useQuery({
+  const { data, isLoading, status, fetchStatus, error } = useQuery({
     queryKey: ['kb-document', id],
     enabled: !!id,
     queryFn: async (): Promise<KbDocument | null> => {
@@ -38,10 +38,12 @@ export default function AdminKnowledgeBaseDetail() {
     // polling enquanto processa
     refetchInterval: (q) => (q.state.data?.status === 'processing' ? 3000 : false),
   });
-  const { data, isLoading } = qDoc;
+  // `status`/`error` são nomeados na própria desestruturação de propósito: guardar a query
+  // num `const q = useQuery(…)` tiraria o sítio do gate da classe por CEGUEIRA (ele só
+  // rastreia `const {…} = useX(…)`), não por conserto.
   // `.single()` LANÇA quando não acha (PGRST116), e isso chegava aqui idêntico a uma queda
   // de rede — a distinção só existe lendo o CÓDIGO do erro.
-  const estadoDoc = estadoDeRegistro(qDoc, data != null);
+  const estadoDoc = estadoDeRegistro({ status, fetchStatus, error }, data != null);
 
   const { data: chunkCount } = useQuery({
     queryKey: ['kb-chunks-count', id],

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -18,11 +18,13 @@ import { SpecLinkPanel } from '@/components/knowledge-base/SpecLinkPanel';
 import { CatalisadorLinkPanel } from '@/components/knowledge-base/CatalisadorLinkPanel';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 export default function AdminKnowledgeBaseDetail() {
   const { id } = useParams<{ id: string }>();
 
-  const { data, isLoading } = useQuery({
+  const qDoc = useQuery({
     queryKey: ['kb-document', id],
     enabled: !!id,
     queryFn: async (): Promise<KbDocument | null> => {
@@ -36,6 +38,10 @@ export default function AdminKnowledgeBaseDetail() {
     // polling enquanto processa
     refetchInterval: (q) => (q.state.data?.status === 'processing' ? 3000 : false),
   });
+  const { data, isLoading } = qDoc;
+  // `.single()` LANÇA quando não acha (PGRST116), e isso chegava aqui idêntico a uma queda
+  // de rede — a distinção só existe lendo o CÓDIGO do erro.
+  const estadoDoc = estadoDeRegistro(qDoc, data != null);
 
   const { data: chunkCount } = useQuery({
     queryKey: ['kb-chunks-count', id],
@@ -47,6 +53,16 @@ export default function AdminKnowledgeBaseDetail() {
       return count ?? 0;
     },
   });
+
+  // ANTES do loading: sem rede a query fica pending+paused, `isLoading` é FALSE, e a tela
+  // caía direto no "não encontrado".
+  if (naoConsegui(estadoDoc)) {
+    return (
+      <div className="container mx-auto p-4">
+        <AvisoLeituraFalhou oque="este documento da base de conhecimento" estado={estadoDoc} variante="bloco" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/AdminReposicaoPromocaoDetail.tsx
+++ b/src/pages/AdminReposicaoPromocaoDetail.tsx
@@ -4,6 +4,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "sonner";
+import { estadoDeRegistro, naoConsegui } from "@/lib/leitura/estado-de-leitura";
+import { AvisoLeituraFalhou } from "@/components/leitura/AvisoLeituraFalhou";
 import { Loader2, ChevronRight } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -38,7 +40,7 @@ export default function AdminReposicaoPromocaoDetail() {
     | "negociacao_cliente";
 
   // ============ QUERIES ============
-  const { data: campanha, isLoading: loadingCampanha } = useQuery({
+  const qCampanha = useQuery({
     queryKey: ["promocao-campanha", id],
     queryFn: async () => {
       if (isNew) return null;
@@ -52,6 +54,10 @@ export default function AdminReposicaoPromocaoDetail() {
     },
     enabled: !isNew,
   });
+  const { data: campanha, isLoading: loadingCampanha } = qCampanha;
+  // `.single()` LANÇA PGRST116 quando não acha, e isso chegava idêntico a uma queda de rede.
+  // O `!isNew` do guard antigo só protegia o modo de CRIAÇÃO: em edição a frase mentia.
+  const estadoCampanha = estadoDeRegistro(qCampanha, campanha != null);
 
   const { data: itens = [], isLoading: loadingItens } = useQuery({
     queryKey: ["promocao-itens", id],
@@ -388,6 +394,16 @@ export default function AdminReposicaoPromocaoDetail() {
 
   // ============ CANCEL DIALOG ============
   const [cancelOpen, setCancelOpen] = useState(false);
+
+  // ANTES do loading: sem rede a query fica pending+paused e `loadingCampanha` é FALSE.
+  // (No modo criação a query é `enabled: false` → estado 'desabilitada', que não avisa.)
+  if (!isNew && naoConsegui(estadoCampanha)) {
+    return (
+      <div className="container mx-auto p-6">
+        <AvisoLeituraFalhou oque="esta campanha de promoção" estado={estadoCampanha} variante="bloco" />
+      </div>
+    );
+  }
 
   if (loadingCampanha && !isNew) {
     return (

--- a/src/pages/AdminReposicaoPromocaoDetail.tsx
+++ b/src/pages/AdminReposicaoPromocaoDetail.tsx
@@ -40,7 +40,7 @@ export default function AdminReposicaoPromocaoDetail() {
     | "negociacao_cliente";
 
   // ============ QUERIES ============
-  const qCampanha = useQuery({
+  const { data: campanha, isLoading: loadingCampanha, status: statusCampanha, fetchStatus: fetchCampanha, error: erroCampanha } = useQuery({
     queryKey: ["promocao-campanha", id],
     queryFn: async () => {
       if (isNew) return null;
@@ -54,10 +54,11 @@ export default function AdminReposicaoPromocaoDetail() {
     },
     enabled: !isNew,
   });
-  const { data: campanha, isLoading: loadingCampanha } = qCampanha;
+  // `status`/`error` nomeados na desestruturação: um `const q = useQuery(…)` tiraria o sítio
+  // do gate da classe por CEGUEIRA, não por conserto.
   // `.single()` LANÇA PGRST116 quando não acha, e isso chegava idêntico a uma queda de rede.
   // O `!isNew` do guard antigo só protegia o modo de CRIAÇÃO: em edição a frase mentia.
-  const estadoCampanha = estadoDeRegistro(qCampanha, campanha != null);
+  const estadoCampanha = estadoDeRegistro({ status: statusCampanha, fetchStatus: fetchCampanha, error: erroCampanha }, campanha != null);
 
   const { data: itens = [], isLoading: loadingItens } = useQuery({
     queryKey: ["promocao-itens", id],

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -129,7 +129,7 @@ export default function RecebimentoConferencia() {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
 
   // Fetch NF-e
-  const qNfe = useQuery({
+  const { data: nfe, isLoading, status: statusNfe, fetchStatus: fetchNfe, error: erroNfe } = useQuery({
     queryKey: ['nfe_conferencia', id],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -146,11 +146,12 @@ export default function RecebimentoConferencia() {
     },
     enabled: !!id,
   });
-  const { data: nfe, isLoading } = qNfe;
+  // `status`/`error` nomeados na desestruturação: um `const q = useQuery(…)` tiraria o sítio
+  // do gate da classe por CEGUEIRA, não por conserto.
   // `.single()` LANÇA PGRST116 quando não acha a NF-e, e isso chegava aqui idêntico a uma
   // queda de rede. Conferência é passo de RECEBIMENTO: "NF-e não encontrada" durante uma
   // falha manda o operador procurar um documento que EXISTE.
-  const estadoNfe = estadoDeRegistro(qNfe, nfe != null);
+  const estadoNfe = estadoDeRegistro({ status: statusNfe, fetchStatus: fetchNfe, error: erroNfe }, nfe != null);
 
   // Fetch scanned lotes grouped
   const { data: lotes } = useQuery<NfeLoteEscaneado[]>({

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -30,6 +30,8 @@ import { reportDivergencia, type ReportDivergenciaVars } from '@/services/recebi
 import { addCte, type AddCteVars } from '@/services/recebimento-cte';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 import { interpretarRespostaEfetivacao } from '@/lib/recebimento/efetivacao-resposta';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 type ItemStatus = 'pendente' | 'em_conferencia' | 'conferido' | 'divergencia';
 
@@ -127,7 +129,7 @@ export default function RecebimentoConferencia() {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
 
   // Fetch NF-e
-  const { data: nfe, isLoading } = useQuery({
+  const qNfe = useQuery({
     queryKey: ['nfe_conferencia', id],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -144,6 +146,11 @@ export default function RecebimentoConferencia() {
     },
     enabled: !!id,
   });
+  const { data: nfe, isLoading } = qNfe;
+  // `.single()` LANÇA PGRST116 quando não acha a NF-e, e isso chegava aqui idêntico a uma
+  // queda de rede. Conferência é passo de RECEBIMENTO: "NF-e não encontrada" durante uma
+  // falha manda o operador procurar um documento que EXISTE.
+  const estadoNfe = estadoDeRegistro(qNfe, nfe != null);
 
   // Fetch scanned lotes grouped
   const { data: lotes } = useQuery<NfeLoteEscaneado[]>({
@@ -455,6 +462,16 @@ export default function RecebimentoConferencia() {
       return next;
     });
   };
+
+  // ANTES do loading: no PWA de campo sem rede a query fica pending+paused, `isLoading` é
+  // FALSE, e a tela caía direto no "NF-e não encontrada".
+  if (naoConsegui(estadoNfe)) {
+    return (
+      <div className="max-w-lg mx-auto py-20 px-4">
+        <AvisoLeituraFalhou oque="esta NF-e" estado={estadoNfe} variante="bloco" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     // PageSkeleton (não Loader2 full-page): o Suspense da rota já mostrou um

--- a/src/pages/ToolHistory.tsx
+++ b/src/pages/ToolHistory.tsx
@@ -103,13 +103,18 @@ const ToolHistory = () => {
   const [showQR, setShowQR] = useState(false);
   const qrRef = useRef<HTMLDivElement>(null);
 
-  const qTool = useUserToolDetail(toolId);
-  const { data: tool } = qTool;
+  // A desestruturação fica DIRETA sobre o hook e nomeia `status`/`error` de propósito:
+  // guardar a query num `const q = useX()` faria o sítio SUMIR do gate da classe por
+  // CEGUEIRA (ele só rastreia `const {…} = useX(…)`), não por conserto — e o gate não
+  // distingue os dois. Com as chaves de erro nomeadas, ele vê o tratamento e segue vigiando
+  // este arquivo.
+  const { data: tool, status: statusTool, fetchStatus: fetchTool, error: erroTool, isPending: loadingTool } =
+    useUserToolDetail(toolId);
   const { data: eventsAsc = [], isPending: loadingEvents } = useToolEvents(toolId);
-  const loading = qTool.isPending || loadingEvents;
+  const loading = loadingTool || loadingEvents;
   // `.maybeSingle()` devolve `null` para "esta ferramenta não existe" e `undefined` só em
   // loading/erro — a diferença que o `if (!tool)` abaixo apagava.
-  const estadoTool = estadoDeRegistro(qTool, tool != null);
+  const estadoTool = estadoDeRegistro({ status: statusTool, fetchStatus: fetchTool, error: erroTool }, tool != null);
   // O hook devolve asc (cache compartilhado com ToolReports); a timeline mostra o mais recente primeiro.
   const events = useMemo(() => [...eventsAsc].reverse(), [eventsAsc]);
 

--- a/src/pages/ToolHistory.tsx
+++ b/src/pages/ToolHistory.tsx
@@ -17,6 +17,8 @@ import { ptBR } from 'date-fns/locale';
 import { QRCodeSVG } from 'qrcode.react';
 import { cn } from '@/lib/utils';
 import { escapeHtml } from '@/lib/escape-html';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 /* ─── Criticality (shared logic with Tools.tsx) ─── */
 
@@ -101,9 +103,13 @@ const ToolHistory = () => {
   const [showQR, setShowQR] = useState(false);
   const qrRef = useRef<HTMLDivElement>(null);
 
-  const { data: tool, isPending: loadingTool } = useUserToolDetail(toolId);
+  const qTool = useUserToolDetail(toolId);
+  const { data: tool } = qTool;
   const { data: eventsAsc = [], isPending: loadingEvents } = useToolEvents(toolId);
-  const loading = loadingTool || loadingEvents;
+  const loading = qTool.isPending || loadingEvents;
+  // `.maybeSingle()` devolve `null` para "esta ferramenta não existe" e `undefined` só em
+  // loading/erro — a diferença que o `if (!tool)` abaixo apagava.
+  const estadoTool = estadoDeRegistro(qTool, tool != null);
   // O hook devolve asc (cache compartilhado com ToolReports); a timeline mostra o mais recente primeiro.
   const events = useMemo(() => [...eventsAsc].reverse(), [eventsAsc]);
 
@@ -159,6 +165,18 @@ const ToolHistory = () => {
 
     return { criticality, avgInterval, daysSinceLast, accumulatedCost, recommendation, intervalDays };
   }, [tool, sharpeningEvents]);
+
+  // ANTES do loading de propósito: sem rede a query fica pending+paused, e o skeleton
+  // ficaria girando para sempre sobre uma leitura que não vai acontecer.
+  if (naoConsegui(estadoTool)) {
+    return (
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <AvisoLeituraFalhou oque="o histórico desta ferramenta" estado={estadoTool} variante="bloco" />
+        </main>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/src/pages/ToolPublicHistory.tsx
+++ b/src/pages/ToolPublicHistory.tsx
@@ -23,13 +23,14 @@ const EVENT_ICONS: Record<string, { label: string; icon: typeof Wrench; color: s
 
 const ToolPublicHistory = () => {
   const { toolId } = useParams<{ toolId: string }>();
-  const q = useToolPublicHistory(toolId);
-  const { data, isPending: loading } = q;
+  // Desestruturação DIRETA nomeando `status`/`error`: um `const q = useX()` tiraria o sítio
+  // do gate da classe por CEGUEIRA, não por conserto (o detector só rastreia `const {…} = useX(…)`).
+  const { data, status, fetchStatus, error, isPending: loading } = useToolPublicHistory(toolId);
   const tool = data?.tool ?? null;
   const events = data?.events ?? [];
   // O `?? null` acima colapsa "a RPC respondeu que não existe" com "a RPC não respondeu";
   // o estado abaixo é lido da QUERY, que ainda sabe a diferença.
-  const estado = estadoDeRegistro(q, data?.tool != null);
+  const estado = estadoDeRegistro({ status, fetchStatus, error }, data?.tool != null);
 
   // ANTES do loading: sem rede a query fica pending+paused e o skeleton giraria para sempre.
   if (naoConsegui(estado)) {

--- a/src/pages/ToolPublicHistory.tsx
+++ b/src/pages/ToolPublicHistory.tsx
@@ -10,6 +10,8 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 const EVENT_ICONS: Record<string, { label: string; icon: typeof Wrench; color: string; bg: string }> = {
   sharpening: { label: 'Afiação', icon: Wrench, color: 'text-status-info', bg: 'bg-status-info-bg' },
@@ -21,9 +23,24 @@ const EVENT_ICONS: Record<string, { label: string; icon: typeof Wrench; color: s
 
 const ToolPublicHistory = () => {
   const { toolId } = useParams<{ toolId: string }>();
-  const { data, isPending: loading } = useToolPublicHistory(toolId);
+  const q = useToolPublicHistory(toolId);
+  const { data, isPending: loading } = q;
   const tool = data?.tool ?? null;
   const events = data?.events ?? [];
+  // O `?? null` acima colapsa "a RPC respondeu que não existe" com "a RPC não respondeu";
+  // o estado abaixo é lido da QUERY, que ainda sabe a diferença.
+  const estado = estadoDeRegistro(q, data?.tool != null);
+
+  // ANTES do loading: sem rede a query fica pending+paused e o skeleton giraria para sempre.
+  if (naoConsegui(estado)) {
+    return (
+      <div className="min-h-screen bg-background">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <AvisoLeituraFalhou oque="o histórico desta ferramenta" estado={estado} variante="bloco" />
+        </main>
+      </div>
+    );
+  }
 
   if (loading) {
     return (
@@ -40,6 +57,9 @@ const ToolPublicHistory = () => {
       <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
         <Wrench className="w-16 h-16 text-muted-foreground mb-4" />
         <h1 className="text-xl font-bold text-foreground">Ferramenta não encontrada</h1>
+        {/* A hipótese do QR só é dita aqui: neste ramo a RPC RESPONDEU que a ferramenta não
+            existe. Antes ela também cobria falha de leitura, e mandava o cliente com a
+            etiqueta na mão jogá-la fora por causa de um timeout. */}
         <p className="text-muted-foreground mt-2">O QR code pode estar desatualizado</p>
       </div>
     );

--- a/src/pages/ToolReports.tsx
+++ b/src/pages/ToolReports.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useUserToolDetail, useToolEvents, useToolPriceHistory } from '@/queries/useUserTools';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import {
   Wrench, DollarSign, TrendingUp,
   BarChart3, Clock, AlertTriangle, ShieldCheck, HelpCircle,
@@ -79,10 +81,14 @@ const ToolReports = () => {
   const { toolId } = useParams<{ toolId: string }>();
   const navigate = useNavigate();
 
-  const { data: tool, isPending: loadingTool } = useUserToolDetail(toolId);
+  const qTool = useUserToolDetail(toolId);
+  const { data: tool } = qTool;
   const { data: events = [], isPending: loadingEvents } = useToolEvents(toolId);
   const { data: priceHistory = [], isPending: loadingPrices } = useToolPriceHistory(toolId);
-  const loading = loadingTool || loadingEvents || loadingPrices;
+  const loading = qTool.isPending || loadingEvents || loadingPrices;
+  // `.maybeSingle()`: `null` é "não existe", `undefined` é loading/erro — o `if (!tool)`
+  // de baixo apagava a diferença que o hook preservou.
+  const estadoTool = estadoDeRegistro(qTool, tool != null);
 
   const analysis = useMemo(() => {
     if (!tool) return null;
@@ -142,6 +148,18 @@ const ToolReports = () => {
       cumulativeChart,
     };
   }, [tool, events, priceHistory]);
+
+  // ANTES do loading de propósito: sem rede a query fica pending+paused e o skeleton
+  // giraria para sempre sobre uma leitura que não vai acontecer.
+  if (naoConsegui(estadoTool)) {
+    return (
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <AvisoLeituraFalhou oque="os relatórios desta ferramenta" estado={estadoTool} variante="bloco" />
+        </main>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/src/pages/ToolReports.tsx
+++ b/src/pages/ToolReports.tsx
@@ -81,14 +81,16 @@ const ToolReports = () => {
   const { toolId } = useParams<{ toolId: string }>();
   const navigate = useNavigate();
 
-  const qTool = useUserToolDetail(toolId);
-  const { data: tool } = qTool;
+  // Desestruturação DIRETA nomeando `status`/`error`: um `const q = useX()` tiraria o sítio
+  // do gate da classe por CEGUEIRA, não por conserto (o detector só rastreia `const {…} = useX(…)`).
+  const { data: tool, status: statusTool, fetchStatus: fetchTool, error: erroTool, isPending: loadingTool } =
+    useUserToolDetail(toolId);
   const { data: events = [], isPending: loadingEvents } = useToolEvents(toolId);
   const { data: priceHistory = [], isPending: loadingPrices } = useToolPriceHistory(toolId);
-  const loading = qTool.isPending || loadingEvents || loadingPrices;
+  const loading = loadingTool || loadingEvents || loadingPrices;
   // `.maybeSingle()`: `null` é "não existe", `undefined` é loading/erro — o `if (!tool)`
   // de baixo apagava a diferença que o hook preservou.
-  const estadoTool = estadoDeRegistro(qTool, tool != null);
+  const estadoTool = estadoDeRegistro({ status: statusTool, fetchStatus: fetchTool, error: erroTool }, tool != null);
 
   const analysis = useMemo(() => {
     if (!tool) return null;

--- a/src/pages/__tests__/AdminKnowledgeBaseDetail.estados.test.tsx
+++ b/src/pages/__tests__/AdminKnowledgeBaseDetail.estados.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard da ficha da BASE DE CONHECIMENTO — 297 documentos vivos, 3 pessoas com acesso.
+ *
+ * Lia `kb_documents` com `.single()` e escrevia `if (!data) return "Documento não
+ * encontrado"`. Com `.single()`, 0 linhas LANÇA PGRST116 e chega ao componente idêntico
+ * a uma falha de leitura (achado 3 de docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * O HOOK roda de verdade; só o `supabase` é mockado.
+ */
+
+const DOC_ID = 'doc-1';
+const NAO_ENCONTRADO = /Documento não encontrado/i;
+
+type Resposta = { data: unknown; error: unknown; count?: number };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(tabela: string) {
+  const resolver = () => Promise.resolve(respostas[tabela] ?? { data: [], error: null, count: 0 });
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    order: () => resolver(),
+    limit: () => resolver(),
+    maybeSingle: () => resolver(),
+    single: () => resolver(),
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => encadear(t), rpc: () => Promise.resolve({ data: null, error: null }) },
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' }, isMaster: true, isStaff: true, loading: false }),
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: 'u1' }),
+}));
+
+import AdminKnowledgeBaseDetail from '../AdminKnowledgeBaseDetail';
+
+const DOCUMENTO = {
+  id: DOC_ID,
+  title: 'Boletim Sayerlack XPTO',
+  type: 'boletim',
+  status: 'aprovado',
+  supplier: 'Sayerlack',
+  product_code: null,
+  tags: [],
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/kb/${DOC_ID}`]}>
+        <Routes>
+          <Route path="/kb/:id" element={<AdminKnowledgeBaseDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('AdminKnowledgeBaseDetail — "não encontrado" só quando o documento não existe', () => {
+  it('PGRST116 (0 linhas no `.single()`) → "Documento não encontrado", sem aviso', async () => {
+    respostas = { kb_documents: { data: null, error: { code: 'PGRST116', message: 'no rows' } } };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADO)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso de falha, e NUNCA "Documento não encontrado"', async () => {
+    respostas = { kb_documents: { data: null, error: { code: '42501', message: 'permission denied' } } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused) → aviso de sem-rede, e NUNCA "Documento não encontrado"', async () => {
+    respostas = { kb_documents: { data: DOCUMENTO, error: null } };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+
+  it('o documento EXISTE → a ficha abre, sem aviso nem não-achado', async () => {
+    respostas = { kb_documents: { data: DOCUMENTO, error: null } };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(/Boletim Sayerlack XPTO/)).toBeInTheDocument());
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+});

--- a/src/pages/__tests__/AdminReposicaoPromocaoDetail.estados.test.tsx
+++ b/src/pages/__tests__/AdminReposicaoPromocaoDetail.estados.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard da campanha de PROMOÇÃO — `.single()` sobre `promocao_campanha`.
+ *
+ * O guard era `if (!isNew && !campanha) return "Campanha não encontrada."`. O `!isNew` só
+ * protege o MODO DE CRIAÇÃO: no modo edição a frase segue mentindo quando a leitura falha
+ * (achado 4 de docs/historico/o-check-verde-que-a-falha-acende.md — este é um dos dois
+ * "falsos positivos" que a medição foi conferir e derrubou).
+ *
+ * O HOOK roda de verdade; só o `supabase` é mockado.
+ */
+
+const CAMPANHA_ID = '7';
+const NAO_ENCONTRADA = /Campanha não encontrada/i;
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(tabela: string) {
+  const resolver = () => Promise.resolve(respostas[tabela] ?? { data: [], error: null });
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    order: () => resolver(),
+    limit: () => resolver(),
+    maybeSingle: () => resolver(),
+    single: () => resolver(),
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => encadear(t), rpc: () => Promise.resolve({ data: null, error: null }) },
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', email: 'lucas@colacor.com.br' }, isMaster: true, isStaff: true, loading: false }),
+}));
+
+import AdminReposicaoPromocaoDetail from '../AdminReposicaoPromocaoDetail';
+
+const CAMPANHA = {
+  id: 7,
+  nome: 'Campanha Sayerlack Outubro',
+  tipo_origem: 'fornecedor_impoe',
+  estado: 'rascunho',
+  fornecedor: 'Sayerlack',
+};
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/promocao/${CAMPANHA_ID}`]}>
+        <Routes>
+          <Route path="/promocao/:id" element={<AdminReposicaoPromocaoDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('AdminReposicaoPromocaoDetail — "não encontrada" só quando a campanha não existe', () => {
+  it('PGRST116 (0 linhas no `.single()`) → "Campanha não encontrada.", sem aviso', async () => {
+    respostas = { promocao_campanha: { data: null, error: { code: 'PGRST116', message: 'no rows' } } };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADA)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso de falha, e NUNCA "Campanha não encontrada"', async () => {
+    respostas = { promocao_campanha: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused) → aviso de sem-rede, e NUNCA "não encontrada"', async () => {
+    respostas = { promocao_campanha: { data: CAMPANHA, error: null } };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+  });
+
+  it('a campanha EXISTE → a tela abre, sem aviso nem não-achado', async () => {
+    respostas = { promocao_campanha: { data: CAMPANHA, error: null } };
+    renderizar();
+    await waitFor(() => expect(screen.getAllByText(/Campanha Sayerlack Outubro/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+});

--- a/src/pages/__tests__/RecebimentoConferencia.estados.test.tsx
+++ b/src/pages/__tests__/RecebimentoConferencia.estados.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard da CONFERÊNCIA DE NF-e — o sítio mais sensível do 3º front.
+ *
+ * A tela lia `nfe_recebimentos` com `.single()` e escrevia `if (!nfe) return "NF-e não
+ * encontrada"`. Com `.single()`, "não achei a linha" LANÇA PGRST116 e chega ao componente
+ * IDÊNTICO a uma queda de rede — a distinção não existe sem ler `error.code`
+ * (achado 3 de docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * Por que este é o pior: a conferência é passo de RECEBIMENTO. "NF-e não encontrada"
+ * durante uma falha manda o operador procurar um documento que EXISTE — ele para a
+ * descarga, liga para o fornecedor, ou pior: conclui que a nota não foi lançada.
+ *
+ * O HOOK roda de verdade; só o `supabase` é mockado. O defeito mora na tradução
+ * "PostgREST lançou" → `data === undefined` → tela do não-achado.
+ */
+
+const NFE_ID = 'nfe-1';
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(tabela: string) {
+  const resolver = () => Promise.resolve(respostas[tabela] ?? { data: [], error: null });
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    order: () => resolver(),
+    maybeSingle: () => resolver(),
+    single: () => resolver(),
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => encadear(t), rpc: () => Promise.resolve({ data: null, error: null }) },
+}));
+vi.mock('@/hooks/useOfflineMutation', () => ({
+  useOfflineMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/components/recebimento/LoteScannerOCR', () => ({ default: () => null }));
+
+import RecebimentoConferencia from '../RecebimentoConferencia';
+
+const NAO_ENCONTRADA = /NF-e não encontrada/i;
+
+const NFE = {
+  id: NFE_ID,
+  numero_nfe: '12345',
+  razao_social_emitente: 'Sayerlack Ind. e Com.',
+  data_emissao: '2026-01-15',
+  valor_total: 12345.67,
+  status: 'em_conferencia',
+  nfe_recebimento_itens: [],
+  cte_associados: [],
+};
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/recebimento/${NFE_ID}`]}>
+        <Routes>
+          <Route path="/recebimento/:id" element={<RecebimentoConferencia />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('RecebimentoConferencia — "NF-e não encontrada" só quando a NF-e não existe', () => {
+  it('PGRST116 (0 linhas no `.single()`) → "NF-e não encontrada", sem aviso de falha', async () => {
+    respostas = {
+      nfe_recebimentos: { data: null, error: { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' } },
+    };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADA)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso de falha, e NUNCA "NF-e não encontrada"', async () => {
+    // O operador não pode ser mandado procurar um documento que existe.
+    respostas = {
+      nfe_recebimentos: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } },
+    };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+  });
+
+  it('erro SEM `code` (queda de rede crua) também é falha, não não-achado', async () => {
+    respostas = { nfe_recebimentos: { data: null, error: { message: 'Failed to fetch' } } };
+    renderizar();
+    await screen.findByTestId('aviso-leitura-falhou');
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA "não encontrada"', async () => {
+    // PWA de campo: `isLoading` é FALSE, `data` é `undefined` e `error` é `null`.
+    respostas = { nfe_recebimentos: { data: NFE, error: null } };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+  });
+
+  it('a NF-e EXISTE → a tela abre a conferência, sem aviso nem não-achado', async () => {
+    respostas = { nfe_recebimentos: { data: NFE, error: null } };
+    renderizar();
+    await waitFor(() => expect(screen.getAllByText(/12345/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(NAO_ENCONTRADA)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+});

--- a/src/pages/__tests__/ToolDetalhe.estados.test.tsx
+++ b/src/pages/__tests__/ToolDetalhe.estados.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard das 3 telas de FERRAMENTA — "não encontrada" não pode ser o que a falha diz.
+ *
+ * As três escreviam `if (!tool) return <p>Ferramenta não encontrada</p>` sobre um hook
+ * `.maybeSingle()` que PRESERVA a diferença (`null` = não existe · `undefined` = loading
+ * ou erro). O componente descartava o que o hook sabia — achado 3 de
+ * docs/historico/o-check-verde-que-a-falha-acende.md.
+ *
+ * `ToolPublicHistory` é o pior texto dos três: acrescentava uma CAUSA INVENTADA ("O QR
+ * code pode estar desatualizado") a um estado que pode ser queda de rede. O cliente com o
+ * QR na mão joga a etiqueta fora por causa de um timeout.
+ *
+ * Os HOOKS rodam de verdade; só o `supabase` é mockado. Mockar `useUserToolDetail`
+ * provaria apenas que a tela renderiza um estado montado por mim — e o defeito mora
+ * exatamente na tradução "PostgREST falhou" → `data === undefined` → tela do não-achado.
+ */
+
+const TOOL_ID = 'ferramenta-1';
+
+type Resposta = { data: unknown; error: unknown };
+/** resposta por tabela (ou 'rpc' para a RPC pública do QR) */
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: null, error: null });
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    order: () => resolver(),
+    maybeSingle: () => resolver(),
+    single: () => resolver(),
+    then: (ok: unknown, falha: unknown) =>
+      resolver().then(ok as never, falha as never),
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (tabela: string) => encadear(tabela),
+    rpc: () => Promise.resolve(respostas.rpc ?? { data: null, error: null }),
+  },
+}));
+
+import ToolHistory from '../ToolHistory';
+import ToolReports from '../ToolReports';
+import ToolPublicHistory from '../ToolPublicHistory';
+
+const FERRAMENTA = {
+  id: TOOL_ID,
+  tool_category_id: 'cat-1',
+  custom_name: 'Serra 300mm',
+  generated_name: null,
+  internal_code: 'FER-001',
+  quantity: 1,
+  specifications: null,
+  sharpening_interval_days: 90,
+  last_sharpened_at: null,
+  next_sharpening_due: null,
+  created_at: '2026-01-01T00:00:00Z',
+  tool_categories: { id: 'cat-1', name: 'Serra', description: null, icon: null, suggested_interval_days: 90 },
+};
+
+function renderizar(Tela: React.ComponentType) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/x/${TOOL_ID}`]}>
+        <Routes>
+          <Route path="/x/:toolId" element={<Tela />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/** o que cada tela lê, e onde o "não existe" mora na resposta de sucesso */
+const TELAS = [
+  {
+    nome: 'ToolHistory',
+    Tela: ToolHistory,
+    achou: { user_tools: { data: FERRAMENTA, error: null }, tool_events: { data: [], error: null } },
+    vazio: { user_tools: { data: null, error: null }, tool_events: { data: [], error: null } },
+    falhou: { user_tools: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } }, tool_events: { data: [], error: null } },
+  },
+  {
+    nome: 'ToolReports',
+    Tela: ToolReports,
+    achou: { user_tools: { data: FERRAMENTA, error: null }, tool_events: { data: [], error: null }, order_price_history: { data: [], error: null } },
+    vazio: { user_tools: { data: null, error: null }, tool_events: { data: [], error: null }, order_price_history: { data: [], error: null } },
+    falhou: { user_tools: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } }, tool_events: { data: [], error: null }, order_price_history: { data: [], error: null } },
+  },
+  {
+    nome: 'ToolPublicHistory',
+    Tela: ToolPublicHistory,
+    achou: { rpc: { data: { tool: FERRAMENTA, events: [] }, error: null } },
+    vazio: { rpc: { data: { tool: null, events: [] }, error: null } },
+    falhou: { rpc: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } } },
+  },
+] as const;
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe.each(TELAS)('$nome — os três estados têm cara própria', ({ Tela, achou, vazio, falhou }) => {
+  it('a ferramenta EXISTE → a tela mostra a ferramenta, sem aviso', async () => {
+    respostas = { ...achou };
+    renderizar(Tela);
+    await waitFor(() => expect(screen.getAllByText(/Serra/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/não encontrada/i)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a ferramenta NÃO EXISTE (maybeSingle devolveu null) → "não encontrada", sem aviso', async () => {
+    respostas = { ...vazio };
+    renderizar(Tela);
+    await waitFor(() => expect(screen.getByText(/não encontrada/i)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso de falha, e NUNCA "não encontrada"', async () => {
+    respostas = { ...falhou };
+    renderizar(Tela);
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(/não encontrada/i)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA "não encontrada"', async () => {
+    // `networkMode:'online'` sem rede deixa a query em pending+paused: `isLoading` é FALSE
+    // e `data` é `undefined`. Quem ramifica só por `isLoading`/`error` cai no não-achado.
+    respostas = { ...achou };
+    onlineManager.setOnline(false);
+    renderizar(Tela);
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(/não encontrada/i)).toBeNull();
+  });
+});
+
+describe('ToolPublicHistory — a causa INVENTADA só pode aparecer quando é verdade', () => {
+  const QR_DESATUALIZADO = /QR code pode estar desatualizado/i;
+
+  it('não existe → a hipótese do QR é legítima', async () => {
+    respostas = { rpc: { data: { tool: null, events: [] }, error: null } };
+    renderizar(ToolPublicHistory);
+    await waitFor(() => expect(screen.getByText(QR_DESATUALIZADO)).toBeInTheDocument());
+  });
+
+  it('a leitura falhou → a tela NÃO manda jogar a etiqueta fora', async () => {
+    respostas = { rpc: { data: null, error: { code: 'PGRST301', message: 'JWT expired' } } };
+    renderizar(ToolPublicHistory);
+    await screen.findByTestId('aviso-leitura-falhou');
+    expect(screen.queryByText(QR_DESATUALIZADO)).toBeNull();
+  });
+});


### PR DESCRIPTION
Os 6 sítios de fonte VIVA do 3º front da classe "erro colapsado em vazio" (achado 3 de
`docs/historico/o-check-verde-que-a-falha-acende.md`). São telas de DETALHE que escreviam
`if (!registro) return <p>não encontrado</p>` sobre uma leitura que podia simplesmente não ter
acontecido — a forma mais afirmativa da classe: em vez de sumir, **mente com especificidade**.

## Dois grupos, dois mecanismos — um fix só não serve aos dois

**GRUPO A — `.maybeSingle()`: a distinção EXISTE no dado e era descartada**

`ToolHistory` · `ToolReports` · `ToolPublicHistory` (`user_tools`). O hook devolve `null` para
"esta ferramenta não existe" e `undefined` só em loading/erro; o `if (!tool)` apagava a
diferença que o hook preservou.

`ToolPublicHistory` era o pior texto do inventário: acrescentava uma **causa inventada** ("O QR
code pode estar desatualizado") a um estado que podia ser queda de rede — o cliente com a
etiqueta na mão jogava fora uma etiqueta boa por causa de um timeout. Agora essa frase só
aparece no ramo em que a RPC **respondeu** que a ferramenta não existe.

**GRUPO B — `.single()`: a distinção NÃO existe sem ler `error.code`**

`AdminKnowledgeBaseDetail` (`kb_documents`=297) · `RecebimentoConferencia`
(`nfe_recebimentos`=47) · `AdminReposicaoPromocaoDetail` (`promocao_campanha`=17). Com
`.single()`, 0 linhas **lança** PGRST116 e chega ao componente idêntico a uma queda de rede.

`RecebimentoConferencia` é o mais sensível dos três: conferência de NF-e é passo de
recebimento, e "NF-e não encontrada" durante uma falha manda o operador procurar um documento
que **existe** — ele para a descarga, liga para o fornecedor, ou conclui que a nota não foi
lançada.

## A ferramenta

`estadoDeRegistro` (em `src/lib/leitura/estado-de-leitura.ts`) lê os **dois** eixos — o dado em
mãos e o código do erro — e devolve 6 estados. `ehNaoEncontrado` casa o **campo** `error.code`,
nunca o texto (um `includes('PGRST116')` casaria também um erro embrulhado por outro, e a
mensagem é do servidor).

Documentada a restrição de uso: `PGRST116` é "não deu UMA linha" — 0 **ou mais de uma** —, então
só vale como "não existe" sobre filtro de chave única. Os 3 sítios do grupo B filtram por PK.

O ramo da falha vem **antes** do loading nos 6 sítios, de propósito: sem rede a query fica
`pending`+`paused` e o skeleton giraria para sempre sobre uma leitura que não vai acontecer. O
4º estado (offline: `isLoading` FALSE, `data` `undefined`, `error` `null`) nunca cai no ramo do
não-achado — tem teste próprio nos 4 hosts.

## O gate entrou na main no meio do trabalho, e cobrou uma prova

O #2280 gateou esta mesma forma enquanto os sítios estavam sendo corrigidos, criando a
`BASELINE_AFIRMATIVO` com os 13. O rebase **não conflitou** — conflito de arquivo é só um eixo —
mas a baseline listava exatamente o que este PR quita.

Pior: o #2283 documentou a armadilha e ela me pegou. Trocar `const { data } = useX()` por
`const q = useX()` faz o sítio **sumir do detector** (ele só rastreia desestruturação direta de
chamada de hook) — e o gate não distingue "consertado" de "cegado". Eu tinha quitado 4 entradas
com um zero que vinha do lado errado.

Corrigido: os 6 voltam a desestruturar direto e nomeiam `status`/`fetchStatus`/`error`
(`CHAVES_DE_ERRO`). O detector vê o tratamento, não conta o sítio, e **segue vigiando** o
arquivo — um hook novo sem `error` volta a taintar amanhã.

Provado, não presumido — apagando a chave de erro do código, um sítio consertado volta a contar
e um cegado fica em zero:

| arquivo | com | sem | veredito |
|---|---|---|---|
| ToolPublicHistory · AdminKnowledgeBaseDetail · RecebimentoConferencia · AdminReposicaoPromocaoDetail | 0 | 1 | CONSERTADO |
| ToolHistory *(useToolEvents neutralizado)* | 0 | 1 | CONSERTADO |
| ToolReports *(2 hooks irmãos neutralizados)* | 0 | 1 | CONSERTADO |

Os dois últimos precisaram da neutralização porque a contagem **deduplica por linha**: o mesmo
`return` é taintado por 2-3 hooks, e com os irmãos ainda cegos a métrica satura em 1 e não
consegue falar sobre o hook que este PR consertou. Medir sem neutralizar teria dado "CEGADO" nos
dois — falso negativo da **medição**, não do fix.

`BASELINE_AFIRMATIVO` 13 → 9. `ToolHistory`/`ToolReports` **ficam** em 1, com o motivo escrito na
própria baseline: o guard deles é `!tool || !healthMetrics`, e `healthMetrics` deriva de
`useToolEvents` — a query irmã, que ainda engole o erro no default `= []`. `tool_events` é uma
das fontes **zeradas** que a medição separou para depois. Resíduo medido com endereço, não fix
pela metade.

## Guards

5 arquivos de teste com os **hooks rodando de verdade** (só o `supabase` é mockado): mockar o
hook provaria apenas um estado montado à mão, e o defeito mora exatamente na tradução
"PostgREST falhou" → `data undefined` → tela do não-achado.

## Validação (evidência positiva, colada)

| verificação | veredito |
|---|---|
| RED, antes do fix | `RED_EXIT=1` — 29 falhas, pelos motivos certos (13× aviso ausente, 13× helper inexistente) |
| suíte + gate + manifesto | `SUITE_EXIT=0` |
| typecheck (2 `tsc`) | `TYPECHECK_EXIT=0` |
| eslint (arquivos do PR) | `LINT3_RC=0` |
| **falsificação** | `SABOTAGENS_QUE_NAO_PEGARAM=0` — **10/10** |

A falsificação sabota **uma camada por vez** e exige vermelho, com **controle verde na mesma
invocação, antes do primeiro `sed`** (sem ele, uma suíte sempre-vermelha aprovaria tudo —
`docs/historico/falsificacao-sem-linha-de-base.md`) e controle final depois de restaurar:

- **helper**: PGRST cego · PGRST guloso · ignora o dado no sucesso · offline colapsa no não-achado
- **call-site**: os 6, um por um

Nenhuma camada ficou verde sob sabotagem — nenhuma é redundante ou inalcançada.

## Fora de escopo, declarado

As queries **irmãs** de `ToolHistory`/`ToolReports` (`useToolEvents`, `useToolPriceHistory`) têm
default `= []` no binding: se falharem, a tela mostra a ferramenta com "nunca afiada" em vez de
avisar. É a forma **lista** sobre fonte zerada, que a medição separou para depois — e é
exatamente o que mantém esses dois arquivos na baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
