### PR TITLE
fix(leitura): o ✓ VERDE de "tudo completo" para de acender quando a leitura falha — o sítio de dano MÁXIMO da classe

### DIFF
--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -141,15 +141,24 @@ const BASELINE = new Map<string, number>([
 // N hooks do componente e contar por hook inflaria (`ToolHistory:174` é UM sítio, não dois).
 //
 // DÍVIDA, em ordem de dano MEDIDO em prod (o doc traz os denominadores):
-//   1. `CompletudeSection` — ÚNICO urgente: 116 pendências reais viram ✓ verde de "tudo
-//      completo" quando `kb_product_specs` não lê. Afirmação positiva em superfície de saúde.
+//   1. `CompletudeSection` — QUITADO: era o ÚNICO urgente (116 pendências reais viravam ✓
+//      verde de "tudo completo" quando `kb_product_specs` não lia — afirmação positiva em
+//      superfície de saúde). Hoje ramifica por `estadoDeLeitura` ANTES do loading, com o
+//      binding ligando `status` de propósito para o detector SEGUIR vigiando o arquivo.
 //   2. os 3 de `.single()` (`kb_documents` 297, `nfe_recebimentos` 47, `promocao_campanha`
-//      17): "não encontrado" cobre também "o banco caiu" → ramificar por `PGRST116`.
-//   3. os 3 de ferramenta (`user_tools` = 4): o hook JÁ devolve `null` vs `undefined`; o
-//      componente só precisa parar de descartar a distinção.
-//   4. os 6 de fonte ZERADA hoje: corrigir ANTES da primeira linha. `ProvasParaAuditar` é o
-//      mais perigoso quando encher — "Nenhuma prova aguardando auditoria" é afirmação de
-//      CONTROLE, e a auditoria some no dia em que a leitura falhar.
+//      17) — QUITADOS (#2293): "não encontrado" cobria também "o banco caiu"; hoje
+//      ramificam por `PGRST116`.
+//   3. os 3 de ferramenta (`user_tools` = 4) — o ÚNICO grupo que ainda resta na baseline
+//      (`ToolHistory`, `ToolReports`; `ToolPublicHistory` já saiu). O hook JÁ devolve
+//      `null` vs `undefined`; o componente só precisa parar de descartar a distinção, e o
+//      resíduo está explicado na nota logo abaixo.
+//   4. os 6 de fonte ZERADA — QUITADOS (#2317), antes da primeira linha, como pedia a
+//      medição. `ProvasParaAuditar` era o mais perigoso quando enchesse: "Nenhuma prova
+//      aguardando auditoria" é afirmação de CONTROLE, e a auditoria sumiria no dia em que
+//      a leitura falhasse.
+//
+// A lista acima foi conferida contra a BASELINE_AFIRMATIVO nesta data — um mapa de dívida
+// que lista grupo já quitado é a mesma falha que este gate persegue, só que no comentário.
 //
 // Dois eixos vizinhos foram medidos junto e vieram ZERO — medido, não presumido:
 // `<EmptyState title="…"/>` (texto por ATRIBUTO, sem JsxText) = 0; ternário cujo ramo do
@@ -157,7 +166,6 @@ const BASELINE = new Map<string, number>([
 // `ternario-null`, JÁ na baseline de cima; contá-lo aqui seria contar o mesmo sítio duas
 // vezes). O critério estrito não esconde fatia nenhuma.
 const BASELINE_AFIRMATIVO = new Map<string, number>([
-  ["src/components/knowledge-base/CompletudeSection.tsx", 1],
   // Resíduo MEDIDO, não fix pela metade: a leitura de `user_tools` já ramifica
   // (`estadoDeRegistro`), mas o guard é `!tool || !healthMetrics` e `healthMetrics` deriva
   // de `useToolEvents` — a query IRMÃ, que ainda engole o erro no default `= []` do binding.

--- a/src/components/knowledge-base/CompletudeSection.tsx
+++ b/src/components/knowledge-base/CompletudeSection.tsx
@@ -1,5 +1,7 @@
 import { useCompletude } from '@/hooks/useCompletude';
 import { rotularCampo } from '@/lib/knowledge-base/campo-labels';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Link } from 'react-router-dom';
@@ -8,11 +10,39 @@ import { Loader2, CheckCircle2 } from 'lucide-react';
 /**
  * Aba "Dados faltantes" (Fase B1): produtos aprovados com campos importantes vazios,
  * do mais incompleto pro menos. Read-only — clica e vai pro detalhe do boletim.
+ *
+ * O ✓ VERDE SÓ PODE APARECER EM `pronta`. `useCompletude` faz `if (error) throw error`,
+ * então na falha `data` é `undefined` — a mesma condição do vazio. O `!data ||
+ * data.length === 0` que estava aqui colapsava as duas à mão, com `||`, e a tela
+ * respondia à queda de leitura com ícone de sucesso e uma frase universal ("Todas as
+ * fichas… estão completas"). Medido em prod (2026-09-06): 119 fichas aprovadas, 116 com
+ * campo faltando — o estado NORMAL desta tela são 116 pendências de trabalho, e a falha
+ * as substituía por um check verde para as 3 pessoas que enxergam esta aba
+ * (docs/historico/o-check-verde-que-a-falha-acende.md, achado 1).
+ *
+ * A desestruturação liga `status` de PROPÓSITO: é chave de `CHAVES_DE_ERRO`, então o
+ * detector de `src/lib/gates/erro-colapsado-em-vazio.ts` enxerga o tratamento e SEGUE
+ * vigiando o arquivo. Trocar por `const q = useCompletude()` sumiria com o sítio do gate
+ * por CEGUEIRA — e o gate não distingue isso de conserto.
  */
 export function CompletudeSection() {
-  const { data, isLoading } = useCompletude();
+  const { data, status, fetchStatus } = useCompletude();
+  const estado = estadoDeLeitura({ status, fetchStatus });
 
-  if (isLoading) {
+  // ANTES do loading, e não depois: sem rede a query fica `pending` + `paused`, com
+  // `isLoading` FALSE, `data` `undefined` e `error` `null`. O 4º estado passa reto por
+  // um guard de `isLoading`/`error` e cai no ramo do "está tudo completo".
+  if (naoConsegui(estado)) {
+    return (
+      <AvisoLeituraFalhou
+        oque="a lista de fichas com dados importantes faltando"
+        estado={estado}
+        variante="bloco"
+      />
+    );
+  }
+
+  if (estado !== 'pronta') {
     return (
       <div className="flex justify-center py-8">
         <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
@@ -20,6 +50,9 @@ export function CompletudeSection() {
     );
   }
 
+  // Só alcançável com a leitura FEITA — aqui o vazio é mesmo "não há pendência", e o ✓
+  // verde é verdade. (`!data` sobrevive porque o tipo de `UseQueryResult` admite
+  // `undefined`; em `success` a `queryFn` sempre devolveu um array.)
   if (!data || data.length === 0) {
     return (
       <Card className="p-8 text-center text-xs text-muted-foreground">

--- a/src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx
+++ b/src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * Guard da aba "Dados faltantes" — o sítio de dano MÁXIMO da classe "erro colapsado em vazio".
+ *
+ * O componente escrevia `if (!data || data.length === 0)` e devolvia um ✓ VERDE com a frase
+ * "Todas as fichas aprovadas estão completas nos dados importantes". `useCompletude` faz
+ * `if (error) throw error`, então na falha `data` é `undefined` — a MESMA condição do vazio.
+ * Medido em prod (2026-09-06): 119 fichas aprovadas, 116 com campo faltando. O estado normal
+ * desta tela são 116 pendências de trabalho, e a queda de leitura as trocava por um check de
+ * sucesso para as 3 pessoas que a enxergam
+ * (docs/historico/o-check-verde-que-a-falha-acende.md, achado 1).
+ *
+ * O HOOK roda de verdade; só o `supabase` é mockado. Mockar o hook provaria apenas um estado
+ * montado à mão — e o defeito mora justamente na tradução "PostgREST falhou" → `data`
+ * `undefined` → tela do ✓ verde.
+ */
+
+const VERDE = /Todas as fichas aprovadas estão completas/i;
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(tabela: string) {
+  const resolver = () => Promise.resolve(respostas[tabela] ?? { data: [], error: null });
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    not: () => chain,
+    is: () => chain,
+    order: () => resolver(),
+    limit: () => resolver(),
+    maybeSingle: () => resolver(),
+    single: () => resolver(),
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => encadear(t), rpc: () => Promise.resolve({ data: null, error: null }) },
+}));
+
+import { CompletudeSection } from '../CompletudeSection';
+
+/** Nenhum campo importante preenchido → 10 faltantes → aparece na lista. */
+const INCOMPLETA = {
+  product_code: 'SL-777',
+  product_name: 'Verniz PU Sayerlack XPTO',
+  document_id: 'doc-1',
+  approved_at: '2026-01-01T00:00:00Z',
+};
+
+/** Todos os `CAMPOS_IMPORTANTES` preenchidos → 0 faltantes → o filtro do hook a remove. */
+const COMPLETA = {
+  ...INCOMPLETA,
+  product_code: 'SL-888',
+  product_name: 'Fundo PU Sayerlack Completo',
+  rendimento_m2_por_litro: 10,
+  catalisador_codigo: 'CAT-1',
+  catalisador_proporcao_pct: 20,
+  demaos_recomendadas: 2,
+  validade_dias: 365,
+  pot_life_horas: 4,
+  diluente_codigo: 'DIL-1',
+  substrato: 'madeira',
+  solidos_pct: 35,
+  dureza: 'alta',
+  extraction_gaps: [],
+};
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CompletudeSection />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('CompletudeSection — o ✓ verde só aparece quando a leitura ACONTECEU', () => {
+  it('há pendências → a lista, sem ✓ verde nem aviso', async () => {
+    respostas = { kb_product_specs: { data: [INCOMPLETA], error: null } };
+    renderizar();
+    await waitFor(() =>
+      expect(screen.getByText(/Verniz PU Sayerlack XPTO/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(VERDE)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('ZERO pendências (leitura OK) → o ✓ verde é VERDADE, e fica', async () => {
+    respostas = { kb_product_specs: { data: [COMPLETA], error: null } };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(VERDE)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso de erro, e NUNCA o ✓ verde', async () => {
+    respostas = {
+      kb_product_specs: { data: null, error: { code: '42501', message: 'permission denied' } },
+    };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(VERDE)).toBeNull();
+  });
+
+  // O 4º estado: `pending` + `paused`, com `isLoading` FALSE, `data` `undefined` e `error`
+  // `null`. Passa reto por qualquer guard de `isLoading`/`error` — é o que obriga o ramo da
+  // falha a vir ANTES do loading.
+  it('SEM REDE (pending+paused) → aviso de sem-rede, e NUNCA o ✓ verde', async () => {
+    respostas = { kb_product_specs: { data: [INCOMPLETA], error: null } };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(VERDE)).toBeNull();
+  });
+});

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -583,6 +583,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/hooks/__tests__/useExtractSpecs.test.tsx",
       "src/hooks/__tests__/useKnowledgeBaseList.test.tsx",
+      "src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx",
       "src/pages/__tests__/AdminKnowledgeBaseDetail.estados.test.tsx",
       "src/pages/__tests__/AdminStandardProcessDetail.estados.test.tsx",
     ],


### PR DESCRIPTION
## O defeito

```tsx
// src/components/knowledge-base/CompletudeSection.tsx:24 (antes)
if (!data || data.length === 0) return (
  <Card …><CheckCircle2 className="… text-status-success" />
    Todas as fichas aprovadas estão completas nos dados importantes.</Card>
);
```

`useCompletude` faz `if (error) throw error` sobre `kb_product_specs`. Quando a leitura falha, `isLoading` é false, `data` é `undefined`, e a tela **afirma saúde com semáforo verde**. O `||` colapsa à mão duas coisas diferentes: `[]` ("não há pendência") e `undefined` ("não consegui ler").

**Denominador medido em prod (2026-09-06):** 119 fichas aprovadas, **116 com campo importante faltando**, 295 campos ao todo. O estado NORMAL desta tela é uma lista de 116 pendências de trabalho — a falha de leitura substituía as 116 linhas por um check verde. Público: 3 pessoas (`user_roles` = 2 employee + 1 master), então um alerta perdido é **um terço da operação**.

Nas outras formas da classe a ausência afirma segurança *por omissão*; aqui ela afirma **com ícone de sucesso e uma frase universal**. É o sítio de dano máximo da classe — o item 1 e único urgente de `docs/historico/o-check-verde-que-a-falha-acende.md`.

## O fix

`estadoDeLeitura`/`naoConsegui` + `<AvisoLeituraFalhou>` (PR #2293). O ✓ verde só é alcançável em `pronta`:

```tsx
const { data, status, fetchStatus } = useCompletude();
const estado = estadoDeLeitura({ status, fetchStatus });

if (naoConsegui(estado)) return <AvisoLeituraFalhou … />;   // ANTES do loading
if (estado !== 'pronta') return <spinner />;
if (!data || data.length === 0) return <✓ verde>;           // agora é VERDADE
```

**O ramo da falha vem ANTES do loading** porque sem rede a query fica `pending`+`paused`: `isLoading` é FALSE, `data` é `undefined` e `error` é `null` — o 4º estado passa reto por um guard de `isLoading`/`error` e cairia no ramo do "está tudo completo".

## O sítio segue vigiado — medido, não presumido

O binding mantém a desestruturação direta e liga **`status`** de propósito (chave de `CHAVES_DE_ERRO`), então o detector de `src/lib/gates/erro-colapsado-em-vazio.ts` enxerga o tratamento e continua vigiando o arquivo. Trocar por `const q = useCompletude()` sumiria com o sítio por **cegueira**, e o gate não distingue isso de conserto.

Prova de que lado veio o zero, rodando `contarRetornoAfirmativo` sobre o arquivo:

| | contagem |
|---|---|
| código entregue (com `status` no binding) | **0** |
| controle: a chave de erro apagada do binding | **1** (linha 57, o ✓ verde) |

O zero desaparece quando a chave desaparece ⇒ **CONSERTADO**. Sem saturação de dedup: `acharColapsos` devolve **um** hook para a linha (o arquivo tem um só).

Entrada `["src/components/knowledge-base/CompletudeSection.tsx", 1]` removida de `BASELINE_AFIRMATIVO`, e o comentário da dívida atualizado — o item 1 deixou de ser dívida.

## Guard

`src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx` — **o hook roda de verdade, só o `supabase` é mockado**. Mockar o hook provaria apenas um estado montado à mão, e o defeito mora na tradução "PostgREST falhou" → `data undefined` → tela do ✓ verde.

4 casos: há pendências → lista · zero pendências → ✓ verde legítimo · leitura falhou → aviso `data-estado="erro"` e NUNCA o ✓ verde · sem rede → aviso `data-estado="sem-rede"` e NUNCA o ✓ verde.

Registrado em `src/lib/modulos/manifesto.ts` (módulo `knowledge-base`).

## Falsificação — 5 camadas, uma por vez

Controle verde na **mesma invocação**, antes do primeiro patch; restauro conferido byte-exato (`git diff --quiet`), não por "ficou verde de novo".

| camada | sabotagem | resultado |
|---|---|---|
| controle | — | GUARD **verde** · GATE **verde** |
| L1 | o defeito original de volta (sem ramo de falha, guard só de `carregando`) | vermelho |
| L2 | trata só `erro`, **cega o 4º estado** (sem-rede) | vermelho |
| L3 | aviso com `estado="erro"` fixo | vermelho |
| L4 | o ✓ verde some de vez | vermelho |
| L5 | reintrodução: o arquivo da main pré-fix, verbatim | **GATE** vermelho |

**0 asserções mortas de 5 camadas**, árvore limpa ao fim. L4 existe para provar que o guard não aprova "apagar o ✓ verde" — o vazio legítimo continua sendo servido. L5 prova que a baseline quitada virou **trinco**: reintroduzir o sítio agora é cobrado.

## Validação

`bun run test` (guard + gate + manifesto): **21 passed, exit 0** · `bun run typecheck`: **exit 0** · `bun run lint`: **exit 0** (só warnings pré-existentes, nenhum nos arquivos tocados).

## Achado adjacente — NÃO corrigido aqui

`src/pages/AdminKnowledgeBase.tsx:30` lê o mesmo hook para o badge da aba: `completude.data?.length ?? 0`, com `{qtdFaltantes > 0 && <Badge>}`. Na falha o `?? 0` fabrica um zero e o badge **some** — quem clica na aba é avisado, quem só olha o cabeçalho não. É a forma `jsx-&&`, que a varredura de 2026-08-22 deixou **deliberadamente fora do gate** (93 sítios, baseline cresceria por idioma legítimo), então não a abri aqui. Registrado como chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Pendências abertas no fecho desta sessão (cópia durável — chip é perecível)

O `/fecho` desta sessão detectou duas pendências e abriu chip para cada uma. Chip morre com a sessão arquivada, então os prompts ficam aqui.

### 1. 🔴 Migration `20260907095841_disparado_simulado_e_estado_pos_disparo.sql` NÃO aplicada em prod

Chip: **"Aplicar migration de disparado_simulado em prod"**. É de OUTRA sessão — confirme com o founder se ele já colou antes de pedir de novo.

Provado via `psql-ro` em 2026-09-07: a migration menciona `disparado_simulado` 26 vezes e as três funções que ela recria não o mencionam nenhuma vez em prod.

```
trigger_conhece_simulado  | f   -- public.reposicao__valida_cancelamento_pos_disparo()
cancelar_conhece_simulado | f   -- public.cancelar_pedido_sugerido(bigint,text,text)
corrigir_conhece_simulado | f   -- public.corrigir_cancelamento_pos_disparo(bigint,text,text,text,text)
```

⚠️ `corrigir_cancelamento_pos_disparo` tem **5 argumentos** — sondar com 2 dá falso negativo (erro que cometi na primeira medição; a função existe).

**Money-path:** o cabeçalho da própria migration mede que o `dry_run` de `disparar-pedidos-aprovados` não é dry-run — chama `IncluirPedCompra` incondicionalmente e cria pedido de compra REAL no Omie. Sem a migration, `disparado_simulado` não é reconhecido pelo trigger de cancelamento pós-disparo, e um pedido já enviado ao fornecedor pode ser cancelado como se nada tivesse saído.

Aplicação: skill `lovable-db-operator` (o founder cola no SQL Editor). Nunca tocar `supabase/migrations/`. Pré-flight com `pg_get_functiondef` da PROD antes de `CREATE OR REPLACE`; se houver `DROP`, reemitir o `REVOKE` nomeando as roles. Provar EXECUTANDO (PL/pgSQL é late-bound).

### 2. Badge de "Dados faltantes" some quando a leitura falha

Chip: **"Badge de "Dados faltantes" some na falha de leitura"**.

`src/pages/AdminKnowledgeBase.tsx:29-30` lê o mesmo `useCompletude` deste PR para o badge da aba:

```tsx
const completude = useCompletude();
const qtdFaltantes = completude.data?.length ?? 0;
// …:62
{qtdFaltantes > 0 && (<Badge …>{qtdFaltantes}</Badge>)}
```

Na falha o `?? 0` fabrica zero e o badge desaparece — quem abre a aba é avisado (este PR), quem só olha o cabeçalho não. Denominador: 116 fichas com campo faltando, 3 pessoas com acesso.

É a forma `jsx-&&`, deixada **deliberadamente fora do gate** na varredura de 2026-08-22 (93 sítios; a baseline cresceria por idioma legítimo) — corrigir este sítio é decisão pontual justificada pelo denominador, **não** abertura do front inteiro. O binding é `const completude = useCompletude()` sem desestruturação, então o detector não o vê de nenhum jeito: a prova é o guard, não o gate. Modelo de teste: `src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx` (deste PR).
