### PR TITLE
fix(reposicao): o UPDATE do cabeçalho vira compare-and-set — a edição inline podia sobrescrever o total PROVADO pelo fornecedor [money-path]

### DIFF
--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -130,11 +130,27 @@ export function PedidoRow({
           }
           // valor_linha null = custo desconhecido → não fabricar valor_total (ausente ≠ zero)
           if (update.valor_linha !== null) {
-            const { error: cabUpErr } = await supabase
+            // O `status` do passo 1 foi lido em OUTRA ida à rede: entre ele e este UPDATE cabe a
+            // aprovação de outra aba, o disparo, o portal e a gravação do custo PROVADO. Sem
+            // predicado, este `.eq("id")` sobrescrevia o total do fornecedor com a soma local —
+            // e nem precisava de fração, nem de edição pós-portal (Codex 2026-09-06). O CAS do
+            // passo 2 protege só a QUANTIDADE do item; o cabeçalho ficava a descoberto.
+            // Repetir o predicado AQUI transforma a leitura do passo 1 em compare-and-set real.
+            const { data: cabGravado, error: cabUpErr } = await supabase
               .from("pedido_compra_sugerido")
               .update({ valor_total: update.valor_linha, atualizado_em: nowIso })
-              .eq("id", row.id);
+              .eq("id", row.id)
+              .in("status", [...STATUS_APROVAVEIS])
+              .select("id");
             if (cabUpErr) throw cabUpErr;
+            // 0 linhas = o pedido saiu da faixa aprovável no meio da edição. O item JÁ mudou (passo
+            // 2), então parar aqui é o certo: seguir para o disparo mandaria ao fornecedor uma
+            // quantidade nova com um cabeçalho que ninguém conferiu. Falha ALTO, não em silêncio.
+            if (!cabGravado || cabGravado.length === 0) {
+              toast.error("O pedido saiu da faixa aprovável enquanto você editava (outra aba aprovou ou disparou) — recarregue e confira a quantidade.");
+              onChanged();
+              return;
+            }
           }
         }
         // Trilha canônica: APROVAR = DISPARAR NA HORA (não mais só UPDATE + esperar o cron).

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.qtd-item.test.tsx
@@ -25,6 +25,9 @@ interface Op { table: string; op: 'select' | 'update' | 'disparo'; payload?: unk
 let ops: Op[] = [];
 let cabecalhoStatus = 'pendente_aprovacao';
 let updateRetornaVazio = false; // simula o compare-and-set NÃO casando (0 linhas)
+// Simula a corrida do cabeçalho: o item casa, mas entre o passo 1 e o UPDATE do cabeçalho o pedido
+// saiu da faixa aprovável (outra aba aprovou/disparou) — o predicado `.in('status', …)` não casa.
+let cabecalhoUpdateVazio = false;
 
 function builder(table: string) {
   const op: Op = { table, op: 'select', filtros: [] };
@@ -32,6 +35,7 @@ function builder(table: string) {
     select: () => { if (op.op === 'update') op.selectApos = true; return b; },
     update: (payload: unknown) => { op.op = 'update'; op.payload = payload; return b; },
     eq: (c: string, v: unknown) => { op.filtros.push([c, v]); return b; },
+    in: (c: string, v: unknown) => { op.filtros.push([`in:${c}`, v]); return b; },
     is: (c: string, v: unknown) => { op.filtros.push([`is:${c}`, v]); return b; },
     maybeSingle: () => b,
     order: () => b,
@@ -39,7 +43,10 @@ function builder(table: string) {
       ops.push(op);
       let out: unknown;
       if (op.op === 'select') out = { data: table === 'pedido_compra_sugerido' ? { status: cabecalhoStatus } : [], error: null };
-      else out = { data: op.selectApos ? (updateRetornaVazio ? [] : [{ id: 501 }]) : null, error: null };
+      else {
+        const vazio = updateRetornaVazio || (cabecalhoUpdateVazio && table === 'pedido_compra_sugerido');
+        out = { data: op.selectApos ? (vazio ? [] : [{ id: 501 }]) : null, error: null };
+      }
       return Promise.resolve(out).then(res, rej);
     },
   };
@@ -76,7 +83,7 @@ const gravouNumSkus = () =>
   ops.some((o) => o.op === 'update' && !!o.payload && typeof o.payload === 'object' && 'num_skus' in (o.payload as object));
 
 beforeEach(() => {
-  ops = []; cabecalhoStatus = 'pendente_aprovacao'; updateRetornaVazio = false;
+  ops = []; cabecalhoStatus = 'pendente_aprovacao'; updateRetornaVazio = false; cabecalhoUpdateVazio = false;
   vi.mocked(supabase.from).mockReset().mockImplementation(builder as never);
   vi.mocked(aprovarEDisparar).mockReset().mockImplementation(async () => {
     ops.push({ table: 'edge', op: 'disparo', filtros: [] }); // entra no MESMO log: a ordem é testável
@@ -220,6 +227,34 @@ describe('PedidoRow (ciclo) — o editor de quantidade edita o ITEM do pedido, n
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/aprov/)));
     expect(updatesDe('pedido_compra_item')).toEqual([]);
     expect(aprovarEDisparar).not.toHaveBeenCalled();
+  });
+
+  // A corrida que o Codex achou (2026-09-06): o status do passo 1 é lido em OUTRA ida à rede. Entre
+  // ela e o UPDATE do cabeçalho cabem a aprovação de outra aba, o disparo, o portal e a gravação do
+  // custo PROVADO pelo fornecedor. Sem predicado, este UPDATE sobrescrevia o total provado com a
+  // soma local — sem precisar de fração nem de edição pós-portal.
+  it('o UPDATE do cabeçalho leva o predicado de status (é compare-and-set, não `.eq(id)` solto)', async () => {
+    montar(linha(), [ITEM]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(aprovarEDisparar).toHaveBeenCalledTimes(1));
+    const upCab = updatesDe('pedido_compra_sugerido')[0];
+    expect(upCab.filtros).toContainEqual(['in:status', ['pendente_aprovacao', 'bloqueado_guardrail']]);
+    expect(upCab.selectApos).toBe(true); // sem `.select()` não há como saber que 0 linhas casaram
+  });
+
+  it('cabeçalho sai da faixa aprovável ENTRE o passo 1 e o UPDATE: erro visível e NADA é disparado', async () => {
+    cabecalhoUpdateVazio = true;
+    const { onChanged } = montar(linha(), [ITEM]);
+    const input = await screen.findByDisplayValue('40');
+    fireEvent.change(input, { target: { value: '35' } });
+    fireEvent.click(botaoAprovar());
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/faixa aprovável/)));
+    // O item JÁ mudou; seguir para o disparo mandaria ao fornecedor uma quantidade nova com um
+    // cabeçalho que ninguém conferiu. Falha ALTO.
+    expect(aprovarEDisparar).not.toHaveBeenCalled();
+    expect(onChanged).toHaveBeenCalled();
   });
 
   it('item com qtde_final NULL (só sugerida): o compare-and-set usa IS NULL, não eq null', async () => {


### PR DESCRIPTION
O UPDATE que a edição inline faz no **cabeçalho** do pedido era `.eq("id", row.id)` puro — sem
predicado, sem `.select()`. O status é conferido no passo 1, mas **em outra ida à rede**: entre a
leitura e a escrita cabem a aprovação de outra aba, o disparo, o portal e a gravação do custo
**provado** pelo fornecedor. O CAS do passo 2 protege só a *quantidade do item*; o cabeçalho ficava
a descoberto.

A corrida (contraexemplo do challenge do Codex, 2026-09-06):

1. Aba A valida `pendente_aprovacao`, muda a quantidade de 3 para 4 e persiste o **item**. Calculou
   `valor_linha = 400`.
2. A aba fica suspensa antes de atualizar o cabeçalho.
3. Aba B aprova. O portal recebe as 4 unidades, cobra **380**, e a RPC grava o custo.
4. Aba A retoma e executa `UPDATE valor_total = 400 WHERE id = …` — **por cima do total provado**.

Não exige fração, nem edição de quantidade depois do portal, nem ausência de PO. É o sexto escritor
de `valor_total` que o inventário do #2267 encontrou, e o único que ficou de fora daquela fatia.

## O que muda

O UPDATE do cabeçalho ganha `.in("status", [...STATUS_APROVAVEIS])` + `.select("id")` — a leitura do
passo 1 vira **compare-and-set de verdade**. E 0 linhas **para a aprovação** com erro visível, em vez
de seguir em frente: o item **já mudou** no passo 2, então prosseguir mandaria ao fornecedor uma
quantidade nova sob um cabeçalho que ninguém conferiu. Falha alto, não em silêncio.

Não fecha a corrida no banco (isso exigiria mover a escrita para uma RPC) — fecha a **janela do
cliente**, que é onde ela existe hoje, com o mesmo padrão de CAS que o passo 2 já usava três linhas
acima.

## Prova — duas camadas, sabotadas uma por vez

Controle e sabotagem na **mesma invocação do laço**, abortando se o controle não fechar verde
(sempre-vermelha aprova tudo):

```
CONTROLE                          14 passed (14)                      ✓
sabotagem 1 — sem o predicado     1 failed | 13 passed                ✗ cai "leva o predicado de status"
sabotagem 2 — sem o guard         1 failed | 13 passed                ✗ cai "sai da faixa aprovável"
restaurado                        guard e predicado de volta, tree limpo
```

Cada teste ataca uma camada distinta: nenhum é redundante, e nenhum ficou inalcançado. O mock do
PostgREST ganhou `in()` e uma flag que faz **só** o update do cabeçalho voltar vazio — o do item
continua casando, que é exatamente o estado da corrida.

## Relação com as outras fatias

Independente do #2267 (mergeado) e do #2286 (draft): toca só o front, não depende da migration nem
da edge. Pode ir sozinho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
