### PR TITLE
docs(shell): a §14 culpava o BSD grep — medi que ele TAMBÉM sai cedo; o que blinda o macOS é o tamanho

### DIFF
--- a/docs/historico/evidencia-positiva-shell.md
+++ b/docs/historico/evidencia-positiva-shell.md
@@ -553,10 +553,29 @@ O tamanho explica a raridade: `$ORIG` tinha 59.252 B contra os 64 KiB de buffer 
 90% da capacidade, margem de 6 KB. Quase sempre o `printf` despeja tudo antes de o `grep` fechar;
 sob escalonamento adverso (runner de 2 vCPUs, logo depois de um `bun` + Postgres), não.
 
-**Não tente reproduzir no macOS:** o BSD grep DRENA o stdin antes de sair, e a corrida não aparece
-nem em 400 tentativas. Falsificar só aqui não prova nada (é a lição do #1483 de novo). O guard
-[`scripts/test-guard-noop-sabotagem.sh`](../../scripts/test-guard-noop-sabotagem.sh) contorna isso
-com um shim que tem a semântica do GNU `grep -q`, tornando a condição determinística nos dois lados.
+**No macOS a corrida não aparece — mas o motivo NÃO é o grep.** Medido em 2026-09-07: com o payload
+passando da capacidade do pipe, tanto o `/usr/bin/grep` (BSD grep 2.6.0-FreeBSD) quanto o `ugrep`
+que embrulha o `grep` desta máquina (§4) saem no primeiro casamento e matam o escritor —
+`writer=141 grep=0`, idêntico ao Linux. O que blinda o macOS é o mesmo que torna o Linux raro: os
+59 KB cabem no buffer, e o `printf` termina antes. Por isso 400 tentativas sob 8 hogs de CPU deram
+zero fabricações — e por isso a atribuição "o BSD grep drena o stdin" está errada.
+
+A consequência é prática, e é o contrário de "não tente": **o macOS reproduz, de forma
+determinística, se você tirar a corrida do caminho** — basta empurrar o payload para além do buffer,
+e aí o escritor tem bytes pendentes por CAPACIDADE em vez de por escalonamento:
+
+```bash
+bash -c 'set -o pipefail
+  ORIG="$(cat scripts/sonda-versao-sql.ts)$(head -c 120000 </dev/zero | tr "\0" x)"
+  printf "%s" "$ORIG" | command grep -qF "l.status_code = 401"
+  ps=("${PIPESTATUS[@]}"); echo "writer=${ps[0]} grep=${ps[1]}"'   # → writer=141 grep=0
+```
+
+Isso é diagnóstico por MECANISMO, não por reprodução do gatilho: o que fica provado é que
+`pipefail` troca o veredito do consumidor pelo do produtor morto; o escalonamento adverso do runner
+continua sem reprodução local, e é honesto dizer isso. O guard
+[`scripts/test-guard-noop-sabotagem.sh`](../../scripts/test-guard-noop-sabotagem.sh) chega no mesmo
+lugar por outro caminho — um shim com a semântica do GNU `grep -q` — e vale nos dois sistemas.
 
 A contramedida é não usar pipeline para decidir presença — busca no próprio shell, sem fork:
 


### PR DESCRIPTION
Correção factual na 14ª armadilha, que entrou na main pelo #2308 hoje.

O #2308 acertou o mecanismo (sob `pipefail`, o SIGPIPE do escritor apaga o `0` do `grep`, que quer dizer ACHEI) e o conserto (`case`, sem pipe). **Este PR não mexe em código** — só na explicação de *por que não reproduz no macOS*, que estava errada.

## O que estava escrito

> **Não tente reproduzir no macOS:** o BSD grep DRENA o stdin antes de sair, e a corrida não aparece nem em 400 tentativas.

## O que eu medi

Com o payload passando da capacidade do pipe, os dois greps desta máquina saem no primeiro casamento e matam o escritor — igualzinho ao GNU:

```
/usr/bin/grep (BSD grep 2.6.0-FreeBSD)   ->  writer=141 grep=0
ugrep 7.8.4 (o shim de `grep` daqui, §4) ->  writer=141 grep=0
```

A observação empírica do #2308 está certa (400 tentativas, zero fabricações). A **atribuição causal** é que não: o que blinda o macOS é o mesmo que torna o Linux raro — os 59 KB cabem no buffer de 64 KiB e o `printf` termina antes de o `grep` fechar. Não é uma diferença de grep.

## Por que importa

Inverte o conselho operacional. Em vez de "não tente reproduzir no macOS", **o macOS reproduz de forma determinística** quando se tira a corrida do caminho — basta empurrar o payload além do buffer, e o escritor passa a ter bytes pendentes por CAPACIDADE em vez de por escalonamento:

```bash
bash -c 'set -o pipefail
  ORIG="$(cat scripts/sonda-versao-sql.ts)$(head -c 120000 </dev/zero | tr "\0" x)"
  printf "%s" "$ORIG" | command grep -qF "l.status_code = 401"
  ps=("${PIPESTATUS[@]}"); echo "writer=${ps[0]} grep=${ps[1]}"'   # → writer=141 grep=0
```

Esse snippet foi extraído do arquivo e executado verbatim antes de ser publicado nele.

O texto novo também deixa explícito o limite honesto que faltava: o que está provado é o **mecanismo**; o escalonamento adverso do runner continua **sem** reprodução local. Diagnóstico por mecanismo + eliminação, não por reprodução do gatilho.

## Verificação independente do conserto do #2308

Antes de descobrir o #2308, cheguei ao mesmo `case "$ORIG" in *"\$de"*)` nos mesmos dois arquivos e rodei as provas — que portanto valem para o código que já está na main:

- `bun run evals:deploy-verify:falsificacao` → `EXIT=0`, `0 cegueira(s)`, 11/11 sabotagens pegadas.
- Falsificação do **próprio guard** (alvo trocado por um genuinamente ausente, nos dois arquivos) → volta a acusar `NO-OP` e sai `1`. O conserto não desligou o guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)