### PR TITLE
feat(ci): o contador que quebra o silêncio — a máquina de exclusividade anunciava "28 gates" com um bloqueante FORA da conta

### DIFF
--- a/docs/historico/custo-de-gate-medido-beneficio-nao.md
+++ b/docs/historico/custo-de-gate-medido-beneficio-nao.md
@@ -126,6 +126,73 @@ A causa é fina: `inventarioCI` filtra `continue-on-error` no **step**, e não e
 de ser informativo — o **job inteiro** ficar fora do `needs`. Quem separa agora é `jobsBloqueantes`,
 pelo fecho transitivo do grafo: derivado, não uma lista de exceções que envelhece sozinha.
 
+## O segundo sub-achado: a própria máquina tinha um gate isento, em silêncio
+
+O cabeçalho anunciava **"28 gate(s) bloqueante(s) no ci.yml"**. O número lia como cobertura total —
+e não era. A lista de gates vem de `gatesCandidatos` → `inventarioCI`, que só reconhece step que
+invoca **script do `package.json`** (`bun run x`, `bunx x`, `bun x`). Step bloqueante escrito em
+shell puro passa direto.
+
+Não é hipótese. O #2364 acrescentou `run: bash db/roda-nucleo-ci.sh` ao `ci.yml`, num job dentro de
+`validate.needs`. Medido depois do merge:
+
+```
+bun -e "import {gatesCandidatos} from './scripts/lib/exclusividade.ts';
+import {readFileSync} from 'node:fs';
+const g=gatesCandidatos(readFileSync('.github/workflows/ci.yml','utf8'));
+console.log(g.length, g.some(x=>/nucleo/.test(x.nome)));"
+# -> 30 false
+```
+
+A máquina que cobra de todo gate novo a prova de contribuição exclusiva tinha, ela própria, um gate
+novo bloqueante **isento e calado**.
+
+### O remédio, e o que ele deliberadamente NÃO faz
+
+O gate passou a imprimir um segundo contador, ao lado do de informativos:
+
+```
+   3 step(s) bloqueante(s) FORA da conta por nao invocarem script (sem nome de comando, ...):
+     - gates-e-falsificacao: shellcheck pinado 0.11.0 (o runner traz 0.9.0)
+       $ ver=v0.11.0
+     - provas-sql: PostgreSQL 17 (PGDG) — instala e confere a versão
+       $ if [ ! -x /usr/lib/postgresql/17/bin/initdb ]; then
+     - provas-sql: Núcleo de provas SQL executadas (db/nucleo-ci.txt)
+       $ bash db/roda-nucleo-ci.sh
+```
+
+Isso **não fecha a lacuna** — fecha o **silêncio**, que era o que fazia o número mentir. É o mesmo
+remédio, e pelo mesmo motivo, do `bloqueantesSemScript` do `gates:frescura`: *exclusão silenciosa lê
+como cobertura total*.
+
+Cobrar de fato desses steps (dar-lhes identidade e incluí-los em `gatesCandidatos`) foi considerado
+e **adiado com motivo medido**, não por preguiça: o motor de medição executa cada gate com
+`spawnSync('bun', ['run', <nome>])`. Sem nome de script **não há o que invocar** — cobrar exigiria
+um segundo executor, e no caso do núcleo SQL um PostgreSQL 17 na máquina que mede. Passar a cobrar
+sem poder medir só teria dois desfechos: reprovar o CI de imediato, ou uma linha nova em
+`dispensados`. Dívida declarada trocada por dívida declarada, com um executor a mais para manter.
+Fica para quando o contador mostrar que a lacuna cresceu.
+
+### Duas decisões finas
+
+**O contador é mais estreito que o do frescura, de propósito.** O do frescura conta todo step sem
+script (5 hoje); este só conta os de job alcançável a partir de `validate.needs` (3). O
+`authz-sentinela` aparece lá e não aqui — certo nos dois: lá o eixo é *"reprova alguma coisa"*, aqui
+é *"reprova o PR"*. Este arquivo tem o grafo de `needs`; o `gates:frescura` não.
+
+**A regra de "tem nome de comando" agora é uma só.** Censo e contador têm de **particionar** os
+steps bloqueantes: se cada ponta usasse sua própria regra, um step poderia cair na fresta e sumir
+das **duas** listas — o silêncio de volta, agora com dois números lhe dando cobertura. Os três
+regexes viraram `nomesDeScript()` em `gates-frescura-check.ts`, usada pelas duas pontas, e a
+partição é asserida contra o `ci.yml` de verdade (nenhum step nas duas listas, nenhum em nenhuma).
+O `bloqueantesSemScript` usava uma aproximação diferente (`/\bbunx?\s+(?:run\s+)?[a-z]/`) que hoje
+concordava — passou a usar a mesma função, e a lista dele não mudou.
+
+Fica anotada uma fresta **latente**: o job `validate` não está no próprio `needs`, então nem
+`bloqueiaPR` nem o contador o alcançam. Hoje não esconde nada — seus únicos steps são o agregador e
+os de Issue. Remendar só o contador faria as duas contas falarem de universos diferentes, que é
+pior que a fresta.
+
 ## O bootstrap tem um nó, e ele é honesto
 
 Um gate novo reprova por falta de medição; a medição exige baseline verde; o baseline inclui o

