### PR TITLE
fix(test): o gate AST corria contra um teto de RENDER — orçamento próprio, POR FONTE, medido

### DIFF
--- a/docs/historico/flaky-sob-carga-teto-e-custo.md
+++ b/docs/historico/flaky-sob-carga-teto-e-custo.md
@@ -63,8 +63,52 @@ coisas que uma memoização apressada erra:
 Medições independentes convergem na ordem de grandeza (29,2s aqui, ~40s lá; a árvore de `src/` e a
 carga diferem entre as datas) — e a correção **não tocou em nenhum timeout**.
 
+## Instância 3 — `erro-colapsado-em-vazio-gate.test.ts` (#2311): medir ISOLADO **subestima 4×**
+
+Gate AST (compiler API do TypeScript sobre 1.473 fontes, 8,5 MiB) estourou com `Test timed out in
+20000ms` — 21.754ms — na M2 saturada; verde no CI. A hipótese de entrada era "o teto de render virou
+orçamento de varredura num repo que quadruplicou" (o `testTimeout: 20000` do #271 foi calibrado com
+195 arquivos de teste; hoje são 786).
+
+**O passo 1 da receita, sozinho, teria mandado fechar como não-reproduzível.** Medido em 2026-09-07,
+do mais limpo ao mais real, o pior `it`:
+
+| regime | pior `it` | folga contra 20s | subestima o real em |
+|---|---|---|---|
+| fora do runner (`bun`/JSC) | 3.267ms | 6,1× | 3,9× |
+| fora do runner (`node`/V8) | 2.435ms | 8,2× | 5,2× |
+| vitest, arquivo **isolado** | 4.890ms | 4,1× | 2,6× |
+| vitest, **suíte completa** | **12.643ms** | **1,58×** | — |
+
+Fora do runner o trabalho é ~3s contra um teto de 20s, e a conclusão sedutora é "o teto está
+folgado, foi a máquina". Errado: o número que governa é o da **suíte completa**, 4× maior, porque o
+regime que custa é a **contenção entre os workers paralelos do vitest** — e nem a execução fora do
+runner nem a execução isolada *dentro* do vitest reproduzem esse regime, por construção. Repetir a
+medição isolada, em duas engines e sob load 120 com 4,1GB de swap, dá sempre ~3s: **estabilidade da
+medida errada não é evidência**.
+
+Contexto que só a suíte completa dá, e que decide a escala da correção: esses dois `it` são o **1º e
+o 2º testes mais lentos de 8.134**; o 3º fica em 9.820ms e nenhum outro passa de 15s. Uma varredura
+estática achou **21 testes** da classe "gate que varre o repo dentro do `it`", todos no teto global —
+mas a medição mostrou o risco **concentrado em um arquivo**, não espalhado. Contar sítios da classe
+prevê exposição; só medir prevê qual estoura.
+
+Fix: orçamento próprio nos dois `it`, **por fonte** (40 ms/fonte, 4,7× o pior medido) e não um número
+fixo — a causa que aperta sozinha é o repo crescer, então o teto acompanha o denominador sem
+afrouxar o custo unitário, que é o que denuncia regressão do detector. Piso `Math.max(20_000, …)`
+para nunca ficar ABAIXO do global (a armadilha da instância 1). E como "teto maior só ajuda se
+preserva o diagnóstico", um `onTestFailed` imprime fontes/ms/ms-por-fonte contra a referência
+medida, separando carga · repo · detector — as três hipóteses que o timeout nu não distingue.
+
+Descartados com medição, não com suposição: motor de JS (bun e node concordam), memória (pico de
+219MB), custo do detector (2,05 ms/fonte, estável), e cache incremental — memoizar `acharColapsos`
+baratearia o **2º** `it`, deixando o 1º, que é o gargalo, intacto.
+
 ## A receita
 
