### PR TITLE
feat(deploy): o prompt de deploy embute o sha256 por arquivo, lido de `origin/main`, com ramo fail-closed

### DIFF
--- a/docs/historico/piloto-deploy-mcp-lovable.md
+++ b/docs/historico/piloto-deploy-mcp-lovable.md
@@ -303,8 +303,47 @@ deploy. Falsificar localmente antes de confiar: com o helper adulterado e os doi
 intactos, exigir **sonda verde + canária vermelha**. Ela pega o que (a) não pega — divergência que
 nasce DEPOIS da entrada do deploy (resolução de dependência, cache de build).
 
-Nenhuma das duas foi implementada aqui. (a) toca o gerador de prompt de TODOS os deploys, então é
-entrega própria, com falsificação própria.
+(a) ESTÁ ENTREGUE (#2362); (b) segue pendente. (a) tocava o gerador de prompt de TODOS os deploys,
+então foi entrega própria, com falsificação própria — o que segue é o que ela mede e o que ela não
+mede.
+
+### (a) entregue — o que o prompt passou a carregar (#2362)
+
+`bun run pendencias:prompt <edge>` agora emite, por arquivo da fatia, `` - `caminho` — sha256 `<hex64>` ``,
+seguido de um bloco de conferência com **três** ramos: bate → deploya · difere → **não deploya** e
+devolve a tabela `file | expected | actual` · **não conseguiu medir** → **não deploya** e diz por
+quê. O terceiro ramo não é preciosismo: sem ele, o `sha256sum` ausente do sandbox cai em "não achei
+diferença", que é ausência de dado lida como aprovação — a falha de
+[sonda-ausente-em-script-que-apaga.md](sonda-ausente-em-script-que-apaga.md).
+
+**Duas decisões que o item (a) original não nomeava, e que mudaram o desenho:**
+
+1. **A fatia e os hashes saem de `origin/main`, nunca do working tree.** `fecharGrafo` ganhou o seam
+   `ArvoreDeFonte` e a borda usa `arvoreDaRef('origin/main')`; o `git fetch` é DO script, porque a
+   ref em disco também é um retrato. Sem isso a entrega teria reintroduzido o eixo **ÁRVORE** de
+   2026-09-04 (5 arquivos contra o disco, 7 contra a ref, na `enviar-pedido-portal-sayerlack`) —
+   que `git fetch` sozinho não fecha, e que produziria hashes de um estado que não vai ao ar.
+2. **A auto-conferência casa o PAR caminho↔hash, não os dois soltos.** Conferir `inclui o caminho?`
+   e `inclui o hash?` separadamente fica verde com os hashes **trocados** entre dois arquivos — os
+   dois aparecem, cada um ao lado do arquivo errado — e aí o agente confere 8, acha 8 divergências
+   e aborta um deploy **correto**. Um renderizador único (`linhaDoArquivo`) serve o prompt e o
+   check, para as duas noções não divergirem.
+
+Medido na entrega: os 8 hashes do prompt real de `copilot-analyze` conferem com
+`git show origin/main:<arq> | shasum -a 256` (8 conferidos, 0 divergências), e a falsificação exigiu
+vermelho **na marca do ramo** em três sabotagens — ler o working tree, devolver o closure do disco,
+e hash constante —, com controle verde na mesma invocação antes do primeiro `sed`.
+
+O teste novo é da FRONTEIRA (`scripts/pendencias-prompt.test.ts`), não do núcleo: o núcleo puro
+tinha 35 verdes e não alcança o eixo ÁRVORE, que só existe na borda de I/O. Mesma lição já registrada
+no `sonda-versao-bump-gate` — "os dois falsos-verdes corrigidos aqui estavam ambos FORA do núcleo
+puro, que tinha 23 testes verdes".
+
+⚠️ **O que (a) NÃO fecha, e o doc não deve deixar virar folclore:** ela prova que os bytes que
+ENTRAM no deploy são os da `main`. Não prova nada sobre o que sai — resolução de dependência e cache
+de build continuam livres, porque `npm:@anthropic-ai/sdk@^0.93.0` e `npm:@supabase/supabase-js@2`
+são ranges ABERTOS, fora do closure. É exatamente a fatia que (b) cobre, e é por isso que as duas
+são complementares e não substitutas.
 
 ## Camada 2 — o Publish do frontend (`deploy_project`): as DUAS metades medidas (2026-09-08)
 

--- a/scripts/lib/prompt-deploy.test.ts
+++ b/scripts/lib/prompt-deploy.test.ts
@@ -1,16 +1,33 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import type { Estado, Veredito } from './pendencias-deploy';
 import {
+  blocoDeConferencia,
   conferirCobertura,
   type EdgeParaDeploy,
   ESTADOS_DE_DEPLOY,
+  MARCAS_DE_CONFERENCIA,
   montarPrompt,
   numeral,
+  type Procedencia,
   selecionarParaDeploy,
 } from './prompt-deploy';
 
 const MAPA = 'supabase/functions/_shared/sonda-fingerprints.ts';
+
+/** Procedência bem-formada — o gerador recusa hash sem dizer de que commit ele é. */
+const PROC: Procedencia = { ref: 'origin/main', sha: '84a115a43' };
+
+/**
+ * Hash de MENTIRA, mas bem-formado e distinto por caminho. Distinto importa: hash igual em todos
+ * os arquivos deixaria o check de cobertura verde mesmo trocando o hash de um arquivo pelo do
+ * outro, e aí ele não estaria medindo nada.
+ */
+function hashDe(caminho: string): string {
+  return createHash('sha256').update(caminho).digest('hex');
+}
 
 function veredito(edge: string, estado: Estado): Veredito {
   return {
@@ -37,7 +54,7 @@ function fatia(edge: string): EdgeParaDeploy {
       `supabase/functions/${edge}/versao.ts`,
       'supabase/functions/_shared/sonda-versao.ts',
       MAPA,
-    ],
+    ].map((caminho) => ({ caminho, sha256: hashDe(caminho) })),
   };
 }
 
