### PR TITLE
fix(agenda): scores ILEGÍVEIS viravam "clique em Recalcular" — a 2ª dimensão do #1908 [money-path]

### DIFF
--- a/src/components/dashboard/AgendaTodayList.tsx
+++ b/src/components/dashboard/AgendaTodayList.tsx
@@ -25,10 +25,12 @@ const AGENDA_META: Record<AgendaItem['agenda_type'], { label: string; icon: type
  * WebRTC makeCall.
  */
 export function AgendaTodayList() {
-  const { agenda, isLoading } = useMyAgendaToday(10);
-  // A agenda sai de `farmer_client_scores` filtrado por [eu, ...cobertos]. Se a cobertura
-  // não pôde ser lida, ela encolhe em silêncio — e o texto de vazio abaixo manda
-  // "Recalcular", instrução ATIVA sobre um vazio que talvez não exista.
+  const { agenda, isLoading, agendaIndisponivel, agendaDesatualizada } = useMyAgendaToday(10);
+  // A agenda sai de `farmer_client_scores` filtrado por [eu, ...cobertos], e o vazio dessa
+  // conta tem DUAS origens que falham calado. Se a cobertura não pôde ser lida, a lista
+  // encolhe em silêncio; se os SCORES não puderam ser lidos, ela some inteira — e o texto de
+  // vazio abaixo manda "Recalcular", instrução ATIVA sobre um vazio que talvez não exista.
+  // A 2ª dimensão vem do próprio hook, em `agendaIndisponivel`/`agendaDesatualizada`.
   const { coberturaIndisponivel } = useCarteirasQueEuCubro();
   const { makeCall } = useWebRTCCallContext();
 
@@ -58,6 +60,22 @@ export function AgendaTodayList() {
     );
   }
 
+  // A leitura dos SCORES não aconteceu e não há nada em mãos. Vem ANTES do aviso de
+  // cobertura porque é a RAIZ da agenda: sem `farmer_client_scores` não há lista nenhuma,
+  // com ou sem cobertura. (Quando a rede cai, as duas leituras pausam juntas e este ramo
+  // responde primeiro — de propósito: um aviso que nomeia a causa mais funda, não dois.)
+  if (agendaIndisponivel) {
+    return (
+      <Card className="p-4">
+        <AvisoLeituraFalhou
+          oque="a sua agenda do dia"
+          estado={agendaIndisponivel}
+          className="mb-0"
+        />
+      </Card>
+    );
+  }
+
   if (coberturaIndisponivel && agenda.length === 0) {
     return (
       <Card className="p-4">
@@ -72,8 +90,13 @@ export function AgendaTodayList() {
 
   if (agenda.length === 0) {
     return (
-      <Card className="p-6 text-center text-xs text-muted-foreground">
-        Sem clientes na agenda. Vá em <span className="font-mono">/farmer</span> antigo e clique &quot;Recalcular&quot; pra popular farmer_client_scores.
+      <Card className="p-6">
+        {agendaDesatualizada && (
+          <AvisoLeituraFalhou oque="a sua agenda do dia" estado={agendaDesatualizada} />
+        )}
+        <div className="text-center text-xs text-muted-foreground">
+          Sem clientes na agenda. Vá em <span className="font-mono">/farmer</span> antigo e clique &quot;Recalcular&quot; pra popular farmer_client_scores.
+        </div>
       </Card>
     );
   }
@@ -92,6 +115,15 @@ export function AgendaTodayList() {
 
   return (
     <Card className="divide-y divide-border">
+      {agendaDesatualizada && (
+        <div className="p-3">
+          <AvisoLeituraFalhou
+            oque="a sua agenda do dia"
+            estado={agendaDesatualizada}
+            className="mb-0"
+          />
+        </div>
+      )}
       {coberturaIndisponivel && (
         <div className="p-3">
           <AvisoLeituraFalhou

--- a/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
+++ b/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
@@ -122,7 +122,13 @@ describe('AgendaTodayList — scores ilegíveis não podem virar "clique em Reca
       farmer_client_scores: { data: [LINHA_SCORE], error: null },
     };
     renderLista();
-    expect(await textoDoAviso()).toMatch(/sem conexão/i);
+    const t = await textoDoAviso();
+    expect(t).toMatch(/sem conexão/i);
+    // ⚠️ O aviso tem de NOMEAR os scores. Só "sem conexão" é teatro: o `onlineManager` é
+    // global, então a COBERTURA também pausa, e o aviso dela diz exatamente a mesma frase.
+    // Medido por falsificação — sabotar o hook para tratar só `erro` (ignorando o
+    // `pending+paused`) deixava este teste VERDE, segurado pelo guard do #1908.
+    expect(t).toMatch(/a sua agenda do dia/i);
     await waitFor(() => expect(screen.queryByText(MANDA_RECALCULAR)).toBeNull());
   });
 

--- a/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
+++ b/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 /**
  * Guard money-path — a agenda do dia não pode mandar "Recalcular" quando não leu os SCORES.
@@ -69,9 +70,13 @@ import { AgendaTodayList } from '../AgendaTodayList';
 
 function renderLista() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  // <Link> dos itens exige Router: o guard de cobertura nunca chega a renderizar item
+  // (todos os casos dele acabam em vazio/aviso), então só o caminho feliz daqui expõe isso.
   const utils = render(
     <QueryClientProvider client={qc}>
-      <AgendaTodayList />
+      <MemoryRouter>
+        <AgendaTodayList />
+      </MemoryRouter>
     </QueryClientProvider>,
   );
   return { ...utils, qc };

--- a/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
+++ b/src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
+
+/**
+ * Guard money-path — a agenda do dia não pode mandar "Recalcular" quando não leu os SCORES.
+ *
+ * O irmão do guard de cobertura (AgendaTodayList.cobertura.test.tsx), na dimensão que ficou
+ * de fora do #1908: `useMyCarteiraScores` LANÇA quando o SELECT em `farmer_client_scores`
+ * falha, então `data` fica `undefined` — a MESMA condição de "a carteira não tem cliente
+ * nenhum". O `data ? … : []` do hook colapsava as duas, e a tela mandava *"Sem clientes na
+ * agenda. Vá em /farmer antigo e clique Recalcular"*: uma INSTRUÇÃO de ação sobre um vazio
+ * que pode não existir. Em prod a tabela tem 6.633 linhas nos 3 vendedores (psql-ro,
+ * 2026-08-23), então esse vazio é FALSO em todos os casos vivos hoje.
+ *
+ * Os HOOKS rodam de verdade (useMyAgendaToday → useMyCarteiraScores); só o supabase é
+ * mockado, e POR TABELA — mockar o hook provaria apenas que o componente renderiza um estado
+ * montado à mão. É a mockagem por tabela que separa a falha dos SCORES da falha da COBERTURA:
+ * aqui `carteira_coverage` responde OK em todos os casos, menos no offline (que é global).
+ */
+const EU = 'vendedor-1';
+const CLIENTE = 'cliente-1';
+type Resposta = { data: unknown; error: { message: string } | null };
+let porTabela: Record<string, Resposta> = {};
+
+function respostaDaTabela(t: string): Resposta {
+  return porTabela[t] ?? { data: [], error: null };
+}
+
+const LINHA_SCORE = {
+  customer_user_id: CLIENTE,
+  farmer_id: EU,
+  health_score: 42,
+  health_class: 'atencao',
+  priority_score: 88,
+  churn_risk: 70,
+  expansion_score: null,
+  recover_score: null,
+  revenue_potential: null,
+  days_since_last_purchase: 30,
+  avg_monthly_spend_180d: 1000,
+  signal_modifiers: null,
+  sales_history_status: 'com_historico',
+  last_signal_recalc_at: null,
+};
+const PERFIL = { user_id: CLIENTE, name: 'Cliente Um', razao_social: null, phone: '+5511999998888' };
+
+vi.mock('@/integrations/supabase/client', () => {
+  const mk = (tabela: string) => {
+    const b: Record<string, unknown> = {};
+    for (const m of ['select', 'eq', 'in', 'order', 'limit', 'range', 'gte', 'lte']) b[m] = () => b;
+    b.then = (ok: (r: Resposta) => unknown, falha?: (e: unknown) => unknown) =>
+      Promise.resolve(respostaDaTabela(tabela)).then(ok, falha);
+    return b;
+  };
+  return { supabase: { from: (t: string) => mk(t) } };
+});
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: EU }, isStaff: true, isMaster: false, loading: false }),
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: null }),
+}));
+vi.mock('@/contexts/webrtc-call-context', () => ({
+  useWebRTCCallContext: () => ({ makeCall: vi.fn() }),
+}));
+
+import { AgendaTodayList } from '../AgendaTodayList';
+
+function renderLista() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <AgendaTodayList />
+    </QueryClientProvider>,
+  );
+  return { ...utils, qc };
+}
+
+const MANDA_RECALCULAR = /Sem clientes na agenda/i;
+/** O <AvisoLeituraFalhou> tem role="status"; o texto quebra em vários nós, então lemos o textContent. */
+async function textoDoAviso(): Promise<string> {
+  return (await screen.findByRole('status')).textContent ?? '';
+}
+
+beforeEach(() => { porTabela = {}; onlineManager.setOnline(true); });
+afterEach(() => { onlineManager.setOnline(true); });
+
+describe('AgendaTodayList — scores ilegíveis não podem virar "clique em Recalcular"', () => {
+  it('VAZIO legítimo: a leitura ACONTECEU e disse vazio — a instrução é honesta aqui', async () => {
+    porTabela = {
+      carteira_coverage: { data: [], error: null },
+      farmer_client_scores: { data: [], error: null },
+    };
+    renderLista();
+    expect(await screen.findByText(MANDA_RECALCULAR)).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('ERRO nos scores: avisa E NÃO manda recalcular — o defeito da classe', async () => {
+    porTabela = {
+      // A cobertura responde OK: se a tela falasse por causa DELA, este caso seria verde
+      // por acidente. O que muda a tela aqui é só a falha de `farmer_client_scores`.
+      carteira_coverage: { data: [], error: null },
+      farmer_client_scores: { data: null, error: { message: 'permission denied' } },
+    };
+    renderLista();
+    expect(await textoDoAviso()).toMatch(/não foi possível carregar a sua agenda do dia/i);
+    // A asserção que carrega o peso: mandar agir sobre um vazio não-lido é pior que sumir.
+    expect(screen.queryByText(MANDA_RECALCULAR)).toBeNull();
+  });
+
+  it('OFFLINE: pending+paused não é agenda vazia (e `isLoading` ali é FALSE)', async () => {
+    onlineManager.setOnline(false);
+    porTabela = {
+      carteira_coverage: { data: [], error: null },
+      farmer_client_scores: { data: [LINHA_SCORE], error: null },
+    };
+    renderLista();
+    expect(await textoDoAviso()).toMatch(/sem conexão/i);
+    await waitFor(() => expect(screen.queryByText(MANDA_RECALCULAR)).toBeNull());
+  });
+
+  it('CAMINHO FELIZ: com linha lida, a agenda renderiza e ninguém avisa nada', async () => {
+    porTabela = {
+      carteira_coverage: { data: [], error: null },
+      farmer_client_scores: { data: [LINHA_SCORE], error: null },
+      profiles: { data: [PERFIL], error: null },
+    };
+    renderLista();
+    expect(await screen.findByText('Cliente Um')).toBeTruthy();
+    expect(screen.queryByText(MANDA_RECALCULAR)).toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('RELEITURA falha COM lista em mãos: mostra os DOIS — apagar seria trocar de defeito', async () => {
+    porTabela = {
+      carteira_coverage: { data: [], error: null },
+      farmer_client_scores: { data: [LINHA_SCORE], error: null },
+      profiles: { data: [PERFIL], error: null },
+    };
+    const { qc } = renderLista();
+    expect(await screen.findByText('Cliente Um')).toBeTruthy();
+
+    porTabela.farmer_client_scores = { data: null, error: { message: 'timeout' } };
+    await qc.invalidateQueries({ queryKey: ['my-carteira-scores'] });
+
+    await waitFor(async () => expect(await textoDoAviso()).toMatch(/a sua agenda do dia/i));
+    // O cache continua na tela: o vendedor em campo não pode perder o que já tinha.
+    expect(screen.getByText('Cliente Um')).toBeTruthy();
+  });
+});

--- a/src/hooks/useMyAgendaToday.ts
+++ b/src/hooks/useMyAgendaToday.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useMyCarteiraScores } from './useMyCarteiraScores';
+import { estadoDeLeitura, naoConsegui, desatualizado, type EstadoSemLeitura } from '@/lib/leitura/estado-de-leitura';
 import { buildAgendaItems, type AgendaItem } from '@/lib/scoring/agenda';
 
 export type { AgendaItem };
@@ -12,14 +13,47 @@ export type { AgendaItem };
  * A modulação de prioridade pelos sinais acontece aqui (read-time): a coluna
  * priority_score continua sendo a base rica do calculate-scores; o
  * scoring-recalc só persiste signal_modifiers. Ver src/lib/scoring/agenda.ts.
+ *
+ * 🔇 POR QUE O ESTADO DA LEITURA SAI DAQUI (classe "erro colapsado em vazio",
+ * docs/historico/fase-sem-sinal.md): `useMyCarteiraScores` LANÇA quando o SELECT em
+ * `farmer_client_scores` falha, então `data` fica `undefined` — a MESMA condição de
+ * "a carteira não tem cliente nenhum". O `data ? … : []` abaixo colapsa as duas, e o
+ * consumidor herda um vazio que não sabe distinguir. Não é dano hipotético: a tabela
+ * tem 6.633 linhas para os 3 vendedores, todas repontuadas hoje (psql-ro, 2026-08-23)
+ * — o vazio dessa leitura é FALSO em 100% dos casos vivos hoje.
+ *
+ * `agenda` SEGUE degradando para `[]` de propósito (mesma decisão de `useCarteirasQueEuCubro`:
+ * a tela mostra o que sabe); o que muda é que a ausência agora viaja ACOMPANHADA do motivo.
+ * Dois campos porque são dois estados distintos, e o segundo é justamente o que engana
+ * quem "já trata erro": com lista no cache e a rede caindo, `status` continua `success`
+ * (`naoConsegui` é FALSE) e só o `fetchStatus: 'paused'` denuncia que ela está velha.
  */
 export function useMyAgendaToday(limit = 10) {
-  const { data, isLoading } = useMyCarteiraScores();
+  const q = useMyCarteiraScores();
+  const { data, isLoading } = q;
+  const estado = estadoDeLeitura(q);
 
   const agenda: AgendaItem[] = useMemo(
     () => (data ? buildAgendaItems(data, limit) : []),
     [data, limit],
   );
 
-  return { agenda, isLoading };
+  const semLeitura: EstadoSemLeitura | null = naoConsegui(estado) ? estado : null;
+
+  return {
+    agenda,
+    isLoading,
+    /**
+     * `erro`/`sem-rede` E nada em mãos: a tela NÃO PODE afirmar "não há" — nem, pior,
+     * mandar agir sobre esse vazio. `null` quando a leitura aconteceu (inclusive quando
+     * ela respondeu vazio de verdade) e em `desabilitada`, que é a pergunta não feita.
+     */
+    agendaIndisponivel: data === undefined ? semLeitura : null,
+    /**
+     * Há lista em mãos, mas a releitura falhou (erro ou sem rede): mostre a lista **e** o
+     * aviso. Apagar uma agenda que está no cache porque um refetch falhou seria trocar um
+     * defeito por outro — o vendedor em campo perderia justamente o que ele tem.
+     */
+    agendaDesatualizada: desatualizado(q, data !== undefined),
+  };
 }

--- a/src/lib/modulos/fronteiras-baseline.ts
+++ b/src/lib/modulos/fronteiras-baseline.ts
@@ -52,6 +52,7 @@ export const FRONTEIRAS_BASELINE: Aresta[] = [
   { de: "src/components/customer360/CustomerHero.tsx", para: "src/components/call/CallButton.tsx", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },
   { de: "src/components/customer360/viewTypes.ts", para: "src/hooks/useCustomerContacts.ts", deModulo: "farmer-inteligencia", paraModulo: "admin-crm", kind: "type" },
   { de: "src/components/dashboard/__tests__/AgendaTodayList.cobertura.test.tsx", para: "src/contexts/webrtc-call-context.ts", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },
+  { de: "src/components/dashboard/__tests__/AgendaTodayList.scores.test.tsx", para: "src/contexts/webrtc-call-context.ts", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },
   { de: "src/components/dashboard/AgendaTodayList.tsx", para: "src/contexts/webrtc-call-context.ts", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },
   { de: "src/components/dashboard/CloserDashboard.tsx", para: "src/components/tarefas/MinhasTarefasCard.tsx", deModulo: "farmer-inteligencia", paraModulo: "tarefas", kind: "runtime" },
   { de: "src/components/dashboard/FarmerDashboardV2.tsx", para: "src/components/tarefas/MinhasTarefasCard.tsx", deModulo: "farmer-inteligencia", paraModulo: "tarefas", kind: "runtime" },


### PR DESCRIPTION
## O defeito

`useMyCarteiraScores` LANÇA quando o SELECT em `farmer_client_scores` falha (`if (error) throw error`), então `data` fica `undefined` — a **mesma condição** de "a carteira não tem cliente nenhum". `useMyAgendaToday` colapsava as duas num `data ? buildAgendaItems(data, limit) : []`, e o consumidor herdava um vazio que não sabia distinguir.

E o vazio ali **não é passivo**: `AgendaTodayList` renderiza *"Sem clientes na agenda. Vá em /farmer antigo e clique **Recalcular** pra popular farmer_client_scores"* — uma **instrução de ação** sobre um vazio que pode não existir, e que "Recalcular" não conserta, porque a causa é rede/permissão e não falta de recompute.

O #1908 corrigiu a dimensão da **cobertura** (`coberturaIndisponivel`). Esta é a dimensão da **própria query de scores** — a raiz da agenda.

## A medição (psql-ro, prod, 2026-09-07) — e por que ela muda o enquadramento

O #1908 se justificou como *gatilho*: `carteira_coverage` tinha **0 linhas**, dano hoje zero. Aqui a medição diz o contrário:

| medida | valor |
|---|---|
| `farmer_client_scores` | **6.633 linhas** |
| farmers distintos com linha | **3** |
| pessoas em `commercial_roles` | 3 — master 3.858 · farmer 1.530 · farmer 1.245 |
| `max(updated_at)` | 2026-09-07 06:25 (repontuado **hoje**; o cron está vivo) |
| `priority_score` não-nulo | 6.633/6.633 |
| `carteira_coverage` | 0 (inalterado desde o #1908) |

**3 de 3 pessoas com papel comercial têm carteira pontuada.** Ninguém tem agenda legitimamente vazia. (Medido duas vezes, com 15 dias de intervalo — 23/08 e 07/09 — com os mesmos números e `updated_at` do dia.)

O que isso prova, com honestidade sobre o limite: **não** que a leitura esteja falhando agora — não há sensor de falha de leitura em prod, e ausência de reclamação é ausência de dado, não aprovação. O que fica provado é que **o vazio exibido seria falso em 100% dos casos vivos**: qualquer falha de leitura hoje produz "clique em Recalcular" para um vendedor com 1.245–3.858 clientes pontuados. Diferente do #1908, o gatilho aqui não é um cadastro futuro — é a primeira falha de leitura.

## A correção

`useMyAgendaToday` passa a expor dois campos derivados. **Sem espalhar `{...query}`**, que desligaria o tracking de propriedades do react-query v5 — o hook lê `status`/`fetchStatus` passando a query a `estadoDeLeitura(q)`, e a desestruturação segue rastreada.

- **`agendaIndisponivel`** — `erro`/`sem-rede` **e** nada em mãos: a tela não pode afirmar "não há", muito menos mandar agir. `null` quando a leitura aconteceu (inclusive respondendo vazio de verdade) e em `desabilitada`, que é a pergunta não feita — alarme ali seria fabricado (precisão > recall).
- **`agendaDesatualizada`** — há lista em mãos e a **releitura** falhou: mostra a lista **e** o aviso. É o estado que engana quem "já trata erro": com dado no cache e a rede caindo, `status` continua `success` (`naoConsegui` é FALSE) e só `fetchStatus: 'paused'` denuncia.

`agenda` **segue degradando para `[]` de propósito** — mesma decisão de `useCarteirasQueEuCubro`: a tela mostra o que sabe. O que muda é que a ausência agora viaja acompanhada do motivo.

Em `AgendaTodayList`, o ramo novo vem **antes** do aviso de cobertura: sem `farmer_client_scores` não há lista nenhuma, com ou sem cobertura. Quando a rede cai as duas leituras pausam juntas e este ramo responde primeiro — de propósito, um aviso que nomeia a causa mais funda em vez de dois.

`useMyCarteiraScores` tem **um único chamador real** (`useMyAgendaToday`); `useFarmerCopilot` e `useFarmerTacticalPlan` só o citam em comentário e consomem `useCarteirasQueEuCubro` direto — conferido por `git grep "useMyCarteiraScores()"`.

## Testes

`AgendaTodayList.scores.test.tsx`, no idioma do guard de cobertura: **os hooks rodam de verdade**, só o supabase é mockado e **por tabela** — mockar o hook provaria apenas que o componente renderiza um estado montado à mão. É a mockagem por tabela que separa a falha dos SCORES da da COBERTURA: nos casos de erro, `carteira_coverage` responde OK.

5 casos: vazio legítimo · erro nos scores · offline (`pending`+`paused`, onde `isLoading` é FALSE) · caminho feliz · releitura falha com lista no cache.

### Falsificação

Commitado antes de sabotar (`restaurar()` é `git checkout --`). 4 sabotagens, cada uma isolando **uma** asserção — e o critério é a **marca do ramo**, não "ficou vermelho". Rodado na base já rebaseada:

| | RC | teste que caiu |
|---|---|---|
| `typecheck` · `lint` | 0 · 0 | — |
| **verde de partida** (3 arquivos) | **0** | — (27 passam) |
| 1 · `agendaIndisponivel` sempre `null` (o defeito original de volta) | 1 | *ERRO nos scores* **+** *OFFLINE* |
| 2 · trata só `'erro'`, não `naoConsegui` | 1 | **só** *OFFLINE* |
| 3 · `agendaDesatualizada` sempre `null` | 1 | **só** *RELEITURA com lista em mãos* |
| 4 · avisa **sempre** (alarme fabricado) | 1 | *VAZIO legítimo*, *CAMINHO FELIZ*, +2 |
| **verde de volta** | **0** | — (27 passam, `git status` limpo) |

**A falsificação pagou duas vezes — as duas primeiras rodadas ficaram vermelhas por defeito MEU:**

1. **O verde de partida falhou** (`RC_VERDE0=1`): `TypeError: Cannot destructure` em `LinkWithRef` — faltava o `MemoryRouter`. O guard de cobertura do #1908 nunca renderiza um item (todos os casos dele acabam em vazio ou aviso), então só o caminho feliz daqui expõe que o componente precisa de Router.
2. **A sabotagem 2 ficou VERDE** — o teste offline era teatro nessa dimensão. O `onlineManager` é global: a cobertura pausa junto, e o `<AvisoLeituraFalhou>` dela diz **a mesma frase** ("sem conexão"). O regex genérico casava o aviso da *cobertura* e segurava o teste de pé mesmo com o hook ignorando `pending+paused`. Corrigido exigindo que o aviso **nomeie** o que não foi lido (`a sua agenda do dia`) — e só então a sabotagem 2 virou vermelha.

O nº 2 é a lição que sobrevive a este PR: **quando dois guards da mesma classe convivem numa tela, o teste do novo tem de casar o SUJEITO do aviso, não só a frase de alerta** — senão o guard antigo mantém o novo verde, e a asserção mede o vizinho, não o alvo.

## Gate

`contarAutoOcultacao` medido nos dois arquivos, **antes e depois**:

```
ANTES  src/hooks/useMyAgendaToday.ts                 => 0
DEPOIS src/hooks/useMyAgendaToday.ts                 => 0
ANTES  src/components/dashboard/AgendaTodayList.tsx  => 0
DEPOIS src/components/dashboard/AgendaTodayList.tsx  => 0
```

**A baseline não muda — e isso não é boa notícia.** É a confirmação empírica do achado nº1 registrado no doc da classe: `acharColapsos` só registra o sítio quando há default no destructuring (`{ data = [] }`) ou silêncio (`return null`). Aqui não havia nenhum dos dois — o colapso morava num ternário (`data ? buildAgendaItems(data, limit) : []`) dentro de um **hook**, que nem JSX retorna. O sítio era invisível ao contador do começo ao fim, e só apareceu porque a leitura foi ao consumidor. Este PR fecha um sítio da classe **sem** tocar no fiscal, porque o fiscal nunca o viu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
