### PR TITLE
fix(picking): os 7 KPIs param de dizer "0" para a leitura que falhou [money-path]

### DIFF
--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -458,6 +458,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/services/__tests__/picking-confirm.test.ts",
       "src/pages/__tests__/AdminEstoquePicking.leitura-falhou.test.tsx",
+      "src/pages/__tests__/AdminEstoquePicking.kpis-nao-fabricam-zero.test.tsx",
       "src/pages/__tests__/RecebimentoConferencia.estados.test.tsx",
     ],
     risco: { moneyPath: true, offlineFirst: true, authSensitive: false },

--- a/src/pages/AdminEstoquePicking.tsx
+++ b/src/pages/AdminEstoquePicking.tsx
@@ -75,36 +75,45 @@ function StatusBadge({ status }: { status: string | null }) {
 
 /* ─── KPIs ─── */
 function KpiCards({ account }: { account: string }) {
-  const { data: tasksAbertas } = useQuery({
+  // Os quatro cards ENGOLIAM o erro (`const { count } = await supabase…; return count ?? 0`). A
+  // leitura que falha deixa `data === undefined`, o `?? 0` do render a converte em "0", e o
+  // separador lê "0 Tasks Abertas" / "0 SKUs Críticos" / "0,0% FEFO" como afirmação sobre o chão
+  // de fábrica. É a classe IRMÃ da que some — `ausente → zero` (CLAUDE.md §Money-path) — e é pior:
+  // um número tem exatamente a mesma aparência quando é medido e quando é fabricado, então nada
+  // na tela convida o usuário a desconfiar. O `throw` é o começo obrigatório: sem ele a UI não tem
+  // como saber que falhou, e degradar o card seria inalcançável por construção (fix inerte).
+  const tasksAbertasQuery = useQuery({
     queryKey: ["pk-tasks-abertas", account],
     queryFn: async () => {
-      const { count } = await supabase
+      const { count, error } = await supabase
         .from("picking_tasks")
         .select("*", { count: "exact", head: true })
         .eq("account", account.toLowerCase())
         .in("status", ["pendente", "em_andamento"]);
+      if (error) throw error;
       return count ?? 0;
     },
     refetchInterval: 60000,
   });
 
-  const { data: pedidosAguardando } = useQuery({
+  const pedidosAguardandoQuery = useQuery({
     queryKey: ["pk-pedidos-aguardando", account],
     queryFn: async () => {
-      const { count } = await supabase
+      const { count, error } = await supabase
         .from("picking_tasks")
         .select("*", { count: "exact", head: true })
         .eq("account", account.toLowerCase())
         .eq("status", "pendente");
+      if (error) throw error;
       return count ?? 0;
     },
     refetchInterval: 60000,
   });
 
-  const { data: skusCriticos } = useQuery({
+  const skusCriticosQuery = useQuery({
     queryKey: ["pk-skus-criticos", account],
     queryFn: async () => {
-      const { count } = await supabase
+      const { count, error } = await supabase
         // Porta OPERACIONAL (FU4-F fase 2): conta SKUs zerados sem tocar custo. `head:true` não
         // retorna linhas — mas a tabela crua exigiria cap_custo_ler e devolveria 0 ao separador,
         // fabricando "nenhum SKU crítico" (o anti-padrão count-exact-vira-0-silencioso).
@@ -112,79 +121,126 @@ function KpiCards({ account }: { account: string }) {
         .select("*", { count: "exact", head: true })
         .eq("account", account)
         .lte("saldo", 0);
+      // O comentário acima já NOMEAVA este anti-padrão e a query mesmo assim não lançava: sem o
+      // `throw`, a negativa de permissão que ele descreve virava o "0" que ele condena.
+      if (error) throw error;
       return count ?? 0;
     },
     refetchInterval: 60000,
   });
 
-  const { data: fefoCompliance } = useQuery({
+  const fefoQuery = useQuery({
     queryKey: ["pk-fefo-compliance", account],
     queryFn: async () => {
-      const { data: tasks } = await supabase
+      const { data: tasks, error: erroTasks } = await supabase
         .from("picking_tasks")
         .select("id")
         .eq("account", account.toLowerCase());
+      if (erroTasks) throw erroTasks;
       const ids = (tasks ?? []).map((t) => t.id);
-      if (!ids.length) return { pct: 0, total: 0, ok: 0 };
-      const { data: items } = await supabase
+      // Sem task não há denominador: `total: 0` é a AUSÊNCIA de itens separados, não 0% de
+      // conformidade. Devolver `pct: 0` aqui pintava o card de vermelho ("0,0%") afirmando um
+      // descumprimento que ninguém cometeu — `pct: null` deixa o render dizer "—".
+      if (!ids.length) return { pct: null, total: 0, ok: 0 };
+      const { data: items, error: erroItens } = await supabase
         .from("picking_task_items")
         .select("lote_fefo, lote_separado")
         .in("picking_task_id", ids)
         .not("lote_separado", "is", null);
+      if (erroItens) throw erroItens;
       const total = (items ?? []).length;
       const ok = (items ?? []).filter(
         (i) => i.lote_fefo && i.lote_separado && i.lote_fefo === i.lote_separado,
       ).length;
-      return { pct: total ? (ok / total) * 100 : 0, total, ok };
+      return { pct: total ? (ok / total) * 100 : null, total, ok };
     },
     refetchInterval: 60000,
   });
 
+  const tasksAbertas = tasksAbertasQuery.data;
+  const pedidosAguardando = pedidosAguardandoQuery.data;
+  const skusCriticos = skusCriticosQuery.data;
+  const fefoCompliance = fefoQuery.data;
+
+  const estados = [
+    estadoDeLeitura(tasksAbertasQuery),
+    estadoDeLeitura(pedidosAguardandoQuery),
+    estadoDeLeitura(skusCriticosQuery),
+    estadoDeLeitura(fefoQuery),
+  ] as const;
+  const [estadoTasks, estadoPedidos, estadoSkus, estadoFefo] = estados;
+  // O aviso é do BLOCO: um único card mudo já basta para que o painel não sirva de base de
+  // decisão, e o usuário não tem como saber QUAL número parou de ser medido só olhando. Entre as
+  // causas, `sem-rede` tem precedência na mensagem — é a única sobre a qual ele pode agir.
+  const semLeitura = estados.filter(naoConsegui);
+  const estadoBloco = semLeitura.find((e) => e === "sem-rede") ?? semLeitura[0];
+
+  // Card que não foi lido não tem número NEM cor: "—" em tom neutro. Pintar de
+  // `text-muted-foreground` (a cor do zero) seria trocar uma mentira por outra mais discreta —
+  // "0 SKUs Críticos" em cinza calmo é a leitura que o separador faz de um estoque sadio.
+  const MUDO = { valor: "—", tone: "text-muted-foreground/60", border: "border-dashed border-border" };
+
   const cards = [
-    {
-      label: "Tasks Abertas",
-      value: tasksAbertas ?? 0,
-      icon: ClipboardList,
-      tone: (tasksAbertas ?? 0) > 0 ? "text-primary" : "text-muted-foreground",
-      border: (tasksAbertas ?? 0) > 0 ? "border-primary/40" : "border-border",
-    },
-    {
-      label: "Pedidos Aguardando",
-      value: pedidosAguardando ?? 0,
-      icon: Clock,
-      tone:
-        (pedidosAguardando ?? 0) > 0 ? "text-warning" : "text-muted-foreground",
-      border:
-        (pedidosAguardando ?? 0) > 0 ? "border-warning/40" : "border-border",
-    },
-    {
-      label: "SKUs Críticos",
-      value: skusCriticos ?? 0,
-      icon: AlertTriangle,
-      tone:
-        (skusCriticos ?? 0) > 0 ? "text-destructive" : "text-muted-foreground",
-      border:
-        (skusCriticos ?? 0) > 0 ? "border-destructive/40" : "border-border",
-    },
-    {
-      label: "FEFO Compliance",
-      value: `${(fefoCompliance?.pct ?? 0).toFixed(1)}%`,
-      icon: ShieldCheck,
-      tone:
-        (fefoCompliance?.pct ?? 0) >= 90
-          ? "text-success"
-          : (fefoCompliance?.pct ?? 0) >= 70
-            ? "text-warning"
-            : "text-destructive",
-      border:
-        (fefoCompliance?.pct ?? 0) >= 90
-          ? "border-success/40"
-          : "border-border",
-    },
+    naoConsegui(estadoTasks)
+      ? { label: "Tasks Abertas", value: MUDO.valor, icon: ClipboardList, tone: MUDO.tone, border: MUDO.border }
+      : {
+          label: "Tasks Abertas",
+          value: tasksAbertas ?? 0,
+          icon: ClipboardList,
+          tone: (tasksAbertas ?? 0) > 0 ? "text-primary" : "text-muted-foreground",
+          border: (tasksAbertas ?? 0) > 0 ? "border-primary/40" : "border-border",
+        },
+    naoConsegui(estadoPedidos)
+      ? { label: "Pedidos Aguardando", value: MUDO.valor, icon: Clock, tone: MUDO.tone, border: MUDO.border }
+      : {
+          label: "Pedidos Aguardando",
+          value: pedidosAguardando ?? 0,
+          icon: Clock,
+          tone:
+            (pedidosAguardando ?? 0) > 0 ? "text-warning" : "text-muted-foreground",
+          border:
+            (pedidosAguardando ?? 0) > 0 ? "border-warning/40" : "border-border",
+        },
+    naoConsegui(estadoSkus)
+      ? { label: "SKUs Críticos", value: MUDO.valor, icon: AlertTriangle, tone: MUDO.tone, border: MUDO.border }
+      : {
+          label: "SKUs Críticos",
+          value: skusCriticos ?? 0,
+          icon: AlertTriangle,
+          tone:
+            (skusCriticos ?? 0) > 0 ? "text-destructive" : "text-muted-foreground",
+          border:
+            (skusCriticos ?? 0) > 0 ? "border-destructive/40" : "border-border",
+        },
+    // `pct == null` cobre DOIS casos que não são 0%: a leitura que falhou e o denominador vazio
+    // (nenhum item separado ainda). Nos dois, o que existe é ausência de medida.
+    naoConsegui(estadoFefo) || fefoCompliance?.pct == null
+      ? { label: "FEFO Compliance", value: MUDO.valor, icon: ShieldCheck, tone: MUDO.tone, border: MUDO.border }
+      : {
+          label: "FEFO Compliance",
+          value: `${fefoCompliance.pct.toFixed(1)}%`,
+          icon: ShieldCheck,
+          tone:
+            fefoCompliance.pct >= 90
+              ? "text-success"
+              : fefoCompliance.pct >= 70
+                ? "text-warning"
+                : "text-destructive",
+          border:
+            fefoCompliance.pct >= 90 ? "border-success/40" : "border-border",
+        },
   ];
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="space-y-3">
+      {estadoBloco && (
+        <AvisoLeituraFalhou
+          oque="os indicadores de picking e estoque"
+          estado={estadoBloco}
+          testId="aviso-picking-kpis"
+        />
+      )}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
       {cards.map((c) => (
         <Card key={c.label} className={c.border}>
           <CardContent className="pt-4 flex items-center justify-between">
@@ -198,6 +254,7 @@ function KpiCards({ account }: { account: string }) {
           </CardContent>
         </Card>
       ))}
+      </div>
     </div>
   );
 }
@@ -326,19 +383,27 @@ function PickingTab({ account }: { account: string }) {
   const { data, isLoading } = listaQuery;
   const estadoLista = estadoDeLeitura(listaQuery);
 
-  const { data: items } = useQuery({
+  // Os itens da task expandida tinham DUAS saídas erradas para a mesma falha: engolindo o erro,
+  // `data` virava `[]` e a gaveta dizia "Sem itens." sobre uma task que tem itens; e um `throw`
+  // sozinho deixaria `data === undefined`, que o render lê como "Carregando itens..." — um
+  // spinner ETERNO, a forma que some disfarçada de lentidão. Por isso o throw vem junto com o
+  // estado, e o render passa a distinguir os três.
+  const itensQuery = useQuery({
     queryKey: ["pk-picking-items", expanded],
     enabled: !!expanded,
     queryFn: async () => {
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("picking_task_items")
         .select(
           "id, product_descricao, quantidade, quantidade_separada, status, lote_fefo, lote_separado",
         )
         .eq("picking_task_id", expanded ?? "");
+      if (error) throw error;
       return data ?? [];
     },
   });
+  const { data: items } = itensQuery;
+  const estadoItens = estadoDeLeitura(itensQuery);
 
   // Handler de scan — v1: registra o último bipe e mostra feedback. A integração com a task ativa
   // (auto-foco no item correspondente, optimistic update) virá quando #19 (TouchPickingView) for
@@ -420,7 +485,13 @@ function PickingTab({ account }: { account: string }) {
                 {expanded === t.id && (
                   <TableRow>
                     <TableCell colSpan={6} className="bg-muted/30 p-4">
-                      {!items ? (
+                      {naoConsegui(estadoItens) ? (
+                        <AvisoLeituraFalhou
+                          oque="os itens desta task"
+                          estado={estadoItens}
+                          testId="aviso-picking-itens"
+                        />
+                      ) : !items ? (
                         <div className="text-sm text-muted-foreground">Carregando itens...</div>
                       ) : items.length === 0 ? (
                         <div className="text-sm text-muted-foreground">Sem itens.</div>
@@ -485,10 +556,13 @@ type LinhaEstoqueOperacional = {
 function EstoqueTab({ account }: { account: string }) {
   const [search, setSearch] = useState("");
 
-  const { data, isLoading } = useQuery({
+  // Única aba com fonte VIVA: `inventory_position` tinha 3.166 linhas em prod (psql-ro,
+  // 2026-09-07). O erro engolido virava `[]` e a tabela dizia "Nenhum SKU encontrado." — e a
+  // negativa de permissão da view operacional é justamente o modo de falha esperado aqui.
+  const inventarioQuery = useQuery({
     queryKey: ["pk-inventory", account],
     queryFn: async () => {
-      const { data } = await supabase
+      const { data, error } = await supabase
         // Porta OPERACIONAL: saldo sem custo (FU4-F fase 2). A tabela inventory_position exige
         // private.cap_custo_ler — o separador não tem, e não precisa: aqui se consulta SALDO.
         // `as never`: a view é nova e ainda não está nos tipos gerados (padrão já usado em
@@ -498,9 +572,12 @@ function EstoqueTab({ account }: { account: string }) {
         .eq("account", account)
         .order("saldo", { ascending: true })
         .limit(500);
+      if (error) throw error;
       return (data ?? []) as unknown as LinhaEstoqueOperacional[];
     },
   });
+  const { data, isLoading } = inventarioQuery;
+  const estadoInventario = estadoDeLeitura(inventarioQuery);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -522,7 +599,14 @@ function EstoqueTab({ account }: { account: string }) {
             className="pl-8"
           />
         </div>
-        {isLoading ? (
+        {naoConsegui(estadoInventario) ? (
+          <AvisoLeituraFalhou
+            oque="as posições de estoque"
+            estado={estadoInventario}
+            variante="bloco"
+            testId="aviso-picking-inventario"
+          />
+        ) : isLoading ? (
           <PageSkeleton variant="list" />
         ) : (
           <Table>

--- a/src/pages/__tests__/AdminEstoquePicking.kpis-nao-fabricam-zero.test.tsx
+++ b/src/pages/__tests__/AdminEstoquePicking.kpis-nao-fabricam-zero.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * Guard da classe IRMÃ da que some: `ausente → zero` (CLAUDE.md §Money-path).
+ *
+ * O painel de KPIs não usa a forma `{data && <X/>}` — ele faz `value: tasksAbertas ?? 0` e PINTA
+ * o card. A leitura que falha deixa `data === undefined`, o `??` a converte em "0", e o separador
+ * lê "0 Tasks Abertas" / "0 SKUs Críticos" / "0,0% FEFO" como afirmação sobre o chão de fábrica.
+ * É pior que sumir: um número tem exatamente a mesma aparência quando é medido e quando é
+ * fabricado, então nada na tela convida a desconfiar.
+ *
+ * ⚠️ DENOMINADOR (psql-ro, 2026-09-07) — as duas metades NÃO são iguais:
+ *   `picking_tasks`/`picking_task_items`/`picking_events` = 0 linhas → dano ainda hipotético.
+ *   `inventory_position` = 3.166 linhas (colacor_vendas 1.452 · vendas 837 · oben 828), com
+ *   5/1/1 SKUs de saldo ≤ 0 → o card "SKUs Críticos" e a aba Estoque JÁ servem dado real, e a
+ *   negativa de permissão da view operacional (`has_role`, medida no psql-ro) é o modo de falha
+ *   ESPERADO ali. Para esses dois sítios o "0" não é risco futuro: é a mentira de hoje.
+ *
+ * O primeiro caso de cada bloco afirma o estado da QUERY, senão o guard aprovaria um fix inerte
+ * (degradar o card não é alcançável enquanto o `queryFn` engolir o erro).
+ *
+ * As queries rodam de verdade; só o supabase é mockado, roteado por tabela.
+ */
+
+type Resposta = { data: unknown; error: { message: string } | null; count?: number | null };
+
+let falharEm: string | null = null;
+let dados: Record<string, unknown[]> = {};
+const ERRO: Resposta = { data: null, error: { message: 'permission denied' }, count: null };
+const ok = (t: string): Resposta => {
+  const linhas = dados[t] ?? [];
+  return { data: linhas, error: null, count: linhas.length };
+};
+
+function builder(resposta: () => Resposta) {
+  const q: Record<string, unknown> = {};
+  for (const m of ['select', 'order', 'limit', 'eq', 'in', 'not', 'lte', 'gte', 'ilike']) q[m] = () => q;
+  q.then = (ok: (r: Resposta) => unknown) => Promise.resolve(resposta()).then(ok);
+  return q;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => builder(() => (t === falharEm ? ERRO : ok(t))) },
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
+vi.mock('@/hooks/useIsTouchDevice', () => ({ useIsTouchDevice: () => false }));
+vi.mock('@/components/picking/ScanBar', () => ({ ScanBar: () => null }));
+vi.mock('@/queries/usePedidosASeparar', () => ({ usePedidosASeparar: () => ({ data: [], isLoading: false }) }));
+vi.mock('@/queries/useEnviarParaSeparacao', () => ({
+  useEnviarParaSeparacao: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import AdminEstoquePicking from '../AdminEstoquePicking';
+
+function renderAba(aba: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return {
+    qc,
+    ...render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[`/admin/estoque/picking?tab=${aba}`]}>
+          <AdminEstoquePicking />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+/**
+ * O VALOR do card, lido pela estrutura (label e valor são irmãos no mesmo `<div>`) — não por
+ * `getByText('0')`, que casaria com qualquer "0" da página e passaria verde pelo card errado.
+ */
+async function valorDoCard(label: string) {
+  const el = await screen.findByText(label);
+  return el.nextElementSibling?.textContent ?? '';
+}
+
+beforeEach(() => { falharEm = null; dados = {}; });
+afterEach(() => { onlineManager.setOnline(true); vi.restoreAllMocks(); });
+
+describe('KPIs — a leitura que falhou não vira o número "0"', () => {
+  it('a query de tasks abertas entra em ERRO quando o count falha (hoje ela engole)', async () => {
+    falharEm = 'picking_tasks';
+    const { qc } = renderAba('picking');
+
+    await waitFor(() => {
+      expect(qc.getQueryState(['pk-tasks-abertas', 'OBEN'])?.status).toBe('error');
+    });
+  });
+
+  it('ERRO: "Tasks Abertas" e "Pedidos Aguardando" mostram "—", nunca "0"', async () => {
+    falharEm = 'picking_tasks';
+    renderAba('picking');
+
+    await waitFor(async () => expect(await valorDoCard('Tasks Abertas')).toBe('—'));
+    expect(await valorDoCard('Pedidos Aguardando')).toBe('—');
+  });
+
+  it('ERRO: o bloco de KPIs FALA — não fica um painel de zeros calado', async () => {
+    falharEm = 'picking_tasks';
+    renderAba('picking');
+
+    const aviso = await screen.findByTestId('aviso-picking-kpis');
+    expect(aviso.getAttribute('data-estado')).toBe('erro');
+  });
+
+  it('a query de SKUs críticos entra em ERRO quando a view operacional nega permissão', async () => {
+    falharEm = 'inventory_position_operacional';
+    const { qc } = renderAba('picking');
+
+    await waitFor(() => {
+      expect(qc.getQueryState(['pk-skus-criticos', 'OBEN'])?.status).toBe('error');
+    });
+  });
+
+  it('ERRO na view: "SKUs Críticos" mostra "—" — o "0" aqui seria "estoque sadio"', async () => {
+    falharEm = 'inventory_position_operacional';
+    renderAba('picking');
+
+    await waitFor(async () => expect(await valorDoCard('SKUs Críticos')).toBe('—'));
+    expect(await screen.findByTestId('aviso-picking-kpis')).toBeTruthy();
+  });
+
+  it('ERRO no FEFO: mostra "—", não "0.0%" pintado de vermelho', async () => {
+    falharEm = 'picking_tasks';
+    renderAba('picking');
+
+    await waitFor(async () => expect(await valorDoCard('FEFO Compliance')).toBe('—'));
+  });
+
+  it('SEM denominador: FEFO é "—" — nenhum item separado não é 0% de conformidade', async () => {
+    renderAba('picking');
+
+    await waitFor(async () => expect(await valorDoCard('FEFO Compliance')).toBe('—'));
+    expect(screen.queryByTestId('aviso-picking-kpis')).toBeNull();
+  });
+
+  it('ZERO real: os counts mostram "0" mesmo, e sem aviso', async () => {
+    renderAba('picking');
+
+    await waitFor(async () => expect(await valorDoCard('Tasks Abertas')).toBe('0'));
+    expect(await valorDoCard('Pedidos Aguardando')).toBe('0');
+    expect(await valorDoCard('SKUs Críticos')).toBe('0');
+    expect(screen.queryByTestId('aviso-picking-kpis')).toBeNull();
+  });
+
+  it('OFFLINE: cards mudos e aviso de rede — não um painel de zeros', async () => {
+    onlineManager.setOnline(false);
+    renderAba('picking');
+
+    const aviso = await screen.findByTestId('aviso-picking-kpis');
+    expect(aviso.getAttribute('data-estado')).toBe('sem-rede');
+    expect(await valorDoCard('Tasks Abertas')).toBe('—');
+  });
+});
+
+describe('Itens da task expandida — "Sem itens." e o spinner eterno', () => {
+  const UMA_TASK = [{ id: 'task-aaa-1111', sales_order_id: 'so-1', status: 'pendente', assigned_to: null, created_at: '2026-09-01T10:00:00Z' }];
+
+  async function expandir() {
+    const linha = (await screen.findByText('task-aaa')).closest('tr');
+    fireEvent.click(linha!.querySelector('button')!);
+  }
+
+  it('a query dos itens entra em ERRO quando o select falha', async () => {
+    dados = { picking_tasks: UMA_TASK };
+    falharEm = 'picking_task_items';
+    const { qc } = renderAba('picking');
+    await expandir();
+
+    await waitFor(() => {
+      expect(qc.getQueryState(['pk-picking-items', 'task-aaa-1111'])?.status).toBe('error');
+    });
+  });
+
+  it('ERRO: não diz "Sem itens." nem trava em "Carregando itens..."', async () => {
+    dados = { picking_tasks: UMA_TASK };
+    falharEm = 'picking_task_items';
+    const { container } = renderAba('picking');
+    await expandir();
+
+    expect(await screen.findByTestId('aviso-picking-itens')).toBeTruthy();
+    expect(container.textContent).not.toMatch(/Sem itens/i);
+    expect(container.textContent).not.toMatch(/Carregando itens/i);
+  });
+
+  it('ZERO real: aí sim "Sem itens.", e sem aviso', async () => {
+    dados = { picking_tasks: UMA_TASK, picking_task_items: [] };
+    renderAba('picking');
+    await expandir();
+
+    expect(await screen.findByText(/Sem itens/i)).toBeTruthy();
+    expect(screen.queryByTestId('aviso-picking-itens')).toBeNull();
+  });
+});
+
+describe('Aba Estoque — fonte VIVA (3.166 linhas em prod)', () => {
+  it('a query de inventário entra em ERRO quando a view nega permissão', async () => {
+    falharEm = 'inventory_position_operacional';
+    const { qc } = renderAba('estoque');
+
+    await waitFor(() => {
+      expect(qc.getQueryState(['pk-inventory', 'OBEN'])?.status).toBe('error');
+    });
+  });
+
+  it('ERRO: não diz "Nenhum SKU encontrado." — diz que não conseguiu ler', async () => {
+    falharEm = 'inventory_position_operacional';
+    const { container } = renderAba('estoque');
+
+    expect(await screen.findByTestId('aviso-picking-inventario')).toBeTruthy();
+    expect(container.textContent).not.toMatch(/Nenhum SKU encontrado/i);
+  });
+
+  it('ZERO real: aí sim "Nenhum SKU encontrado.", e sem aviso', async () => {
+    const { container } = renderAba('estoque');
+
+    expect(await screen.findByText(/Nenhum SKU encontrado/i)).toBeTruthy();
+    expect(screen.queryByTestId('aviso-picking-inventario')).toBeNull();
+    expect(container.textContent).toBeTruthy();
+  });
+
+  it('OFFLINE: não afirma estoque vazio — diz que falta rede', async () => {
+    onlineManager.setOnline(false);
+    const { container } = renderAba('estoque');
+
+    const aviso = await screen.findByTestId('aviso-picking-inventario');
+    expect(aviso.getAttribute('data-estado')).toBe('sem-rede');
+    expect(container.textContent).not.toMatch(/Nenhum SKU encontrado/i);
+  });
+});

--- a/src/pages/__tests__/AdminEstoquePicking.kpis-nao-fabricam-zero.test.tsx
+++ b/src/pages/__tests__/AdminEstoquePicking.kpis-nao-fabricam-zero.test.tsx
@@ -78,6 +78,24 @@ async function valorDoCard(label: string) {
   return el.nextElementSibling?.textContent ?? '';
 }
 
+/**
+ * Espera a query ASSENTAR antes de ler o card — e esta espera é a asserção, não cerimônia.
+ *
+ * MEDIDO no laço de falsificação (2026-09-07): durante o loading o card já exibe o valor
+ * TRANSITÓRIO — `fefoCompliance?.pct == null` é true quando `data` ainda é `undefined`, então o
+ * FEFO mostra "—" antes de qualquer leitura acontecer. Um `waitFor(() => expect(valor).toBe('—'))`
+ * passava na PRIMEIRA tentativa, e o teste aprovava o spinner em vez da medição: sabotar
+ * `pct: null → 0` ficava VERDE. O espelho vale para os counts, que mostram "0" no loading
+ * (`undefined ?? 0`) — ali um teste de "ZERO real" passaria sem nunca ver o zero medido.
+ */
+async function assentar(
+  qc: QueryClient,
+  chave: readonly unknown[],
+  status: 'success' | 'error',
+) {
+  await waitFor(() => expect(qc.getQueryState([...chave])?.status).toBe(status));
+}
+
 beforeEach(() => { falharEm = null; dados = {}; });
 afterEach(() => { onlineManager.setOnline(true); vi.restoreAllMocks(); });
 
@@ -93,9 +111,11 @@ describe('KPIs — a leitura que falhou não vira o número "0"', () => {
 
   it('ERRO: "Tasks Abertas" e "Pedidos Aguardando" mostram "—", nunca "0"', async () => {
     falharEm = 'picking_tasks';
-    renderAba('picking');
+    const { qc } = renderAba('picking');
 
-    await waitFor(async () => expect(await valorDoCard('Tasks Abertas')).toBe('—'));
+    await assentar(qc, ['pk-tasks-abertas', 'OBEN'], 'error');
+    await assentar(qc, ['pk-pedidos-aguardando', 'OBEN'], 'error');
+    expect(await valorDoCard('Tasks Abertas')).toBe('—');
     expect(await valorDoCard('Pedidos Aguardando')).toBe('—');
   });
 
@@ -118,30 +138,38 @@ describe('KPIs — a leitura que falhou não vira o número "0"', () => {
 
   it('ERRO na view: "SKUs Críticos" mostra "—" — o "0" aqui seria "estoque sadio"', async () => {
     falharEm = 'inventory_position_operacional';
-    renderAba('picking');
+    const { qc } = renderAba('picking');
 
-    await waitFor(async () => expect(await valorDoCard('SKUs Críticos')).toBe('—'));
+    await assentar(qc, ['pk-skus-criticos', 'OBEN'], 'error');
+    expect(await valorDoCard('SKUs Críticos')).toBe('—');
     expect(await screen.findByTestId('aviso-picking-kpis')).toBeTruthy();
   });
 
   it('ERRO no FEFO: mostra "—", não "0.0%" pintado de vermelho', async () => {
     falharEm = 'picking_tasks';
-    renderAba('picking');
+    const { qc } = renderAba('picking');
 
-    await waitFor(async () => expect(await valorDoCard('FEFO Compliance')).toBe('—'));
+    await assentar(qc, ['pk-fefo-compliance', 'OBEN'], 'error');
+    expect(await valorDoCard('FEFO Compliance')).toBe('—');
   });
 
   it('SEM denominador: FEFO é "—" — nenhum item separado não é 0% de conformidade', async () => {
-    renderAba('picking');
+    const { qc } = renderAba('picking');
 
-    await waitFor(async () => expect(await valorDoCard('FEFO Compliance')).toBe('—'));
+    // Assentar em `success` é o que separa esta asserção do "—" do loading: aqui a leitura
+    // ACONTECEU e devolveu 0 tasks, e é a AUSÊNCIA de denominador que precisa virar "—".
+    await assentar(qc, ['pk-fefo-compliance', 'OBEN'], 'success');
+    expect(await valorDoCard('FEFO Compliance')).toBe('—');
     expect(screen.queryByTestId('aviso-picking-kpis')).toBeNull();
   });
 
   it('ZERO real: os counts mostram "0" mesmo, e sem aviso', async () => {
-    renderAba('picking');
+    const { qc } = renderAba('picking');
 
-    await waitFor(async () => expect(await valorDoCard('Tasks Abertas')).toBe('0'));
+    await assentar(qc, ['pk-tasks-abertas', 'OBEN'], 'success');
+    await assentar(qc, ['pk-pedidos-aguardando', 'OBEN'], 'success');
+    await assentar(qc, ['pk-skus-criticos', 'OBEN'], 'success');
+    expect(await valorDoCard('Tasks Abertas')).toBe('0');
     expect(await valorDoCard('Pedidos Aguardando')).toBe('0');
     expect(await valorDoCard('SKUs Críticos')).toBe('0');
     expect(screen.queryByTestId('aviso-picking-kpis')).toBeNull();


### PR DESCRIPTION
## O resíduo da fatia de gatilho — a classe IRMÃ

O #2294 quitou os 3 sítios de `AdminEstoquePicking.tsx` listados no inventário. Sobravam **sete `queryFn` no mesmo arquivo** engolindo o erro (`const { count } = await supabase…; return count ?? 0`), e eles não são a forma que some — são a que **mente**: `ausente → zero` (CLAUDE.md §Money-path).

O `KpiCards` não usa `{data && <X/>}`. Ele faz `value: tasksAbertas ?? 0` e **pinta o card**. A leitura que falha vira "0 Tasks Abertas" / "0 Pedidos Aguardando" / "0 SKUs Críticos" / "0,0% FEFO", que o separador lê como afirmação sobre o chão de fábrica. É pior que sumir: um número tem exatamente a mesma aparência quando é medido e quando é fabricado, então nada na tela convida a desconfiar. O comentário do próprio `pk-skus-criticos` já **nomeava** o anti-padrão ("count-exact-vira-0-silencioso") e a query mesmo assim não lançava.

## Denominador re-medido — e ele corrige o briefing

`psql-ro`, 2026-09-07. As duas metades **não** são iguais:

| fonte | linhas | leitura |
|---|---|---|
| `picking_tasks` · `picking_task_items` · `picking_events` | **0** | dano ainda hipotético |
| `inventory_position` | **3.166** (colacor_vendas 1.452 · vendas 837 · oben 828) | **fonte viva** |

Com 5 / 1 / 1 SKUs de saldo ≤ 0 por conta. Ou seja: o card "SKUs Críticos" e a aba Estoque **já servem dado real hoje**, e a view `inventory_position_operacional` nega permissão por `has_role` — modo de falha que bateu no meu próprio `claude_ro` ao medir. Para esses dois sítios o "0" não é risco futuro, é a mentira de hoje.

## O que muda

- `if (error) throw error` nos 7 `queryFn`. Sem isso a UI não tem como saber que falhou e degradar o card seria **inalcançável por construção** — fix inerte.
- Cards degradam para **"—" em tom neutro** quando `naoConsegui(estado)`, nunca para 0. Pintar de `text-muted-foreground` (a cor do zero) trocaria a mentira por uma mais discreta: "0 SKUs Críticos" em cinza calmo lê-se como estoque sadio.
- `<AvisoLeituraFalhou>` no bloco de KPIs, na aba Estoque e na gaveta de itens.

Dois pontos onde estendi o escopo, mesma classe, sinalizados no código:

- **FEFO sem denominador** devolvia `pct: 0` → card "0,0%" **em vermelho**, afirmando descumprimento onde não há item separado nenhum. Com `picking_tasks` = 0, é o que está no ar hoje. Virou `pct: null` → "—".
- **Itens da task expandida** tinham duas saídas erradas para a mesma falha: engolindo, "Sem itens."; com `throw` sozinho, `data === undefined` cai no ramo `!items` e vira **"Carregando itens…" eterno** — a forma que some disfarçada de lentidão. Por isso o throw foi junto com o estado.

## Falsificação — e o que ela pegou

Controle verde na mesma invocação, uma camada por vez, com o typecheck como portão antes de qualquer `sed`.

**A 1ª rodada reprovou.** Sabotar `pct: null → 0` ficou **VERDE**: durante o loading `fefoCompliance` é `undefined`, então `?.pct == null` já é true e o card exibe "—" **antes de qualquer leitura acontecer**. O `waitFor` passava na primeira tentativa e afirmava o spinner, não a medição. O espelho valia para os counts, que mostram "0" no loading (`undefined ?? 0`) — o caso de "ZERO real" passaria sem nunca ver o zero medido. Dois testes verdes que não testavam nada.

Corrigido em `daf602cf0`: toda leitura de card espera a query **assentar** (`getQueryState().status`) antes de afirmar o valor, e entrou uma sabotagem do lado da precisão (card sempre mudo), que só o caso de ZERO real pega.

## Teste

16 casos, hook rodando de verdade e só o supabase mockado (roteado por tabela). O primeiro caso de cada bloco afirma `getQueryState(...).status === 'error'` — senão o guard aprovaria um fix inerte. Cada bloco tem "ZERO real" de controle e caso OFFLINE (`networkMode:'online'` → pending+paused, que `isLoading` não pega).

## Deploy

Só front — **Publish do Lovable**, sem edge e sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
