### PR TITLE
fix(leitura): "não há" para de ser o que a falha diz — os 6 sítios de fonte ZERADA do 3º front

### DIFF
--- a/docs/historico/o-check-verde-que-a-falha-acende.md
+++ b/docs/historico/o-check-verde-que-a-falha-acende.md
@@ -210,3 +210,58 @@ aprova tudo. Cada camada restaura com `git checkout --` e o restauro é conferid
 | L4 | **detector cego** (predicado de texto sempre falso) | 13→0: um gate cego passaria verde para sempre |
 | L5 | **dedup quebrada** (contar por hook) | `ToolHistory` 1→2: a dedup é load-bearing em dado real, não só na fixture |
 
+
+## Quitação da fatia de fonte ZERADA (2026-09-07, PR desta sessão)
+
+O item 4 acima previa **chip com gatilho**. O que foi feito em vez disso: **correção agora**,
+pelo motivo que o próprio item dá — "corrigir ANTES da primeira linha". Com a tabela vazia não há
+comportamento observável a regredir, o fix é o mais barato que vai ficar, e quando a fonte encher o
+defeito já não existe. Chip com gatilho só teria valor se o fix fosse caro; ele não é.
+
+Os 6, com a forma e o mecanismo do colapso:
+
+| sítio | fonte (linhas) | como o colapso era escrito | fix |
+|---|---|---|---|
+| `ProvasParaAuditar:244` | `v_tarefas_estado` (0) | default `= []` no binding | `estadoDeLeitura` |
+| `CustomerCallsTab:16` | `farmer_calls` (0) | `!data \|\| length === 0` | `estadoDeLeitura` |
+| `CustomerVisitsTab:26` | `route_visits` (0) | `!data \|\| length === 0` | `estadoDeLeitura` |
+| `GrupoCliente360:42` | `cliente_grupos` (0) | derivada: `!grupo` de `grupos?.find()` | `estadoDeLeitura` |
+| `OrderDetail:166` | `orders` (0) | `!order` sobre `.maybeSingle()` | `estadoDeRegistro` |
+| `AdminStandardProcessDetail:45` | `standard_processes` (0) | `!data` sobre `.maybeSingle()` | `estadoDeRegistro` |
+
+**`ProvasParaAuditar` não era a forma que a medição registrou.** A tabela do achado 3 o classificou
+como lista `!data || data.length === 0`; o código escreve `const { data: provas = [], isLoading }` e
+`if (provas.length === 0)`. O colapso vinha do **default no binding** — a forma do 2º front — e não
+do `||` digitado à mão. O erro de classificação não muda o veredito (o hook lança, o sítio é
+alcançável) mas muda o FIX: não há `!data` para desdobrar, e a query precisa ser lida por
+`estadoDeLeitura` antes do `data` já achatado em `[]`.
+
+### O que a medição provou, e o que ela não provaria sozinha
+
+`contarRetornoAfirmativo` foi de **9 para 3**. Zero, porém, é o que a CEGUEIRA também produz: o
+detector só rastreia desestruturação direta (`const {…} = useX(…)`), e um `const q = useX()` faria
+os 6 sumirem sem conserto nenhum. A prova de que lado veio o zero: **apagar a chave de erro de cada
+binding e re-medir** — 6/6 voltaram a contar 1, isto é, o detector VÊ o tratamento e segue vigiando
+os arquivos. Um sítio cegado teria ficado em zero nas duas medições.
+
+Falsificação: **18/18 sabotagens pegas** (3 camadas × 6 sítios), com controle verde (24/24) na mesma
+invocação **antes do 1º `sed`** — guard morto, guard estreitado a `'erro'` só (o 4º estado volta a
+mentir), e aviso incondicional (que prova que o teste também exige o SILÊNCIO quando a leitura deu
+certo — senão "sempre avisa" passaria como fix).
+
+O controle pagou o próprio custo na 1ª execução: **abortou sem sabotar nada**, porque um dos 5
+arquivos estava vermelho (o mock de `supabase` não tinha `channel`, e o `<OrderChat>` do caminho
+feliz derrubava a árvore). Sem ele, as 18 sabotagens teriam dado "vermelho" contra uma suíte já
+quebrada e eu teria reportado 18/18 com um teste morto no meio — a falsificação sem linha de base
+que `falsificacao-sem-linha-de-base.md` descreve.
+
+Nota de ambiente, porque custou duas execuções: `heavy` **aborta com exit 1** quando esgota os 1800s
+de fila, e o exit 1 do laço starvado é indistinguível do exit 1 de "sabotagem passou verde" se você
+olhar só o código. O sinal que separa os dois é textual (`heavy: timeout (1800s)` vs `VEREDITO:`).
+Laço longo em máquina saturada precisa que o monitor vigie **a tomada do slot**, não só o veredito.
+
+### Resíduo da classe, medido
+
+Sobram **3** na `BASELINE_AFIRMATIVO`: `CompletudeSection` — em voo no PR #2305 — e
+`ToolHistory`/`ToolReports`, resíduo já documentado na própria baseline (a query IRMÃ `useToolEvents`
+ainda engole o erro no default `= []`; `tool_events` tem 0 linhas).

