### PR TITLE
refactor(ci): a auditoria do repo real sai do vitest — mas a duplicata do índice só saiu PELA METADE (a guarda anti-vácuo pega o órfão por igualdade de conjunto)

### DIFF
--- a/docs/historico/custo-de-gate-medido-beneficio-nao.md
+++ b/docs/historico/custo-de-gate-medido-beneficio-nao.md
@@ -80,7 +80,7 @@ para prever o CI (`medir-ganho-de-ci-sob-ruido.md`: o runner varia 45%).
 | `docs:links` | **1**/7 | 2 | 903ms | só ele pega link quebrado FORA de índice |
 | `exclusividade` | **1**/7 | 1 | 245ms | só ele lê a matriz — nenhum outro gate a enxerga |
 | `gates:frescura` | **1**/7 | 1 | 419ms | só ele pega gate que sumiu do censo |
-| `docs:indice` | **0**/7 | 2 | 58ms | **redundante — ver abaixo** |
+| `docs:indice` | **0**/7 | 2 | 58ms | zero **por CÓPIA**, e a cópia só saiu pela metade — ver abaixo |
 | `test` (vitest) | 0/7 | 2 | 128s | `[s/ mira]`: nenhum defeito foi escrito para ele |
 | `docs:citacoes` | 0/7 | 0 | 3,8s | `[s/ mira]`: idem — e é o mais caro dos "baratos" |
 
@@ -101,8 +101,53 @@ quebrou, na hora. Cortar a asserção do vitest tira a mesma detecção de dentr
 onde ela chega ao autor no meio de 800 arquivos.
 
 **A recomendação é manter o step e retirar a duplicata do vitest** — o inverso do que "o step é
-redundante" sugeriria. O corte em si não foi executado: é decisão de produto, e a evidência está
-na matriz.
+redundante" sugeriria.
+
+#### O corte foi executado — e a duplicação NÃO saiu inteira
+
+A asserção que auditava o repo de ponta a ponta dentro do vitest
+(`auditarIndices(lerDiretoriosIndexados())`) saiu. Remedindo `indice-orfao` logo depois:
+
+```
+defeito indice-orfao
+  VERMELHO docs:indice (363ms)
+  VERMELHO test (687061ms)      <- continuou pegando
+[redund]  docs:indice  exclusivos 0/8 - pegou 2
+```
+
+`docs:indice` segue com exclusivo ZERO. O corte acertou o alvo — o step continua vermelho, então
+não foi ele que se perdeu —, mas a detecção do órfão **sobrevive noutro lugar do mesmo arquivo**:
+a guarda anti-vácuo `cada índice real tem exatamente uma entrada por doc do diretório`. Sabotando
+o repo e rodando só aquele arquivo (controle verde de 34 na mesma invocação), o vermelho é único e
+tem nome:
+
+```
+× o repo de verdade > cada índice real tem exatamente uma entrada por doc do diretório
+  Tests  1 failed | 33 passed (34)
+```
+
+As outras duas guardas do bloco ficaram VERDES sob o defeito — elas são cegas ao órfão, anti-vácuo
+de verdade. A duplicação está inteira num `expect` só.
+
+**A lição é sobre o formato da asserção, não sobre o gate.** A guarda declara, no próprio
+comentário, proteger as invariantes 3/4/5 de um parse que devolvesse `[]`. Mas ela foi escrita como
+IGUALDADE DE CONJUNTO entre as entradas do índice e os arquivos do diretório — e igualdade de
+conjunto *é* a invariante do órfão. A implementação excede o contrato declarado, e o excedente é
+exatamente a parte que duplica o step. Uma guarda fiel ao que ela diz proteger cobraria *volume* de
+entradas ("o parse não morreu"), não *identidade* com a lista de arquivos.
+
+Estreitá-la é decisão em aberto, e deliberadamente não tomada aqui: enfraquecer uma rede anti-vácuo
+para ganhar 0 exclusivo é caro pelo lado errado. Fica medido para quem decidir.
+
+#### Cuidado ao ler a coluna `mediana` desta remedição
+
+O `test` acima aparece com 687s, contra os 128s da primeira medição — a mesma máquina sob swap
+(~30 sessões vivas na M2 8GB), não uma regressão do gate. O baseline saltou de 215s para 468s no
+mesmo intervalo. **O eixo VERDE/VERMELHO atravessou a carga sem se mexer; o eixo do TEMPO variou
+5×** — bem além dos 45% de ruído de runner que `medir-ganho-de-ci-sob-ruido.md` registra. A matriz
+guarda `medidoEm`/`sourceHead` GLOBAIS, mas a remedição é PARCIAL por desenho (`--defeitos`/
+`--gates` reescrevem só as células pedidas): logo, medianas de células diferentes podem vir de
+máquinas e cargas diferentes, e não são comparáveis entre si.
 
 A sobreposição parcial com `docs:links` que o Codex também anotou está medida na segunda linha:
 os dois pegam o alvo-fantasma, mas só `docs:links` pega o link quebrado fora de um índice. As

