### PR TITLE
docs(historico): a fila de ENTREGA não tem sensor de desfecho — 41 branches com trabalho e sem PR

### DIFF
--- a/docs/historico/README.md
+++ b/docs/historico/README.md
@@ -11,6 +11,7 @@ Registro consultável de **PRs/bugs/programas/auditorias já entregues** — a n
 | [bugs-resolvidos.md](bugs-resolvidos.md) | (era §10) cada bug/contradição/débito resolvido, com PR + lição (multi-domínio: KB, Radar, reposição, sync…) |
 | [programas-vendas.md](programas-vendas.md) | WhatsApp + Motor de Rota; copiloto "Buddy" |
 | [fila-plano-tatico.md](fila-plano-tatico.md) | PTPL fase 1: 533 planos com zero desfecho e 72% inalcançáveis — a fila sem saída (expiração + recorte por risco). Fase 2: os 533 eram **80 clientes** — a trava de idempotência media o DIA, e a fila mede a JANELA |
+| [fila-de-entrega-sem-sensor-de-desfecho.md](fila-de-entrega-sem-sensor-de-desfecho.md) | a fila de ENTREGA (PRs/worktrees) medida em 2026-09-07: 41 branches com commit e sem PR (25 paradas ≥7d), 41 worktrees já mergeadas, lead time ~10d pela Lei de Little — e o vão entre `wt:status` e `wt:orfas`, onde nada mede "trabalho commitado sem desfecho"; inclui os comandos de re-medição |
 | [auditoria-ux-redesign.md](auditoria-ux-redesign.md) | (era §9/§9b/§11) auditoria UX 2026-05-13 + redesign visual v3 + premissas/glossário |
 | [estoque-picking-recebimento.md](estoque-picking-recebimento.md) | offline-first + closed-loop (Picking Bridge Oben, Recebimento honesto) |
 | [tintometrico.md](tintometrico.md) | vínculo `tint_skus`↔Omie (resgate de 62 cores que somem do seletor) + lições de matching de catálogo |

