### PR TITLE
revert(ci): `issues: write` NÃO conserta o auto-close — cobaia reprovou, e o comentário mentia

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,16 +20,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # `issues: write` NÃO é para o merge — é para o FECHAMENTO da issue vinculada.
-  # Medido no #2320 (2026-09-07): o corpo trazia `Resolve #2311`, o GitHub REGISTROU o
-  # vínculo (`closingIssuesReferences` retornava a issue), o PR mergeou na main às
-  # 14:47:25Z — e 21min depois a issue seguia aberta. O timeline dela tem um único
-  # ClosedEvent, manual, com `closer: null`. Falha SILENCIOSA: keyword reconhecida,
-  # fechamento não acontece, ninguém recebe erro, e a issue entregue parece pendente.
-  # `issues:` e `pull-requests:` são escopos DISTINTOS no GITHUB_TOKEN, e fechar uma
-  # issue (não um PR) cai no primeiro. Detalhe e teste em #2322.
-  # Cobaia que mede o efeito desta linha: #2329 (resultado registrado em #2322).
-  issues: write
+  # ⚠️ NÃO adicione `issues: write` achando que conserta o auto-close de `Closes #N`.
+  # Foi testado e REPROVOU (#2322): com a permissão na main, o PR #2330 mergeou às
+  # 19:02:53Z com o vínculo registrado, e a issue #2329 seguia aberta 7min depois —
+  # mesmo desfecho do #2320/#2311 SEM a permissão. O bloco `permissions:` governa o
+  # token DURANTE o run; o auto-merge acontece depois, fora dele, e em ambos os casos
+  # `mergedBy` foi `app/github-actions`. A pista viva é essa — o ator do merge —, não
+  # o escopo do token. Investigação em #2322.
 
 jobs:
   enable-auto-merge:


### PR DESCRIPTION
Ref #2322. Reverte a permissão do #2324 e, principalmente, **corrige um comentário meu na `main` que afirmava uma causa refutada**.

## O experimento

| | |
|---|---|
| permissão na `main` | `{"contents":"write","pull-requests":"write","issues":"write"}` (parse do YAML, não grep) |
| cobaia | issue #2329, vinculada por `Closes` no PR #2330 |
| vínculo registrado | sim — `closingIssuesReferences` = `[#2329]` |
| PR #2330 mergeado | 19:02:53Z |
| issue #2329 em 19:09:57Z | **`state=OPEN`, `closedAt=null`** |
| controle negativo (#2311, sem a permissão) | aberta 21min após o merge, `closer: null` |

**Mesmo desfecho com e sem a permissão. Hipótese refutada.**

## Por que este PR existe

A permissão em si era inerte — remover é higiene, não urgência. O que exigia PR é que eu havia deixado na `main` um bloco de comentário afirmando a causa como estabelecida. Refutada, isso vira **desinformação num arquivo que a próxima pessoa lê antes de mexer no auto-merge** — e o erro que ela induz é exatamente o que acabei de cometer. No lugar fica o aviso de não repetir a tentativa, com o número medido.

Removo a permissão em vez de mantê-la "para a correção futura": least privilege não aceita escopo justificado por hipótese morta nem por trabalho que não existe. Quando a correção real vier, ela traz o escopo de que precisar.

## A pista que o experimento produziu de graça

`mergedBy` foi **`app/github-actions`** tanto no #2330 quanto no #2320. E o bloco `permissions:` governa o token **durante o run** — o auto-merge executa depois, fora de qualquer run. Então o escopo do token provavelmente nunca esteve em jogo, o que explica por que mexer nele não mudou nada.

O suspeito agora é o **ator do merge**, não a permissão. Registrado no #2322; não implemento correção aqui porque ainda é hipótese, e acabei de mostrar o custo de tratar hipótese como diagnóstico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)