--- a/scripts/docs-indice-gate-check.test.ts
+++ b/scripts/docs-indice-gate-check.test.ts
@@ -262,10 +262,11 @@ describe('lerDiretoriosIndexados — descoberta', () => {
 });
 
 describe('o repo de verdade', () => {
-  it('os índices REAIS do repo passam no gate', () => {
-    const achados = auditarIndices(lerDiretoriosIndexados());
-    expect(achados, `gate vermelho no repo: ${msgs(achados)}`).toHaveLength(0);
-  });
+  // A auditoria de ponta a ponta do repo real (`auditarIndices(lerDiretoriosIndexados())`) NÃO mora
+  // aqui: ela é o step `docs:indice` do CI. Medido em #2366, o exclusivo dos dois era ZERO um por
+  // causa do outro — e entre um step de 58ms que diz na hora o que quebrou e a mesma detecção no
+  // fim de um vitest de 128s, quem sai é a cópia lenta. O que fica abaixo são as guardas
+  // ANTI-VÁCUO, que o step não tem como fazer por si: elas vigiam o próprio gate, não o repo.
 
   // ⚠️ Guarda ANTI-VÁCUO. Sem ela, um glob que para de casar (ou um `docs/` renomeado) faz o gate
   // acima passar por não achar NADA — "verde por ausência de dado", a mesma família do "glob de

--- a/scripts/exclusividade-matriz.json
+++ b/scripts/exclusividade-matriz.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "medidoEm": "2026-09-08T01:45:24.393Z",
-  "sourceHead": "97a0eda93643a5c74566ac9160d21d79ee0ae597",
+  "medidoEm": "2026-09-08T09:32:20.005Z",
+  "sourceHead": "fe40aaa4dbbbca4bc09e4eea9a8b57c449f26257",
   "dispensados": [
     {
       "gate": "authz:carimbo",
@@ -123,7 +123,7 @@
     {
       "gate": "docs:indice",
       "verde": true,
-      "ms": 56
+      "ms": 99
     },
     {
       "gate": "docs:links",
@@ -153,7 +153,7 @@
     {
       "gate": "test",
       "verde": true,
-      "ms": 215527
+      "ms": 468349
     },
     {
       "gate": "tsc",
@@ -433,7 +433,7 @@
         {
           "gate": "docs:indice",
           "reprovou": true,
-          "ms": 182,
+          "ms": 363,
           "fingerprint": "a41d30136cdb032d",
           "fonteResolvida": true
         },
@@ -461,7 +461,7 @@
         {
           "gate": "test",
           "reprovou": true,
-          "ms": 128437,
+          "ms": 687061,
           "fingerprint": "ad6cd6b8acf39571",
           "fonteResolvida": false
         }


### PR DESCRIPTION
## O que foi feito

O #2366 mediu que `docs:indice` (step de 58ms) e o bloco `o repo de verdade` do vitest (128s)
pegam **os mesmos defeitos** no **mesmo repositório real**. Decisão tomada: manter o step, retirar
a duplicata de dentro do vitest — o step diz o que quebrou na hora, a cópia chega ao autor no fim
de um gate de 128s, no meio de 800 arquivos.

Removida **apenas** a asserção que auditava o repo de ponta a ponta
(`auditarIndices(lerDiretoriosIndexados())`). As **três guardas anti-vácuo do bloco ficaram**.

## O resultado contraria a previsão — e isso é o achado

```
defeito indice-orfao
  VERMELHO docs:indice (363ms)
  VERMELHO test (687061ms)      <- continuou pegando
[redund]  docs:indice  exclusivos 0/8 - pegou 2
```

O corte **acertou o alvo**: `docs:indice` segue vermelho, então não foi ele que se perdeu. Mas o
`test` também segue vermelho — `docs:indice` continua com exclusivo ZERO.

A detecção sobreviveu **noutro lugar do mesmo arquivo**. Sabotando o repo com o defeito, com
controle verde de 34 na mesma invocação, o vermelho é único e tem nome:

```
CONTROLE:  34 passed, EXIT=0
SABOTADO:  EXIT=1 — 1 failed | 33 passed
  × o repo de verdade > cada índice real tem exatamente uma entrada por doc do diretório
```

As outras duas guardas ficaram **verdes** sob o defeito — cegas ao órfão, anti-vácuo de verdade.
A duplicação está inteira num `expect` só.

## A lição: o formato da asserção, não o gate

A guarda declara, no próprio comentário, proteger as invariantes 3/4/5 de um parse que devolvesse
`[]`. Mas foi escrita como **igualdade de conjunto** entre as entradas do índice e os arquivos do
diretório — e igualdade de conjunto **é** a invariante do órfão. A implementação **excede o
contrato declarado**, e o excedente é exatamente a parte que duplica o step. Uma guarda fiel ao que
diz proteger cobraria *volume* de entradas ("o parse não morreu"), não *identidade* com a lista de
arquivos.

**Estreitá-la fica em aberto de propósito.** Enfraquecer uma rede anti-vácuo para ganhar 0
exclusivo é caro pelo lado errado, e o briefing era explícito: na dúvida, manter.

## Ressalva sobre a coluna `mediana`

A matriz remedida traz `test` em 687s (contra 128s) e baseline em 468s (contra 215s): mesma
máquina sob swap (~30 sessões, M2 8GB), não regressão. **O eixo VERDE/VERMELHO atravessou a carga
intacto; o do TEMPO variou 5×** — muito além dos 45% de ruído de runner do
`medir-ganho-de-ci-sob-ruido.md`. Como `medidoEm`/`sourceHead` são GLOBAIS e a remedição é PARCIAL
por desenho, medianas de células diferentes podem vir de cargas diferentes e não são comparáveis
entre si. Registrado no doc.

## Verificação

| gate | exit |
|---|---|
| `test` (suíte completa, no head `fe40aaa4d`) | 0 (`verde test` no baseline da medição) |
| `typecheck` · `lint` | 0 · 0 (75 warnings pré-existentes) |
| `gates:frescura` · `exclusividade` | 0 · 0 |
| `docs:indice` · `docs:links` · `docs:citacoes` · `claude:size` | 0 |

O step `docs:indice` **não** foi removido do `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 📌 Pendência com destino durável — prompt do chip "Estreitar a guarda anti-vácuo que duplica o docs:indice"

Salvo aqui porque chip não-clicado morre com a sessão (`/fecho`, passo 6). Copie o bloco abaixo
para uma sessão nova.

> O PR #2378 retirou de `scripts/docs-indice-gate-check.test.ts` a asserção que auditava o
> repositório real de ponta a ponta (`auditarIndices(lerDiretoriosIndexados())`), porque ela
> duplicava o step `docs:indice` do CI (58ms) dentro de um gate vitest de 128s.
>
> **O corte não bastou, e isso foi MEDIDO:**
>
> ```
> bun run exclusividade:medir -- --defeitos indice-orfao --gates docs:indice,test --sem-poda
> defeito indice-orfao
>   VERMELHO docs:indice (363ms)
>   VERMELHO test (687061ms)     <- continuou pegando
> [redund] docs:indice  exclusivos 0/8 - pegou 2
> ```
>
> Sabotando o repo e rodando só o arquivo (controle verde de 34 na MESMA invocação), o vermelho é
> único: `× o repo de verdade > cada índice real tem exatamente uma entrada por doc do diretório`.
> As outras duas guardas anti-vácuo ficaram VERDES sob o defeito — cegas ao órfão.
>
> **Tarefa:** a guarda declara proteger as invariantes 3/4/5 de um parse que devolvesse `[]`, mas
> foi escrita como igualdade de conjunto entre entradas e arquivos — e igualdade de conjunto É a
> invariante do órfão. Estreite-a para cobrar VOLUME de entradas, não IDENTIDADE com a lista de
> arquivos. Falsifique: sabote `parseEntradas` para devolver `[]` e exija vermelho, com controle
> verde na mesma invocação. Piso frouxo (`> 0` num repo de 40 docs) é teatro.
>
> **Critério de aceitação (medido):** o mesmo `exclusividade:medir` acima deve dar `docs:indice`
> VERMELHO e `test` VERDE. Aí `docs:indice` deixa de ser `[redund]` e a seção "O corte foi
> executado — e a duplicação NÃO saiu inteira" de
> `docs/historico/custo-de-gate-medido-beneficio-nao.md` precisa ser atualizada, junto da tabela.
> A medição exige árvore limpa e baseline verde — commite antes; o `test` leva de 2 a 11 min.
>
> **Não faça:** remover o step `docs:indice` do `ci.yml`; remover as outras duas guardas; tratar
> "exclusividade zero" como prova de gate inútil (é a armadilha nº 1 do repo, explicada no doc).