--- a/docs/historico/fila-de-entrega-sem-sensor-de-desfecho.md
+++ b/docs/historico/fila-de-entrega-sem-sensor-de-desfecho.md
@@ -1,0 +1,120 @@
+# A fila de ENTREGA não tem sensor de desfecho — 41 branches com trabalho e sem PR
+
+> Diagnóstico medido em **2026-09-07** (`gh`, `git`, `wt:status`), a pedido do founder ("como podemos
+> resolver esses problemas de fila?"). **Evidência de contagem tem validade — re-meça antes de agir
+> sobre qualquer número daqui.** Os comandos de re-medição estão no fim, e são o item mais útil deste doc.
+
+## O pedido, e por que ele quase virou outra coisa
+
+"Fila" neste app é ~10 coisas: `FilaDoDia`, `FilaDeCaca`, a fila do plano tático
+([fila-plano-tatico.md](fila-plano-tatico.md)), a de prontidão da reposição
+([fila-de-prontidao-e-sensor-de-derivada.md](fila-de-prontidao-e-sensor-de-derivada.md)),
+`analytics_outbox`, `score_recalc_queue`, `afiacao_os_sync_fila`, a fila de aprovação da KB.
+Antes de perguntar, as filas TÉCNICAS foram medidas e estavam **limpas**: outbox 277 linhas
+100% drenadas, `score_recalc_queue` e `afiacao_os_sync_fila` vazias, `visit_score_recalc_queue`
+37.919 linhas 100% processadas com 0 erro. O founder queria a fila de **entrega** — PRs e sessões.
+
+## O que foi medido
+
+**Máquina** (M2 8GB, no instante da medição):
+
+| Sinal | Valor |
+|---|---|
+| RAM disponível | 2,0–2,2 GB de 8 |
+| Swap em uso | **4,5 → 5,9 GB** (subiu durante a própria sessão) |
+| Worktrees com branch | **85** (667 MB de `node_modules` cada) |
+| Sessões Claude vivas | **44** · 185 pastas de projeto, **134 órfãs**, 427 transcritos |
+| Processos órfãos | **7** a 60–83% de CPU por ~52 min |
+
+**Fila de trabalho:**
+
+| Fato | Valor |
+|---|---|
+| Branches com commit **e sem PR** | **41** |
+| …paradas há **≥7 dias** | **25** (a mais velha há **92 dias**) |
+| Pior caso | `fu4f-fase3-product-costs` **22 commits** · `sayerlack-captura-precos-fase1` **18 commits**, 51 dias |
+| Worktrees cuja branch **já está mergeada** | **41** (lixo puro: RAM, disco, ruído no `wt:status`) |
+| PRs abertos | 5 — um deles (#2093) parado há **227h**, `CONFLICTING` |
+| Vazão | **~4 PRs/dia**; a main recebe **60–65 commits/dia** nos picos |
+
+## O diagnóstico
+
+**Lei de Little:** WIP 41 ÷ vazão 4/dia ⇒ lead time ≈ **10 dias** — que é exatamente o observado
+(25 branches paradas ≥7 dias). **Não é problema de velocidade: é WIP sem teto e sem drenagem.**
+E branch parada envelhece contra uma main de 60 commits/dia ⇒ conflito garantido.
+
+⚠️ **Uma medição inicial estava errada e vale registrar o erro:** "CI com 36% de falha (8 em 22
+runs)". Das 14 falhas nos 60 runs seguintes, **11 eram o mesmo passo** (`mutcheck`), de uma janela
+de 2h que os PRs #2227/#2232 já haviam consertado. A taxa real depois do fix: **1 em 26 (~4%)**.
+Medir uma janela que contém um incidente e chamar isso de taxa é fabricar tendência a partir de
+um evento — a régua é a janela DEPOIS do conserto conhecido.
+
+## O vão: nenhuma ferramenta mede "trabalho commitado sem desfecho"
+
+Existe toolkit para quase tudo — e ele passa exatamente ao lado disto:
+
+| Ferramenta | O que enxerga | O que NÃO enxerga |
+|---|---|---|
+| `wt:status` | RAM, disco, `node_modules`, órfãos de CPU | se há trabalho não entregue |
+| `wt:orfas` | sessão cujo **worktree sumiu** (cruza com `gh pr list`) | worktree que **existe**, com commit e sem PR |
+| `wt:reap` / `wt:clean` / `wt:prune` | processos, `node_modules`, worktree de conversa excluída | idem |
+| `onde-parei.sh` | o estado de **uma** sessão | a fila inteira |
+
+As 41 branches caem no vão entre `wt:status` e `wt:orfas`. É a MESMA classe de
+[fila-plano-tatico.md](fila-plano-tatico.md) (533 planos gerados, zero desfecho) e de
+[fase-sem-sinal.md](fase-sem-sinal.md) — só que aplicada ao processo de entrega do próprio repo:
+**a fila gera, ninguém drena, e não há sensor sobre o DESFECHO.**
+
+## O custo, demonstrado no mesmo dia
+
+Destravar o **#2093** (parado 227h por um conflito de 2 linhas) custou **4 rodadas de re-merge** —
+a main mergeou por cima 3× durante o conserto — e revelou **4 defeitos latentes** que só apareceram
+porque cada correção destravava a seguinte:
+
+1. Conflito de 1 token no `test:hooks`.
+2. **O gate dependia da versão do shellcheck do runner** — 0.9.0 no CI × 0.11.0 local: **108 × 0**
+   achados, 86 deles SC2317 (falso-positivo notório da 0.9.0). Corrigido pinando a versão, não
+   baixando a severidade. Gate cujo veredito depende do runner não é gate.
+3. `## Stack` do CLAUDE.md estourou o teto por 1 palavra.
+4. **O caso que provava o *fail-closed* do gate ficava VERDE no Ubuntu**: simulava "shellcheck
+   ausente" por DIRETÓRIO (`PATH=/usr/bin:/bin`), premissa válida no macOS (homebrew) e falsa no
+   runner, onde o apt instala em `/usr/bin`. O caso aprovava a si mesmo. Corrigido para simular
+   por SÍMBOLO, com asserção positiva de que o sandbox realmente não resolve o binário.
+
+O nº 4 é a lição transferível: **teste de fail-closed escrito e validado num só SO herda a topologia
+daquele SO.** Se a simulação de ausência depende de ONDE o binário mora, ela é verdadeira só na
+máquina de quem a escreveu.
+
+## Como re-medir (o item perecível deste doc)
+
+```bash
+# branches com commit e SEM PR, por idade do último commit
+gh pr list --limit 100 --json headRefName --state open | jq -r '.[].headRefName' > /tmp/pr-branches.txt
+git worktree list --porcelain | awk '/^branch /{print substr($2,12)}' | while read -r b; do
+  git merge-base --is-ancestor "refs/heads/$b" origin/main 2>/dev/null && continue   # já mergeada
+  grep -qx "$b" /tmp/pr-branches.txt && continue                                     # já tem PR
+  echo "$(( ($(date +%s) - $(git log -1 --format=%ct "refs/heads/$b")) / 86400 ))|$(git rev-list --count origin/main..refs/heads/$b)|$b"
+done | sort -rn
+
+# worktrees cuja branch JÁ está mergeada (descartáveis)
+git worktree list --porcelain | awk '/^branch /{print substr($2,12)}' \
+  | while read -r b; do git merge-base --is-ancestor "refs/heads/$b" origin/main 2>/dev/null && echo "$b"; done | wc -l
+
+# vazão real (merges/dia) — o denominador da Lei de Little
+git log origin/main --since=14.days --format='%ad' --date=short | sort | uniq -c
+```
+
+⚠️ **Duas armadilhas de shell atingidas ao medir isto** (a classe está em
+[evidencia-positiva-shell.md](evidencia-positiva-shell.md)): em **zsh**, `git show $sha:caminho`
+sem chaves faz o `:s` virar MODIFICADOR (`bad substitution`) e a contagem sai **0** — zero
+fabricado, não medido; use `"${sha}:caminho"`. E um `grep -c` de padrão com `$` devolveu 0 para
+texto que existia — a medição boa foi refeita em Python. **Contagem que sai 0 num shell merece um
+segundo eixo antes de virar conclusão.**
+
+## Lição
+
+**Fila sem sensor de desfecho acumula em silêncio, e o custo não aparece na fila — aparece no
+conserto.** O que fica caro não é a branch parada; é que ela envelhece contra uma main veloz, e
+quando alguém finalmente a empurra, paga N rodadas de re-merge e descobre os defeitos que o tempo
+plantou. Medir "quantos itens entraram" é fácil e inútil; o que decide é **quantos saíram, e há
+quanto tempo o mais velho espera**.


### PR DESCRIPTION
Medição de **2026-09-07**, a pedido do founder ("como podemos resolver esses problemas de fila?"). O doc grava o diagnóstico e, principalmente, **os comandos de re-medição** — sem eles a contagem morre com a sessão que a fez.

## Por que não era a fila que parecia

"Fila" neste app é ~10 coisas. As **técnicas** foram medidas primeiro e estavam limpas: `analytics_outbox` 277 linhas 100% drenadas, `score_recalc_queue` e `afiacao_os_sync_fila` vazias, `visit_score_recalc_queue` 37.919 linhas 100% processadas com 0 erro. A que dói é a de **entrega**.

| Fato | Valor |
|---|---|
| Branches com commit **e sem PR** | **41** |
| …paradas há **≥7 dias** | **25** (a mais velha há **92 dias**) |
| Worktrees cuja branch **já mergeou** | **41** |
| Sessões vivas / swap | 44 · **5,9 GB** |
| Vazão × entrada | ~4 PRs/dia contra **60–65 commits/dia** na main |

Lei de Little: WIP 41 ÷ 4/dia ⇒ lead time **~10 dias** — exatamente o observado.

## O vão que o doc nomeia

`wt:status` vê RAM/disco · `wt:orfas` vê sessão cujo worktree **sumiu** · `onde-parei.sh` vê **uma** sessão. **Nada mede "trabalho commitado sem desfecho" enquanto o worktree ainda existe.** É a mesma classe de [fila-plano-tatico.md](../blob/main/docs/historico/fila-plano-tatico.md) (533 planos, zero desfecho), aplicada ao processo de entrega do próprio repo.

## O custo, demonstrado no mesmo dia

Destravar o **#2093** (227h parado por um conflito de 2 linhas) custou **4 rodadas de re-merge** e revelou **4 defeitos latentes**. Dois valem por si:

- **O gate dependia da versão do shellcheck do runner** — 0.9.0 no CI × 0.11.0 local: **108 × 0** achados, 86 deles SC2317 (falso-positivo da 0.9.0). Corrigido pinando a versão, não baixando a severidade.
- **O caso que provava o fail-closed do gate ficava VERDE no Ubuntu**: simulava "shellcheck ausente" por DIRETÓRIO (`PATH=/usr/bin:/bin`), premissa válida no macOS e falsa no runner, onde o apt instala em `/usr/bin`. O caso aprovava a si mesmo.

## Dois erros de medição meus, registrados de propósito

1. A "taxa de 36% de falha do CI" media uma janela que **continha um incidente já consertado** (#2227/#2232). A real, depois do fix: **1 em 26**.
2. Duas contagens de shell devolveram **0 para texto que existia** — em zsh, `git show $sha:caminho` sem chaves faz o `:s` virar modificador. Zero fabricado, não medido.

## Gates

```
docs-indice    35 testes  ✓
docs-links     25 testes  ✓
docs-citacoes  50 testes  ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)