### PR TITLE
fix(gate): o detector segue o alias por uma indireção — o buraco que aprovava cegueira e conserto pelo mesmo número

### DIFF
--- a/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
+++ b/docs/historico/a-forma-que-some-e-a-forma-que-mente.md
@@ -149,6 +149,113 @@ Corolário para quem varrer o resto do inventário: a correção desta classe **
 desestruturação do hook**, então quase todo sítio corrigido vai encolher a baseline. Cada
 encolhimento precisa dizer POR QUE — e "o número caiu" não é o porquê.
 
+## FECHADO — o detector segue o alias por uma indireção (2026-09-07)
+
+O buraco da tabela acima está fechado: `acharColapsos` passou a reconhecer o sítio também
+quando o resultado do hook é ligado a um nome e lido depois — `const q = useQuery(…)` seguido
+de `q.data`, ou de `const { data } = q` num segundo statement.
+
+**A decisão foi por MEDIDA, não por gosto.** A pergunta anterior à correção era o
+denominador: se quase ninguém escrevesse na forma por alias, o certo seria registrar a
+limitação e não endurecer nada. Medido em `src/**` antes de tocar no detector: **1.266**
+declarações `const x = use…()` sem desestruturação, **123** delas lendo `x.data`, e **100**
+lendo `data` sem NENHUMA chave de `CHAVES_DE_ERRO`. Não é ~0 — e a lista inclui exatamente os
+domínios que este doc classifica como de maior dano: `useDataHealth`, `useCashflowAlertas`,
+`useCarteiraSaude`, `usePrecoCockpit`.
+
+As três regras da forma direta valem inteiras pelo alias, e é isso que mantém a baseline
+confiável em vez de só maior:
+
+| regra | pela desestruturação | pelo alias |
+|---|---|---|
+| sem `data` não há colapso a afirmar | binding sem `data` | nenhum `q.data` no escopo |
+| `CHAVES_DE_ERRO` ABSOLVE | `const { data, status } = useX()` | `q.error` / `q.status`, ou `const { data, status } = q` |
+| `...rest` pode carregar o error → não afirmar | `const { data, ...rest }` | passar `q` adiante (`<Filho q={q}/>`, `f(q)`, `{...q}`, `q["data"]`) |
+
+### Duas armadilhas que a implementação encontrou
+
+**A raiz do tainting deixou de ser só identificador.** Na forma por alias sem
+desestruturação, o que carrega o dado é o ACESSO `q.data` — que não é identificador nenhum. O
+ponto fixo das derivadas varria só identificadores e devolveria o mesmo falso "consertado"
+que o endurecimento existe para fechar.
+
+**Outra chamada de hook NÃO é derivada do data — é outra FONTE, com error próprio.** Sem essa
+exclusão, `const outraQ = useQuery({ queryKey: [q.data] })` marcava `outraQ` como derivada, e
+daí `if (outraQ.isLoading) return null` — guarda de CARREGAMENTO — passava a contar como
+colapso de leitura. Em `src/hooks/useExcecoesGestor.ts` isso produzia **4 sítios falsos**: o
+`const data = useMemo(…)` marcava o nome `data`, que colide com o `const { data, error } =
+await supabase…` de cada `queryFn`, e a contaminação chegava até o `isLoading`. `useMemo` e
+`useCallback` ficam FORA da exclusão — são o veículo canônico da derivada, o caminho pelo qual
+o `DataHealthBanner` escapou da primeira versão desta varredura. Baseline que cresce por
+motivo benigno é como um gate morre, e essa é a mesma aritmética que mantém `jsx-&&` fora.
+
+### O crescimento é ACHADO, não regressão
+
+Medido antes e depois, arquivo a arquivo: **nenhum arquivo encolheu**. O que apareceu são
+sítios que já estavam lá e eram invisíveis.
+
+| baseline | antes | depois | entraram |
+|---|---|---|---|
+| auto-ocultação | 27 arquivos | 34 (+8 sítios) | `useCheckinQualitativo`, `useSimuladorData` (2), `ApprovalQueueSection`, `RadarMapa`, `ExcecaoCreditoDialog`, `useReposicaoSessao`, `useSinalPositivacao` |
+| `return-afirmativo` | 2 arquivos | 4 | `PosicaoAtualTab`, `ApprovalQueueSection` |
+
+A medida vale para a árvore em que ela foi feita, e esta foi RE-MEDIDA três vezes. A primeira
+passagem deu 32→38; depois a main mergeou o #2297 (5 sítios de card de dashboard), o #2298
+(mexeu em `useSinalPositivacao`) e, na véspera da entrega, o #2305/#2317 (que esvaziaram quase
+toda a baseline afirmativa). Rebasar sem RE-MEDIR teria reintroduzido entradas já quitadas e
+perdido a 8ª — número medido em árvore velha não é número. **Nenhum arquivo encolheu em nenhuma
+das três medições.**
+
+Nem todo sítio novo é auto-ocultação de COMPONENTE, e quem for quitar precisa saber disso:
+`ApprovalQueueSection` e `PosicaoAtualTab` apagam ou mentem na tela; `RadarMapa`,
+`useSinalPositivacao` e o `handleExtrair` da fila são `return` PELADO dentro de effect ou
+handler — que o detector conta como silêncio desde 2026-08-22, semântica pré-existente e não
+classe nova. São a classe MEDIDA, não sítios aprovados.
+
+O pior dos novos é `ApprovalQueueSection`: quando a leitura da fila falha, a tela acende o ✓
+VERDE com "Nada pra aprovar — suba boletins na aba Documentos". É literalmente o padrão de
+`docs/historico/o-check-verde-que-a-falha-acende.md`, uma indireção mais fundo.
+
+### Falsificação
+
+Cinco sabotagens, uma camada por vez, com o CONTROLE verde na MESMA invocação do laço
+(abortando antes do 1º `sed` se ele não fosse verde): matar a forma por alias inteira ·
+desligar `CHAVES_DE_ERRO` pelo alias · desligar a regra do `...rest`/repasse · tirar a raiz
+`q.data` do ponto fixo · tirar a exclusão de OUTRA FONTE. **5/5 ficaram vermelhas**, e cada
+uma derrubou exatamente os casos previstos — nenhuma camada sobreviveu como redundante.
+
+### Achado de brinde: exit 1 com 19/19 VERDES
+
+A primeira execução da suíte real reprovou por **timeout**, não por asserção — e cronometrar
+antes de consertar foi o que impediu o conserto errado: a varredura ficou mais RÁPIDA com o
+detector endurecido (12,3s → 9,8s, mesma máquina, back-to-back), então o estouro era custo de
+infra, não regressão deste PR.
+
+O modo de falha merece nome próprio. Com ~79s de laço CPU-bound segurando o event loop, o worker
+do vitest morria com `Timeout calling "onTaskUpdate"` e a suíte saía com **exit 1 exibindo
+`Tests 19 passed (19)`**. Quem lesse o resumo diria "passou". É a mesma família de
+`docs/historico/evidencia-positiva-shell.md`: **o veredito é o exit code, não o texto bonito
+acima dele** — e um vermelho que aparece como verde ensina a ignorar vermelho.
+
+O conserto NÃO é deste PR: a `main` resolveu antes, pelo #2311
+(`docs/historico/flaky-sob-carga-teto-e-custo.md`), com **orçamento por FONTE** em vez de um teto
+fixo. Eu tinha escrito o meu (varredura compartilhada entre as duas baselines + pré-filtro
+textual) e **descartei no rebase**, porque o do #2311 é melhor onde importa: um teto em ms/fonte
+acompanha o repo crescer sem afrouxar o **custo unitário**, que é justamente o sinal que
+denunciaria uma regressão do detector. Compartilhar a varredura teria zerado o tempo do segundo
+teste e apagado esse sinal. Conflito de arquivo é só um eixo — antes de insistir na própria
+versão, vale ver se a `main` já entregou a coisa, e melhor.
+
+### O que NÃO foi fechado
+
+O tainting continua **cego a escopo**: ele casa NOMES. Quando o nome marcado é `data` — o mais
+comum do repo — ele colide com qualquer `const { data, error } = await supabase…` aninhado num
+`queryFn`. A exclusão de OUTRA FONTE corta o caminho pelo qual essa colisão estava chegando a
+guardas de carregamento, mas **não remove a colisão**. Quem for endurecer o próximo eixo:
+o conserto de verdade é sombreamento (desmarcar, dentro de cada função aninhada, os nomes que
+ela re-declara) — e ele mexe também na forma direta, então precisa da mesma medida
+antes/depois, arquivo a arquivo, que esta entrega usou.
+
 ## O que considero LEGÍTIMO, e por quê
 
 Sete padrões cobrem a maioria dos 93. Em nenhum deles a ausência afirma segurança:

