### PR TITLE
fix(ci): auto-merge ganha `issues: write` — sem ele o `Closes #N` é falha SILENCIOSA

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,6 +20,15 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # `issues: write` NÃO é para o merge — é para o FECHAMENTO da issue vinculada.
+  # Medido no #2320 (2026-09-07): o corpo trazia `Resolve #2311`, o GitHub REGISTROU o
+  # vínculo (`closingIssuesReferences` retornava a issue), o PR mergeou na main às
+  # 14:47:25Z — e 21min depois a issue seguia aberta. O timeline dela tem um único
+  # ClosedEvent, manual, com `closer: null`. Falha SILENCIOSA: keyword reconhecida,
+  # fechamento não acontece, ninguém recebe erro, e a issue entregue parece pendente.
+  # `issues:` e `pull-requests:` são escopos DISTINTOS no GITHUB_TOKEN, e fechar uma
+  # issue (não um PR) cai no primeiro. Detalhe e teste em #2322.
+  issues: write
 
 jobs:
   enable-auto-merge:


### PR DESCRIPTION
Ref #2322. **Este PR não usa keyword de fechamento de propósito** — ver "Desenho do teste" abaixo.

## O defeito, medido

No #2320 o corpo trazia `Resolve #2311.` na primeira linha. O GitHub **reconheceu** a keyword — `closingIssuesReferences` do PR retornava `[#2311]`, então não é erro de grafia nem de posição. O PR mergeou na `main` (branch default) às **14:47:25Z**, e **21 minutos depois** a issue seguia `state=OPEN`, `closedAt=null`.

O timeline da #2311 tem um único evento de fechamento:

```
CLOSED_EVENT: actor=LucasSardenbergL  closer=null  createdAt=15:08:04Z
```

`closer: null` = fechamento manual. Se o auto-close tivesse disparado haveria um `ClosedEvent` com `closer` apontando para o PR. Os 21 minutos descartam corrida de propagação.

## A correção

`issues:` e `pull-requests:` são escopos **distintos** do `GITHUB_TOKEN`. Fechar uma *issue* (não um PR) cai no primeiro, e o workflow declarava apenas `contents: write` + `pull-requests: write`. A identidade que habilita o auto-merge não teria permissão para fechar a issue vinculada — e falharia em silêncio, que é o sintoma observado.

## Desenho do teste (por que este PR não fecha nada)

Se eu pusesse `Closes #2322` aqui, um fechamento bem-sucedido seria **ambíguo**: para eventos `pull_request` de mesmo repo o workflow roda a partir do *head ref*, então este PR já rodaria com a permissão nova — e eu não saberia distinguir "a permissão corrigiu" de "o head ref antecipou o efeito".

Então: este PR só muda a permissão. A cobaia vem **depois**, sob o workflow já na `main`, e é ela que fecha a #2322.

- **Controle negativo (pré-mudança):** #2311, com o timeline acima. Sintoma reproduzido.
- **Teste (pós-mudança):** issue cobaia + PR trivial com `Closes #N`, a criar assim que este mergear.
- **Se a cobaia não fechar:** a hipótese cai, a permissão fica (é correta de qualquer forma) e a investigação continua na #2322 com o suspeito mais provável eliminado.

## Verificação local

`permissions` parseado do YAML após a mudança: `{"contents":"write","pull-requests":"write","issues":"write"}`, job `enable-auto-merge` intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)