### PR TITLE
fix(kb): a lista de 116 pendências não some quando a atualização falha [irmão do #2305]

### DIFF
--- a/src/components/knowledge-base/CompletudeSection.tsx
+++ b/src/components/knowledge-base/CompletudeSection.tsx
@@ -1,6 +1,6 @@
 import { useCompletude } from '@/hooks/useCompletude';
 import { rotularCampo } from '@/lib/knowledge-base/campo-labels';
-import { estadoDeLeitura, naoConsegui } from '@/lib/leitura/estado-de-leitura';
+import { estadoDeLeitura, naoConsegui, desatualizado } from '@/lib/leitura/estado-de-leitura';
 import { AvisoLeituraFalhou } from '@/components/leitura/AvisoLeituraFalhou';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -29,31 +29,39 @@ export function CompletudeSection() {
   const { data, status, fetchStatus } = useCompletude();
   const estado = estadoDeLeitura({ status, fetchStatus });
 
-  // ANTES do loading, e não depois: sem rede a query fica `pending` + `paused`, com
-  // `isLoading` FALSE, `data` `undefined` e `error` `null`. O 4º estado passa reto por
-  // um guard de `isLoading`/`error` e cai no ramo do "está tudo completo".
-  if (naoConsegui(estado)) {
-    return (
-      <AvisoLeituraFalhou
-        oque="a lista de fichas com dados importantes faltando"
-        estado={estado}
-        variante="bloco"
-      />
-    );
-  }
-
-  if (estado !== 'pronta') {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  // Só alcançável com a leitura FEITA — aqui o vazio é mesmo "não há pendência", e o ✓
-  // verde é verdade. (`!data` sobrevive porque o tipo de `UseQueryResult` admite
-  // `undefined`; em `success` a `queryFn` sempre devolveu um array.)
+  // NADA EM MÃOS — os três estados que colapsavam num só. A guarda externa é o que
+  // impede o aviso de ENGOLIR uma lista que já está na tela (ver o `velho`, adiante):
+  // sem ela, `status:'error'` com as 116 pendências no cache troca a lista por uma faixa.
+  // Para todo caso SEM lista o comportamento é idêntico ao do #2305 — `[]` de sucesso
+  // entra aqui igual, e `undefined` + `pronta` segue caindo no ✓ verde.
   if (!data || data.length === 0) {
+    // ANTES do loading, e não depois: sem rede a query fica `pending` + `paused`, com
+    // `isLoading` FALSE, `data` `undefined` e `error` `null`. O 4º estado passa reto por
+    // um guard de `isLoading`/`error` e cai no ramo do "está tudo completo".
+    // Sem lista em mãos não há o que preservar, então o aviso vai SOZINHO — é o caso que
+    // o próprio `desatualizado` manda tratar assim, e é o que impede o ✓ verde de
+    // aparecer com uma nota de rodapé ao lado de "não consegui ler".
+    if (naoConsegui(estado)) {
+      return (
+        <AvisoLeituraFalhou
+          oque="a lista de fichas com dados importantes faltando"
+          estado={estado}
+          variante="bloco"
+        />
+      );
+    }
+
+    if (estado !== 'pronta') {
+      return (
+        <div className="flex justify-center py-8">
+          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+        </div>
+      );
+    }
+
+    // Só alcançável com a leitura FEITA — aqui o vazio é mesmo "não há pendência", e o ✓
+    // verde é verdade. (`!data` sobrevive porque o tipo de `UseQueryResult` admite
+    // `undefined`; em `success` a `queryFn` sempre devolveu um array.)
     return (
       <Card className="p-8 text-center text-xs text-muted-foreground">
         <CheckCircle2 className="w-8 h-8 mx-auto mb-2 text-status-success opacity-70" />
@@ -62,8 +70,26 @@ export function CompletudeSection() {
     );
   }
 
+  // LISTA EM MÃOS. Um refetch que FALHA não pode apagá-la: trocar as
+  // 116 pendências de trabalho por um aviso é consertar o sensor quebrando a tela —
+  // honesto para o alarme, regressão para quem ia pedir os dados à fábrica. O desenho que
+  // serve aos dois é composto: lista PRESERVADA + a faixa dizendo que está velha
+  // (`desatualizado`, em @/lib/leitura/estado-de-leitura, medido no MixGapCard pelo #1892).
+  //
+  // ⚠️ `{ status, fetchStatus }` de novo, e não um `q` inteiro: a desestruturação que liga
+  // `status` é o que mantém este arquivo VISÍVEL para o gate (ver o cabeçalho).
+  const velho = desatualizado({ status, fetchStatus }, true);
+
   return (
     <div className="space-y-2">
+      {velho && (
+        <AvisoLeituraFalhou
+          oque="a atualização da lista de fichas com dados faltando"
+          estado={velho}
+          className="mb-0"
+          testId="aviso-completude-desatualizada"
+        />
+      )}
       <p className="text-2xs text-muted-foreground">
         {data.length} produto{data.length > 1 ? 's' : ''} com dados importantes faltando — sua lista pra pedir à fábrica.
       </p>

--- a/src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx
+++ b/src/components/knowledge-base/__tests__/CompletudeSection.estados.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -74,13 +74,16 @@ const COMPLETA = {
 
 function renderizar() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-  return render(
-    <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <CompletudeSection />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
+  return {
+    client,
+    ...render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <CompletudeSection />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 beforeEach(() => {
@@ -129,6 +132,85 @@ describe('CompletudeSection — o ✓ verde só aparece quando a leitura ACONTEC
     renderizar();
     const aviso = await screen.findByTestId('aviso-leitura-falhou');
     expect(aviso).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(VERDE)).toBeNull();
+  });
+});
+
+/**
+ * O OUTRO lado do mesmo helper: a leitura falhou MAS há dado em mãos.
+ *
+ * O #2305 fechou o ✓ verde e parou aí. Com `naoConsegui` guardando a FUNÇÃO INTEIRA, uma
+ * atualização que FALHA com as 116 pendências já no cache troca a lista por uma faixa de
+ * aviso — honesto para o alarme e regressão para quem ia pedir os dados à fábrica. É o
+ * defeito-irmão que o cabeçalho de `desatualizado()` nomeia ("apagar 14 alertas de fluxo de
+ * caixa que estão no cache porque um refetch falhou é trocar um defeito por outro", medido no
+ * MixGapCard pelo #1892). O desenho que serve aos dois é composto: lista PRESERVADA + faixa.
+ *
+ * ⚠️ O ALCANCE é mais estreito do que parece, e foi a falsificação que mediu: sabotando este
+ * arquivo de volta ao comportamento do #2305, só o caso do REFETCH QUE FALHA fica vermelho.
+ * O caso SEM REDE segue verde — porque `estadoDeLeitura` testa `status === 'success'` ANTES
+ * de olhar `fetchStatus`, então com dado no cache o offline dá `'pronta'`, e o #2305 já
+ * preservava a lista ali. O que o caso sem-rede guarda, então, é só a FAIXA (`desatualizado`
+ * devolve `'sem-rede'` porque ele olha `fetchStatus` primeiro) — e isso é útil, mas não é
+ * "a lista sobreviveu". Anotado para que ninguém leia deste arquivo uma garantia maior do
+ * que ele dá.
+ *
+ * Sem lista em mãos nada muda em relação ao #2305 — e o caso de cache VAZIO abaixo é o que
+ * prova isso, porque é justamente onde um aviso "composto" teria reacendido o ✓ verde com uma
+ * nota de rodapé ao lado.
+ */
+describe('CompletudeSection — a lista já na tela sobrevive à atualização que falha', () => {
+  it('refetch que FALHA com a lista no cache → lista PRESERVADA + faixa de desatualizada', async () => {
+    respostas = { kb_product_specs: { data: [INCOMPLETA], error: null } };
+    const { client } = renderizar();
+    await waitFor(() => expect(screen.getByText(/Verniz PU Sayerlack XPTO/)).toBeInTheDocument());
+
+    respostas = { kb_product_specs: { data: null, error: { code: '57014', message: 'timeout' } } };
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ['kb-completude'] }).catch(() => {});
+    });
+
+    // O que o #2305 perderia: as pendências de trabalho continuam na tela...
+    expect(screen.getByText(/Verniz PU Sayerlack XPTO/)).toBeInTheDocument();
+    // ...com a faixa dizendo que o número está velho...
+    const faixa = await screen.findByTestId('aviso-completude-desatualizada');
+    expect(faixa).toHaveAttribute('data-estado', 'erro');
+    // ...e sem o aviso que SUBSTITUI a tela, que é o desfecho que esta correção evita.
+    expect(screen.queryByTestId('aviso-leitura-falhou')).toBeNull();
+    expect(screen.queryByText(VERDE)).toBeNull();
+  });
+
+  // Este caso guarda a FAIXA, não a preservação da lista: sob o #2305 ele já passava (com
+  // `status:'success'` no cache, offline vira `'pronta'` e o early return não dispara).
+  it('SEM REDE com a lista no cache → a faixa fala de conexão, não de suporte', async () => {
+    respostas = { kb_product_specs: { data: [INCOMPLETA], error: null } };
+    const { client } = renderizar();
+    await waitFor(() => expect(screen.getByText(/Verniz PU Sayerlack XPTO/)).toBeInTheDocument());
+
+    onlineManager.setOnline(false);
+    await act(async () => { void client.invalidateQueries({ queryKey: ['kb-completude'] }); });
+
+    expect(screen.getByText(/Verniz PU Sayerlack XPTO/)).toBeInTheDocument();
+    const faixa = await screen.findByTestId('aviso-completude-desatualizada');
+    // `sem-rede`, não `erro`: mandar avisar o suporte por falta de sinal queima o canal de
+    // incidente — é a mesma distinção que o caso sem cache já faz.
+    expect(faixa).toHaveAttribute('data-estado', 'sem-rede');
+    expect(screen.queryByText(VERDE)).toBeNull();
+  });
+
+  it('cache VAZIO + refetch que falha → aviso SOZINHO, nunca o ✓ verde com uma faixa ao lado', async () => {
+    respostas = { kb_product_specs: { data: [COMPLETA], error: null } };
+    const { client } = renderizar();
+    await waitFor(() => expect(screen.getByText(VERDE)).toBeInTheDocument());
+
+    respostas = { kb_product_specs: { data: null, error: { code: '57014', message: 'timeout' } } };
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ['kb-completude'] }).catch(() => {});
+    });
+
+    // Sem lista não há o que preservar: o comportamento tem de ser IDÊNTICO ao do #2305.
+    expect(await screen.findByTestId('aviso-leitura-falhou')).toBeInTheDocument();
+    expect(screen.queryByTestId('aviso-completude-desatualizada')).toBeNull();
     expect(screen.queryByText(VERDE)).toBeNull();
   });
 });