--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -91,16 +91,38 @@ function listarFontes(dir: string, acc: string[] = []): string[] {
 // um silêncio por um alarme FABRICADO para todo staff não-gestor. O gate de acesso foi
 // para o `enabled` do hook, onde a negativa vira `desabilitada` — estado que `naoConsegui`
 // exclui de propósito — em vez de virar aviso.
+//
+// CRESCEU EM 2026-09-07 (+7 arquivos, +8 sítios) e o crescimento é ACHADO, não regressão: o
+// detector passou a seguir o resultado do hook por UMA indireção (`const q = useQuery(...)` e,
+// adiante, `q.data` ou `const { data } = q`). Antes disso a forma por alias era INVISÍVEL — e o
+// buraco não era teórico: mover a desestruturação para o statement seguinte derrubava a
+// contagem com a linha de silêncio INTACTA, produzindo o MESMO delta do conserto legítimo. O
+// gate aprovava a cegueira e o conserto pelo mesmo número
+// (docs/historico/a-forma-que-some-e-a-forma-que-mente.md; medido no #2283).
+//
+// Denominador da fatia, medido ANTES de mexer: 1.266 declarações `const x = use…()` sem
+// desestruturação, 123 lendo `x.data`, 100 sem NENHUMA chave de `CHAVES_DE_ERRO`. Não era ~0 —
+// por isso endurecer ganhou de só registrar a limitação.
+//
+// LEIA ANTES DE QUITAR UM DESTES: nem todo sítio novo é auto-ocultação de COMPONENTE.
+// `ApprovalQueueSection` e `PosicaoAtualTab` apagam ou mentem na tela; `RadarMapa`,
+// `useSinalPositivacao` e o `handleExtrair` da fila são `return` PELADO dentro de effect ou
+// handler — que o detector conta como silêncio desde 2026-08-22, semântica pré-existente e não
+// classe nova. São a classe MEDIDA, não sítios aprovados.
 const BASELINE = new Map<string, number>([
   ["src/components/adminPrime/PrimePlanosTab.tsx", 1],
   ["src/components/customerDashboard/RecomendacoesCliente.tsx", 1],
   ["src/components/dashboard/FollowupsSugeridosCard.tsx", 1],
   ["src/components/dashboard/GestorExcecoes.tsx", 1],
+  ["src/components/des/checkinQualitativo/useCheckinQualitativo.ts", 1],
+  ["src/components/des/simulador/useSimuladorData.ts", 2],
   ["src/components/farmer/ChamadasPendentesNudge.tsx", 1],
   ["src/components/farmer/copilot/OfertaCruaCard.tsx", 1],
   ["src/components/financeiro/cashflow/EventosOnboarding.tsx", 1],
+  ["src/components/knowledge-base/ApprovalQueueSection.tsx", 1],
   ["src/components/knowledge-base/RendimentoCalculator.tsx", 1],
   ["src/components/knowledge-base/VersionHistory.tsx", 1],
+  ["src/components/radar/RadarMapa.tsx", 1],
   ["src/components/reposicao/aplicacao/useAplicacaoFila.ts", 2],
   ["src/components/reposicao/cadeiaLogistica/useCadeiaLogistica.ts", 1],
   ["src/components/reposicao/pedidos/useDetalhesModal.ts", 1],
@@ -109,7 +131,10 @@ const BASELINE = new Map<string, number>([
   ["src/components/tarefas/MinhasTarefasCard.tsx", 1],
   ["src/components/tarefas/RecorrentesHojeCard.tsx", 1],
   ["src/components/tintColorSelect/useTintColorSelect.ts", 1],
+  ["src/components/unified-order/ExcecaoCreditoDialog.tsx", 1],
   ["src/components/whatsapp/SlaCardMeuDia.tsx", 1],
+  ["src/hooks/useReposicaoSessao.ts", 1],
+  ["src/hooks/useSinalPositivacao.ts", 1],
   ["src/hooks/useUnifiedOrder.ts", 2],
   ["src/pages/AdminReposicaoAlertas.tsx", 1],
   // 2→1 (fatia #2 do inventário `{data && <X/>}`, 2026-09-06): a query do CICLO passou a
@@ -165,7 +190,14 @@ const BASELINE = new Map<string, number>([
 // colapso é afirmativo = 0 (o único candidato, `Training.tsx:150`, tem ramo `null` — é
 // `ternario-null`, JÁ na baseline de cima; contá-lo aqui seria contar o mesmo sítio duas
 // vezes). O critério estrito não esconde fatia nenhuma.
+//
+// CRESCEU EM 2026-09-07 (+2) pelo MESMO endurecimento da baseline de cima — a forma por alias
+// passou a ser visível. `PosicaoAtualTab` diz "Nenhum dado disponível para <empresa> ·
+// T<trimestre>/<ano>" e `ApprovalQueueSection` acende o ✓ VERDE com "Nada pra aprovar" — as
+// duas afirmam com especificidade o que a leitura falhada não sabe.
 const BASELINE_AFIRMATIVO = new Map<string, number>([
+  ["src/components/des/PosicaoAtualTab.tsx", 1],
+  ["src/components/knowledge-base/ApprovalQueueSection.tsx", 1],
   // Resíduo MEDIDO, não fix pela metade: a leitura de `user_tools` já ramifica
   // (`estadoDeRegistro`), mas o guard é `!tool || !healthMetrics` e `healthMetrics` deriva
   // de `useToolEvents` — a query IRMÃ, que ainda engole o erro no default `= []` do binding.
@@ -472,6 +504,113 @@ describe('gate: erro colapsado em vazio', () => {
       }`;
     expect(contarAutoOcultacao(soNull, 'Card.tsx')).toBe(1);
     expect(contarRetornoAfirmativo(soNull, 'Card.tsx'), 'auto-ocultação vazou para a baseline afirmativa').toBe(0);
+  });
+
+  // ── A INDIREÇÃO DO ALIAS (2026-09-07) ───────────────────────────────────────────────
+  // O buraco medido no #2283: o detector só reconhecia o sítio quando a desestruturação
+  // acontecia NA PRÓPRIA CHAMADA. Mover para o statement seguinte fazia a contagem CAIR com
+  // a linha de silêncio intacta — e o delta era IDÊNTICO ao do conserto legítimo, então a
+  // baseline aprovava a cegueira e o conserto pelo mesmo número.
+  const SILENCIO = 'if (!pedidos) return null;';
+
+  it('refactor SEM desestruturação não derruba a contagem — o buraco do #2283', () => {
+    const direto = `
+      export function Painel() {
+        const { data: pedidos } = usePedidos();
+        ${SILENCIO}
+        return <div>{pedidos.length}</div>;
+      }`;
+    const porAlias = `
+      export function Painel() {
+        const q = usePedidos();
+        const { data: pedidos } = q;
+        ${SILENCIO}
+        return <div>{pedidos.length}</div>;
+      }`;
+    const semDesestruturar = `
+      export function Painel() {
+        const q = usePedidos();
+        if (!q.data) return null;
+        return <div>{q.data.length}</div>;
+      }`;
+
+    expect(contarAutoOcultacao(direto, 'Painel.tsx'), 'controle: a forma direta precisa contar 1').toBe(1);
+    expect(
+      contarAutoOcultacao(porAlias, 'Painel.tsx'),
+      'mover a desestruturação para o statement seguinte NÃO pode zerar o sítio — a linha de ' +
+      'silêncio continua lá, e o gate estaria aprovando cegueira com o delta do conserto',
+    ).toBe(1);
+    expect(
+      contarAutoOcultacao(semDesestruturar, 'Painel.tsx'),
+      'ler `q.data` direto, sem desestruturar em lugar nenhum, é o mesmo sítio',
+    ).toBe(1);
+  });
+
+  it('a regra de CHAVES_DE_ERRO vale pelo alias: ler `q.error`/`q.status` ABSOLVE', () => {
+    const porPropriedade = `
+      export function Painel() {
+        const q = usePedidos();
+        if (q.error) return <Erro/>;
+        if (!q.data) return null;
+        return <div>{q.data.length}</div>;
+      }`;
+    const porDesestruturacao = `
+      export function Painel() {
+        const q = usePedidos();
+        const { data: pedidos, status } = q;
+        ${SILENCIO}
+        return <div>{pedidos.length}</div>;
+      }`;
+    expect(contarAutoOcultacao(porPropriedade, 'Painel.tsx'), '`q.error` prova acesso ao estado de falha').toBe(0);
+    expect(contarAutoOcultacao(porDesestruturacao, 'Painel.tsx'), '`status` está em CHAVES_DE_ERRO — absolve igual').toBe(0);
+  });
+
+  it('o análogo do `...rest` pelo alias: passar `q` adiante não afirma o colapso', () => {
+    const rest = `
+      export function Painel() {
+        const q = usePedidos();
+        const { data: pedidos, ...resto } = q;
+        ${SILENCIO}
+        return <div>{pedidos.length}</div>;
+      }`;
+    const repassado = `
+      export function Painel() {
+        const q = usePedidos();
+        if (!q.data) return null;
+        return <Filho q={q}/>;
+      }`;
+    expect(contarAutoOcultacao(rest, 'Painel.tsx'), '`...resto` pode carregar o error — precisão > recall').toBe(0);
+    expect(
+      contarAutoOcultacao(repassado, 'Painel.tsx'),
+      'entregar `q` inteiro torna as chaves não-enumeráveis AQUI — mesma regra do `...rest`',
+    ).toBe(0);
+  });
+
+  it('a derivada continua propagando pelo alias, e OUTRA FONTE não contamina', () => {
+    const derivada = `
+      export function Painel() {
+        const q = usePedidos();
+        const check = q.data?.find((p) => p.urgente);
+        if (!check) return null;
+        return <div>{check.id}</div>;
+      }`;
+    expect(contarAutoOcultacao(derivada, 'Painel.tsx'), 'o ponto fixo precisa enxergar `q.data` como raiz').toBe(1);
+
+    // `outraQ` é uma query NOVA, com error PRÓPRIO — não é derivada do data de `q`. Sem esta
+    // regra, `if (outraQ.isLoading) return null` (guarda de CARREGAMENTO) virava colapso de
+    // leitura: 4 sítios falsos em `useExcecoesGestor.ts`, por colisão do nome `data`.
+    const outraFonte = `
+      export function Painel() {
+        const q = usePedidos();
+        const outraQ = usePerfis({ chave: q.data });
+        if (outraQ.isLoading) return null;
+        return <div>{q.data?.length}</div>;
+      }`;
+    expect(
+      contarAutoOcultacao(outraFonte, 'Painel.tsx'),
+      'guarda sobre o ESTADO de outra query não é colapso da leitura desta — baseline que ' +
+      'cresce por motivo benigno é como um gate morre',
+    ).toBe(0);
   });
 
   it('a forma `jsx-&&` é detectada mas NÃO gateada — a distinção é deliberada', () => {

--- a/src/lib/gates/erro-colapsado-em-vazio.ts
+++ b/src/lib/gates/erro-colapsado-em-vazio.ts
@@ -37,13 +37,6 @@ export type SitioColapso = {
   colapsos: { forma: FormaDeColapso; linha: number }[];
 };
 
-const identsDe = (no: ts.Node): Set<string> => {
-  const s = new Set<string>();
-  const v = (n: ts.Node) => { if (ts.isIdentifier(n)) s.add(n.text); ts.forEachChild(n, v); };
-  v(no);
-  return s;
-};
-
 const ehSilencio = (e: ts.Expression | undefined): boolean =>
   !e || e.kind === ts.SyntaxKind.NullKeyword
   || (ts.isIdentifier(e) && e.text === "undefined")
@@ -84,6 +77,115 @@ const funcaoDona = (n: ts.Node): ts.Node | undefined => {
  * seguido de `if (!check) return null` foi exatamente como o DataHealthBanner escapou da
  * primeira versão desta varredura.
  */
+/**
+ * O que a chamada do hook LIGOU no componente — a mesma pergunta em duas formas de escrita.
+ *
+ * DIRETA: `const { data: x, error } = useQuery(...)` — as chaves estão na desestruturação.
+ * POR ALIAS: `const q = useQuery(...)` e, adiante, `q.data` ou `const { data: x } = q` — as
+ * mesmas chaves, uma indireção depois.
+ *
+ * A forma por alias NÃO é refinamento cosmético: sem ela o gate é BURLÁVEL por refactor
+ * puro. Mover a desestruturação para o statement seguinte fazia o sítio sumir da contagem
+ * com a linha de silêncio intacta — e o delta na baseline (2→1) era IDÊNTICO ao do conserto
+ * legítimo (desestruturar `status`), então o gate aprovava a cegueira e o conserto pelo
+ * mesmo número. Medido em 2026-09-06 no #2283, registrado em
+ * docs/historico/a-forma-que-some-e-a-forma-que-mente.md.
+ */
+type Ligacao = {
+  /** nome legível do data para quem investiga: `pedidos` ou `q.data`. */
+  aliasData: string;
+  padraoDefault: string | null;
+  /** identificadores que JÁ carregam o data — raiz do ponto fixo das derivadas. */
+  raizes: string[];
+  /** alias do hook quando o data é lido como `q.data`; null na forma direta. */
+  aliasHook: string | null;
+};
+
+const ligacaoDireta = (bind: ts.ObjectBindingPattern, sf: ts.SourceFile): Ligacao | null => {
+  let aliasData: string | null = null;
+  let padraoDefault: string | null = null;
+  let temErro = false;
+  let temRest = false;
+  for (const el of bind.elements) {
+    if (el.dotDotDotToken) { temRest = true; continue; }
+    const prop = el.propertyName ? el.propertyName.getText(sf) : el.name.getText(sf);
+    if (CHAVES_DE_ERRO.has(prop)) temErro = true;
+    if (prop === "data") {
+      aliasData = el.name.getText(sf);
+      padraoDefault = el.initializer ? el.initializer.getText(sf) : null;
+    }
+  }
+  // `...rest` pode carregar o `error`; não dá para afirmar o colapso — precisão > recall.
+  if (!aliasData || temErro || temRest) return null;
+  return { aliasData, padraoDefault, raizes: [aliasData], aliasHook: null };
+};
+
+/**
+ * Enumera as chaves que o escopo lê DO ALIAS. As três regras da forma direta valem inteiras:
+ * sem `data` não há colapso a afirmar; qualquer chave de `CHAVES_DE_ERRO` (inclusive lida
+ * como `q.status`) prova acesso ao estado de falha e ABSOLVE o sítio; e o análogo do
+ * `...rest` — passar `q` adiante em vez de ler chave dele — torna as chaves não-enumeráveis
+ * aqui e também absolve, porque precisão > recall é o que mantém a baseline confiável.
+ */
+const ligacaoPorAlias = (alias: string, escopo: ts.Node, sf: ts.SourceFile): Ligacao | null => {
+  let leData = false;
+  let temErro = false;
+  let opaco = false;
+  let padraoDefault: string | null = null;
+  const raizes: string[] = [];
+  const anota = (prop: string) => {
+    if (CHAVES_DE_ERRO.has(prop)) temErro = true;
+    if (prop === "data") leData = true;
+  };
+  const v = (n: ts.Node): void => {
+    if (ts.isIdentifier(n) && n.text === alias) {
+      const p: ts.Node | undefined = n.parent;
+      // `q.data`, `q.error`, `q?.status`
+      if (p && ts.isPropertyAccessExpression(p) && p.expression === n) { anota(p.name.text); return; }
+      if (p && ts.isVariableDeclaration(p)) {
+        if (p.name === n) return;                       // a própria `const q = useQuery(...)`
+        if (p.initializer === n && ts.isObjectBindingPattern(p.name)) {
+          for (const el of p.name.elements) {           // `const { data: pedidos, error } = q`
+            if (el.dotDotDotToken) { opaco = true; continue; }
+            const prop = el.propertyName ? el.propertyName.getText(sf) : el.name.getText(sf);
+            anota(prop);
+            if (prop === "data") {
+              raizes.push(el.name.getText(sf));
+              if (el.initializer) padraoDefault = el.initializer.getText(sf);
+            }
+          }
+          return;
+        }
+      }
+      opaco = true;   // `<X q={q}/>`, `f(q)`, `{...q}`, `q["data"]` — chaves não enumeráveis
+      return;
+    }
+    ts.forEachChild(n, v);
+  };
+  v(escopo);
+  if (!leData || temErro || opaco) return null;
+  return { aliasData: raizes[0] ?? `${alias}.data`, padraoDefault, raizes, aliasHook: alias };
+};
+
+/**
+ * `const outraQ = useQuery({ queryKey: [q.data] })` NÃO é derivada do data: é OUTRA FONTE,
+ * com error próprio. Propagar tainting por ela contamina tudo que só toca o ESTADO dela
+ * (`outraQ.isLoading`) e faz o gate contar guarda de CARREGAMENTO como colapso de leitura —
+ * medido em `useExcecoesGestor.ts`, onde `if (isLoading) return null` dentro de um `useMemo`
+ * virava 4 sítios por colisão de NOME (o `const { data } = await supabase` de cada `queryFn`
+ * colide com o `data` marcado). Baseline que cresce por motivo benigno é como um gate morre.
+ *
+ * `useMemo`/`useCallback` ficam de FORA da exclusão porque são o veículo canônico da
+ * derivada — `const check = useMemo(() => q.data?.find(...), [q.data])` é exatamente o
+ * caminho pelo qual o DataHealthBanner escapou da primeira versão desta varredura.
+ */
+const DERIVA = new Set(["useMemo", "useCallback"]);
+const ehOutraFonte = (e: ts.Expression): boolean => {
+  const c = ts.isAwaitExpression(e) ? e.expression : e;
+  return ts.isCallExpression(c) && ts.isIdentifier(c.expression)
+    && /^use[A-Z]/.test(c.expression.text) && !DERIVA.has(c.expression.text);
+};
+
 export function acharColapsos(conteudo: string, nomeArquivo: string): SitioColapso[] {
   const sf = ts.createSourceFile(
     nomeArquivo, conteudo, ts.ScriptTarget.Latest, /* setParentNodes */ true,
@@ -93,30 +195,39 @@ export function acharColapsos(conteudo: string, nomeArquivo: string): SitioColap
   const linhaDe = (n: ts.Node) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
 
   const visita = (node: ts.Node): void => {
-    if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name) && node.initializer) {
+    if (ts.isVariableDeclaration(node) && node.initializer
+        && (ts.isObjectBindingPattern(node.name) || ts.isIdentifier(node.name))) {
       const chamada = ts.isAwaitExpression(node.initializer) ? node.initializer.expression : node.initializer;
       if (ts.isCallExpression(chamada) && ts.isIdentifier(chamada.expression) && /^use[A-Z]/.test(chamada.expression.text)) {
-        let aliasData: string | null = null;
-        let padraoDefault: string | null = null;
-        let temErro = false;
-        let temRest = false;
-        for (const el of node.name.elements) {
-          if (el.dotDotDotToken) { temRest = true; continue; }
-          const prop = el.propertyName ? el.propertyName.getText(sf) : el.name.getText(sf);
-          if (CHAVES_DE_ERRO.has(prop)) temErro = true;
-          if (prop === "data") {
-            aliasData = el.name.getText(sf);
-            padraoDefault = el.initializer ? el.initializer.getText(sf) : null;
-          }
-        }
-        // `...rest` pode carregar o `error`; não dá para afirmar o colapso — precisão > recall.
-        if (aliasData && !temErro && !temRest) {
-          const escopo = funcaoDona(node) ?? sf;
+        const escopo = funcaoDona(node) ?? sf;
+        const lig = ts.isObjectBindingPattern(node.name)
+          ? ligacaoDireta(node.name, sf)
+          : ligacaoPorAlias((node.name as ts.Identifier).text, escopo, sf);
+        if (lig) {
+          const marcados = new Set(lig.raizes);
+          /**
+           * A raiz do tainting tem DUAS formas: o identificador que carrega o data e — na
+           * forma por alias sem desestruturação — o acesso `q.data`, que não é identificador
+           * nenhum. Uma varredura só de identificadores não vê a segunda e devolve o mesmo
+           * falso "consertado" que este endurecimento existe para fechar.
+           */
+          const contemRaiz = (no: ts.Node): boolean => {
+            let achou = false;
+            const v = (n: ts.Node) => {
+              if (achou) return;
+              if (lig.aliasHook && ts.isPropertyAccessExpression(n) && ts.isIdentifier(n.expression)
+                  && n.expression.text === lig.aliasHook && n.name.text === "data") { achou = true; return; }
+              if (ts.isIdentifier(n) && marcados.has(n.text)) { achou = true; return; }
+              ts.forEachChild(n, v);
+            };
+            v(no);
+            return achou;
+          };
 
-          const marcados = new Set([aliasData]);
           const declaracoes: ts.VariableDeclaration[] = [];
           const coleta = (n: ts.Node) => {
-            if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)) declaracoes.push(n);
+            if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)
+                && !ehOutraFonte(n.initializer)) declaracoes.push(n);
             ts.forEachChild(n, coleta);
           };
           coleta(escopo);
@@ -124,13 +235,11 @@ export function acharColapsos(conteudo: string, nomeArquivo: string): SitioColap
             let mudou = false;
             for (const d of declaracoes) {
               if (marcados.has((d.name as ts.Identifier).text)) continue;
-              for (const id of identsDe(d.initializer!)) {
-                if (marcados.has(id)) { marcados.add((d.name as ts.Identifier).text); mudou = true; break; }
-              }
+              if (contemRaiz(d.initializer!)) { marcados.add((d.name as ts.Identifier).text); mudou = true; }
             }
             if (!mudou) break;
           }
-          const toca = (no: ts.Node) => [...identsDe(no)].some((id) => marcados.has(id));
+          const toca = contemRaiz;
 
           const colapsos: SitioColapso["colapsos"] = [];
           const busca = (n: ts.Node): void => {
@@ -167,8 +276,8 @@ export function acharColapsos(conteudo: string, nomeArquivo: string): SitioColap
           };
           busca(escopo);
 
-          if (colapsos.length || padraoDefault) {
-            sitios.push({ hook: chamada.expression.text, aliasData, linha: linhaDe(node), padraoDefault, colapsos });
+          if (colapsos.length || lig.padraoDefault) {
+            sitios.push({ hook: chamada.expression.text, aliasData: lig.aliasData, linha: linhaDe(node), padraoDefault: lig.padraoDefault, colapsos });
           }
         }
       }


### PR DESCRIPTION
## O buraco

O gate de "erro colapsado em vazio" só reconhecia o sítio quando o resultado do hook era desestruturado **na própria chamada**. Refatorar

```ts
const { data: pedidos } = useQuery({...});   // sítio CONTADO
```
para
```ts
const q = useQuery({...});
const { data: pedidos } = q;                  // sítio SOME da contagem
```

derrubava `contarAutoOcultacao` **com a linha de silêncio intacta** — e o delta era **idêntico** ao do conserto legítimo (desestruturar `status`, que está em `CHAVES_DE_ERRO`). O gate aprovava a cegueira e o conserto pelo mesmo número. Medido no #2283.

## A decisão foi por MEDIDA, não por gosto

Se quase ninguém escrevesse na forma por alias, o certo era registrar a limitação e não endurecer nada. Medido em `src/**` **antes** de tocar no detector:

| | |
|---|---|
| `const x = use…()` sem desestruturação | **1.266** |
| …dessas, lendo `x.data` | **123** |
| …dessas, sem nenhuma chave de `CHAVES_DE_ERRO` | **100** |

Não é ~0 — e a lista inclui os domínios que o próprio doc classifica como de maior dano: `useDataHealth`, `useCashflowAlertas`, `useCarteiraSaude`, `usePrecoCockpit`.

## As três regras atravessaram inteiras (precisão > recall)

| regra | pela desestruturação | pelo alias |
|---|---|---|
| sem `data` não há colapso a afirmar | binding sem `data` | nenhum `q.data` no escopo |
| `CHAVES_DE_ERRO` **absolve** | `const { data, status } = useX()` | `q.error` / `q.status`, ou `const { data, status } = q` |
| `...rest` pode carregar o error → não afirmar | `const { data, ...rest }` | passar `q` adiante (`<Filho q={q}/>`, `f(q)`, `{...q}`, `q["data"]`) |

Duas armadilhas na implementação:

- **A raiz do tainting deixou de ser só identificador.** Na forma por alias, quem carrega o dado é o *acesso* `q.data` — que não é identificador nenhum. Uma varredura só de identificadores devolveria o mesmo falso "consertado" que este PR existe para fechar.
- **Outra chamada de hook não é derivada — é outra FONTE, com `error` próprio.** Sem essa exclusão, `const outraQ = useQuery({queryKey:[q.data]})` marcava `outraQ` como derivada e `if (outraQ.isLoading) return null` — guarda de **carregamento** — virava colapso de leitura: **4 sítios falsos** em `useExcecoesGestor.ts`, por colisão do nome `data` com o `const { data, error } = await supabase` de cada `queryFn`. `useMemo`/`useCallback` ficam fora da exclusão: são o veículo canônico da derivada.

## Baseline cresceu — ACHADO, não regressão

Medido arquivo a arquivo, antes e depois: **nenhum arquivo encolheu.**

| baseline | antes | depois |
|---|---|---|
| auto-ocultação | 27 arquivos | 34 (+8 sítios) |
| `return-afirmativo` | 9 | 11 |

O pior dos novos é `ApprovalQueueSection`: quando a leitura da fila falha, a tela acende o **✓ verde** com "Nada pra aprovar — suba boletins na aba Documentos".

Medi **duas vezes**: a main mergeou o #2297 no meio (quitou 5 sítios) e eu rebasei — re-medir achou um 8º sítio (`useSinalPositivacao`) que a árvore velha não tinha. Número medido em árvore velha não é número.

## Falsificação

Cinco sabotagens no detector, **uma camada por vez**, com o controle verde na **mesma invocação** do laço (abortando antes do 1º `sed` se não fosse verde): matar a forma por alias · desligar `CHAVES_DE_ERRO` pelo alias · desligar `...rest`/repasse · tirar a raiz `q.data` do ponto fixo · tirar a exclusão de outra fonte. **5/5 vermelhas**, cada uma derrubando exatamente os casos previstos. Mais uma sexta na suíte real: sabotar o pré-filtro deixa **3 testes vermelhos**.

## Achado de brinde: exit 1 com 19/19 VERDES

A primeira execução da suíte reprovou por **timeout**, não por asserção. Cronometrar antes de consertar impediu o conserto errado: a varredura ficou **mais rápida** com o detector endurecido (12,3s → 9,8s, mesma máquina, back-to-back) — o estouro era custo de infra. Consertado: uma varredura só para as duas baselines (era 1 parse por arquivo **por teste**) + pré-filtro conservador (arquivo sem a substring `use[A-Z]` não pode ter sítio; a regex escolhe quem o **parser** olha, quem **mede** continua sendo o parser, e um teste prova que nenhum arquivo de baseline é descartado).

**119s e exit 1 → 16s e exit 0.** O modo de falha merece nome: com 79s de laço CPU-bound o worker do vitest morria com `Timeout calling "onTaskUpdate"` e a suíte saía com **exit 1 exibindo `Tests 19 passed (19)`**. Quem lesse o resumo diria "passou".

## Evidência

- `bunx vitest run src/__tests__/erro-colapsado-em-vazio-gate.test.ts` → **20 passed (20), RC=0**
- `bunx eslint` nos dois arquivos → RC=0 · `docs:citacoes` / `docs:links` / `docs:indice` → RC=0

## O que NÃO foi fechado (registrado no doc)

O tainting continua **cego a escopo** — casa nomes, e `data` é o mais comum do repo. A exclusão de outra fonte corta o caminho por onde a colisão chegava a guardas de carregamento, mas não remove a colisão. O conserto de verdade é sombreamento, e mexe também na forma direta.

## Multi-sessão

Os PRs abertos #2305 e #2317 **quitam sítios** (encolhem a baseline afirmativa); este **endurece o detector** (cresce). Trabalho distinto — `ligacaoPorAlias`/`aliasHook` não existem na `origin/main`. O conflito é mecânico, só no mapa de baseline: quem mergear primeiro, o outro rebasa.

Não toquei em `AdminReposicaoPedidos.tsx` (já corrigido, com guard próprio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)