### PR TITLE
test(ci): cobaia do auto-close — este PR fecha (ou não) a #2329 por keyword

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,7 @@ permissions:
   # fechamento não acontece, ninguém recebe erro, e a issue entregue parece pendente.
   # `issues:` e `pull-requests:` são escopos DISTINTOS no GITHUB_TOKEN, e fechar uma
   # issue (não um PR) cai no primeiro. Detalhe e teste em #2322.
+  # Cobaia que mede o efeito desta linha: #2329 (resultado registrado em #2322).
   issues: write
 
 jobs:


### PR DESCRIPTION
Closes #2329

**PR de teste.** A mudança é uma linha de comentário, deliberadamente trivial — o conteúdo não importa, o que importa é o desfecho da issue vinculada.

## O que está sendo medido

O #2324 adicionou `issues: write` ao `permissions` do `auto-merge.yml`, sob a hipótese (#2322) de que a falta desse escopo era o que impedia o auto-close por keyword.

Este PR roda sob o workflow **já corrigido na `main`** — confirmado por parse do YAML de `origin/main`, não por grep de comentário:

```
permissions = {"contents":"write","pull-requests":"write","issues":"write"}
```

## Controle negativo (pré-mudança)

#2311: o #2320 trazia `Resolve #2311`, o GitHub registrou o vínculo, o PR mergeou às 14:47:25Z, e 21 minutos depois a issue seguia aberta. O timeline tem um único `ClosedEvent`, manual, com `closer: null`.

## Como ler o resultado

- **#2329 fecha sozinha, com `closer` apontando para este PR** → hipótese confirmada.
- **#2329 continua aberta** → hipótese refutada; a permissão fica (é correta de qualquer forma) e a investigação segue no #2322 com o suspeito mais provável eliminado.

O resultado será anotado no #2322 nos dois casos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)