### PR TITLE
docs(authz): o §8.5 item 5 fechou por FORA — a reconciliação chegou por #2224/#2251, não pela migration que ele previa

### DIFF
--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -402,24 +402,39 @@ baseline vira decoração e nada mais a segura.
 4. ~~**`DROP FUNCTION` + `CREATE FUNCTION` reseta o ACL**~~ — o item 1 do §7.4 foi **FECHADO em
    2026-08-15 pela Parte E** (§9): `authz:check` passou a vigiar o grant de EXECUTE das funções
    classificadas, e `bun run authz:funcoes:prod` mede o ACL vivo em prod.
-5. **A reconciliação repo×prod de `get_preco_cockpit` e `get_defasagem_cliente` está ABERTA**
-   (aberta pelo pagamento da dívida de contrato do §8.1, em 2026-08-15). O gate de bloqueio já é o
-   mesmo nos dois lados — `has_role(employee|master)` —, então **não há risco de autorização
-   pendente**; o que diverge é o MASCARAMENTO do numérico: repo `pode_ver_carteira_completa`, prod
-   `cap_custo_ler`. Enquanto durar, a Parte A mede um corpo que não é o que roda e as duas seguem
-   na baseline de reescritas. Fechar = uma migration `CREATE OR REPLACE` trazendo o corpo do repo
-   para o de prod, o que as devolve à auditabilidade estática e apaga as duas entradas da baseline.
-   Custo real: migration nova ⇒ ritual `lovable-db-operator` + apply MANUAL no SQL Editor, e o
-   corpo colado precisa preservar `SECURITY DEFINER`/`STABLE`/`SET search_path`/ACL — exatamente o
-   que o §8.2 lembra que um corpo colado perde de graça. Não é urgente; é dívida declarada.
+5. ~~**A reconciliação repo×prod de `get_preco_cockpit` e `get_defasagem_cliente` está ABERTA**~~ —
+   **FECHADO em 2026-09-07**, e *não* pela migration que este item previa. As duas se reconciliaram
+   sozinhas, por entregas de outro domínio que recriaram as funções com `CREATE OR REPLACE` textual
+   partindo do corpo VIVO: `20260905225613_preco_ausente_nao_e_zero.sql` (#2224) para
+   `get_defasagem_cliente` e `20260906164001_captura_authz_gate_custo_rpcs_preco.sql` (#2251) para
+   `get_preco_cockpit` — ambas mergeadas **e aplicadas em prod** (medido por `psql-ro` em
+   2026-09-07: `order_items.unit_price` nullable sem default; `COMMENT ON FUNCTION`, o sensor de
+   apply da captura, presente). Com o last-writer do repo virando um `CREATE` parseável, a Parte A
+   voltou a medir o corpo que roda: o `prosrc` do repo é **byte-a-byte idêntico** ao de prod nas
+   duas (md5 normalizado `4f3fb7df939e467f82d36a065e2f0957` e `7856c3052596d66a6f5ac8eb0a06c1c0`).
+   A poda das duas entradas de `scripts/authz-reescritas-conhecidas.ts` saiu no **#2339**; sobra só
+   `reposicao_pos_candidatos`. **Nenhuma migration foi escrita para fechar este item** — escrever
+   uma teria sido apply redundante no colo do founder (`deploy-redundante-ledger-e-cron-de-sonda.md`).
+
+   **O custo real do item não foi a dívida; foi o modo como ela caducou.** Entre a #2224 (05/09) e a
+   poda, a baseline ficou MENTINDO: o `md5ProdEsperado` de `get_defasagem_cliente` seguiu
+   `037ede84…` depois de o corpo mudar legitimamente, e `authz:audit:prod` passou a **falhar** com
+   `MD5_DIVERGIU` acusando "drift em prod" — quando o que houve foi o *repo alcançar prod*, o
+   desfecho que a baseline queria. **Uma entrada só se justifica enquanto a migration que ela cita
+   ainda for a última a definir aquela função**, e nenhuma das três guardas de
+   `AUTHZ_REESCRITAS_CONHECIDAS — a baseline não pode ser decoração` olhava esse eixo: todas
+   conferem a entrada contra o ARQUIVO da reescrita, que é imutável e casa o detector para sempre.
+   Pior, a Parte D **emudece** de propósito quando existe `CREATE` posterior — o silêncio certo de
+   uma máquina virava o ponto cego da outra. Coberto pelo erro `REESCRITA_BASELINE_OBSOLETA` do
+   #2339, que faz a poda ser cobrada pelo CI em vez de aparecer como incêndio de prod.
 
 ---
 
 # 9. O grant de EXECUTE de FUNÇÃO entra no contrato — Parte E (2026-08-15)
 
 > Fecha o **§7.4 item 1**, reafirmado no §8.5 item 4 — o último item aberto de VIGILÂNCIA
-> deste documento (o §8.5 item 5, aberto no mesmo dia, é dívida de RECONCILIAÇÃO repo×prod:
-> não é ponto cego do CI, e não há autorização pendente nele).
+> deste documento (o §8.5 item 5, aberto no mesmo dia, era dívida de RECONCILIAÇÃO repo×prod:
+> não era ponto cego do CI, e não havia autorização pendente nele — **FECHADO em 2026-09-07**).
 > `CREATE OR REPLACE FUNCTION` PRESERVA o ACL; o par `DROP FUNCTION` + `CREATE
 > FUNCTION` **não** — a função renasce com o default privilege do projeto. As Partes A/D julgam o
 > GATE no corpo, a Parte C julga grant de TABELA, e **nada** julgava grant de FUNÇÃO.


### PR DESCRIPTION
## O que a tarefa pedia, e por que não foi feito assim

Fechar o **§8.5 item 5** de `docs/historico/sentinela-authz-controle-nao-mencao.md` escrevendo uma migration `CREATE OR REPLACE` que trouxesse o corpo de `public.get_preco_cockpit` e `public.get_defasagem_cliente` do repo para o de prod.

**Medido antes de escrever (psql-ro, 2026-09-07): não há o que escrever.** O repo já alcançou prod.

| função | last-writer do repo | aplicada em prod? | md5 normalizado repo | md5 prod |
|---|---|---|---|---|
| `get_preco_cockpit` | `20260906164001_captura_authz_gate_custo_rpcs_preco.sql` (#2251) | ✅ (`COMMENT ON FUNCTION` presente) | `4f3fb7df…` | `4f3fb7df…` |
| `get_defasagem_cliente` | `20260905225613_preco_ausente_nao_e_zero.sql` (#2224) | ✅ (`order_items.unit_price` nullable sem default) | `7856c305…` | `7856c305…` |

O `prosrc` é **byte-a-byte idêntico** nas duas. Escrever a migration prevista seria um apply redundante no colo do founder — o que [`deploy-redundante-ledger-e-cron-de-sonda.md`](docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md) existe para evitar.

## Por que este PR existe mesmo assim

A poda das duas entradas de `scripts/authz-reescritas-conhecidas.ts` e o erro `REESCRITA_BASELINE_OBSOLETA` saem no **#2339** (aberto, `validate` verde). Esse PR **não toca este doc** — sem esta mudança, o item 5 continuaria marcado **ABERTO** depois de #2339 mergear, descrevendo uma dívida que já não existe e mandando escrever uma migration que ninguém deve escrever.

Diff: **1 arquivo, só doc**. Zero colisão com #2339.

## A lição registrada

`authz:audit:prod` estava **vermelho na main** quando comecei (`MD5_DIVERGIU` em `get_defasagem_cliente`, esperado `037ede84…` vs prod `7856c305…`) — acusando "drift em prod" quando o que houve foi o **repo alcançar prod**. Uma entrada da baseline só se justifica enquanto a migration que ela cita ainda for a última a definir aquela função; as três guardas existentes conferem a entrada contra o **arquivo** da reescrita, que é imutável e casa o detector para sempre. E a Parte D **emudece de propósito** quando há `CREATE` posterior — o silêncio certo de uma máquina era o ponto cego da outra.

## Validação

| comando | resultado |
|---|---|
| `bun run docs:links` | ✅ 708 docs, todo link resolve |
| `bun run docs:citacoes` | ✅ |
| `bun run docs:indice` | ✅ |
| `heavy bun run test` | ✅ 797 arquivos, 8257 testes |
| `bun run authz:check` | ✅ |
| `bun run authz:audit:prod` | ✅ (fica verde após #2339 podar a baseline) |

**Sem falsificação neste PR**: não há asserção nova minha para sabotar — o diff é prosa. A falsificação do detector novo pertence ao #2339.

## ⚠️ Achado separado, não deste PR

`bun run authz:funcoes:prod` está **vermelho na main** por outra causa: `public.reposicao_claim_disparo` está na allowlist e **não existe no banco** (0 linhas em `pg_proc`). A migration `20260906190615_reposicao_claim_disparo_cenario_b.sql` (**#2285, money-path**, TOCTOU Cenário B) mergeou e **não foi aplicada em produção**. O audit está certo; é a falha silenciosa do Lovable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)