--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -157,13 +157,7 @@ const BASELINE = new Map<string, number>([
 // `ternario-null`, JÁ na baseline de cima; contá-lo aqui seria contar o mesmo sítio duas
 // vezes). O critério estrito não esconde fatia nenhuma.
 const BASELINE_AFIRMATIVO = new Map<string, number>([
-  ["src/components/customer/CustomerCallsTab.tsx", 1],
-  ["src/components/customer/CustomerVisitsTab.tsx", 1],
   ["src/components/knowledge-base/CompletudeSection.tsx", 1],
-  ["src/components/tarefas/ProvasParaAuditar.tsx", 1],
-  ["src/pages/AdminStandardProcessDetail.tsx", 1],
-  ["src/pages/GrupoCliente360.tsx", 1],
-  ["src/pages/OrderDetail.tsx", 1],
   // Resíduo MEDIDO, não fix pela metade: a leitura de `user_tools` já ramifica
   // (`estadoDeRegistro`), mas o guard é `!tool || !healthMetrics` e `healthMetrics` deriva
   // de `useToolEvents` — a query IRMÃ, que ainda engole o erro no default `= []` do binding.

--- a/src/components/customer/CustomerCallsTab.tsx
+++ b/src/components/customer/CustomerCallsTab.tsx
@@ -3,10 +3,25 @@ import { useCustomerCalls, type CustomerCallRow } from '@/hooks/useCustomerCalls
 import { CallSessionRow } from './CallSessionRow';
 import { CallSessionDetail } from './CallSessionDetail';
 import { Loader2 } from 'lucide-react';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 export function CustomerCallsTab({ customerId }: { customerId: string }) {
-  const { data, isLoading } = useCustomerCalls(customerId);
+  // Desestruturação DIRETA nomeando `status`/`fetchStatus`: um `const q = useX()` faria o
+  // sítio sumir do gate da classe por CEGUEIRA, não por conserto.
+  const { data, status, fetchStatus, isLoading } = useCustomerCalls(customerId);
+  const leitura = estadoDeLeitura({ status, fetchStatus });
   const [selected, setSelected] = useState<CustomerCallRow | null>(null);
+
+  // ANTES do loading: sem rede a query fica pending+paused e `isLoading` é FALSE — o 4º
+  // estado cairia no "Nenhuma chamada com transcript ainda".
+  if (naoConsegui(leitura)) {
+    return (
+      <div className="py-4">
+        <AvisoLeituraFalhou oque="as chamadas deste cliente" estado={leitura} testId="aviso-chamadas" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return <div className="flex items-center justify-center py-8 text-xs text-muted-foreground"><Loader2 className="w-3.5 h-3.5 animate-spin mr-2"/>Carregando…</div>;

--- a/src/components/customer/CustomerVisitsTab.tsx
+++ b/src/components/customer/CustomerVisitsTab.tsx
@@ -2,6 +2,8 @@ import { Loader2 } from 'lucide-react';
 import { useCustomerVisits } from '@/hooks/useCustomerVisits';
 import { visitResultLabel, resumoVisitas } from '@/lib/visitas/visit-result';
 import { formatBRL, formatarFracaoPct } from '@/components/customer360/format';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 const toneClass: Record<string, string> = {
   success: 'text-status-success',
@@ -12,7 +14,20 @@ const toneClass: Record<string, string> = {
 };
 
 export function CustomerVisitsTab({ customerId }: { customerId: string }) {
-  const { data, isLoading } = useCustomerVisits(customerId);
+  // Desestruturação DIRETA nomeando `status`/`fetchStatus`: um `const q = useX()` faria o
+  // sítio sumir do gate da classe por CEGUEIRA, não por conserto.
+  const { data, status, fetchStatus, isLoading } = useCustomerVisits(customerId);
+  const leitura = estadoDeLeitura({ status, fetchStatus });
+
+  // ANTES do loading: sem rede a query fica pending+paused e `isLoading` é FALSE — o 4º
+  // estado cairia no "Nenhuma visita registrada".
+  if (naoConsegui(leitura)) {
+    return (
+      <div className="py-4">
+        <AvisoLeituraFalhou oque="as visitas deste cliente" estado={leitura} testId="aviso-visitas" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/components/customer/__tests__/CustomerTabs.estados.test.tsx
+++ b/src/components/customer/__tests__/CustomerTabs.estados.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+
+/**
+ * Guard das duas abas de histórico do cliente (chamadas · visitas) — "nunca aconteceu" não
+ * pode ser o que a falha de leitura diz.
+ *
+ * `farmer_calls` e `route_visits` (para este recorte) têm 0 linhas hoje: é por isso que o
+ * fix é barato agora — não há comportamento observável a regredir, e quando as tabelas
+ * encherem o defeito já não existe (docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * As duas escreviam `if (!data || data.length === 0)` — o colapso digitado À MÃO, com `||`:
+ * ambos os hooks lançam no erro (`throw error` / `throw new Error`), então `data` é
+ * `undefined` na falha e `[]` no vazio de verdade, e o `||` juntava os dois.
+ *
+ * Os HOOKS rodam de verdade; só o `supabase` é mockado — o defeito mora na tradução
+ * "PostgREST falhou" → `data === undefined` → tela do "não há".
+ */
+
+const CLIENTE = 'cliente-1';
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: [], error: null });
+  // Todo método devolve a própria chain, e a chain é THENABLE: o `await` funciona em
+  // qualquer ponto da cadeia, sem eu precisar saber qual terminador cada hook usa.
+  const chain: Record<string, unknown> = {
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  for (const m of ['select', 'eq', 'in', 'not', 'order', 'limit', 'maybeSingle', 'single']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => encadear(tabela) },
+}));
+
+import { CustomerCallsTab } from '../CustomerCallsTab';
+import { CustomerVisitsTab } from '../CustomerVisitsTab';
+
+const CHAMADA = {
+  id: 'call-1', farmer_id: 'f-1', customer_user_id: CLIENTE, phone_dialed: '11999990000',
+  call_backend: 'webrtc', started_at: '2026-09-01T12:00:00Z', ended_at: '2026-09-01T12:09:00Z',
+  duration_seconds: 540, call_result: 'pedido_fechado', call_type: 'ativa',
+  revenue_generated: 1200, margin_generated: 300, notes: null,
+  transcript: [{ role: 'user', text: 'oi' }], analyses: null, entities_extracted: null,
+};
+
+const VISITA = {
+  id: 'visit-1', visited_by: 'vend-1', visit_date: '2026-09-01', check_in_at: '2026-09-01T10:00:00Z',
+  check_out_at: '2026-09-01T10:40:00Z', result: 'pedido_fechado', notes: 'Levou catálogo novo.',
+  revenue_generated: 980, order_created: true,
+};
+
+function renderizar(Tela: React.ComponentType<{ customerId: string }>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <Tela customerId={CLIENTE} />
+    </QueryClientProvider>,
+  );
+}
+
+/** o que cada aba lê, o texto do "não há" e a âncora do seu próprio aviso */
+const ABAS = [
+  {
+    nome: 'CustomerCallsTab',
+    Tela: CustomerCallsTab,
+    tabela: 'farmer_calls',
+    linha: CHAMADA,
+    vazioRe: /Nenhuma chamada com transcript ainda/i,
+    // CallSessionRow renderiza `{durationMin}min · {backend} · {call_result}` num só div.
+    comDadoRe: /pedido_fechado/,
+    testId: 'aviso-chamadas',
+  },
+  {
+    nome: 'CustomerVisitsTab',
+    Tela: CustomerVisitsTab,
+    tabela: 'route_visits',
+    linha: VISITA,
+    vazioRe: /Nenhuma visita registrada/i,
+    comDadoRe: /Levou catálogo novo/i,
+    testId: 'aviso-visitas',
+  },
+] as const;
+
+beforeEach(() => {
+  respostas = { profiles: { data: [{ user_id: 'vend-1', name: 'Ana' }], error: null } };
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe.each(ABAS)('$nome — o vazio e a falha têm cara própria', ({ Tela, tabela, linha, vazioRe, comDadoRe, testId }) => {
+  it('HÁ registros → a aba lista, sem aviso', async () => {
+    respostas[tabela] = { data: [linha], error: null };
+    renderizar(Tela);
+    await waitFor(() => expect(screen.getByText(comDadoRe)).toBeInTheDocument());
+    expect(screen.queryByText(vazioRe)).toBeNull();
+    expect(screen.queryByTestId(testId)).toBeNull();
+  });
+
+  it('VAZIO de verdade → o empty state legítimo, sem aviso', async () => {
+    respostas[tabela] = { data: [], error: null };
+    renderizar(Tela);
+    await waitFor(() => expect(screen.getByText(vazioRe)).toBeInTheDocument());
+    expect(screen.queryByTestId(testId)).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso, e NUNCA o empty state', async () => {
+    respostas[tabela] = { data: null, error: { code: 'PGRST301', message: 'JWT expired' } };
+    renderizar(Tela);
+    const aviso = await screen.findByTestId(testId);
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(vazioRe)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA o empty state', async () => {
+    // Sem rede a query fica pending+paused: `isLoading` é FALSE, `data` é `undefined` e
+    // `error` é `null`. O `!data ||` mandava esse estado direto para o "não há".
+    respostas[tabela] = { data: [linha], error: null };
+    onlineManager.setOnline(false);
+    renderizar(Tela);
+    const aviso = await screen.findByTestId(testId);
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(vazioRe)).toBeNull();
+  });
+});

--- a/src/components/tarefas/ProvasParaAuditar.tsx
+++ b/src/components/tarefas/ProvasParaAuditar.tsx
@@ -26,6 +26,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { useProvasParaAuditar, useAuditarTarefa } from '@/hooks/useTarefasFase2';
 import { useSalespeople } from '@/hooks/useCoverage';
 import type { TarefaInstancia } from '@/lib/tarefas/templates-types';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -222,7 +224,14 @@ function ControlesAuditoria({ prova, auditarTarefa }: ControlesAuditoriaProps) {
 // ---------------------------------------------------------------------------
 
 export function ProvasParaAuditar() {
-  const { data: provas = [], isLoading } = useProvasParaAuditar();
+  // A desestruturação fica DIRETA sobre o hook e nomeia `status`/`fetchStatus` de
+  // propósito: guardar a query num `const q = useX()` faria o sítio SUMIR do gate da
+  // classe por CEGUEIRA (ele só rastreia `const {…} = useX(…)`), não por conserto.
+  const { data: provas = [], status: statusProvas, fetchStatus: fetchProvas, isLoading } =
+    useProvasParaAuditar();
+  // O default `= []` do binding colapsa "falhou" em "não há": `data` é `undefined` no erro
+  // e vira `[]` aqui. `estadoDeLeitura` lê a query, não o `data` já achatado.
+  const leituraProvas = estadoDeLeitura({ status: statusProvas, fetchStatus: fetchProvas });
   const { auditarTarefa } = useAuditarTarefa();
   const { data: salespeople = [] } = useSalespeople();
 
@@ -230,6 +239,19 @@ export function ProvasParaAuditar() {
     (userId: string) => salespeople.find((s) => s.user_id === userId)?.name ?? userId.slice(0, 8),
     [salespeople],
   );
+
+  // ANTES do loading de propósito: sem rede a query fica pending+paused e `isLoading` é
+  // FALSE — o 4º estado cairia direto no "Nenhuma prova aguardando auditoria".
+  if (naoConsegui(leituraProvas)) {
+    return (
+      <AvisoLeituraFalhou
+        oque="as provas aguardando auditoria"
+        estado={leituraProvas}
+        variante="bloco"
+        testId="aviso-provas-auditar"
+      />
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/components/tarefas/__tests__/ProvasParaAuditar.estados.test.tsx
+++ b/src/components/tarefas/__tests__/ProvasParaAuditar.estados.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+
+/**
+ * Guard do painel de AUDITORIA — "Nenhuma prova aguardando auditoria" é uma AFIRMAÇÃO DE
+ * CONTROLE, e não pode ser o que a falha de leitura diz.
+ *
+ * `v_tarefas_estado` (requer_auditoria) tem 0 linhas hoje: é exatamente por isso que o fix
+ * é barato agora — não há comportamento observável a regredir, e quando a fila encher o
+ * defeito já não existe (docs/historico/o-check-verde-que-a-falha-acende.md, item 4).
+ *
+ * O colapso aqui NÃO era `!data || data.length === 0`: era o default `= []` do binding.
+ * `useProvasParaAuditar` faz `if (error) throw error`, então no erro `data` é `undefined`
+ * e o default o converte em `[]` — a lista vazia e a leitura falha viram a MESMA tela.
+ *
+ * O hook roda de verdade; só `supabase` e o `useAuth` são mockados. Mockar
+ * `useProvasParaAuditar` provaria apenas que a tela renderiza um estado montado por mim —
+ * e o defeito mora na tradução "PostgREST falhou" → `data === undefined` → `[]`.
+ */
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: [], error: null });
+  // Todo método devolve a própria chain, e a chain é THENABLE: assim o `await` funciona em
+  // qualquer ponto da cadeia, sem eu precisar saber qual terminador cada hook usa.
+  const chain: Record<string, unknown> = {
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  for (const m of ['select', 'eq', 'in', 'not', 'order', 'limit', 'maybeSingle', 'single']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (tabela: string) => encadear(tabela),
+    storage: { from: () => ({ createSignedUrl: () => Promise.resolve({ data: null, error: null }) }) },
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'gestor-1' }, isMaster: true, isStaff: true }),
+}));
+
+import { ProvasParaAuditar } from '../ProvasParaAuditar';
+
+const PROVA = {
+  id: 'prova-1',
+  descricao: 'Conferir estoque do balcão',
+  assigned_to: 'vendedora-1',
+  comprovacao_em: '2026-09-01T12:00:00Z',
+  comprovacao_url: null,
+  comprovacao_leitura: 42,
+  leitura_unidade: 'un',
+  leitura_min: null,
+  leitura_max: null,
+  requer_auditoria: true,
+};
+
+const VAZIO = 'Nenhuma prova aguardando auditoria';
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProvasParaAuditar />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = { commercial_roles: { data: [], error: null } };
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('ProvasParaAuditar — a fila vazia e a leitura falha têm cara própria', () => {
+  it('HÁ provas → a tela lista a fila, sem aviso', async () => {
+    respostas.v_tarefas_estado = { data: [PROVA], error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(/1 prova aguardando/)).toBeInTheDocument());
+    expect(screen.queryByText(VAZIO)).toBeNull();
+    expect(screen.queryByTestId('aviso-provas-auditar')).toBeNull();
+  });
+
+  it('a fila está VAZIA de verdade → o empty state legítimo, sem aviso', async () => {
+    respostas.v_tarefas_estado = { data: [], error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(VAZIO)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-provas-auditar')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso, e NUNCA "Nenhuma prova aguardando auditoria"', async () => {
+    respostas.v_tarefas_estado = { data: null, error: { code: 'PGRST301', message: 'JWT expired' } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-provas-auditar');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(VAZIO)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA o empty state', async () => {
+    // `networkMode:'online'` sem rede deixa a query em pending+paused: `isLoading` é FALSE,
+    // `data` é `undefined` e `error` é `null`. O default `= []` transformava isso em "não há".
+    respostas.v_tarefas_estado = { data: [PROVA], error: null };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-provas-auditar');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(VAZIO)).toBeNull();
+  });
+});

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -61,6 +61,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/pages/__tests__/CentralFerramenta.test.tsx",
       "src/pages/__tests__/ToolDetalhe.estados.test.tsx",
+      "src/pages/__tests__/OrderDetail.estados.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },
@@ -97,7 +98,7 @@ export const MODULOS: ModuloApp[] = [
       "src/pages/TarefasTemplates.tsx",
       "src/hooks/useTarefas*.ts",
     ],
-    testes: [],
+    testes: ["src/components/tarefas/__tests__/ProvasParaAuditar.estados.test.tsx"],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },
   {
@@ -390,6 +391,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/pages/__tests__/AdminCustomers.erro-honesto.test.tsx",
       "src/components/customer/__tests__/CustomerProfile360Summary.estados.test.tsx",
+      "src/components/customer/__tests__/CustomerTabs.estados.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },
@@ -542,6 +544,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/hooks/__tests__/useAuditTrail.test.tsx",
       "src/hooks/__tests__/useIniciativasIceberg.test.ts",
+      "src/pages/__tests__/GrupoCliente360.estados.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },
@@ -581,6 +584,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useExtractSpecs.test.tsx",
       "src/hooks/__tests__/useKnowledgeBaseList.test.tsx",
       "src/pages/__tests__/AdminKnowledgeBaseDetail.estados.test.tsx",
+      "src/pages/__tests__/AdminStandardProcessDetail.estados.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },

--- a/src/pages/AdminStandardProcessDetail.tsx
+++ b/src/pages/AdminStandardProcessDetail.tsx
@@ -13,6 +13,8 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import type { StandardProcessEtapa } from '@/lib/standard-process/types';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 const ETAPA_TYPE_COLOR: Record<string, string> = {
   preparacao: 'bg-status-info-bg text-status-info-foreground',
@@ -29,9 +31,24 @@ export default function AdminStandardProcessDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { isMaster, user } = useAuth();
-  const { data, isLoading, refetch } = useStandardProcess(id ?? null);
+  // Desestruturação DIRETA nomeando as chaves de erro: um `const q = useX()` faria o sítio
+  // sumir do gate da classe por CEGUEIRA, não por conserto.
+  const { data, status, fetchStatus, error, isLoading, refetch } = useStandardProcess(id ?? null);
+  // `.maybeSingle()` devolve `null` para "este processo não existe" e `undefined` só em
+  // loading/erro — a diferença que o `if (!data)` abaixo apagava.
+  const estadoProcesso = estadoDeRegistro({ status, fetchStatus, error }, data != null);
   const approve = useApproveStandardProcess();
   const [editing, setEditing] = useState(false);
+
+  // ANTES do loading: sem rede a query fica pending+paused e `isLoading` é FALSE — o 4º
+  // estado cairia no "Processo não encontrado.".
+  if (naoConsegui(estadoProcesso)) {
+    return (
+      <div className="container mx-auto p-4">
+        <AvisoLeituraFalhou oque="este processo padrão" estado={estadoProcesso} variante="bloco" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -16,6 +16,8 @@ import { GrupoFinanceiroTab } from '@/components/grupos/GrupoFinanceiroTab';
 import { GrupoComercialTab } from '@/components/grupos/GrupoComercialTab';
 import { GrupoContatosTab } from '@/components/grupos/GrupoContatosTab';
 import { formatDoc } from '@/lib/grupos/format';
+import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 const RELATION_BADGE: Record<RelationType, string> = {
   sucessao: 'sucessão',
@@ -26,11 +28,28 @@ const RELATION_BADGE: Record<RelationType, string> = {
 export default function GrupoCliente360() {
   const { grupoId } = useParams<{ grupoId: string }>();
   const navigate = useNavigate();
-  const { data: grupos, isLoading } = useClienteGrupos();
+  // Desestruturação DIRETA nomeando as chaves de erro: um `const q = useX()` faria o sítio
+  // sumir do gate da classe por CEGUEIRA, não por conserto.
+  const { data: grupos, status: statusGrupos, fetchStatus: fetchGrupos, isLoading } =
+    useClienteGrupos();
+  const leituraGrupos = estadoDeLeitura({ status: statusGrupos, fetchStatus: fetchGrupos });
   const removeMembro = useRemoveMembro();
   const [addOpen, setAddOpen] = useState(false);
 
   const grupo = grupos?.find((g) => g.id === grupoId);
+
+  // ANTES do loading: sem rede a query fica pending+paused e `isLoading` é FALSE — o `.find()`
+  // sobre `undefined` daria `undefined` e a tela afirmaria "Grupo não encontrado".
+  if (naoConsegui(leituraGrupos)) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 p-4 sm:p-6">
+        <Button variant="ghost" size="sm" className="gap-1" onClick={() => navigate('/gestao/grupos-cliente')}>
+          <ArrowLeft className="h-4 w-4" /> Grupos
+        </Button>
+        <AvisoLeituraFalhou oque="os grupos de cliente" estado={leituraGrupos} variante="bloco" />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -38,6 +38,8 @@ import {
 } from '@/components/ui/alert-dialog';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { estadoDeRegistro, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 
 const WHATSAPP_NUMBER = '553732221035';
 
@@ -75,7 +77,9 @@ const OrderDetail = () => {
   const [copied, setCopied] = useState(false);
   const [qualityData, setQualityData] = useState<QualityData[]>([]);
 
-  const { data: order, isLoading } = useQuery({
+  // Desestruturação DIRETA nomeando as chaves de erro: um `const q = useX()` faria o sítio
+  // sumir do gate da classe por CEGUEIRA, não por conserto.
+  const { data: order, status: statusOrder, fetchStatus: fetchOrder, error: erroOrder, isLoading } = useQuery({
     queryKey: ['order-detail', id],
     queryFn: async () => {
       if (!id) return null;
@@ -111,6 +115,10 @@ const OrderDetail = () => {
     },
     enabled: !!id,
   });
+  const estadoOrder = estadoDeRegistro(
+    { status: statusOrder, fetchStatus: fetchOrder, error: erroOrder },
+    order != null,
+  );
 
   const queryClient = useQueryClient();
   const [confirmAprovar, setConfirmAprovar] = useState(false);
@@ -157,6 +165,18 @@ const OrderDetail = () => {
       <div className="min-h-screen bg-background pb-24">
         <main className="pt-16 px-4 max-w-lg mx-auto">
           <PageSkeleton variant="detail" />
+        </main>
+      </div>
+    );
+  }
+
+  // `.maybeSingle()` devolve `null` para "este pedido não existe" e `undefined` só em
+  // loading/erro — a diferença que o `if (!order)` abaixo apagava.
+  if (naoConsegui(estadoOrder)) {
+    return (
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <AvisoLeituraFalhou oque="este pedido" estado={estadoOrder} variante="bloco" />
         </main>
       </div>
     );

--- a/src/pages/__tests__/AdminStandardProcessDetail.estados.test.tsx
+++ b/src/pages/__tests__/AdminStandardProcessDetail.estados.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard do detalhe do PROCESSO PADRÃO — "Processo não encontrado." não pode ser o que a
+ * falha de leitura diz.
+ *
+ * `standard_processes` tem 0 linhas hoje: o fix sai antes da primeira linha, quando não há
+ * comportamento observável a regredir (docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * O `.maybeSingle()` PRESERVA a diferença — `null` = este processo não existe, `undefined`
+ * = loading ou erro — e o `if (!data)` a descartava. O hook roda de verdade; só o
+ * `supabase` e o `useAuth` são mockados.
+ */
+
+const PROCESSO_ID = 'processo-1';
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: null, error: null });
+  const chain: Record<string, unknown> = {
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  for (const m of ['select', 'eq', 'in', 'not', 'order', 'limit', 'maybeSingle', 'single']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => encadear(tabela) },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'master-1' }, isMaster: true, isStaff: true }),
+}));
+
+import AdminStandardProcessDetail from '../AdminStandardProcessDetail';
+
+const PROCESSO = {
+  id: PROCESSO_ID,
+  name: 'Acabamento poliuretano fosco',
+  slug: 'acabamento-pu-fosco',
+  description: null,
+  segmento: 'moveleiro',
+  porte_alvo: [],
+  tags: [],
+  etapas: [],
+  expected_outcomes: [],
+  target_audience: null,
+  prerequisites: [],
+  status: 'draft',
+  status_notes: null,
+  version: 1,
+  parent_id: null,
+  created_by: 'master-1',
+  reviewed_by: null,
+  reviewed_at: null,
+  created_at: '2026-09-01T12:00:00Z',
+  updated_at: '2026-09-01T12:00:00Z',
+};
+
+const NAO_ENCONTRADO = /Processo não encontrado/i;
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/admin/processos/${PROCESSO_ID}`]}>
+        <Routes>
+          <Route path="/admin/processos/:id" element={<AdminStandardProcessDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('AdminStandardProcessDetail — "não encontrado" volta a significar não encontrado', () => {
+  it('o processo EXISTE → a tela mostra o processo, sem aviso', async () => {
+    respostas.standard_processes = { data: PROCESSO, error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(/Acabamento poliuretano fosco/)).toBeInTheDocument());
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('o processo NÃO EXISTE (maybeSingle devolveu null) → "não encontrado", sem aviso', async () => {
+    respostas.standard_processes = { data: null, error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADO)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso, e NUNCA "Processo não encontrado."', async () => {
+    respostas.standard_processes = { data: null, error: { code: 'PGRST301', message: 'JWT expired' } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA o não-achado', async () => {
+    respostas.standard_processes = { data: PROCESSO, error: null };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+});

--- a/src/pages/__tests__/GrupoCliente360.estados.test.tsx
+++ b/src/pages/__tests__/GrupoCliente360.estados.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard do 360 do GRUPO DE CLIENTE — "Grupo não encontrado." não pode ser o que a falha diz.
+ *
+ * `cliente_grupos` tem 0 linhas hoje; o fix sai antes da primeira linha, quando não há
+ * comportamento observável a regredir (docs/historico/o-check-verde-que-a-falha-acende.md).
+ *
+ * Este sítio é o da DERIVADA: o guard é `if (!grupo)` sobre `grupos?.find(g => g.id === …)`.
+ * Com a leitura falha, `grupos` é `undefined`, o `?.` devolve `undefined` sem erro e a tela
+ * afirma que o grupo não existe — a mesma frase que ela usaria para um id de rota inválido.
+ * São coisas diferentes e agora dizem coisas diferentes.
+ *
+ * O hook roda de verdade; só o `supabase` é mockado.
+ */
+
+const GRUPO_ID = 'grupo-1';
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: [], error: null });
+  const chain: Record<string, unknown> = {
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  for (const m of ['select', 'eq', 'in', 'not', 'order', 'limit', 'maybeSingle', 'single']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => encadear(tabela) },
+}));
+
+import GrupoCliente360 from '../GrupoCliente360';
+
+const GRUPO = {
+  id: GRUPO_ID,
+  nome: 'Grupo Colacor',
+  notas: null,
+  ativo: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  membros: [
+    { id: 'm-1', grupo_id: GRUPO_ID, documento: '12345678000199', relation_type: 'multi_ativo', created_at: '2026-01-01T00:00:00Z' },
+  ],
+};
+
+const NAO_ENCONTRADO = /Grupo não encontrado/i;
+
+function renderizar(rota = GRUPO_ID) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/gestao/grupos-cliente/${rota}`]}>
+        <Routes>
+          <Route path="/gestao/grupos-cliente/:grupoId" element={<GrupoCliente360 />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('GrupoCliente360 — "não encontrado" volta a significar não encontrado', () => {
+  it('o grupo EXISTE → a tela mostra o grupo, sem aviso', async () => {
+    respostas.cliente_grupos = { data: [GRUPO], error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText('Grupo Colacor')).toBeInTheDocument());
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a leitura foi OK e o id não está na lista → "não encontrado" legítimo, sem aviso', async () => {
+    respostas.cliente_grupos = { data: [GRUPO], error: null };
+    renderizar('grupo-que-nao-existe');
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADO)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso, e NUNCA "Grupo não encontrado."', async () => {
+    respostas.cliente_grupos = { data: null, error: { code: 'PGRST301', message: 'JWT expired' } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA o não-achado', async () => {
+    respostas.cliente_grupos = { data: [GRUPO], error: null };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+});

--- a/src/pages/__tests__/OrderDetail.estados.test.tsx
+++ b/src/pages/__tests__/OrderDetail.estados.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * Guard do detalhe do pedido de afiação — "Pedido não encontrado" não pode ser o que a
+ * falha de leitura diz.
+ *
+ * NOTA SOBRE O DENOMINADOR: esta tela lê `orders`, que tem 0 linhas, enquanto
+ * `sales_orders` tem 31.248. O zero é VERDADE, não erro de medição — o escritor confirma
+ * (`OrderDetail.tsx` faz `.from('orders').update(...)` ao aprovar o orçamento). É uma tela
+ * VIVA em código e MORTA em dados, e por isso o fix sai agora, de graça
+ * (docs/historico/o-check-verde-que-a-falha-acende.md, achado 5 e item 4).
+ *
+ * O `.maybeSingle()` PRESERVA a diferença — `null` = este pedido não existe, `undefined` =
+ * loading ou erro — e o `if (!order)` a descartava. A query roda de verdade; só o
+ * `supabase` é mockado.
+ */
+
+const ORDER_ID = 'pedido-1';
+
+type Resposta = { data: unknown; error: unknown };
+let respostas: Record<string, Resposta> = {};
+
+function encadear(chave: string) {
+  const resolver = () => Promise.resolve(respostas[chave] ?? { data: null, error: null });
+  const chain: Record<string, unknown> = {
+    then: (ok: unknown, falha: unknown) => resolver().then(ok as never, falha as never),
+  };
+  for (const m of ['select', 'eq', 'in', 'not', 'order', 'limit', 'maybeSingle', 'single', 'update']) {
+    chain[m] = () => chain;
+  }
+  return chain;
+}
+
+// <OrderChat> abre um canal realtime no caminho feliz; sem `channel`/`removeChannel` o
+// efeito lança e o React desmonta a árvore inteira — o teste do "há dado" ficaria vermelho
+// por infraestrutura do mock, não pelo defeito sob teste.
+// O canal nasce DENTRO da factory: o `vi.mock` é içado acima dos `const` do módulo, e um
+// `const` de fora cairia em TDZ quando a factory rodasse. `encadear` sobrevive por ser
+// function declaration (essa sim é içada).
+vi.mock('@/integrations/supabase/client', () => {
+  const canal: Record<string, unknown> = {};
+  canal.on = () => canal;
+  canal.subscribe = () => canal;
+  return {
+    supabase: {
+      from: (tabela: string) => encadear(tabela),
+      channel: () => canal,
+      removeChannel: () => {},
+    },
+  };
+});
+
+// O caminho feliz monta <OrderChat>, que chama `useAuth()` e explode fora do AuthProvider.
+// Mockar a identidade não afrouxa o guard: o que está sob teste é a tradução
+// "leitura falhou" → tela, e ela não passa por auth.
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'cliente-1' }, isMaster: false, isStaff: false }),
+}));
+
+import OrderDetail from '../OrderDetail';
+
+const PEDIDO = {
+  id: 'abcdef1234567890',
+  user_id: 'cliente-1',
+  items: [],
+  status: 'aprovado',
+  delivery_option: 'retirada',
+  time_slot: null,
+  subtotal: 100,
+  delivery_fee: 0,
+  total: 100,
+  notes: null,
+  address: null,
+  created_at: '2026-09-01T12:00:00Z',
+  updated_at: '2026-09-01T12:00:00Z',
+};
+
+const NAO_ENCONTRADO = /Pedido não encontrado/i;
+
+function renderizar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/pedido/${ORDER_ID}`]}>
+        <Routes>
+          <Route path="/pedido/:id" element={<OrderDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  respostas = {};
+  onlineManager.setOnline(true);
+});
+afterEach(() => {
+  onlineManager.setOnline(true);
+  vi.restoreAllMocks();
+});
+
+describe('OrderDetail — "não encontrado" volta a significar não encontrado', () => {
+  it('o pedido EXISTE → a tela mostra o pedido, sem aviso', async () => {
+    respostas.orders = { data: PEDIDO, error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(/#ABCDEF12/)).toBeInTheDocument());
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('o pedido NÃO EXISTE (maybeSingle devolveu null) → "não encontrado", sem aviso', async () => {
+    respostas.orders = { data: null, error: null };
+    renderizar();
+    await waitFor(() => expect(screen.getByText(NAO_ENCONTRADO)).toBeInTheDocument());
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+  });
+
+  it('a LEITURA FALHOU → aviso, e NUNCA "Pedido não encontrado"', async () => {
+    respostas.orders = { data: null, error: { code: 'PGRST301', message: 'JWT expired' } };
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'erro');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+
+  it('SEM REDE (pending+paused, o 4º estado) → aviso de sem-rede, e NUNCA o não-achado', async () => {
+    respostas.orders = { data: PEDIDO, error: null };
+    onlineManager.setOnline(false);
+    renderizar();
+    const aviso = await screen.findByTestId('aviso-leitura-falhou');
+    expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(NAO_ENCONTRADO)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Instância única ou classe?

**Classe** — a 3ª forma de "erro colapsado em vazio" (`return <mensagem afirmativa>`), já varrida e
já gateada em 2026-09-06. Este PR é o passo 3 (**ERRADICAÇÃO**) da fatia que faltava, não uma
varredura nova: os 13 sítios foram medidos em `docs/historico/o-check-verde-que-a-falha-acende.md`,
7 de fonte viva (PR #2293) e **6 de fonte ZERADA — estes**.

## O que muda

Seis telas diziam "não há" / "não encontrado" sobre uma leitura que podia simplesmente **não ter
acontecido**. Todos os 6 hooks fazem `throw` no erro, então `data` fica `undefined` — a MESMA
condição de "vazio" e de "nunca carregou".

`ProvasParaAuditar` é o mais perigoso do grupo: **"Nenhuma prova aguardando auditoria" é uma
afirmação de controle** — a auditoria sumiria da tela no dia em que a leitura falhasse.

| sítio | fonte (linhas) | como o colapso era escrito |
|---|---|---|
| `ProvasParaAuditar:244` | `v_tarefas_estado` (0) | default `= []` no binding |
| `CustomerCallsTab:16` | `farmer_calls` (0) | `!data \|\| length === 0` |
| `CustomerVisitsTab:26` | `route_visits` (0) | `!data \|\| length === 0` |
| `GrupoCliente360:42` | `cliente_grupos` (0) | derivada: `!grupo` de `grupos?.find()` |
| `OrderDetail:166` | `orders` (0) | `!order` sobre `.maybeSingle()` |
| `AdminStandardProcessDetail:45` | `standard_processes` (0) | `!data` sobre `.maybeSingle()` |

## Por que AGORA, com a tabela vazia

Porque é o que torna o fix barato: **não há regressão possível de comportamento observável**, e
quando a fonte encher o defeito já não existe. O doc previa "chip com gatilho"; chip só teria valor
se o fix fosse caro — ele não é, e adiar só transfere o custo para depois da primeira linha.

`OrderDetail` merece nota: lê `orders` (0 linhas) enquanto `sales_orders` tem 31.248. O zero é
**verdade, não erro de medição** — o escritor confirma (`OrderDetail.tsx:123` faz
`.from('orders').update(...)`). É uma tela viva em código e morta em dados.

## Correção de classificação

A tabela do achado 3 registrou `ProvasParaAuditar` como lista `!data || data.length === 0`. O código
escreve `const { data: provas = [], isLoading }` + `if (provas.length === 0)`: o colapso vinha do
**default no binding**, não do `||` à mão. Não muda o veredito (o hook lança, o sítio é alcançável),
muda o FIX — não há `!data` para desdobrar, e a query precisa ser lida ANTES do `data` já achatado.

## Evidência

**Medição** (`contarRetornoAfirmativo` do próprio gate): **9 → 3**.

Zero é também o que a CEGUEIRA produz — o detector só rastreia desestruturação direta
(`const {…} = useX(…)`), e um `const q = useX()` faria os 6 sumirem sem conserto. Então:
**apaguei a chave de erro de cada binding e re-medi — 6/6 voltaram a contar 1.** O detector VÊ o
tratamento e segue vigiando os arquivos; um sítio cegado teria ficado em zero nas duas medições.

**Falsificação: 18/18 sabotagens pegas**, com **controle verde (24/24) na mesma invocação, antes do
1º `sed`**:
- `guard-morto` — o ramo de falha some ⇒ `erro` e `sem-rede` voltam a cair no "não há"
- `so-erro` — o guard passa a ver só `'erro'` ⇒ o 4º estado (sem-rede) volta a mentir
- `sempre-aviso` — aviso incondicional ⇒ prova que o teste exige também o **silêncio** quando a
  leitura deu certo (senão "sempre avisa" passaria como fix)

O controle pagou o próprio custo na 1ª execução: **abortou sem sabotar nada**, porque um dos 5
arquivos estava vermelho (o mock de `supabase` não tinha `channel`, e o `<OrderChat>` do caminho
feliz derrubava a árvore). Sem ele, as 18 sabotagens teriam dado "vermelho" contra uma suíte já
quebrada, e o "18/18" seria falsificação sem linha de base.

**Guards:** 5 arquivos de teste de host, hooks rodando de verdade (só `supabase`/`useAuth`
mockados), 4 casos cada — há dado · vazio de verdade · leitura falhou · sem rede
(`onlineManager.setOnline(false)`, o 4º estado em que `isLoading` é FALSE e `error` é `null`).

**Fronteira de módulo:** os 6 vivem em 5 módulos (`tarefas`, `admin-crm`, `governanca`,
`loja-afiacao`, `knowledge-base`). Cada teste foi co-locado no módulo da sua fonte — verificado com
`donoDoArquivo(caminho, MODULOS)`, 6/6 fonte e teste no mesmo módulo — e registrado no manifesto.

## Gate

As 6 entradas saem da `BASELINE_AFIRMATIVO`. Sobram 3: `CompletudeSection` (em voo no #2305) e
`ToolHistory`/`ToolReports` (resíduo já documentado na baseline — a query irmã `useToolEvents` ainda
engole o erro no default `= []`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