@@ -88,7 +105,7 @@ describe('selecionarParaDeploy', () => {
 });
 
 describe('montarPrompt — 1 edge', () => {
-  const prompt = montarPrompt([fatia('minha-edge')]);
+  const prompt = montarPrompt([fatia('minha-edge')], PROC);
 
   it('nomeia TODOS os arquivos da fatia, não só o index', () => {
     expect(conferirCobertura(prompt, [fatia('minha-edge')])).toEqual({ ok: true, faltando: [] });
@@ -103,7 +120,7 @@ describe('montarPrompt — 1 edge', () => {
 
 describe('montarPrompt — leva', () => {
   const edges = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map(fatia);
-  const prompt = montarPrompt(edges);
+  const prompt = montarPrompt(edges, PROC);
 
   it('declara o total por extenso e proíbe pular', () => {
     expect(prompt).toContain('**eight**');
@@ -133,9 +150,9 @@ describe('conferirCobertura — o check que segura o modo de falha', () => {
     // verde, o check é decorativo e o gerador não segura nada.
     const semMapa: EdgeParaDeploy = {
       edge: 'minha-edge',
-      arquivos: fatia('minha-edge').arquivos.filter((a) => a !== MAPA),
+      arquivos: fatia('minha-edge').arquivos.filter((a) => a.caminho !== MAPA),
     };
-    const promptCego = montarPrompt([semMapa]);
+    const promptCego = montarPrompt([semMapa], PROC);
 
     const r = conferirCobertura(promptCego, [fatia('minha-edge')]);
     expect(r.ok).toBe(false);
@@ -144,23 +161,25 @@ describe('conferirCobertura — o check que segura o modo de falha', () => {
 
   it('CONTROLE: a MESMA fatia, com o mapa, fica verde — senão o vermelho acima não prova nada', () => {
     const completa = fatia('minha-edge');
-    expect(conferirCobertura(montarPrompt([completa]), [completa]).ok).toBe(true);
+    expect(conferirCobertura(montarPrompt([completa], PROC), [completa]).ok).toBe(true);
   });
 
   it('não se deixa enganar por substring — `sonda-versao.ts` ⊄ `sonda-versao_test.ts`', () => {
     const pedido: EdgeParaDeploy = {
       edge: 'x',
-      arquivos: ['supabase/functions/_shared/sonda-versao.ts'],
+      arquivos: [{ caminho: 'supabase/functions/_shared/sonda-versao.ts', sha256: hashDe('a') }],
     };
     const promptErrado: EdgeParaDeploy = {
       edge: 'x',
-      arquivos: ['supabase/functions/_shared/sonda-versao_test.ts'],
+      arquivos: [
+        { caminho: 'supabase/functions/_shared/sonda-versao_test.ts', sha256: hashDe('a') },
+      ],
     };
-    expect(conferirCobertura(montarPrompt([promptErrado]), [pedido]).ok).toBe(false);
+    expect(conferirCobertura(montarPrompt([promptErrado], PROC), [pedido]).ok).toBe(false);
   });
 
   it('acusa edge inteira ausente do prompt', () => {
-    const prompt = montarPrompt([fatia('a')]);
+    const prompt = montarPrompt([fatia('a')], PROC);
     const r = conferirCobertura(prompt, [fatia('a'), fatia('esquecida')]);
     expect(r.ok).toBe(false);
     expect(r.faltando).toContain('edge:esquecida');
@@ -169,11 +188,11 @@ describe('conferirCobertura — o check que segura o modo de falha', () => {
 
 describe('recusas', () => {
   it('leva vazia LANÇA — colagem que não deploya nada pareceria trabalho feito', () => {
-    expect(() => montarPrompt([])).toThrow(/leva vazia/);
+    expect(() => montarPrompt([], PROC)).toThrow(/leva vazia/);
   });
 
   it('fatia vazia LANÇA — o closure nunca é vazio, então é falha de leitura', () => {
-    expect(() => montarPrompt([{ edge: 'x', arquivos: [] }])).toThrow(/fatia vazia/);
+    expect(() => montarPrompt([{ edge: 'x', arquivos: [] }], PROC)).toThrow(/fatia vazia/);
   });
 });
 
@@ -183,5 +202,148 @@ describe('numeral', () => {
     expect(numeral(8)).toBe('eight');
     expect(numeral(12)).toBe('twelve');
     expect(numeral(13)).toBe('13');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// O sha256 por arquivo e o ramo fail-CLOSED
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+//
+// Por que isto existe: o deploy de edge sai do SANDBOX do Lovable, não de um checkout da `main`, e
+// o sandbox pode estar atrasado (medido: 2026-08-08, `5f5523df9`→`942a69b89`→`aa00a3909`, a linha
+// velha empurrada de volta 2 min 36 s depois do merge e deployada dali). Ali o bot COMMITOU. Sem
+// commit, `git log`, `list_edits`, `get_diff` e o `fonte` da sonda ficariam todos verdes — o `fonte`
+// é fingerprint DECLARADO, lido de um arquivo commitado. O hash embutido é a única rede que não
+// depende de nenhum dos quatro.
+
+describe('montarPrompt — o sha256 esperado ao lado de cada arquivo', () => {
+  const f = fatia('minha-edge');
+  const prompt = montarPrompt([f], PROC);
+
+  it('emite o hash DAQUELE arquivo ao lado DAQUELE caminho, não um hash solto na página', () => {
+    for (const a of f.arquivos) {
+      expect(prompt).toContain(`- \`${a.caminho}\` — sha256 \`${a.sha256}\``);
+    }
+  });
+
+  it('declara a PROCEDÊNCIA — hash sem commit de origem não dá para refazer no `get_message`', () => {
+    expect(prompt).toContain('`origin/main` at commit `84a115a43`');
+  });
+
+  it('manda CONFERIR com o comando nomeado, não "compare os hashes" no vácuo', () => {
+    expect(prompt).toContain('run `sha256sum <path>`');
+  });
+
+  it('tem os TRÊS ramos: bate → deploya · difere → aborta · NÃO CONSEGUIU medir → aborta', () => {
+    expect(prompt).toContain('Every hash matches → deploy.');
+    expect(prompt).toContain('ANY hash differs → **do NOT deploy.**');
+    expect(prompt).toContain('**cannot compute** a hash');
+    // O terceiro ramo é o que separa este bloco de um recado bem-intencionado: sem ele, o
+    // `sha256sum` ausente do sandbox cai em "não achei diferença", que é ausência de dado lida
+    // como aprovação (docs/historico/sonda-ausente-em-script-que-apaga.md).
+    expect(prompt).toContain('Not being able to check is not');
+  });
+
+  it('fecha as duas saídas laterais que um agente prestativo inventaria: consertar e deployar parcial', () => {
+    expect(prompt).toContain('Do not resolve a mismatch by editing files');
+    expect(prompt).toContain('do not deploy the subset that matched');
+  });
+
+  it('vale para a LEVA também, não só para a edge sozinha', () => {
+    const leva = ['a', 'b', 'c'].map(fatia);
+    const p = montarPrompt(leva, PROC);
+    for (const e of leva) {
+      for (const a of e.arquivos) {
+        expect(p).toContain(`- \`${a.caminho}\` — sha256 \`${a.sha256}\``);
+      }
+    }
+    expect(p).toContain('run `sha256sum <path>`');
+    expect(p).toContain('do NOT deploy');
+  });
+});
+
+describe('blocoDeConferencia — a procedência é do PARÂMETRO, não hardcoded', () => {
+  it('carrega o ref e o sha que recebeu', () => {
+    const b = blocoDeConferencia({ ref: 'origin/qualquer', sha: 'deadbee' });
+    expect(b).toContain('`origin/qualquer` at commit `deadbee`');
+  });
+});
+
+describe('conferirCobertura — FALSIFICAÇÃO do hash e do ramo fail-closed', () => {
+  const f = fatia('minha-edge');
+
+  it('CONTROLE: o prompt intacto fica VERDE — sem isto, todo vermelho abaixo prova nada', () => {
+    expect(conferirCobertura(montarPrompt([f], PROC), [f])).toEqual({ ok: true, faltando: [] });
+  });
+
+  it('FALSIFICAÇÃO: prompt com a coluna de hash AMPUTADA fica VERMELHO, nomeando cada arquivo', () => {
+    // O modo de falha real: alguém "simplifica" a lista de volta para só o caminho. A colagem
+    // continua parecendo completa — mesmos arquivos, mesma forma — e manda deployar sem conferir
+    // nada. Se esta asserção ficar verde, o hash no prompt é decoração.
+    const semHash = montarPrompt([f], PROC).replace(/ — sha256 `[0-9a-f]{64}`/g, '');
+    const r = conferirCobertura(semHash, [f]);
+    expect(r.ok).toBe(false);
+    expect(r.faltando).toEqual(f.arquivos.map((a) => `minha-edge:${a.caminho}:sha256`));
+  });
+
+  it('FALSIFICAÇÃO: hash TROCADO entre dois arquivos fica VERMELHO (não basta "tem 64 hex")', () => {
+    const trocada: EdgeParaDeploy = {
+      edge: 'minha-edge',
+      arquivos: [
+        { caminho: f.arquivos[0].caminho, sha256: f.arquivos[1].sha256 },
+        { caminho: f.arquivos[1].caminho, sha256: f.arquivos[0].sha256 },
+      ],
+    };
+    const pedido: EdgeParaDeploy = { edge: 'minha-edge', arquivos: f.arquivos.slice(0, 2) };
+    // Os dois hashes APARECEM no prompt, mas cada um ao lado do arquivo errado. O check casa
+    // caminho e hash como PAR entre crases, então acusa; um `includes(hash)` solto não acusaria.
+    const r = conferirCobertura(montarPrompt([trocada], PROC), pedido.arquivos.length ? [pedido] : []);
+    expect(r.ok).toBe(false);
+    expect(r.faltando.every((x) => x.endsWith(':sha256'))).toBe(true);
+  });
+
+  it.each(MARCAS_DE_CONFERENCIA)(
+    'FALSIFICAÇÃO: prompt SEM a marca "%s" fica VERMELHO nomeando a marca',
+    (marca) => {
+      const mutilado = montarPrompt([f], PROC).split(marca).join('«amputado»');
+      const r = conferirCobertura(mutilado, [f]);
+      expect(r.ok).toBe(false);
+      expect(r.faltando).toContain(`fail-closed:${marca}`);
+    },
+  );
+});
+
+describe('recusas — o gerador não emite colagem que aprova por vacuidade', () => {
+  it('hash VAZIO lança nomeando o arquivo — comparar contra placeholder é aprovar sem medir', () => {
+    const ruim: EdgeParaDeploy = {
+      edge: 'x',
+      arquivos: [{ caminho: 'supabase/functions/x/index.ts', sha256: '' }],
+    };
+    expect(() => montarPrompt([ruim], PROC)).toThrow(/sha256 ausente ou malformado/);
+    expect(() => montarPrompt([ruim], PROC)).toThrow(/x:supabase\/functions\/x\/index\.ts/);
+  });
+
+  it('hash CURTO (63 hex) e hash com MAIÚSCULA também lançam — `sha256sum` imprime 64 minúsculo', () => {
+    const curto = { caminho: 'a.ts', sha256: 'a'.repeat(63) };
+    const maiusculo = { caminho: 'a.ts', sha256: 'A'.repeat(64) };
+    expect(() => montarPrompt([{ edge: 'x', arquivos: [curto] }], PROC)).toThrow(/malformado/);
+    expect(() => montarPrompt([{ edge: 'x', arquivos: [maiusculo] }], PROC)).toThrow(/malformado/);
+  });
+
+  it('CONTROLE: 64 hex minúsculo PASSA — senão as recusas acima estariam só rejeitando tudo', () => {
+    const ok = { caminho: 'a.ts', sha256: 'a'.repeat(64) };
+    expect(() => montarPrompt([{ edge: 'x', arquivos: [ok] }], PROC)).not.toThrow();
+  });
+
+  it('procedência sem sha (ou com sha que não é sha) lança', () => {
+    expect(() => montarPrompt([fatia('x')], { ref: 'origin/main', sha: '' })).toThrow(
+      /procedência inválida/,
+    );
+    expect(() => montarPrompt([fatia('x')], { ref: 'origin/main', sha: 'HEAD' })).toThrow(
+      /procedência inválida/,
+    );
+    expect(() => montarPrompt([fatia('x')], { ref: '', sha: '84a115a43' })).toThrow(
+      /procedência inválida/,
+    );
   });
 });

--- a/scripts/lib/prompt-deploy.ts
+++ b/scripts/lib/prompt-deploy.ts
@@ -39,8 +39,14 @@ export const ESTADOS_DE_DEPLOY: readonly Estado[] = [
   'SEM_MAPA_NO_BUNDLE',
 ] as const;
 
-/** Um arquivo da fatia, com o sha256 dos bytes que a REF tem — não os do working tree. */
-export interface ArquivoDaFatia {
+/**
+ * Um arquivo da fatia, com o sha256 dos bytes que a REF tem — não os do working tree.
+ *
+ * Não exportada: quem monta a fatia (`pendencias-prompt.ts`) escreve o literal e o tipo é checado
+ * estruturalmente por `EdgeParaDeploy`. Exportar sem consumidor que a NOMEIE é export morto, e o
+ * `knip` reprova (com razão).
+ */
+interface ArquivoDaFatia {
   caminho: string;
   /** SHA-256 dos bytes crus, em hex minúsculo: o número que `sha256sum <caminho>` imprime. */
   sha256: string;
@@ -77,7 +83,7 @@ const HEX64 = /^[0-9a-f]{64}$/;
  * deploy correto. É o mesmo erro de `includes()` cru que a nota de substring abaixo já registrava,
  * num eixo diferente.
  */
-export function linhaDoArquivo(a: ArquivoDaFatia): string {
+function linhaDoArquivo(a: ArquivoDaFatia): string {
   return `- \`${a.caminho}\` — sha256 \`${a.sha256}\``;
 }
 

--- a/scripts/lib/prompt-deploy.ts
+++ b/scripts/lib/prompt-deploy.ts
@@ -39,11 +39,64 @@ export const ESTADOS_DE_DEPLOY: readonly Estado[] = [
   'SEM_MAPA_NO_BUNDLE',
 ] as const;
 
+/** Um arquivo da fatia, com o sha256 dos bytes que a REF tem — não os do working tree. */
+export interface ArquivoDaFatia {
+  caminho: string;
+  /** SHA-256 dos bytes crus, em hex minúsculo: o número que `sha256sum <caminho>` imprime. */
+  sha256: string;
+}
+
 /** Uma edge da leva, com a fatia que o prompt precisa nomear (closure ∪ {mapa}). */
 export interface EdgeParaDeploy {
   edge: string;
-  arquivos: string[];
+  arquivos: ArquivoDaFatia[];
 }
+
+/**
+ * De onde os hashes saíram. Obrigatória, não opcional: prompt que embute hash sem dizer de QUAL
+ * commit é hash sem procedência — quem lê o `get_message` depois não consegue refazer a conta, e o
+ * agente não tem como saber contra que estado está comparando.
+ */
+export interface Procedencia {
+  /** O ref lido. É o que o Lovable deploya — não o `<sha>` do PR nomeado (#2123). */
+  ref: string;
+  /** SHA do ref no instante da geração. O prompt carrega; o `get_message` audita depois. */
+  sha: string;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Como UMA linha de arquivo se escreve. Existe como função porque `montarPrompt` e
+ * `conferirCobertura` precisam da MESMA definição: se o check remontasse a linha por conta
+ * própria, as duas poderiam divergir e o check ficaria verde contra um prompt que não existe.
+ *
+ * O par caminho↔hash é ATÔMICO de propósito. Conferir os dois soltos (`inclui o caminho?` e
+ * `inclui o hash?`) fica verde com os hashes TROCADOS entre dois arquivos — os dois aparecem, cada
+ * um ao lado do arquivo errado — e aí o agente confere 8 hashes, acha 8 divergências e aborta um
+ * deploy correto. É o mesmo erro de `includes()` cru que a nota de substring abaixo já registrava,
+ * num eixo diferente.
+ */
+export function linhaDoArquivo(a: ArquivoDaFatia): string {
+  return `- \`${a.caminho}\` — sha256 \`${a.sha256}\``;
+}
+
+/**
+ * As marcas que a conferência EXIGE na saída. Cada uma existe por um modo de falha nomeado, e
+ * `conferirCobertura` reprova se qualquer uma sumir — hash embutido sem ordem de abortar é hash
+ * DECORATIVO: o agente compara, vê diferente e deploya assim mesmo.
+ *
+ *   `sha256sum`      → o COMO. Sem o comando nomeado, "compare os hashes" é recado vago.
+ *   `do NOT deploy`  → o ramo de DIVERGÊNCIA medida.
+ *   `cannot compute` → o ramo de AUSÊNCIA. Sonda que não roda ≠ sonda verde: sem este ramo, o
+ *                      `sha256sum` ausente do sandbox vira deploy aprovado por silêncio
+ *                      (`docs/historico/sonda-ausente-em-script-que-apaga.md`).
+ */
+export const MARCAS_DE_CONFERENCIA: readonly string[] = [
+  'sha256sum',
+  'do NOT deploy',
+  'cannot compute',
+] as const;
 
 /**
  * Filtra os vereditos pelos estados que exigem deploy. Ordena por nome para a saída ser
@@ -78,14 +131,70 @@ export function numeral(n: number): string {
 }
 
 /**
+ * O bloco fail-CLOSED — o miolo desta entrega.
+ *
+ * ## Por que hash, e por que no PROMPT
+ *
+ * O deploy de edge no Lovable sai do SANDBOX do projeto (`supabase--deploy_edge_functions`), não de
+ * um checkout limpo da `main`, e o sandbox pode estar atrasado na hora do deploy. Não é hipótese:
+ * em 2026-08-08 o bot empurrou a linha VELHA de volta 2 min 36 s depois de um merge e deployou dali
+ * (`5f5523df9` → `942a69b89` → `aa00a3909`, `@2`→`@^2` em `carteira-positivacao-snapshot`). Ali ele
+ * COMMITOU, então vimos. Se tivesse deployado sem commitar, `git log`, `list_edits` e `get_diff`
+ * ficariam limpos — o estado exato em que o piloto do MCP declarou "nenhuma edição registrada" — e
+ * o `fonte` da sonda bateria assim mesmo, porque ele é fingerprint DECLARADO (lê a constante
+ * `FONTE_SHA256[edge]` de um arquivo commitado), não hash calculado sobre o bundle servido. A
+ * taxa-base não é zero: o bot commita na main 171×/60 dias.
+ *
+ * Hash é dado que LLM não fabrica. Ele fecha esse buraco SEM depender de commit do bot, de
+ * `list_edits` nem do `fonte` declarado — e vale para o canal MANUAL também, que é onde a maioria
+ * dos deploys acontece. Detalhe em `docs/historico/piloto-deploy-mcp-lovable.md`.
+ *
+ * ## Os três ramos, e por que o terceiro não é preciosismo
+ *
+ * "Confira e, se diferir, aborte" cobre dois estados e deixa o terceiro em aberto: NÃO CONSEGUI
+ * conferir. Sem ramo próprio, o `sha256sum` ausente cai em "não achei diferença" — que é ausência
+ * de dado lida como aprovação, exatamente a falha do
+ * `docs/historico/sonda-ausente-em-script-que-apaga.md`. Por isso os três ramos são explícitos, e
+ * a última linha fecha as duas saídas laterais que um agente prestativo inventaria sozinho:
+ * "conserto o arquivo" e "deployo só os que bateram" (= deploy parcial, o modo de falha que o
+ * gerador inteiro existe para evitar).
+ *
+ * ## O que isto NÃO pega
+ *
+ * Divergência que nasce DEPOIS da entrada do deploy — resolução de dependência e cache de build.
+ * `copilot-analyze/index.ts` importa `npm:@anthropic-ai/sdk@^0.93.0` e `npm:@supabase/supabase-js@2`,
+ * ranges ABERTOS que estão fora do closure (que só anda em imports locais `./` e `../`): o bundle
+ * pode mudar sem uma linha do repo mudar. Isso é a canária determinística com fixture, entrega
+ * separada. Não prometa aqui o que este bloco não entrega.
+ */
+export function blocoDeConferencia(p: Procedencia): string {
+  return [
+    `**Verify the files before deploying.** The \`sha256\` values above were computed from`,
+    `\`${p.ref}\` at commit \`${p.sha}\` — that is the exact state that must go live. For EACH file`,
+    `listed, run \`sha256sum <path>\` and compare the result with the hash printed next to it.`,
+    '',
+    `- Every hash matches → deploy.`,
+    `- ANY hash differs → **do NOT deploy.** Reply with a table of \`file | expected | actual\` for`,
+    `  every file you checked, and stop.`,
+    `- You **cannot compute** a hash for a listed file — file missing, command unavailable, or any`,
+    `  error → **do NOT deploy.** Say which file and why, and stop. Not being able to check is not`,
+    `  the same as checking and matching.`,
+    '',
+    `Do not resolve a mismatch by editing files, and do not deploy the subset that matched.`,
+    `Report and stop.`,
+  ].join('\n');
+}
+
+/**
  * Monta a colagem. UMA por LEVA, nunca uma por edge — o cabeçalho declara o total e proíbe pular,
- * cada edge é uma seção numerada com a SUA fatia, e o fecho pede confirmação item a item (que é o
- * relato que a sessão compara com a sonda depois).
+ * cada edge é uma seção numerada com a SUA fatia (cada arquivo com o sha256 esperado), e o fecho
+ * pede confirmação item a item (que é o relato que a sessão compara com a sonda depois).
  *
  * Lança com leva vazia: quem chama decide o exit, e "prompt vazio" seria uma colagem que não
- * deploya nada e parece trabalho feito.
+ * deploya nada e parece trabalho feito. Lança também com hash que não é hex de 64 — placeholder
+ * renderizado vira comparação contra nada, e o agente aprova por vacuidade.
  */
-export function montarPrompt(edges: readonly EdgeParaDeploy[]): string {
+export function montarPrompt(edges: readonly EdgeParaDeploy[], proc: Procedencia): string {
   if (edges.length === 0) {
     throw new Error('montarPrompt: leva vazia — nada pendente de deploy, não há prompt a emitir');
   }
@@ -95,9 +204,24 @@ export function montarPrompt(edges: readonly EdgeParaDeploy[]): string {
       `montarPrompt: fatia vazia para ${semArquivo.join(', ')} — o closure nunca é vazio (o index.ts está nele), logo isto é falha de leitura, não leva sem arquivo`,
     );
   }
+  const semHash = edges.flatMap((e) =>
+    e.arquivos.filter((a) => !HEX64.test(a.sha256)).map((a) => `${e.edge}:${a.caminho}`),
+  );
+  if (semHash.length > 0) {
+    throw new Error(
+      `montarPrompt: sha256 ausente ou malformado em ${semHash.join(', ')} — o prompt manda o ` +
+        `agente COMPARAR, e comparar contra placeholder é aprovar por vacuidade`,
+    );
+  }
+  if (!/^[0-9a-f]{7,40}$/.test(proc.sha) || proc.ref === '') {
+    throw new Error(
+      `montarPrompt: procedência inválida (ref "${proc.ref}", sha "${proc.sha}") — hash sem dizer ` +
+        `de que commit é hash sem procedência`,
+    );
+  }
 
-  const lista = (arquivos: readonly string[]): string =>
-    arquivos.map((a) => `- \`${a}\``).join('\n');
+  const lista = (arquivos: readonly ArquivoDaFatia[]): string =>
+    arquivos.map(linhaDoArquivo).join('\n');
 
   if (edges.length === 1) {
     const [only] = edges;
@@ -108,7 +232,10 @@ export function montarPrompt(edges: readonly EdgeParaDeploy[]): string {
       '',
       lista(only.arquivos),
       '',
-      `After deploying, confirm that \`${only.edge}\` shows **Active**.`,
+      blocoDeConferencia(proc),
+      '',
+      `After deploying, confirm that \`${only.edge}\` shows **Active**, and report the result of the`,
+      `hash check.`,
     ].join('\n');
   }
 
@@ -125,16 +252,26 @@ export function montarPrompt(edges: readonly EdgeParaDeploy[]): string {
     '',
     secoes,
     '',
-    `After deploying, list the ${n} function names and confirm that **each one** shows **Active**.`,
+    blocoDeConferencia(proc),
+    '',
+    `After deploying, list the ${n} function names and confirm that **each one** shows **Active**,`,
+    `and report the result of the hash check.`,
   ].join('\n');
 }
 
 /**
- * O check barato que segura o modo de falha: TODO arquivo da fatia aparece no prompt, e todo nome
- * de edge também. Falsificado no teste removendo o mapa da fatia — sem isso o check é decorativo.
+ * O check barato que segura o modo de falha: TODO arquivo da fatia aparece no prompt COM o seu
+ * hash, todo nome de edge também, e as marcas do ramo fail-closed continuam lá. Falsificado no
+ * teste removendo o mapa da fatia, zerando o hash e amputando cada marca — sem isso o check é
+ * decorativo.
  *
  * Casa o arquivo entre crases, não solto: `sonda-versao.ts` é substring de `sonda-versao_test.ts`,
  * e um `includes()` cru daria verde para a fatia errada.
+ *
+ * O hash entra no check porque a colagem sem ele não é "menos completa": é OUTRO artefato — um que
+ * manda deployar sem conferir nada, e que o agente obedece igual. E entra PAREADO com o caminho
+ * (via `linhaDoArquivo`), não solto: hash certo ao lado do arquivo errado passaria num
+ * `includes(hash)` e faria o agente abortar um deploy correto.
  */
 export function conferirCobertura(
   prompt: string,
@@ -144,8 +281,17 @@ export function conferirCobertura(
   for (const e of edges) {
     if (!prompt.includes(`\`${e.edge}\``)) faltando.push(`edge:${e.edge}`);
     for (const arquivo of e.arquivos) {
-      if (!prompt.includes(`\`${arquivo}\``)) faltando.push(`${e.edge}:${arquivo}`);
+      if (!prompt.includes(`\`${arquivo.caminho}\``)) {
+        faltando.push(`${e.edge}:${arquivo.caminho}`);
+        continue; // arquivo ausente já está acusado; somar `:sha256` seria ruído do mesmo defeito
+      }
+      if (!prompt.includes(linhaDoArquivo(arquivo))) {
+        faltando.push(`${e.edge}:${arquivo.caminho}:sha256`);
+      }
     }
+  }
+  for (const marca of MARCAS_DE_CONFERENCIA) {
+    if (!prompt.includes(marca)) faltando.push(`fail-closed:${marca}`);
   }
   return { ok: faltando.length === 0, faltando };
 }

--- a/scripts/pendencias-prompt.test.ts
+++ b/scripts/pendencias-prompt.test.ts
@@ -1,0 +1,302 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  arvoreDaRef,
+  type ExecutorGitBytes,
+  fatiaDeDeploy,
+  gitBytes,
+  main,
+  REF_DEPLOYADA,
+  type SaidaGitBytes,
+  sincronizarRef,
+} from './pendencias-prompt';
+import { sha256Arquivo } from './sonda-fingerprint';
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// Por que este arquivo existe
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+//
+// O núcleo puro (`lib/prompt-deploy.test.ts`) tem 35 testes verdes e NÃO alcança o defeito que
+// mais dói aqui: ler a árvore ERRADA. Mesma lição do `sonda-versao-bump-gate` — "os dois
+// falsos-verdes corrigidos aqui estavam ambos FORA do núcleo puro, que tinha 23 testes verdes".
+// O eixo ÁRVORE só aparece na fronteira de I/O, então é aqui que ele se prova, com git de verdade.
+//
+// O repo é de MENTIRA, num tmpdir com um `origin` bare: um teste que lê a árvore real mede o que
+// alguém acabou de mudar, não a régua (mesma doutrina do `sonda-fan-out.test.ts`).
+
+const SHARED = 'supabase/functions/_shared';
+const MAPA = `${SHARED}/sonda-fingerprints.ts`;
+
+let raiz: string;
+let remoto: string;
+
+function gitF(...args: string[]): string {
+  return execFileSync(
+    'git',
+    ['-C', raiz, '-c', 'user.email=t@t', '-c', 'user.name=t', '-c', 'commit.gpgsign=false', ...args],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+function escrever(rel: string, conteudo: string): void {
+  const abs = join(raiz, rel);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, conteudo, 'utf8');
+}
+
+const sha256De = (texto: string): string => createHash('sha256').update(texto).digest('hex');
+
+// ── O conteúdo COMMITADO (= o que `origin/main` tem, = o que o Lovable deploya) ───────────────
+const INDEX_MAIN = `import "./a.ts";\nimport "../_shared/b.ts";\nexport default {};\n`;
+const A_MAIN = `export const a = "main";\n`;
+const B_MAIN = `export const b = "main";\n`;
+const VERSAO_MAIN = `export const VERSAO = "v1.0-main";\n`;
+const MAPA_MAIN = `export const FONTE_SHA256: Record<string, string> = {\n  "e": "${'0'.repeat(64)}",\n};\n`;
+
+/** Repo local + `origin` bare, com a fatia da `edge-e` commitada e publicada. */
+function montarRepo(): void {
+  execFileSync('git', ['init', '--bare', '-q', '-b', 'main', remoto]);
+  gitF('init', '-q', '-b', 'main');
+  gitF('remote', 'add', 'origin', remoto);
+  escrever('supabase/functions/edge-e/index.ts', INDEX_MAIN);
+  escrever('supabase/functions/edge-e/a.ts', A_MAIN);
+  escrever('supabase/functions/edge-e/versao.ts', VERSAO_MAIN);
+  escrever(`${SHARED}/b.ts`, B_MAIN);
+  escrever(MAPA, MAPA_MAIN);
+  gitF('add', '-A');
+  gitF('commit', '-q', '-m', 'base');
+  gitF('push', '-q', 'origin', 'main');
+}
+
+/**
+ * O working tree DIVERGE da main, do jeito medido em 2026-09-04: o `index.ts` do disco importa
+ * MENOS, e o arquivo que sumiu do import também sumiu do disco. Contra o disco o closure sai curto
+ * e a função não bootaria; contra a ref ele sai inteiro.
+ */
+function divergirDoMain(): void {
+  escrever('supabase/functions/edge-e/index.ts', `import "./a.ts";\nexport default {};\n`);
+  escrever('supabase/functions/edge-e/a.ts', `export const a = "DISCO SUJO";\n`);
+  unlinkSync(join(raiz, SHARED, 'b.ts'));
+}
+
+beforeEach(() => {
+  const base = mkdtempSync(join(tmpdir(), 'pendencias-prompt-'));
+  raiz = join(base, 'local');
+  remoto = join(base, 'remoto.git');
+  mkdirSync(raiz, { recursive: true });
+});
+afterEach(() => rmSync(join(raiz, '..'), { recursive: true, force: true }));
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// O eixo ÁRVORE — o teste que fica VERMELHO se alguém trocar a ref pelo disco
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+
+describe('fatiaDeDeploy lê a REF, não o working tree', () => {
+  it('CONTROLE: com o disco IGUAL à main, a fatia é a esperada e os hashes batem', () => {
+    montarRepo();
+    const f = fatiaDeDeploy('edge-e', raiz, arvoreDaRef(REF_DEPLOYADA, gitBytes(raiz)));
+    expect(f.arquivos.map((a) => a.caminho)).toEqual([
+      `${SHARED}/b.ts`,
+      MAPA,
+      'supabase/functions/edge-e/a.ts',
+      'supabase/functions/edge-e/index.ts',
+    ]);
+    const porCaminho = Object.fromEntries(f.arquivos.map((a) => [a.caminho, a.sha256]));
+    expect(porCaminho[`${SHARED}/b.ts`]).toBe(sha256De(B_MAIN));
+    expect(porCaminho['supabase/functions/edge-e/a.ts']).toBe(sha256De(A_MAIN));
+  });
+
+  it('FALSIFICAÇÃO (ÁRVORE): disco DIVERGENTE não muda nem a lista nem os hashes', () => {
+    // Este é o teste que morre se `arvoreDaRef` virar `arvoreDeTrabalho`, ou se `fatiaDeDeploy`
+    // voltar a `existsSync`/`readFileSync`. Contra o disco: 2 arquivos (`b.ts` sumiu do import E
+    // do disco) e o hash de `a.ts` seria o do conteúdo sujo. Contra a ref: 4 arquivos e os hashes
+    // da main. É o 5-vs-7 da `enviar-pedido-portal-sayerlack` reproduzido em miniatura.
+    montarRepo();
+    divergirDoMain();
+    const f = fatiaDeDeploy('edge-e', raiz, arvoreDaRef(REF_DEPLOYADA, gitBytes(raiz)));
+
+    expect(f.arquivos.map((a) => a.caminho)).toContain(`${SHARED}/b.ts`);
+    expect(f.arquivos).toHaveLength(4);
+    const porCaminho = Object.fromEntries(f.arquivos.map((a) => [a.caminho, a.sha256]));
+    expect(porCaminho['supabase/functions/edge-e/a.ts']).toBe(sha256De(A_MAIN));
+    expect(porCaminho['supabase/functions/edge-e/a.ts']).not.toBe(sha256De('export const a = "DISCO SUJO";\n'));
+    expect(porCaminho['supabase/functions/edge-e/index.ts']).toBe(sha256De(INDEX_MAIN));
+  });
+
+  it('o MAPA entra na fatia mesmo sem estar no closure — omiti-lo serve FONTE_SHA256 velho', () => {
+    montarRepo();
+    const f = fatiaDeDeploy('edge-e', raiz, arvoreDaRef(REF_DEPLOYADA, gitBytes(raiz)));
+    const mapa = f.arquivos.find((a) => a.caminho === MAPA);
+    expect(mapa?.sha256).toBe(sha256De(MAPA_MAIN));
+  });
+
+  it('edge que existe SÓ no disco é recusada NOMEANDO a ref — não é edge para deployar', () => {
+    montarRepo();
+    escrever('supabase/functions/edge-fantasma/index.ts', `export default {};\n`);
+    expect(() => fatiaDeDeploy('edge-fantasma', raiz, arvoreDaRef(REF_DEPLOYADA, gitBytes(raiz))))
+      .toThrow(/edge inexistente em origin\/main/);
+  });
+
+  it('import da ref que não resolve NA REF é fail-closed, e a mensagem diz QUAL árvore', () => {
+    montarRepo();
+    escrever('supabase/functions/edge-e/index.ts', `import "./sumido.ts";\nexport default {};\n`);
+    gitF('add', '-A');
+    gitF('commit', '-q', '-m', 'import quebrado');
+    gitF('push', '-q', 'origin', 'main');
+    gitF('fetch', '-q', 'origin', 'main');
+    expect(() => fatiaDeDeploy('edge-e', raiz, arvoreDaRef(REF_DEPLOYADA, gitBytes(raiz))))
+      .toThrow(/import local que NÃO resolve em origin\/main/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// O hash é o MESMO que `sha256sum` imprime — a premissa da entrega inteira
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+
+describe('sha256Arquivo bate com o binário que o agente vai rodar', () => {
+  it('CONTROLE POSITIVO: o hash embutido = a saída de `sha256sum`/`shasum -a 256`', () => {
+    // Se estes dois divergirem, TODO deploy aborta com divergência fabricada. Não dá para provar
+    // isto lendo o código: só medindo contra o binário. Sem `sha256sum` nem `shasum` a asserção
+    // FALHA de propósito — não conseguir medir não é o mesmo que ter medido e batido.
+    montarRepo();
+    escrever('amostra.bin', 'linha 1\nacentuação çãé\n');
+    const nossa = sha256Arquivo(Buffer.from('linha 1\nacentuação çãé\n', 'utf8'));
+
+    const tentativas: [string, string[]][] = [
+      ['sha256sum', ['amostra.bin']],
+      ['shasum', ['-a', '256', 'amostra.bin']],
+    ];
+    let doBinario: string | null = null;
+    for (const [cmd, args] of tentativas) {
+      try {
+        doBinario = execFileSync(cmd, args, { cwd: raiz, encoding: 'utf8' }).trim().split(/\s+/)[0];
+        break;
+      } catch {
+        /* tenta o próximo — macOS tem `shasum`, Linux tem `sha256sum` */
+      }
+    }
+    expect(doBinario, 'nem `sha256sum` nem `shasum` responderam — impossível provar a premissa').not.toBeNull();
+    expect(nossa).toBe(doBinario);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// A sincronização — fail-closed nas duas portas
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+
+/** `git` de mentira que grava o que foi pedido. Injetável porque a DECISÃO é o que se testa. */
+function gitFake(resposta: (args: string[]) => SaidaGitBytes): {
+  git: ExecutorGitBytes;
+  chamadas: string[][];
+} {
+  const chamadas: string[][] = [];
+  return {
+    chamadas,
+    git: (args) => {
+      chamadas.push(args);
+      return resposta(args);
+    },
+  };
+}
+
+const ok = (texto: string): SaidaGitBytes => ({ ok: true, bytes: Buffer.from(texto), erro: '' });
+const falha = (erro: string): SaidaGitBytes => ({ ok: false, bytes: Buffer.alloc(0), erro });
+
+describe('sincronizarRef', () => {
+  it('busca a ref ANTES de ler — comparar contra retrato velho é o mesmo defeito um nível acima', () => {
+    const { git, chamadas } = gitFake((a) => (a[0] === 'fetch' ? ok('') : ok('84a115a43\n')));
+    expect(sincronizarRef(git, false)).toBe('84a115a43');
+    expect(chamadas[0]).toEqual(['fetch', '--quiet', 'origin', 'main']);
+  });
+
+  it('fetch que FALHA aborta nomeando --sem-rede — não degrada para aviso', () => {
+    const { git } = gitFake((a) => (a[0] === 'fetch' ? falha('Could not resolve host') : ok('abc1234')));
+    expect(() => sincronizarRef(git, false)).toThrow(/git fetch origin main` falhou/);
+    expect(() => sincronizarRef(git, false)).toThrow(/Nenhum prompt foi emitido/);
+  });
+
+  it('--sem-rede pula SÓ o fetch; a leitura continua saindo da ref', () => {
+    const { git, chamadas } = gitFake(() => ok('84a115a43\n'));
+    expect(sincronizarRef(git, true)).toBe('84a115a43');
+    expect(chamadas.some((c) => c[0] === 'fetch')).toBe(false);
+  });
+
+  it('origin/main que não existe aborta — ausência de dado não é aprovação', () => {
+    const { git } = gitFake((a) => (a[0] === 'fetch' ? ok('') : falha('')));
+    expect(() => sincronizarRef(git, false)).toThrow(/origin\/main não existe neste repo/);
+  });
+
+  it('rev-parse que sai 0 com stdout VAZIO também aborta (o exit não é o veredito)', () => {
+    const { git } = gitFake(() => ok('   \n'));
+    expect(() => sincronizarRef(git, true)).toThrow(/não existe neste repo/);
+  });
+});
+
+describe('gitBytes — spawn que não respondeu NÃO é sucesso', () => {
+  it('binário inexistente devolve ok:false, não ok:true com bytes vazios', () => {
+    montarRepo();
+    const r = gitBytes(raiz)(['nao-e-um-subcomando-de-git']);
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// `main()` — os exits, e o que sai (ou não) no stdout
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+
+describe('main — nunca imprime colagem num caminho de erro', () => {
+  let saida: string;
+  beforeEach(() => {
+    saida = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((c) => {
+      saida += String(c);
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('caminho feliz: exit 0, prompt com os arquivos, os hashes da MAIN e a procedência', () => {
+    montarRepo();
+    divergirDoMain(); // o disco sujo NÃO pode aparecer na saída
+    const sha = gitF('rev-parse', REF_DEPLOYADA);
+    expect(main(['edge-e'], raiz)).toBe(0);
+    expect(saida).toContain(`- \`${SHARED}/b.ts\` — sha256 \`${sha256De(B_MAIN)}\``);
+    expect(saida).toContain(`- \`supabase/functions/edge-e/a.ts\` — sha256 \`${sha256De(A_MAIN)}\``);
+    expect(saida).not.toContain(sha256De('export const a = "DISCO SUJO";\n'));
+    expect(saida).toContain(`\`origin/main\` at commit \`${sha}\``);
+    expect(saida).toContain('run `sha256sum <path>`');
+    expect(saida).toContain('do NOT deploy');
+  });
+
+  it('fetch quebrado: exit 2 e stdout VAZIO — colagem sem conferência é pior que colagem nenhuma', () => {
+    montarRepo();
+    const { git } = gitFake((a) => (a[0] === 'fetch' ? falha('sem rede') : ok('84a115a43')));
+    expect(main(['edge-e'], raiz, git)).toBe(2);
+    expect(saida).toBe('');
+  });
+
+  it('edge que não existe na ref: exit 2 e stdout vazio', () => {
+    montarRepo();
+    expect(main(['edge-fantasma'], raiz)).toBe(2);
+    expect(saida).toBe('');
+  });
+
+  it('--sem-rede emite o prompt e não é confundido com nome de edge', () => {
+    montarRepo();
+    expect(main(['edge-e', '--sem-rede'], raiz)).toBe(0);
+    expect(saida).toContain('supabase/functions/edge-e/index.ts');
+  });
+
+  it('sem argumento nenhum: exit 2, uso no stderr, nada no stdout', () => {
+    montarRepo();
+    expect(main([], raiz)).toBe(2);
+    expect(saida).toBe('');
+  });
+});

--- a/scripts/pendencias-prompt.ts
+++ b/scripts/pendencias-prompt.ts
@@ -7,47 +7,176 @@
  * emite UMA colagem para a leva inteira. Ele NÃO decide se a edge precisa de deploy — quem decide
  * é o ledger, e "o mapa mudou" não é motivo (Passo 2 da `lovable-deploy-verify`).
  *
- * A lógica pura vive em `lib/prompt-deploy.ts`. Aqui fica só a borda: argv, stdin, fs e os exits.
+ * A lógica pura vive em `lib/prompt-deploy.ts`. Aqui fica só a borda: argv, stdin, git e os exits.
+ *
+ * ‼️ TUDO QUE ALIMENTA O PROMPT SAI DE `origin/main` — NUNCA DO WORKING TREE.
+ * ============================================================================================
+ * O Lovable deploya a MAIN, não este checkout (#2123). E `git fetch` sozinho NÃO fecha o eixo:
+ * ele move `origin/main`, enquanto `existsSync`/`readFileSync` continuam lendo os bytes do disco.
+ * Medido em 2026-09-04 na `enviar-pedido-portal-sayerlack`: contra o working tree o closure deu
+ * **5** arquivos; contra a ref, **7**. Os dois que sumiram eram `qtde-portal.ts` (arquivo novo) e
+ * `escrita-critica.ts` (import novo em arquivo pré-existente) — sem nenhum dos dois a função não
+ * boota, e um closure curto se PARECE com um closure: mesma forma, menos arquivos, nada na saída
+ * denuncia. `ausente ≠ zero` na dimensão ÁRVORE
+ * (`.claude/skills/lovable-deploy-verify/SKILL.md` §Passo 3).
+ *
+ * Por isso a árvore lida é `arvoreDaRef(REF_MAIN)` e não o disco, e por isso o `git fetch` é DO
+ * SCRIPT: comparar contra a `origin/main` que está em disco é o mesmo defeito um nível acima — o
+ * remote-tracking ref também é um retrato. "Sincronize antes de MEDIR" só vale se a sincronização
+ * for parte da MEDIÇÃO (mesmo argumento, medido, do `sonda-versao-sql.ts`: o fetch custa ~0,9 s).
  *
  * Uso:
  *   bun run pendencias:prompt <edge> [edge...]              # leva explícita
  *   bun run pendencias:deploy --json | bun run pendencias:prompt -
+ *   bun run pendencias:prompt <edge> --sem-rede             # pula só o fetch (ver abaixo)
  *
  * EXIT CODES:
  *   0  prompt emitido (stdout = a colagem; o resto vai para stderr)
  *   1  nada pendente de deploy — não há colagem a emitir
- *   2  MECÂNICA não confiável: JSON ilegível ou de outro formato, edge inexistente, import local
- *      que não resolve (a `fecharGrafo` é fail-closed), ou a auto-conferência de cobertura vermelha.
+ *   2  MECÂNICA não confiável: JSON ilegível ou de outro formato, `git fetch`/`origin/main` que não
+ *      respondem, edge inexistente na ref, import local que não resolve (a `fecharGrafo` é
+ *      fail-closed), arquivo da fatia ausente da ref, ou a auto-conferência de cobertura vermelha.
  *      Nunca imprime prompt no exit 2 — colagem incompleta é o modo de falha que este script existe
  *      para evitar (deploy parcial: boota e serve `FONTE_SHA256` velho).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 import {
   conferirCobertura,
   type EdgeParaDeploy,
   FORMATO_ACEITO,
   montarPrompt,
+  type Procedencia,
   selecionarParaDeploy,
 } from './lib/prompt-deploy';
-import { ARQ_MAPA, fecharGrafo, RAIZ_EDGES } from './sonda-fingerprint';
+import { ARQ_MAPA, type ArvoreDeFonte, fecharGrafo, RAIZ_EDGES, sha256Arquivo } from './sonda-fingerprint';
+
+/** O que o Lovable deploya. Mesmo ref que o `pendencias-deploy.ts` usa para decidir a leva. */
+const REMOTO = 'origin';
+const RAMO_DEPLOYADO = 'main';
+export const REF_DEPLOYADA = `${REMOTO}/${RAMO_DEPLOYADO}`;
+
+// ─── git que devolve BYTES ────────────────────────────────────────────────────────────────────
+//
+// Os leitores de git que já existem no repo (`lerNaRev` do `sonda-versao-bump-gate`, `gitReal` do
+// `sonda-versao-sql`) devolvem STRING utf8, e para o que eles fazem — comparar fonte, casar regex —
+// isso está certo. Aqui não serve: o número que o prompt embute tem de ser o mesmo que
+// `sha256sum <arquivo>` imprime, e `sha256sum` hasheia os bytes CRUS. Decodificar para utf8 e
+// re-codificar só volta igual se a entrada for utf8 VÁLIDO; byte inválido vira U+FFFD e o hash sai
+// de um conteúdo que não existe — divergência FABRICADA, que aborta um deploy correto.
+
+/** Saída crua de um `git`. `ok:false` cobre erro, status ≠ 0 e morte por sinal (status null). */
+export interface SaidaGitBytes {
+  ok: boolean;
+  bytes: Buffer;
+  erro: string;
+}
+
+export type ExecutorGitBytes = (args: string[]) => SaidaGitBytes;
 
 /**
- * A fatia que o deploy tem de nomear: fecho transitivo ∪ {mapa}.
+ * `git` de verdade, sem `encoding` (⇒ Buffer).
+ *
+ * `r.status` nulo (morto por sinal, timeout, binário ausente) NÃO é 0: um spawn que não respondeu é
+ * ausência de dado, e ausência de dado tem de cair no ramo fail-closed junto com o erro explícito.
+ */
+export function gitBytes(raiz: string): ExecutorGitBytes {
+  return (args) => {
+    const r = spawnSync('git', args, { cwd: raiz, maxBuffer: 64 * 1024 * 1024, timeout: 30_000 });
+    if (r.error) return { ok: false, bytes: Buffer.alloc(0), erro: r.error.message };
+    return {
+      ok: r.status === 0,
+      bytes: r.stdout ?? Buffer.alloc(0),
+      erro: (r.stderr ?? Buffer.alloc(0)).toString('utf8'),
+    };
+  };
+}
+
+/**
+ * A árvore de uma REV do git — o que `fecharGrafo` e o hash têm de ler.
+ *
+ * Nenhum `existsSync`, nenhum `readFileSync`: se o arquivo não está na rev, `git show` sai ≠ 0 e
+ * isto devolve `null`, que é o `ausente` que a `fecharGrafo` transforma em erro. O disco desta
+ * worktree não participa da decisão em nenhum ponto.
+ */
+export function arvoreDaRef(rev: string, git: ExecutorGitBytes): ArvoreDeFonte {
+  return {
+    rotulo: rev,
+    ler(rel) {
+      const r = git(['show', `${rev}:${rel}`]);
+      return r.ok ? r.bytes : null;
+    },
+  };
+}
+
+/**
+ * Busca a `origin/main` e devolve o SHA dela, ou LANÇA.
+ *
+ * `--sem-rede` pula SÓ o fetch — a leitura continua saindo da ref, nunca do disco. Ela existe
+ * porque preparar a colagem offline é uso real (o deploy em si é manual, depois), e é explícita
+ * justamente para não ser o padrão: o que ela admite é que a ref pode ser um retrato velho.
+ */
+export function sincronizarRef(git: ExecutorGitBytes, semRede: boolean): string {
+  if (!semRede) {
+    const f = git(['fetch', '--quiet', REMOTO, RAMO_DEPLOYADO]);
+    if (!f.ok) {
+      throw new Error(
+        `\`git fetch ${REMOTO} ${RAMO_DEPLOYADO}\` falhou: ${primeiraLinha(f.erro)}. O prompt ` +
+          `embute o sha256 de cada arquivo COMO ELE ESTÁ na ${REF_DEPLOYADA}, e uma ref velha ` +
+          `manda o agente conferir contra um estado que já não é o que vai ao ar. Sem rede, ` +
+          `repita com \`--sem-rede\` — a leitura continua saindo da ref que está em disco. ` +
+          `Nenhum prompt foi emitido.`,
+      );
+    }
+  }
+  const r = git(['rev-parse', '--verify', '--quiet', `${REF_DEPLOYADA}^{commit}`]);
+  const sha = r.bytes.toString('utf8').trim();
+  if (!r.ok || sha === '') {
+    throw new Error(
+      `${REF_DEPLOYADA} não existe neste repo${semRede ? ' e --sem-rede proíbe buscá-la' : ''} — ` +
+        `não há de onde tirar os bytes que o Lovable vai deployar, e ausência de dado não é ` +
+        `aprovação. Rode \`git fetch ${REMOTO}\` num repo com o remote configurado. ` +
+        `Nenhum prompt foi emitido.`,
+    );
+  }
+  return sha;
+}
+
+function primeiraLinha(s: string): string {
+  return (s.split('\n').find((l) => l.trim() !== '') ?? '(sem stderr)').trim();
+}
+
+/**
+ * A fatia que o deploy tem de nomear: fecho transitivo ∪ {mapa}, cada arquivo com o sha256 dos
+ * bytes que a ÁRVORE tem.
  *
  * O mapa entra SEMPRE, mesmo em edge não instrumentada: nomear um `_shared` a mais é inócuo (ele
  * já está no bundle), enquanto omiti-lo produz deploy que boota e serve fingerprint velho. A
  * assimetria manda no default — fail-closed no lado que dói.
+ *
+ * O hash é por ARQUIVO (`sha256Arquivo`), não o da fatia (`digerir`): quem vai recalcular é um
+ * agente rodando `sha256sum` no sandbox, e nenhum comando de shell reproduz o encadeamento
+ * `caminho \0 tamanho \0 bytes` do fingerprint. Hash que o outro lado não consegue refazer é
+ * decoração.
  */
-export function fatiaDeDeploy(edge: string, raiz: string): EdgeParaDeploy {
+export function fatiaDeDeploy(edge: string, raiz: string, arvore: ArvoreDeFonte): EdgeParaDeploy {
   const entrada = `${RAIZ_EDGES}/${edge}/index.ts`;
-  if (!existsSync(resolve(raiz, entrada))) {
-    throw new Error(`edge inexistente na main: ${entrada}`);
+  if (arvore.ler(entrada) === null) {
+    throw new Error(`edge inexistente em ${arvore.rotulo}: ${entrada}`);
   }
-  const closure = fecharGrafo(entrada, raiz);
-  const arquivos = [...new Set([...closure, ARQ_MAPA])].sort();
+  const caminhos = [...new Set([...fecharGrafo(entrada, raiz, arvore), ARQ_MAPA])].sort();
+  const arquivos = caminhos.map((caminho) => {
+    const bytes = arvore.ler(caminho);
+    if (bytes === null) {
+      throw new Error(
+        `arquivo da fatia não existe em ${arvore.rotulo}: ${caminho} — a colagem nomearia um ` +
+          `arquivo que o deploy não tem como ler, e o hash sairia de lugar nenhum`,
+      );
+    }
+    return { caminho, sha256: sha256Arquivo(bytes) };
+  });
   return { edge, arquivos };
 }
 
@@ -72,11 +201,13 @@ export function lerVeredito(bruto: string): string[] {
   return selecionarParaDeploy(rel.vereditos);
 }
 
-export function main(argv: string[], raiz = process.cwd()): number {
+export function main(argv: string[], raiz = process.cwd(), git = gitBytes(raiz)): number {
   const args = argv.filter((a) => a !== '');
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+  const semRede = args.includes('--sem-rede');
+  const nomesArgs = args.filter((a) => a !== '--sem-rede');
+  if (nomesArgs.length === 0 || args.includes('--help') || args.includes('-h')) {
     process.stderr.write(
-      'uso: bun run pendencias:prompt <edge> [edge...]\n' +
+      'uso: bun run pendencias:prompt <edge> [edge...] [--sem-rede]\n' +
         '     bun run pendencias:deploy --json | bun run pendencias:prompt -\n',
     );
     return 2;
@@ -84,7 +215,9 @@ export function main(argv: string[], raiz = process.cwd()): number {
 
   let nomes: string[];
   try {
-    nomes = args.length === 1 && args[0] === '-' ? lerVeredito(readFileSync(0, 'utf8')) : args;
+    nomes = nomesArgs.length === 1 && nomesArgs[0] === '-'
+      ? lerVeredito(readFileSync(0, 'utf8'))
+      : nomesArgs;
   } catch (e) {
     process.stderr.write(`⛔ mecânica: ${(e as Error).message}\n`);
     return 2;
@@ -95,15 +228,18 @@ export function main(argv: string[], raiz = process.cwd()): number {
     return 1;
   }
 
+  let proc: Procedencia;
   let leva: EdgeParaDeploy[];
   try {
-    leva = nomes.map((n) => fatiaDeDeploy(n, raiz));
+    proc = { ref: REF_DEPLOYADA, sha: sincronizarRef(git, semRede) };
+    const arvore = arvoreDaRef(REF_DEPLOYADA, git);
+    leva = nomes.map((n) => fatiaDeDeploy(n, raiz, arvore));
   } catch (e) {
     process.stderr.write(`⛔ mecânica: ${(e as Error).message}\n`);
     return 2;
   }
 
-  const prompt = montarPrompt(leva);
+  const prompt = montarPrompt(leva, proc);
 
   // Auto-conferência: o próprio check que o histórico prescreve, aplicado à saída antes de
   // imprimi-la. Vermelho aqui é bug do gerador, não do repo — e imprimir mesmo assim entregaria
@@ -118,7 +254,9 @@ export function main(argv: string[], raiz = process.cwd()): number {
 
   const totalArquivos = leva.reduce((s, e) => s + e.arquivos.length, 0);
   process.stderr.write(
-    `✓ leva de ${leva.length} edge(s) · ${totalArquivos} arquivos · cobertura conferida\n` +
+    `✓ leva de ${leva.length} edge(s) · ${totalArquivos} arquivos · sha256 de ` +
+      `${proc.ref}@${proc.sha.slice(0, 9)}${semRede ? ' (--sem-rede: ref NÃO buscada)' : ''} · ` +
+      `cobertura conferida\n` +
       `  Cole no chat do Lovable APÓS o merge na main. Depois: bun run sonda:sql ${nomes.join(' ')}\n\n`,
   );
   process.stdout.write(`${prompt}\n`);

--- a/scripts/sonda-fingerprint.ts
+++ b/scripts/sonda-fingerprint.ts
@@ -117,23 +117,74 @@ export function extrairImportsLocais(fonte: string): string[] {
   return [...new Set(achados)];
 }
 
+/**
+ * De ONDE o fecho lê os bytes. `ler` devolve `null` quando o arquivo não existe NAQUELA árvore, e
+ * `rotulo` entra na mensagem de erro — "não resolve" tem desfechos diferentes conforme a árvore
+ * (working tree defasado ≠ import quebrado na main).
+ *
+ * ‼️ O seam existe porque `git fetch` NÃO fecha o eixo ÁRVORE: ele move `origin/main`, e
+ * `readFileSync` continua lendo o working tree, que é onde o HEAD da worktree estiver. Medido em
+ * 2026-09-04 na `enviar-pedido-portal-sayerlack` — **5** arquivos contra o disco, **7** contra a
+ * ref, e os dois que sumiram (`qtde-portal.ts`, `escrita-critica.ts`) eram exatamente os que
+ * impediam a função de bootar. Um fecho curto se PARECE com um fecho: mesma forma, mesmo formato,
+ * menos arquivos, e nada na saída denuncia. É `ausente ≠ zero` na dimensão ÁRVORE
+ * (`.claude/skills/lovable-deploy-verify/SKILL.md` §Passo 3).
+ *
+ * Quem precisa da REF pede a árvore da ref; o default continua sendo o disco, que é o certo para o
+ * GATE (ele julga o que está sendo commitado).
+ */
+export interface ArvoreDeFonte {
+  /** Como esta árvore se chama numa mensagem de erro. Ex.: `working tree`, `origin/main`. */
+  rotulo: string;
+  /** Bytes CRUS de `rel` (relativo à raiz do repo), ou `null` se não existe nesta árvore. */
+  ler(rel: string): Buffer | null;
+}
+
+/** A árvore de trabalho — o default histórico do `fecharGrafo`, agora nomeado. */
+export function arvoreDeTrabalho(raiz = process.cwd()): ArvoreDeFonte {
+  return {
+    rotulo: 'working tree',
+    ler(rel) {
+      const abs = resolve(raiz, rel);
+      return existsSync(abs) ? readFileSync(abs) : null;
+    },
+  };
+}
+
+/**
+ * SHA-256 dos bytes CRUS de UM arquivo — o mesmo número que `sha256sum <arquivo>` imprime.
+ *
+ * Não confundir com `digerir()`: aquele é o fingerprint da FATIA INTEIRA
+ * (`caminho \0 tamanho \0 bytes` encadeados, em ordem), e nenhum comando de shell o reproduz.
+ * Este aqui existe justamente para ser CONFERÍVEL DO OUTRO LADO — é o que o prompt de deploy embute
+ * para o agente do Lovable recalcular no sandbox dele antes de publicar.
+ */
+export function sha256Arquivo(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
 /** Fecho transitivo dos imports locais a partir de `entrada`. Caminhos relativos ao repo, ordenados. */
-export function fecharGrafo(entrada: string, raiz = process.cwd()): string[] {
+export function fecharGrafo(
+  entrada: string,
+  raiz = process.cwd(),
+  arvore: ArvoreDeFonte = arvoreDeTrabalho(raiz),
+): string[] {
   const vistos = new Set<string>();
   const fila = [resolve(raiz, entrada)];
   while (fila.length > 0) {
     const abs = fila.pop() as string;
     const rel = relative(raiz, abs);
     if (vistos.has(rel)) continue;
-    if (!existsSync(abs)) {
+    const bytes = arvore.ler(rel);
+    if (bytes === null) {
       throw new Error(
-        `import local que NÃO resolve: ${rel} (a partir de ${entrada}). Fail-closed: um fecho ` +
-          `incompleto produziria fingerprint que ignora arquivo servido.`,
+        `import local que NÃO resolve em ${arvore.rotulo}: ${rel} (a partir de ${entrada}). ` +
+          `Fail-closed: um fecho incompleto produziria fingerprint que ignora arquivo servido.`,
       );
     }
     if (ehTeste(rel) || rel === ARQ_MAPA) continue;
     vistos.add(rel);
-    for (const esp of extrairImportsLocais(readFileSync(abs, 'utf8'))) {
+    for (const esp of extrairImportsLocais(bytes.toString('utf8'))) {
       fila.push(resolve(dirname(abs), esp));
     }
   }


### PR DESCRIPTION
Implementa a **proposta (a)** de `docs/historico/piloto-deploy-mcp-lovable.md` §"O que fazer com isso".

## O problema, medido

O deploy de edge no Lovable sai do **sandbox** do projeto (`supabase--deploy_edge_functions`), não de um checkout limpo da `main` — e o sandbox pode estar atrasado. Com carimbo no nosso próprio git log:

```
5f5523df9 2026-08-08 00:56:48 LucasSardenbergL      | chore(ci): consolidar @supabase/supabase-js num especificador só
942a69b89 2026-08-08 00:59:24 gpt-engineer-app[bot] | Changes
aa00a3909 2026-08-08 00:59:59 gpt-engineer-app[bot] | Deployed snapshot edge func
```

2m36s após o merge o bot empurrou a linha VELHA de volta e deployou dali. Ele **commitou**, então vimos. Sem commit, `git log`, `list_edits` e `get_diff` ficariam limpos — o estado exato em que o piloto do MCP declarou "nenhuma edição registrada" — e o `fonte` da sonda bateria assim mesmo, porque ele é fingerprint **DECLARADO** (lê `FONTE_SHA256[edge]` de arquivo commitado), não hash do bundle servido. Taxa-base: o bot commita na main **171×/60 dias**.

E o prompt dizia "update it from `main`" **sem ramo que mandasse abortar**.

## O que muda

- `pendencias:prompt` emite `- \`arquivo\` — sha256 \`<hex64>\`` por arquivo da fatia, com bloco de conferência de **três** ramos: bate → deploya · difere → **não deploya** e devolve a tabela · **não conseguiu medir** → **não deploya** e diz por quê. O terceiro não é preciosismo: sem ele o `sha256sum` ausente cai em "não achei diferença", que é ausência de dado lida como aprovação (`sonda-ausente-em-script-que-apaga.md`).
- **Tudo sai de `origin/main`, nunca do working tree.** `fecharGrafo` ganha o seam `ArvoreDeFonte`; a borda usa `arvoreDaRef('origin/main')`; o `git fetch` é **do script** (ref em disco também é retrato). É o eixo **ÁRVORE** de 2026-09-04 — 5 arquivos contra o disco, 7 contra a ref, na `enviar-pedido-portal-sayerlack` —, que `git fetch` sozinho não fecha.
- `conferirCobertura` passa a exigir o **par** caminho↔hash (via `linhaDoArquivo`, renderizador único) e as marcas do ramo fail-closed. Par solto ficaria verde com os hashes **trocados** entre arquivos, e aí o agente abortaria um deploy correto.
- `montarPrompt` recusa hash malformado e procedência sem sha.

## O que isto NÃO resolve

Divergência que nasce **depois** da entrada do deploy: resolução de dependência e cache de build. `copilot-analyze/index.ts` importa `npm:@anthropic-ai/sdk@^0.93.0` e `npm:@supabase/supabase-js@2` — ranges abertos, fora do closure. Isso é a proposta (b), canária determinística com fixture, entrega separada.

## Validação

| passo | resultado |
|---|---|
| `bun run typecheck` (2 tsconfig) | exit **0** |
| `bun lint` | exit **0** (75 warnings pré-existentes em `src/`) |
| `bun run test` | **804 arquivos · 8344 passed · 1 skipped**, exit 0 |
| hashes do prompt real vs `git show origin/main:<arq> \| shasum -a 256` | **8 conferidos, 0 divergências** |

**Falsificação** — controle verde na MESMA invocação, antes do 1º `sed`; cada sabotagem exigida vermelha **na marca do ramo**, não em "lançou algo":

| sabotagem | asserção que morreu |
|---|---|
| S1 — `fatiaDeDeploy` lê o working tree | `expected [ …(3) ] to include 'supabase/functions/_shared/b.ts'` |
| S2 — só o closure volta ao disco | idem, **e** o rótulo virou `import local que NÃO resolve em working tree`; o controle "disco IGUAL à main" seguiu verde |
| S3 — `sha256Arquivo` devolve constante | `expected 'aaaa…' to be 'c074ff58…'` no controle contra o binário |

Fecho: árvore restaurada volta a 17/17 verde, `git status` limpo.

`scripts/pendencias-prompt.test.ts` é **novo**: o núcleo puro tinha 35 verdes e não alcança a fronteira de I/O, que é onde o eixo ÁRVORE mora (mesma lição do `sonda-versao-bump-gate`). Repo git de mentira em tmpdir com `origin` bare; controle positivo `sha256Arquivo` = `sha256sum`/`shasum -a 256`, que falha de propósito se nenhum binário responder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)