### PR DESCRIPTION
## O que é

Irmão do #2305, que fechou o ✓ verde de `CompletudeSection` e parou aí.

O #2305 põe `naoConsegui(estado)` guardando a **função inteira**, com `return` antes de tudo.
Isso é certo quando não há nada em mãos — e é o defeito-irmão quando há: com as **116
pendências** já no cache, um refetch que **falha** troca a lista inteira por uma faixa de aviso.
Honesto para o alarme, regressão para quem ia pedir os dados à fábrica.

É o caso que o cabeçalho do próprio `desatualizado()` nomeia — *"apagar 14 alertas de fluxo de
caixa que estão no cache porque um refetch falhou é trocar um defeito por outro"* — medido antes
no `MixGapCard` (#1892). O desenho que serve aos dois é composto: **lista PRESERVADA + faixa**
dizendo que o número está velho.

## A mudança

A **guarda externa**: os três early returns do #2305 passam a valer só sob
`!data || data.length === 0`.

Para todo caso **sem** lista o comportamento é idêntico ao do #2305 — `[]` de sucesso entra
igual, `undefined` + `pronta` segue no ✓ verde, e cache vazio + refetch que falha continua
mostrando o aviso **sozinho** (é onde um aviso "composto" teria reacendido o verde com uma nota
de rodapé). Há teste para esse controle.

## ⚠️ Alcance — medido pela falsificação, não presumido

Sabotando o arquivo de volta ao comportamento do #2305, **só o caso do refetch que falha fica
vermelho**. O caso **sem-rede segue verde**: `estadoDeLeitura` testa `status === 'success'`
**antes** de olhar `fetchStatus`, então com dado no cache o offline vira `'pronta'` e o early
return nem dispara — o #2305 já preservava a lista ali.

O teste sem-rede fica no arquivo porque guarda a **faixa** (`desatualizado` olha `fetchStatus`
primeiro), e está anotado como isso, não como "a lista sobreviveu". A 1ª redação deste PR dizia
"refetch que falha **ou a rede caindo**" e estava errada — a falsificação pegou.

## ⚠️ A desestruturação de `status` é proposital

`desatualizado({ status, fetchStatus }, true)`, não um `q` inteiro: é a desestruturação que liga
`status` (chave de `CHAVES_DE_ERRO`) que mantém o arquivo **visível** para o detector de
`erro-colapsado-em-vazio`. Trocá-la sumiria com o sítio do gate por **cegueira** — como o
cabeçalho do #2305 já avisava.

## Evidência

| etapa | resultado |
|---|---|
| controle (`CompletudeSection.estados.test.tsx`) | 7 passed |
| **S1** — reintroduz o comportamento do #2305 | vermelho **só** no refetch-que-falha; os 4 casos do #2305 + sem-rede + controle de cache vazio seguem **verdes** |
| **S2** — `desatualizado(…)` → `null` | vermelho nos 2 casos de cache; controle de cache vazio verde |
| `bun run typecheck` | exit 0 |
| `bunx eslint` (arquivos tocados) | exit 0 |
| gates (`erro-colapsado-em-vazio`, `manifesto`, `fronteiras`) | 24 passed |

3 casos novos sobre os 4 do #2305: refetch que falha com lista no cache, sem-rede com lista no
cache (guarda a faixa), e o controle de cache vazio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