+0. **Meça no regime que falhou.** Fora do runner e isolado-no-runner medem *o custo*; só a **suíte
+   completa** mede a *contenção entre workers*, que na instância 3 valia 4× e era o número que
+   governava. Medida isolada estável, repetida em duas engines, continua sendo a medida errada.
 1. **Meça o trabalho real fora do runner** (`bun run` num script solto, `performance.now()`). Um
    teste que leva 29s de CPU não é flaky — está acima do teto, e o teto não é o problema.
 2. **Enumere as camadas de teto**, não "o timeout": `it(..., N)` · `testTimeout` do runner ·

--- a/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
+++ b/src/__tests__/erro-colapsado-em-vazio-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, onTestFailed } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { acharColapsos, contarAutoOcultacao, contarRetornoAfirmativo } from '@/lib/gates/erro-colapsado-em-vazio';
@@ -170,6 +170,47 @@ const BASELINE_AFIRMATIVO = new Map<string, number>([
 describe('gate: erro colapsado em vazio', () => {
   const fontes = listarFontes(DIRS[0]);
 
+  // ORÇAMENTO DA VARREDURA — medido 2026-09-07 nesta M2 8GB (issue #2311).
+  //
+  // Os dois `it` que varrem as fontes são o 1º e o 2º testes MAIS LENTOS da suíte inteira
+  // (8.134 testes): 12.643ms e 10.263ms. O 3º colocado fica em 9.820ms e NENHUM outro teste
+  // do repo passa de 15s. Medido para o pior deles, do mais limpo ao mais real:
+  //   2,05 ms/fonte fora do runner (bun/JSC e node/V8 concordam) · 3,32 ms/fonte no vitest
+  //   isolado · 8,58 ms/fonte no vitest sob a suíte COMPLETA (contenção entre workers).
+  // Contra o `testTimeout: 20000` global sobra 1,58× — folga fina demais para a variância de
+  // uma máquina de dev saturada, e foi ela que estourou em 2026-09-06 (21.754ms). O teto
+  // global não é orçamento desta classe: nasceu no #271 dimensionado para cold-start de
+  // RENDER, com 195 arquivos de teste no repo (hoje 786).
+  //
+  // O teto é POR FONTE e não um número fixo, porque a causa que aperta sozinha é o repo
+  // crescer: assim ele acompanha o denominador sem afrouxar o custo UNITÁRIO, que é o que
+  // denuncia regressão do detector. O piso mantém o orçamento SEMPRE acima do global —
+  // teto abaixo do global ENCURTARIA a folga em vez de ampliá-la, que é exatamente como o
+  // `it(..., 15000)` removido em docs/historico/flaky-sob-carga-teto-e-custo.md criava
+  // falsa leitura de folga.
+  const MS_POR_FONTE_TETO = 40; // 4,7× o pior medido sob contenção (8,58 ms/fonte)
+  const ORCAMENTO_VARREDURA_MS = Math.max(20_000, fontes.length * MS_POR_FONTE_TETO);
+
+  // `Test timed out in Nms` não nomeia causa nenhuma — e teto maior só ajuda se PRESERVA o
+  // diagnóstico (mesma lição do doc acima). Isto imprime, na falha, o discriminante das três
+  // hipóteses que a #2311 deixou abertas: carga, crescimento do repo, ou custo do detector.
+  function armarDiagnosticoDeVarredura(): void {
+    const inicio = performance.now();
+    onTestFailed(() => {
+      const ms = performance.now() - inicio;
+      const porFonte = ms / fontes.length;
+      console.error(
+        `\n[#2311] varredura: ${fontes.length} fontes em ${Math.round(ms)}ms = ` +
+          `${porFonte.toFixed(2)} ms/fonte (orçamento ${ORCAMENTO_VARREDURA_MS}ms a ${MS_POR_FONTE_TETO} ms/fonte).\n` +
+          `  Referência medida 2026-09-07: 2,05 fora do runner · 3,32 isolado · 8,58 sob a suíte completa.\n` +
+          `  ms/fonte DENTRO da referência  → foi CARGA da máquina; o detector está íntegro.\n` +
+          `  ms/fonte ACIMA da referência   → é o DETECTOR (acharColapsos), e teto maior só esconde.\n` +
+          `  fontes muito acima de 1.473    → o REPO cresceu; suba MS_POR_FONTE_TETO apenas se o\n` +
+          `                                   custo unitário continuar dentro da referência.`,
+      );
+    });
+  }
+
   it('o walker enxerga o repo — varredura vazia seria verde por CEGUEIRA', () => {
     expect(fontes.length, 'walker listou fontes de menos — glob/recursão quebrada').toBeGreaterThan(1000);
     expect(fontes, 'o alvo corrigido sumiu da varredura').toContain('src/components/dataHealth/DataHealthBanner.tsx');
@@ -177,6 +218,7 @@ describe('gate: erro colapsado em vazio', () => {
   });
 
   it('nenhum sítio NOVO de auto-ocultação, e a baseline não encolhe sem registro', () => {
+    armarDiagnosticoDeVarredura();
     const medido = new Map<string, number>();
     for (const rel of fontes) {
       const n = contarAutoOcultacao(readFileSync(resolve(RAIZ, rel), 'utf8'), rel);
@@ -208,7 +250,7 @@ describe('gate: erro colapsado em vazio', () => {
       'Sítio da classe foi corrigido — ATUALIZE a BASELINE deste gate (a lista só ' +
       `encolhe registrada). Arquivos (baseline→medido): ${quitados.join(', ')}`,
     ).toEqual([]);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   it('calibração: a assinatura casa o controle PRÉ-fix do #1859', () => {
     // Verbatim do MixGapCard antes do #1859 (git show 588aa2ad8~1) — reduzido ao miolo.
@@ -293,6 +335,7 @@ describe('gate: erro colapsado em vazio', () => {
   // ─────────────────────────────────────────────────────────────────────────────────────
 
   it('nenhum sítio NOVO de `return` afirmativo, e a baseline não encolhe sem registro', () => {
+    armarDiagnosticoDeVarredura();
     const medido = new Map<string, number>();
     for (const rel of fontes) {
       const n = contarRetornoAfirmativo(readFileSync(resolve(RAIZ, rel), 'utf8'), rel);
@@ -324,7 +367,7 @@ describe('gate: erro colapsado em vazio', () => {
       'Sítio da 3ª forma foi corrigido — ATUALIZE a BASELINE_AFIRMATIVO (a lista só encolhe ' +
       `registrada). Arquivos (baseline→medido): ${quitados.join(', ')}`,
     ).toEqual([]);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   it('calibração: casa o pior sítio medido — o ✓ VERDE que a falha acende', () => {
     // Verbatim reduzido de src/components/knowledge-base/CompletudeSection.tsx:24.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}", "scripts/**/*.test.ts"],
-    // Cold-start de um render síncrono (init de módulos + 1ª varredura a11y do getByRole) pode passar dos 5s default quando o suite de 184 arquivos satura a CPU (M2 8GB). Teto generoso elimina falha falsa sem frear teste que passa; só atrasa morte de hang real.
+    // Cold-start de um render síncrono (init de módulos + 1ª varredura a11y do getByRole) pode passar dos 5s default quando o suite satura a CPU (M2 8GB). Teto generoso elimina falha falsa sem frear teste que passa; só atrasa morte de hang real.
+    // ⚠️ ESTE TETO É PARA RENDER, NÃO PARA GATE QUE VARRE O REPO. Nasceu no #271 (2026-05-24) com 195 arquivos de teste; hoje são 786, e ninguém o redimensionou. Medido em 2026-09-07 (#2311): dos 8.134 testes, só DOIS passam de 10s — os dois `it` de varredura AST de src/__tests__/erro-colapsado-em-vazio-gate.test.ts (12.643ms e 10.263ms sob a suíte completa), que por isso declaram orçamento PRÓPRIO, acima deste. O 3º mais lento fica em 9.820ms, com 2× de folga.
+    // Gate de varredura NOVO que encoste em 10s deve declarar o seu teto (3º arg do `it`, POR FONTE), não subir este: subir aqui afrouxaria os outros 8.132 testes para acomodar 2.
     testTimeout: 20000,
   },
   resolve: {


### PR DESCRIPTION
Resolve #2311.

## O que a medição mostrou (e onde ela contrariou a issue)

A issue supunha que a varredura tivesse ficado cara demais para o teto. **Medindo, o custo não é o problema — a contenção é.** Pior `it`, do regime mais limpo ao mais real (2026-09-07, M2 8GB a load 120 com 4,1 GB de swap):

| regime | pior `it` | folga contra o teto de 20s |
|---|---|---|
| fora do runner (`bun`/JSC) | 3.267 ms | 6,1× |
| fora do runner (`node`/V8) | 2.435 ms | 8,2× |
| vitest, arquivo **isolado** | 4.890 ms | 4,1× |
| vitest, **suíte completa** | **12.643 ms** | **1,58×** |

Fora do runner o trabalho é ~3 s contra 20 s e a conclusão sedutora é "está folgado, foi a máquina". O número que governa é o da suíte completa, **4× maior**: o regime que custa é a contenção entre os workers paralelos do vitest, que nem a medição fora do runner nem a execução isolada reproduzem. Era esse o buraco entre o trabalho real (~3 s) e os 21.754 ms do incidente.

Contexto que decide a escala: **esses dois `it` são o 1º e o 2º testes mais lentos de 8.134**; o 3º fica em 9.820 ms e nenhum outro passa de 15 s. Uma varredura estática achou **21 testes** da classe "gate que varre o repo dentro do `it`", todos no teto global — mas o risco medido está **concentrado neste arquivo**, então corrijo aqui em vez de mexer em 21 arquivos quentes.

## A correção

- **Orçamento por fonte, não número fixo** (`40 ms/fonte`, 4,66× o pior medido → 58.920 ms hoje). A causa que aperta sozinha é o repo crescer, então o teto acompanha o denominador **sem afrouxar o custo unitário**, que é o que denuncia regressão do detector.
- **Piso `Math.max(20_000, …)`**: nunca abaixo do global. Teto abaixo do global *encurta* a folga — foi assim que o `it(..., 15000)` removido em `docs/historico/flaky-sob-carga-teto-e-custo.md` criava falsa leitura de folga.
- **O global fica intacto** (subir lá afrouxaria 8.132 testes para acomodar 2) e ganha o comentário que faltava: ele foi calibrado no #271 para cold-start de *render* com 195 arquivos de teste — hoje são 786.
- **`onTestFailed` preserva o diagnóstico**: `Test timed out in Nms` não nomeia causa, e teto maior só ajuda se o diagnóstico sobrevive. Agora a falha imprime fontes/ms/ms-por-fonte contra a referência medida, separando as três hipóteses que a issue deixou abertas — carga · repo · detector.

Varredura e controles do detector **intactos**: nenhum arquivo saiu do escopo.

## Falsificação (nos dois sentidos, controle verde na MESMA invocação)

| prova | resultado |
|---|---|
| controle verde antes do 1º `sed` (aborta se vermelho) | `Tests 15 passed` |
| teto=1 → sintoma **exato com o número novo** (`Test timed out in 1ms`) | ✅ o 3º arg governa |
| `onTestFailed` dispara **em timeout** (era pergunta aberta) | ✅ confirmado |
| sabotar `BASELINE` → vermelho **na asserção** | ✅ não cegou |
| sabotar `BASELINE_AFIRMATIVO` → vermelho **na asserção** | ✅ não cegou |

Suíte completa pré-mudança: `Test Files 786 passed · Tests 8133 passed | 1 skipped`.

## Descartado com medição, não com suposição

Motor de JS (bun e node concordam) · memória (pico 219 MB) · custo do detector (2,05 ms/fonte, estável) · **cache incremental** — memoizar `acharColapsos` baratearia o **2º** `it` e deixaria o 1º, que é o gargalo, intacto; não resolve, e cria obrigação de invalidação. A issue já suspeitava disso, e a medição confirma.

## ⚠️ Colisão conhecida

#2318 reescreve o corpo do mesmo `describe` e altera o detector. Meu diff é ortogonal (orçamento/timeout) mas textualmente adjacente — quem mergear depois rebaseia. #2305 e #2317 tocam só as baselines, sem colisão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)