### PR TITLE
test(sonda): o timeout media a FORMA, nao o piso — `:= 1` passava por "explicito"

### DIFF
--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -65,8 +65,27 @@ PEGA      | cast para jsonb sem o filtro textual antes            | s/AND left\(
 # psql-ro. Recorte que vaza um lado no outro devolve a leitura para a mao do founder.
 PEGA      | --so-disparo passa a emitir a leitura junto           | s/const querLeitura = !opts\.soDisparo;/const querLeitura = true;/
 PEGA      | --so-leitura passa a emitir o disparo junto           | s/const querDisparo = !opts\.soLeitura;/const querDisparo = true;/
-SOBREVIVE | timeout 20s -> 30s (valor nao e pinado)    | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
-SOBREVIVE | ORDER BY por posicao (cosmetico)           | s/ORDER BY l\.edge;/ORDER BY 1;/
+# O `timeout_milliseconds`. A linha `PEGA` la em cima ja provava que ele nao pode ficar IMPLICITO
+# (o default de 5s do net.http_post mata silencioso). O que faltava era o PISO: a assercao de entao
+# so exigia `:= \d+`, que e a FORMA e nao a invariante — e `:= 1` satisfaz "explicito" sendo PIOR
+# que o default. MEDIDO 2026-09-07 com controle+ verde na MESMA invocacao: 20000 -> 3000, -> 1 e
+# -> 0 SOBREVIVIAM as 54 mutacoes deste contrato. As duas abaixo sao o dente novo; a de 5000 e a
+# mutacao de FRONTEIRA (pina que a comparacao e `>` estrito, nao `>=`: com `>=` ela sobrevive).
+PEGA      | timeout IGUAL ao default de 5s (fronteira > vs >=) | s/timeout_milliseconds := 20000/timeout_milliseconds := 5000/
+PEGA      | timeout ABAIXO do default (3s: pior que implicito) | s/timeout_milliseconds := 20000/timeout_milliseconds := 3000/
+# ACEITO, com justificativa: 20s e TUNING, nao fronteira. Nenhuma decisao do gerador depende de o
+# numero ser 20000 em vez de 30000 — o que decide e estar ACIMA do piso de 5s, e ISSO agora tem
+# asercao (as duas PEGA acima). Pinar 20000 seria fachada: travaria o valor sem invariante atras,
+# e a proxima pessoa que ajustasse o tuning ficaria vermelha sem ter quebrado nada.
+SOBREVIVE | timeout 20s -> 30s (tuning acima do piso)  | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
+# ACEITO, com justificativa: INERTE, nao apenas cosmetico. `SELECT l.edge,` e a PRIMEIRA coluna da
+# projecao final (conferido em 2026-09-07), entao `ORDER BY 1` e EXATAMENTE o mesmo plano e a mesma
+# ordem — o mutante nao muda nem a saida. E mesmo que a 1a coluna mudasse, ordem de LINHAS de um
+# relatorio de leitura nao entra em veredito nenhum: o veredito e por linha, no CASE.
+# ⚠️ O que tornaria isto FALSO: alguem inserir coluna antes de `l.edge` no SELECT. Ai `ORDER BY 1`
+# passa a ordenar por outra coisa — continua sem mudar veredito, mas deixa de ser inerte. Se essa
+# insercao acontecer, esta linha vira `?` ou some; nao a promova a PEGA sem invariante atras.
+SOBREVIVE | ORDER BY por posicao (inerte: edge e a 1a col) | s/ORDER BY l\.edge;/ORDER BY 1;/
 # Os 8 abaixo guardam o GUARD DE SINCRONIA (worktree defasado). O gerador já lia a fonte da verdade
 # do repo em vez da memória do operador — mas "o repo" pode ser um checkout VELHO, e aí o
 # `esperado(...)` sai de um retrato que a main já superou. MEDIDO 2026-09-05: worktree dois merges

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -250,9 +250,20 @@ describe('PASSO 1 — dispara a leva numa tacada', () => {
     expect(sql).toContain('jsonb_object_agg(edge, request_id)::text');
   });
 
-  it('timeout_milliseconds é EXPLÍCITO — o default de 5s mata silencioso', () => {
+  // O default do `net.http_post` é 5s e mata silencioso (CLAUDE.md §armadilhas · docs/agent/sync.md).
+  // A asserção ANTERIOR era `/timeout_milliseconds\s*:=\s*\d+/`: ela media a FORMA (existe UM
+  // número), não a invariante que o próprio nome promete. `:= 1` e `:= 0` são "explícitos" e são
+  // PIORES que o default — matam a sondagem antes de qualquer resposta, e o desfecho é a leitura
+  // devolvendo ausência de linha para uma edge que respondeu. MEDIDO 2026-09-07 por mutcheck
+  // exploratório (controle+ verde na mesma invocação): 20000→3000, →1 e →0 SOBREVIVIAM.
+  // Pinar o valor em 20000 seria fachada: 20s é TUNING, não fronteira — por isso 20000→30000 segue
+  // `SOBREVIVE` declarado no .mut. A fronteira é o piso, e é ela que esta asserção pina.
+  const DEFAULT_PG_NET_MS = 5000;
+  it('timeout_milliseconds é EXPLÍCITO e ACIMA do default de 5s, que mata silencioso', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
-    expect(sql).toMatch(/timeout_milliseconds\s*:=\s*\d+/);
+    const m = sql.match(/timeout_milliseconds\s*:=\s*(\d+)\)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThan(DEFAULT_PG_NET_MS);
   });
 
   it('o corpo pede a SONDA, não o fluxo real', () => {


### PR DESCRIPTION
## O que eu fui investigar (e o que a medida devolveu)

O briefing era "o `mutation-check` está vermelho na main". **Está verde.** O run vermelho ([34073214705](https://github.com/LucasSardenbergL/afiacao/actions/runs/34073214705)) é do sha `59ccede` (#2279); o **#2289** (`c79677ece`), mergeado ~10h depois, já consertou as 3 inválidas — desdobrando cada padrão ambíguo em dois ancorados no texto próprio. O CI da main para `317b3a988` ([34116782376](https://github.com/LucasSardenbergL/afiacao/actions/runs/34116782376)) confirma: `mutation-check: success`.

E os **2 sobreviventes nunca foram o problema**: são `EXPECT=SOBREVIVE` declarados, e o exit code do mutcheck é `problems` — sobrevivente esperado não incrementa. No mesmo run vermelho, 13 dos 23 contratos tinham sobreviventes e todos reportaram "0 problema(s)".

## O buraco que apareceu indo atrás do mérito

Fui decidir "por medida" se o `timeout` devia ser pinado, e a asserção estava cega:

```
PEGA  CONTROLE+: timeout implicito (default 5s) ✓ PEGA
?     20s -> 30s (o SOBREVIVE ja declarado)    ⚠ SOBREVIVE
?     20s -> 3s  (ABAIXO do default de 5s)     ⚠ SOBREVIVE   ← buraco
?     20s -> 1ms (absurdo: mata tudo)          ⚠ SOBREVIVE   ← buraco
?     20s -> 0   (zero = sem espera)           ⚠ SOBREVIVE   ← buraco
```

`/timeout_milliseconds\s*:=\s*\d+/` media a **forma** (existe um número), não a invariante que o nome do teste promete ("o default de 5s mata silencioso"). `:= 1` satisfaz "explícito" e é **pior** que o default: mata a sondagem antes de qualquer resposta, e a leitura devolve ausência de linha para uma edge que respondeu — falso negativo que manda redeployar à toa.

O remédio **não** é pinar `20000` (fachada: 20s é tuning, e travaria o valor sem invariante atrás). É pinar o **piso**.

## O que muda

- **Asserção**: captura o número e o exige acima do default de 5s do `net.http_post`.
- **Contrato**: ganha as duas mutações que lhe dão dente — a de `:= 5000` é a de **fronteira** (pina `>` estrito, não `>=`).
- **Os dois `SOBREVIVE` continuam `SOBREVIVE`**, agora com justificativa medida em vez de rótulo:
  - `20s→30s` é tuning acima do piso;
  - `ORDER BY 1` é **inerte**, não só cosmético — `SELECT l.edge,` é a 1ª coluna da projeção, então é o mesmo plano e a mesma ordem. Com a condição nomeada que tornaria isso falso (inserir coluna antes de `l.edge`).

## Evidência

Contrato: `56 mutações · 54 pegas · 2 sobreviventes · 0 inválidas · controle+ ✓ (54/54) · 0 problema(s)` — exit 0.

Falsificação com controle verde **antes do 1º `sed`**, marcador positivo (exige `Tests 1 passed|failed`: um `-t` que não casa roda 0 testes e sai 0), restauro por cópia+trap, e contra-prova:

```
CONTROLE (sem sabotagem): VERDE ✓
:= 5000 (fronteira) VERMELHO ✓   := 3000 VERMELHO ✓   := 1 VERMELHO ✓
:= 0 VERMELHO ✓                  removido VERMELHO ✓
:= 30000 VERDE ✓ (contra-prova)  := 5001 VERDE ✓ (`>` estrito)
POS-RESTAURO: VERDE ✓
```

`TOTAL_FALHAS_NOS_2_LOCALES=0` (`LC_ALL=C` e `pt_BR.UTF-8`). `typecheck` e `lint` em 0.

## Nota de escopo

Não mexi no fonte: o defeito medido está na **asserção**, e extrair constante não fecha buraco nenhum por si. O `mutation-check` segue não-bloqueante — decisão já tomada e documentada em `ci.yml:677`, com o motivo certo (os `.mut` casam texto exato; refactor legítimo dessincroniza e travaria PRs alheias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)