--- a/scripts/exclusividade-gate.test.ts
+++ b/scripts/exclusividade-gate.test.ts
@@ -13,10 +13,12 @@
 import { readFileSync, readdirSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 import {
   CORPUS_DIR,
   avaliar,
+  bloqueantesOpacos,
   derivar,
   fingerprintDefeito,
   fonteDoGate,
@@ -24,11 +26,13 @@ import {
   gatesCandidatos,
   jobsBloqueantes,
   parseDefeitos,
+  primeiraLinhaComCarne,
   resumir,
   type GateAlvo,
   type LinhaMatriz,
   type Matriz,
 } from './lib/exclusividade';
+import { nomesDeScript } from './gates-frescura-check';
 
 const linha = (over: Partial<LinhaMatriz> = {}): LinhaMatriz => ({
   defeito: 'd1',
@@ -119,6 +123,85 @@ describe('jobsBloqueantes — o que de fato reprova um PR', () => {
     for (const j of ['typecheck', 'testes', 'edges-e-build', 'gates-e-falsificacao']) {
       expect(b.has(j), `${j} deveria bloquear`).toBe(true);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// O contador de opacos — o que o numero "N gate(s) bloqueante(s)" estava escondendo
+// ---------------------------------------------------------------------------------------------
+
+describe('bloqueantesOpacos — exclusao silenciosa le como cobertura total', () => {
+  const ci = readFileSync('.github/workflows/ci.yml', 'utf8');
+  const yml = (jobs: string) => `jobs:\n${jobs}\n  validate:\n    needs: [j]`;
+
+  it('step bloqueante SEM nome de script aparece', () => {
+    const y = yml("  j:\n    steps:\n      - name: nucleo\n        run: bash db/roda-nucleo-ci.sh");
+    expect(bloqueantesOpacos(y)).toEqual([{ job: 'j', step: 'nucleo', comando: 'bash db/roda-nucleo-ci.sh' }]);
+  });
+
+  it('step COM nome de script nao aparece — ele ja e cobrado pelo censo', () => {
+    const y = yml("  j:\n    steps:\n      - name: t\n        run: bun run test");
+    expect(bloqueantesOpacos(y)).toEqual([]);
+  });
+
+  it('continue-on-error nao aparece — informativo por desenho nao e lacuna', () => {
+    const y = yml("  j:\n    steps:\n      - name: aviso\n        continue-on-error: true\n        run: bash x.sh");
+    expect(bloqueantesOpacos(y)).toEqual([]);
+  });
+
+  // O eixo aqui e "reprova o PR", nao "reprova alguma coisa" — e o que separa este contador do
+  // `bloqueantesSemScript` do gates:frescura, que nao tem o grafo de `needs` e por isso lista
+  // tambem o `authz-sentinela`. Os dois estao certos, em eixos diferentes.
+  it('step de job FORA de validate.needs nao aparece', () => {
+    const y = `jobs:\n  solto:\n    steps:\n      - name: x\n        run: bash x.sh\n  j: {}\n  validate:\n    needs: [j]`;
+    expect(bloqueantesOpacos(y)).toEqual([]);
+    expect(bloqueantesOpacos(ci).some((o) => o.job === 'authz-sentinela')).toBe(false);
+  });
+
+  // A REGRESSAO que originou tudo: o #2364 pos `bash db/roda-nucleo-ci.sh` num job bloqueante e
+  // `gatesCandidatos` nao o viu — o cabecalho seguiu dizendo "28 gate(s)" e ninguem soube.
+  it('o ci.yml de VERDADE: o nucleo SQL do #2364 esta fora do censo e DENTRO do contador', () => {
+    expect(gatesCandidatos(ci).some((g) => /nucleo/.test(g.nome)), 'o censo nao o nomeia').toBe(false);
+    const nucleo = bloqueantesOpacos(ci).find((o) => o.comando.includes('roda-nucleo-ci.sh'));
+    expect(nucleo, 'o contador tem de ve-lo').toBeDefined();
+    expect(nucleo!.job).toBe('provas-sql');
+  });
+
+  // A invariante que impede a FRESTA: censo e contador tem de PARTICIONAR os steps bloqueantes.
+  // Se as duas pontas usassem regras diferentes para "tem nome de comando", um step poderia sumir
+  // das DUAS listas — e aí o silencio voltaria, agora com dois numeros para dar-lhe cobertura.
+  it('todo step bloqueante com `run` cai em EXATAMENTE uma das duas listas', () => {
+    const doc = parse(ci) as { jobs?: Record<string, { steps?: unknown[] }> };
+    const bloq = jobsBloqueantes(ci);
+    const opacos = new Set(bloqueantesOpacos(ci).map((o) => `${o.job}\u0000${o.step}`));
+    let vistos = 0;
+
+    for (const [job, corpo] of Object.entries(doc.jobs ?? {})) {
+      if (!bloq.has(job)) continue;
+      for (const bruto of corpo?.steps ?? []) {
+        const st = bruto as { name?: string; run?: unknown; 'continue-on-error'?: unknown };
+        if (typeof st.run !== 'string' || st['continue-on-error'] === true) continue;
+        vistos++;
+        const chave = `${job}\u0000${st.name ?? '(sem nome)'}`;
+        const noCenso = nomesDeScript(st.run).size > 0;
+        expect(noCenso !== opacos.has(chave), `${chave} caiu nas duas listas ou em nenhuma`).toBe(true);
+      }
+    }
+    expect(vistos, 'a varredura tem de ter olhado steps de verdade').toBeGreaterThan(10);
+  });
+});
+
+describe('primeiraLinhaComCarne', () => {
+  it('pula vazio, comentario e prologo de shell', () => {
+    expect(primeiraLinhaComCarne('\n# comenta\nset -euo pipefail\nexport A=1\nbash x.sh')).toBe('bash x.sh');
+  });
+
+  it('so prologo devolve o prologo, nunca string vazia (presenca > silencio)', () => {
+    expect(primeiraLinhaComCarne('set -euo pipefail')).toBe('set -euo pipefail');
+  });
+
+  it('trunca com reticencia dentro do limite', () => {
+    expect(primeiraLinhaComCarne('bash '.repeat(30), 20)).toBe('bash bash bash ba...');
   });
 });
 

--- a/scripts/exclusividade-gate.ts
+++ b/scripts/exclusividade-gate.ts
@@ -27,6 +27,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import {
   MATRIZ_PATH,
   avaliar,
+  bloqueantesOpacos,
   derivar,
   fingerprintGate,
   fonteDoGate,
@@ -64,9 +65,10 @@ function main(): number {
   );
 
   const vereditos: Veredito[] = avaliar(matriz, gates, fps);
+  const opacos = bloqueantesOpacos(fonteCI);
 
   if (comoJson) {
-    console.log(JSON.stringify({ vereditos, matrizPresente: matriz !== null }, null, 2));
+    console.log(JSON.stringify({ vereditos, opacos, matrizPresente: matriz !== null }, null, 2));
     return vereditos.some((v) => v.severidade === 'REPROVA') ? 1 : 0;
   }
 
@@ -91,6 +93,16 @@ function main(): number {
   if (informativos.length) {
     console.log(`   (fora da conta, informativos por desenho: ${informativos.map((g) => g.nome).join(', ')})`);
   }
+  // O segundo contador, e o que MAIS importa: estes bloqueiam o PR e nao aparecem no numero acima,
+  // porque nao ha nome de script para cobrar. Sem esta linha, "N gate(s) bloqueante(s)" le como
+  // cobertura total — e foi assim que `bash db/roda-nucleo-ci.sh` (#2364) entrou isento e calado.
+  console.log(
+    `   ${opacos.length} step(s) bloqueante(s) FORA da conta por nao invocarem script ` +
+      `(sem nome de comando, o motor nao sabe roda-los):` +
+      (opacos.length
+        ? `\n${opacos.map((o) => `     - ${o.job}: ${o.step}\n       $ ${o.comando}`).join('\n')}`
+        : ' (nenhum)'),
+  );
 
   const ordem = { REPROVA: 0, AVISA: 1, RELATA: 2 } as const;
   for (const v of [...vereditos].sort((a, b) => ordem[a.severidade] - ordem[b.severidade])) {

--- a/scripts/gates-frescura-check.ts
+++ b/scripts/gates-frescura-check.ts
@@ -165,6 +165,22 @@ export interface GateCI {
 }
 
 /**
+ * Nomes de script (`package.json`) que um `run:` invoca. É a ÚNICA definição de "este step tem
+ * nome de comando" no repo, de propósito: `inventarioCI` a usa para incluir, e
+ * `bloqueantesSemScript` (aqui) e `bloqueantesOpacos` (na máquina de exclusividade) a usam para o
+ * complemento — contar quem ficou de fora. Se as duas pontas usassem regras diferentes, um step
+ * poderia cair na fresta e sumir das DUAS listas, que é exatamente o silêncio que os contadores
+ * existem para quebrar.
+ */
+export function nomesDeScript(run: string): Set<string> {
+  const nomes = new Set<string>();
+  for (const m of run.matchAll(/\bbunx?\s+run\s+([a-zA-Z0-9:_.-]+)/g)) nomes.add(m[1]);
+  for (const m of run.matchAll(/\bbunx\s+(?!run\b)([a-z][a-zA-Z0-9_.-]*)/g)) nomes.add(m[1]);
+  for (const m of run.matchAll(/\bbun\s+(?!run\b|x\b)([a-z][a-zA-Z0-9_-]*)/g)) nomes.add(m[1]);
+  return nomes;
+}
+
+/**
  * Todo step com `run` que invoca um script e NÃO carrega `continue-on-error: true`.
  * O YAML é lido por parser (`yaml`), nunca por regex: `continue-on-error` é a diferença entre
  * bloqueio e aviso, e errá-la nos dois sentidos (acusar ruído / aprovar buraco) desliga o gate.
@@ -180,10 +196,7 @@ export function inventarioCI(fonte: string): GateCI[] {
       if (typeof st.run !== 'string') continue;
       if (st['continue-on-error'] === true) continue;
 
-      const nomes = new Set<string>();
-      for (const m of st.run.matchAll(/\bbunx?\s+run\s+([a-zA-Z0-9:_.-]+)/g)) nomes.add(m[1]);
-      for (const m of st.run.matchAll(/\bbunx\s+(?!run\b)([a-z][a-zA-Z0-9_.-]*)/g)) nomes.add(m[1]);
-      for (const m of st.run.matchAll(/\bbun\s+(?!run\b|x\b)([a-z][a-zA-Z0-9_-]*)/g)) nomes.add(m[1]);
+      const nomes = nomesDeScript(st.run);
 
       const alvo = st.name ? `name: ${st.name}` : st.run.split('\n')[0].trim();
       const idx = linhas.findIndex((l) => l.includes(alvo));
@@ -215,7 +228,7 @@ export function bloqueantesSemScript(fonte: string): string[] {
     for (const bruto of corpo?.steps ?? []) {
       const st = bruto as { name?: string; run?: unknown; 'continue-on-error'?: unknown };
       if (typeof st.run !== 'string' || st['continue-on-error'] === true) continue;
-      if (/\bbunx?\s+(?:run\s+)?[a-z]/.test(st.run)) continue;
+      if (nomesDeScript(st.run).size > 0) continue;
       saida.push(`${job}: ${st.name ?? '(sem nome)'}`);
     }
   }

--- a/scripts/lib/exclusividade.ts
+++ b/scripts/lib/exclusividade.ts
@@ -36,7 +36,7 @@ import { existsSync, readFileSync } from 'node:fs';
 
 import { parse } from 'yaml';
 
-import { inventarioCI, type GateCI } from '../gates-frescura-check';
+import { inventarioCI, nomesDeScript, type GateCI } from '../gates-frescura-check';
 
 export const MATRIZ_PATH = 'scripts/exclusividade-matriz.json';
 export const CORPUS_DIR = 'scripts/exclusividade.d';
@@ -135,6 +135,73 @@ export function jobsBloqueantes(fonteCI: string): Set<string> {
 export function gatesCandidatos(fonteCI: string): GateAlvo[] {
   const bloq = jobsBloqueantes(fonteCI);
   return inventarioCI(fonteCI).map((g) => ({ ...g, bloqueiaPR: bloq.has(g.job) }));
+}
+
+export interface StepOpaco {
+  job: string;
+  step: string;
+  /** 1a linha COM CARNE do `run:`, truncada — o que ele executa, ja que nome ele nao tem. */
+  comando: string;
+}
+
+/**
+ * Steps que BLOQUEIAM o PR e que `gatesCandidatos` nao consegue nomear, porque nao invocam script
+ * do `package.json`. E o COMPLEMENTO exato do censo: mesma fonte, mesmo filtro de
+ * `continue-on-error`, mesmo `nomesDeScript` — o que sobra aqui e precisamente o que faltou la.
+ *
+ * ## Por que isto existe (a lacuna era medida, nao hipotetica)
+ *
+ * O #2364 acrescentou `run: bash db/roda-nucleo-ci.sh` ao `ci.yml`: um gate bloqueante REAL, em
+ * shell puro. `gatesCandidatos` nao o ve — e o cabecalho seguia anunciando "28 gate(s)
+ * bloqueante(s)", numero que le como cobertura TOTAL. Ou seja, a maquina que cobra prova de
+ * exclusividade de todo gate novo tinha, ela propria, um gate novo isento em silencio.
+ *
+ * Contar em voz alta nao fecha a lacuna — o motor de medicao invoca `bun run <nome>`, e sem nome
+ * de script nao ha o que invocar. Fecha o SILENCIO, que e o que fazia o numero mentir. Mesmo
+ * remedio, e pelo mesmo motivo, do `bloqueantesSemScript` do `gates:frescura`.
+ *
+ * ## Onde este contador e MAIS estreito que o do frescura, de proposito
+ *
+ * O do frescura conta todo step sem script; este so conta os de job alcancavel a partir de
+ * `validate.needs`. `authz-sentinela` aparece la e nao aqui — e certo nos dois: la o eixo e
+ * "reprova alguma coisa", aqui e "reprova o PR". Este arquivo tem o grafo de `needs`; o frescura
+ * nao.
+ *
+ * O job `validate` fica fora por consequencia: ele nao esta no proprio `needs`. Hoje nao esconde
+ * nada (seus unicos steps sao o agregador e os de Issue), mas e uma fresta latente — vale um
+ * arquivo proprio, nao um remendo local que faria o contador e `bloqueiaPR` falarem de universos
+ * diferentes.
+ */
+/**
+ * A 1a linha do `run:` que de fato EXECUTA algo. Pula vazio, comentario e prologo (`set -euo
+ * pipefail`, `shopt`, `export`), que sao 100% dos primeiros-linhas dos steps opacos de hoje: sem
+ * este filtro o contador imprimia `$ set -euo pipefail` tres vezes, que e presenca sem informacao
+ * — a mesma doenca, um andar abaixo, do numero que se queria consertar.
+ */
+export function primeiraLinhaComCarne(run: string, limite = 60): string {
+  const carne = run
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l && !l.startsWith('#') && !/^(?:set|shopt|export|umask)\s/.test(l));
+  const escolhida = carne ?? run.split('\n').find((l) => l.trim())?.trim() ?? '';
+  return escolhida.length > limite ? `${escolhida.slice(0, limite - 3)}...` : escolhida;
+}
+
+export function bloqueantesOpacos(fonteCI: string): StepOpaco[] {
+  const doc = parse(fonteCI) as { jobs?: Record<string, { steps?: unknown[] }> };
+  const bloq = jobsBloqueantes(fonteCI);
+  const saida: StepOpaco[] = [];
+
+  for (const [job, corpo] of Object.entries(doc.jobs ?? {})) {
+    if (!bloq.has(job)) continue;
+    for (const bruto of corpo?.steps ?? []) {
+      const st = bruto as { name?: string; run?: unknown; 'continue-on-error'?: unknown };
+      if (typeof st.run !== 'string' || st['continue-on-error'] === true) continue;
+      if (nomesDeScript(st.run).size > 0) continue;
+      saida.push({ job, step: st.name ?? '(sem nome)', comando: primeiraLinhaComCarne(st.run) });
+    }
+  }
+  return saida;
 }
 
 // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## O achado, medido e não hipotético

`bun run exclusividade` abria com **"28 gate(s) bloqueante(s) no ci.yml"**. O número lia como cobertura total — e não era. A lista vem de `gatesCandidatos` → `inventarioCI`, que **só reconhece step que invoca script do `package.json`** (`bun run x`, `bunx x`, `bun x`). Step bloqueante escrito em shell puro passa direto.

O #2364 pôs `run: bash db/roda-nucleo-ci.sh` num job dentro de `validate.needs`. Conferido depois do merge:

```
bun -e "import {gatesCandidatos} from './scripts/lib/exclusividade.ts';
import {readFileSync} from 'node:fs';
const g=gatesCandidatos(readFileSync('.github/workflows/ci.yml','utf8'));
console.log(g.length, g.some(x=>/nucleo/.test(x.nome)));"
# -> 30 false
```

A máquina que cobra de todo gate novo a prova de contribuição exclusiva tinha, ela própria, um gate novo bloqueante **isento e calado**.

## Caminho escolhido: (a) — o contador visível

```
exclusividade — 28 gate(s) bloqueante(s) no ci.yml, matriz com 8 defeito(s) medida em 2026-09-08
   (fora da conta, informativos por desenho: mutcheck, mutcheck:selftest)
   3 step(s) bloqueante(s) FORA da conta por nao invocarem script (sem nome de comando, ...):
     - gates-e-falsificacao: shellcheck pinado 0.11.0 (o runner traz 0.9.0)
       $ ver=v0.11.0
     - provas-sql: PostgreSQL 17 (PGDG) — instala e confere a versão
       $ if [ ! -x /usr/lib/postgresql/17/bin/initdb ]; then
     - provas-sql: Núcleo de provas SQL executadas (db/nucleo-ci.txt)
       $ bash db/roda-nucleo-ci.sh
```

Isso **não fecha a lacuna** — fecha o **silêncio**, que era o que fazia o número mentir. Mesmo remédio, e pelo mesmo motivo, do `bloqueantesSemScript` do `gates:frescura`. O contador imprime a 1ª linha **com carne** do `run:` (pula `set -euo pipefail`): sem esse filtro, três dos três apareciam como `$ set -euo pipefail` — presença sem informação, a mesma doença um andar abaixo.

### Por que (b) foi adiado, com motivo medido

O motor de medição executa cada gate com `spawnSync('bun', ['run', <nome>])` ([exclusividade-medir.ts:114](scripts/exclusividade-medir.ts:114)). **Sem nome de script não há o que invocar** — cobrar exigiria um segundo executor e, no caso do núcleo SQL, um PostgreSQL 17 na máquina que mede. Passar a cobrar sem poder medir teria só dois desfechos: reprovar o CI de imediato, ou uma linha nova em `dispensados`. Dívida declarada trocada por dívida declarada, com um executor a mais para manter. Fica para quando o contador mostrar que a lacuna cresceu — que é exatamente o que ele agora permite ver.

## Duas decisões finas

**O contador é mais estreito que o do frescura, de propósito.** O do frescura conta todo step sem script (5); este só os de job alcançável a partir de `validate.needs` (3). `authz-sentinela` aparece lá e não aqui — certo nos dois: lá o eixo é *"reprova alguma coisa"*, aqui é *"reprova o PR"*. Este arquivo tem o grafo de `needs`; o frescura não.

**A regra de "tem nome de comando" virou UMA só.** Censo e contador precisam **particionar** os steps bloqueantes: com duas regras, um step poderia cair na fresta e sumir das **duas** listas — o silêncio de volta, agora com dois números lhe dando cobertura. Os três regexes viraram `nomesDeScript()` em [gates-frescura-check.ts](scripts/gates-frescura-check.ts), usada pelas duas pontas. `bloqueantesSemScript` usava a aproximação `/\bbunx?\s+(?:run\s+)?[a-z]/`, que hoje concordava; passou a usar a mesma função e **a lista dele não mudou** (conferido por diff antes/depois).

Fica anotada uma fresta **latente**: o job `validate` não está no próprio `needs`, então nem `bloqueiaPR` nem o contador o alcançam. Hoje não esconde nada (agregador + steps de Issue). Remendar só o contador faria as duas contas falarem de universos diferentes, que é pior que a fresta.

## Verificação (evidência positiva, exit colado)

| comando | exit |
|---|---|
| `bun run exclusividade` | **0** |
| `bun run gates:frescura` | **0** (lista de opacos idêntica à de antes) |
| `bun run lint` | **0** (75 warnings pré-existentes) |
| `bun run typecheck` | **0** |
| `bunx vitest run scripts/exclusividade-gate.test.ts` | **0** — 46 passed (37 antes + 9 novos) |

### Falsificação — 4 camadas, uma por vez, controle verde na mesma invocação

```
CONTROLE-VERDE: 46 passed antes da 1a sabotagem
VERMELHO-CERTO [sem filtro de job bloqueante]: falhou em "step de job FORA de validate.needs nao aparece"
VERMELHO-CERTO [inverte o filtro de script (some com os opacos)]: falhou em "o ci.yml de VERDADE"
VERMELHO-CERTO [regra PROPRIA em vez da compartilhada (fresta entre as duas listas)]: falhou em "cai em EXATAMENTE uma das duas listas"
VERMELHO-CERTO [nao pula prologo de shell]: falhou em "pula vazio, comentario e prologo de shell"
RESTAURADO: 0 alteracao(oes) pendente(s) no alvo
```

A 3ª é a que importa mais: prova que o teste de partição **de fato** pega a fresta entre as duas listas — o motivo de existir do `nomesDeScript` compartilhado. O script aborta antes do 1º `sed` se o controle não estiver verde, e casa o **nome do teste**, não "falhou algo".

Registro em [docs/historico/custo-de-gate-medido-beneficio-nao.md](docs/historico/custo-de-gate-medido-beneficio-nao.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Chips abertos no `/fecho` desta sessão (prompt durável)

Chip é destino perecível — morre com a sessão. Os prompts ficam aqui para sobreviverem ao arquivamento.

<details>
<summary><b>1. "Fechar a fresta do job validate em jobsBloqueantes"</b> — fresta latente que este PR deliberadamente não remendou</summary>

`jobsBloqueantes()` em `scripts/lib/exclusividade.ts` calcula o fecho transitivo de `validate.needs` mas **não inclui o próprio job `validate`**. Consequência: um step dentro de `validate` fica invisível para as duas contas — nem `gatesCandidatos()` o marca `bloqueiaPR: true` (nunca é cobrado pela prova de exclusividade), nem `bloqueantesOpacos()` o lista no contador deste PR.

Hoje **não esconde nada**, conferido: o job `validate` (`.github/workflows/ci.yml:827`) tem só o step agregador "Todos os jobs passaram?" e steps de Issue via `actions/github-script` (sem `run:`). É fresta **latente**.

O que fazer: (1) decidir se `validate` entra em `jobsBloqueantes()` — ele É o required check do auto-merge, então semanticamente bloqueia o PR; é uma linha. (2) Se entrar, atualizar os testes de `scripts/exclusividade-gate.test.ts` que asseguram `toEqual(['a','b'])` (~l.98) e o de `needs` como string (~l.103). (3) Conferir que o número de bloqueantes não muda (hoje 28) e decidir se o ruído de 1 linha no contador ("validate: Todos os jobs passaram?") vale a proteção — ou se o agregador merece filtro **nomeado e documentado**, nunca silencioso.

Por que ficou fora deste PR: remendar só o contador faria ele e `bloqueiaPR` falarem de universos diferentes, que é pior que a fresta.

Verificação: `bun run exclusividade`, `bun run gates:frescura`, `bunx vitest run scripts/exclusividade-gate.test.ts` (46 testes após este PR). Falsificar sabotando e exigindo vermelho no ramo certo, com controle verde na mesma invocação.
</details>

<details>
<summary><b>2. "Corrigir o passo 5 do /fecho: lê o run, não o validate"</b> — achado do próprio fecho desta sessão</summary>

O passo 5 de `.claude/skills/fecho/SKILL.md` lê o `conclusion` do RUN inteiro do CI e trata `failure` como "investigue antes de fechar". Medido em 2026-09-08: o run `34215435046` (workflow_dispatch na main) veio `conclusion=failure`, mas

```
failure  mutation-check     <- informativo POR DESENHO (fora de validate.needs, abre Issue desde #2344)
success  validate           <- o required check do auto-merge
success  typecheck / testes / edges-e-build / gates-e-falsificacao / provas-sql / authz-sentinela
```

A main estava verde no eixo que bloqueia. Como o `mutation-check` é informativo desde o #2344, **todo** `/fecho` numa janela com mutcheck vermelho lê "main quebrada" sobre main verde — e o custo real não é a investigação perdida, é ensinar a ignorar o vermelho seguinte.

O que fazer: (1) ler o job `validate` (`gh run view <id> --json jobs --jq '.jobs[]|select(.name=="validate")|.conclusion'`) em vez do `conclusion` do run — o eixo já está derivado em `jobsBloqueantes()`, considere reusar. (2) Preservar os TRÊS ramos (`success`/`failure`/resto) que a skill já exige. (3) **Não silenciar** o informativo vermelho — ele continua no relatório com a severidade certa; exclusão silenciosa é a mesma classe que este PR consertou. (4) Registrar em `docs/historico/` (irmã de `ci-validate-timeout-15min.md`).

Verificação: passo 5 corrigido deve dar VERDE no run `34215435046` (com o `mutation-check` relatado, não escondido) e VERMELHO num run realmente quebrado.
</details>
