### PR TITLE
fix(farmer): o melhor individual era eleito pelo uuid — ordem persistida, duas rotas e cinco estados [money-path]

### DIFF
--- a/db/test-farmer-escopo-carteira.sh
+++ b/db/test-farmer-escopo-carteira.sh
@@ -439,6 +439,25 @@ neg_ordem() { # <json> <sqlstate> <rótulo>
     *) bad "$3 — veio: $(printf '%s' "$saida" | tr '\n' ' ' | cut -c1-170)" ;;
   esac
 }
+neg_ordem_valor() { # como neg_ordem, mas DEVOLVE o veredito em vez de contar assert
+  local vista saida
+  vista=$(Pq -c "SELECT coalesce(quote_literal(run_id::text)||'::uuid','NULL')
+                   FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$A';")
+  [ -n "$vista" ] || vista=NULL
+  saida=$(P -tA -c "$COMO_A DO \$t\$ BEGIN
+      PERFORM public.farmer_recomendacoes_substituir('$A','99999999-0000-4000-8000-0000000000fe',
+                $vista,'$1'::jsonb,'completa',NULL,NULL,NULL);
+      RAISE NOTICE 'PASSOU';
+    EXCEPTION WHEN OTHERS THEN RAISE NOTICE 'RECUSOU:%', SQLSTATE;
+    END \$t\$;" 2>&1 || true)
+  case "$saida" in
+    *PASSOU*)       echo "PASSOU" ;;
+    *RECUSOU:FG007*) echo "RECUSOU" ;;
+    *RECUSOU:*)     echo "RECUSOU-OUTRO-MOTIVO:$(printf '%s' "$saida" | sed -n 's/.*RECUSOU:\([A-Z0-9]*\).*/\1/p' | head -1)" ;;
+    *)              echo "ERRO" ;;
+  esac
+  [ -n "${DEBUG_NEG:-}" ] && printf 'DEBUG_NEG[%s] vista=[%s] saida=[%s]\n' "$1" "$vista" "$(printf '%s' "$saida" | tr '\n' ' ' | cut -c1-300)" >&2
+}
 LB="\"customer_user_id\":\"$C1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD\",\"affinity_score\":0.5"
 neg_ordem "[{$LB,\"ordem\":0}]"                       FG007 "O19 ordem 0 recusada (0 não é posição)"
 neg_ordem "[{$LB,\"ordem\":-1}]"                      FG007 "O20 ordem negativa recusada"
@@ -489,6 +508,105 @@ eq "O32 ordem numérica e flag booleana continuam aceitas" \
 eq "O33 sob a identidade do DONO a carteira volta NÃO-vazia" \
    "$(Pq -c "SET test.uid='$D'; SET test.role='authenticated';
              SELECT jsonb_array_length(public.farmer_melhores_individuais_por_cliente('$D'));" | tail -1)" "8"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FALSIFICAÇÃO DA ORDEM — uma camada por vez
+#
+# ⚠️ LINHA DE BASE NA MESMA INVOCAÇÃO. Uma suíte sempre-vermelha aprova TODA
+# sabotagem, e rodar o controle noutra execução não prova nada sobre esta. Os
+# valores íntegros são re-lidos aqui e conferidos ANTES do primeiro `sed`; se
+# algum divergir, aborta em vez de "falsificar".
+# ═══════════════════════════════════════════════════════════════════════════════
+echo "─── falsificação: a ordem ───"
+
+BASE_OK=1
+base_confere() { # $1=rótulo $2=obtido $3=esperado
+  if [ "$2" = "$3" ]; then ok "base íntegra: $1 (=$2)"; else BASE_OK=0; bad "BASE JÁ VERMELHA em $1 — esperado [$3], veio [$2]; falsificar aqui seria teatro"; fi
+}
+base_confere "O6 ambígua"      "$(campo "$CM" situacao)" "referencia_ambigua"
+base_confere "O7 flag nula"    "$(campo "$CN" situacao)" "referencia_ambigua"
+base_confere "O26 mistura"     "$(campo "$CG" situacao)" "ordem_indisponivel"
+base_confere "O8 topo"         "$(nprod "$CT")"          "2"
+base_confere "O3 singleton"    "$(campo "$CU" situacao)" "unico_registrado"
+
+if [ "$BASE_OK" -ne 1 ]; then
+  bad "falsificação ABORTADA: a linha de base não está verde nesta invocação"
+else
+  SABO="$(mktemp /tmp/sabota-ordem.XXXXXX)"
+  restaura_ordem() { P -q -f "$MIG_ORDEM" >/dev/null 2>&1; }
+  sabota_ordem() { # $1=rótulo  $2=expressão sed  $3=marca obrigatória no sabotado
+    sed "$2" "$MIG_ORDEM" > "$SABO"
+    if ! command grep -q "$3" "$SABO"; then
+      bad "SABOTAGEM '$1' NÃO casou o padrão — o assert abaixo seria teatro"
+      return 1
+    fi
+    if ! P -q -f "$SABO" >/dev/null 2>&1; then
+      bad "SABOTAGEM '$1' casou o padrão mas NÃO APLICOU — o assert abaixo seria teatro"
+      return 1
+    fi
+    return 0
+  }
+  vermelho() { # $1=rótulo $2=obtido $3=o valor ÍNTEGRO, que NÃO pode sobreviver
+    if [ "$2" = "$3" ]; then bad "FALSIFICAÇÃO SEM DENTE: $1 continuou [$2] com a migration sabotada"
+    else ok "mordeu: $1 virou [$2] (íntegro: [$3])"; fi
+  }
+
+  # F1 — o fail-closed da flag nula vira fail-OPEN.
+  if sabota_ordem "flag nula fail-open" \
+       's/coalesce(b\.referencia_ambigua, b\.ordem IS NOT NULL)/coalesce(b.referencia_ambigua, false)/' \
+       'coalesce(b.referencia_ambigua, false)'; then
+    vermelho "F1 flag NULA com ordem" "$(campo "$CN" situacao)" "referencia_ambigua"
+  fi
+  restaura_ordem
+
+  # F2 — a precedência deixa de barrar geração misturada.
+  if sabota_ordem "mistura ignorada" \
+       's/WHEN g\.geracoes > 1/WHEN false/' 'WHEN false'; then
+    vermelho "F2 geração misturada" "$(campo "$CG" situacao)" "ordem_indisponivel"
+  fi
+  restaura_ordem
+
+  # F3 — `produtos` deixa de recortar o topo e nomeia o grupo inteiro no empate.
+  if sabota_ordem "produtos sem recorte de topo" \
+       "s/AND (f\.situacao NOT IN ('eleito', 'empatado') OR b\.ordem = f\.ordem_minima)/AND true/" \
+       'AND true'; then
+    vermelho "F3 empate nomeia só o topo" "$(nprod "$CT")" "2"
+  fi
+  restaura_ordem
+
+  # F4 — a precedência do singleton some, e ele passa a ser eleito por "topo único".
+  if sabota_ordem "singleton sem precedência" \
+       's/WHEN g\.candidatos = 1  *THEN/WHEN false THEN/' 'WHEN false THEN'; then
+    vermelho "F4 singleton COM ordem" "$(campo "$CS" situacao)" "unico_registrado"
+  fi
+  restaura_ordem
+
+  # F5 — a validação de ordem < 1 vira decoração.
+  if sabota_ordem "ordem < 1 desligada" \
+       's/AND r\.ordem < 1)/AND r.ordem < -32000)/' 'AND r.ordem < -32000)'; then
+    # ⚠️ o JSON sai para uma variável ANTES da chamada: dentro de `$( )` o bash faz BRACE
+    # EXPANSION em `{a,b}` e parte o payload em duas palavras — a função recebia `["ordem":0]`
+    # e o erro virava 22P02, um vermelho pelo motivo ERRADO.
+    J5="[{$LB,\"ordem\":0}]"
+    vermelho "F5 ordem 0 recusada" "$(neg_ordem_valor "$J5")" "RECUSOU"
+  fi
+  restaura_ordem
+
+  # F6 — a checagem de TIPO JSON some. Este é o que prova o achado: sem ela o cast
+  # CONVERTE "false" em false e grava uma negativa explícita de ambiguidade.
+  if sabota_ordem "tipo JSON não checado" \
+       's/IF v_tipo_errado > 0 THEN/IF v_tipo_errado > 999999 THEN/' 'v_tipo_errado > 999999'; then
+    J6="[{$LB,\"referencia_ambigua\":\"false\"}]"
+    vermelho "F6 flag \"false\" recusada" "$(neg_ordem_valor "$J6")" "RECUSOU"
+  fi
+  restaura_ordem
+
+  rm -f "$SABO"
+  # E o CONTROLE de saída: restaurada, a base volta a ficar verde na MESMA invocação.
+  eq "F7 restaurada, a migration volta a barrar a geração misturada" "$(campo "$CG" situacao)" "ordem_indisponivel"
+  eq "F8 restaurada, o fail-closed da flag volta"                    "$(campo "$CN" situacao)" "referencia_ambigua"
+fi
 
 echo "─── falsificação ───"
 P -q <<SQL

--- a/db/test-farmer-escopo-carteira.sh
+++ b/db/test-farmer-escopo-carteira.sh
@@ -299,6 +299,164 @@ P -q -f <(sem_guard "$MIG")
 eq "V1b restaurado: o gate de escopo volta a morder" "$(chamar farmer_recomendacoes_substituir "$(linha "$C3")" "$(geracao_atual farmer_recommendations)")" "FG009"
 rm -f "$DIVERG"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — A ORDEM DO MELHOR INDIVIDUAL (20260907230000)
+#
+# Esta migration sucede a 20260906164002 no MESMO writer (`CREATE OR REPLACE`, a
+# última a recriar vence), então é aqui que ela se prova — e não no harness de
+# head, cuja cadeia para na 20260815181500 e produz um writer que produção já não
+# tem (sem o gate de escopo). ⚠️ Dívida PREEXISTENTE, declarada: o
+# `db/test-farmer-head-geracao.sh` testa uma versão do writer anterior à de ontem.
+# ═══════════════════════════════════════════════════════════════════════════════
+echo "─── ordem do melhor individual ───"
+
+MIG_ORDEM="$REPO_ROOT/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql"
+[ -f "$MIG_ORDEM" ] || { echo "migração ausente: $MIG_ORDEM"; exit 1; }
+P -q -f "$MIG_ORDEM"
+P -q -f "$MIG_ORDEM"
+ok "O0 migration da ordem é idempotente (aplicada 2x sem erro)"
+
+D="dddddddd-0000-4000-8000-00000000000d"      # farmer só desta zona
+VAZIO="eeeeeeee-0000-4000-8000-00000000000e"  # farmer sem NENHUMA linha
+CE="cccccccc-0000-4000-8000-0000000000e1"     # eleito
+CT="cccccccc-0000-4000-8000-0000000000a1"     # empatado com 3º candidato fora do topo
+CU="cccccccc-0000-4000-8000-0000000000b1"     # singleton SEM ordem
+CS="cccccccc-0000-4000-8000-0000000000c1"     # singleton COM ordem
+CP="cccccccc-0000-4000-8000-0000000000d1"     # ordenação parcial [1,2,NULL]
+CM="cccccccc-0000-4000-8000-0000000000f1"     # referência ambígua declarada
+CN="cccccccc-0000-4000-8000-0000000000e2"     # flag NULA com ordem preenchida
+P2="dddddddd-0000-4000-8000-000000000002"
+P3="dddddddd-0000-4000-8000-000000000003"
+RUND="99999999-0000-4000-8000-00000000000d"
+
+P -q <<SQL
+INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id) VALUES
+  ('$CE','$D'),('$CT','$D'),('$CU','$D'),('$CS','$D'),('$CP','$D'),('$CM','$D'),('$CN','$D');
+
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, affinity_score,
+   status, run_id, ordem, referencia_ambigua)
+VALUES
+  ('$D','$CE','cross_sell','$PROD',0.1,'pendente','$RUND',1,false),
+  ('$D','$CE','cross_sell','$P2'  ,0.1,'pendente','$RUND',2,false),
+
+  ('$D','$CT','cross_sell','$PROD',0.1,'pendente','$RUND',1,false),
+  ('$D','$CT','cross_sell','$P2'  ,0.1,'pendente','$RUND',1,false),
+  ('$D','$CT','cross_sell','$P3'  ,0.1,'pendente','$RUND',2,false),
+
+  ('$D','$CU','up_sell'   ,'$PROD',0.1,'pendente','$RUND',NULL,false),
+  ('$D','$CS','cross_sell','$PROD',0.1,'pendente','$RUND',1,false),
+
+  ('$D','$CP','cross_sell','$PROD',0.1,'pendente','$RUND',1,false),
+  ('$D','$CP','cross_sell','$P2'  ,0.1,'pendente','$RUND',2,false),
+  ('$D','$CP','cross_sell','$P3'  ,0.1,'pendente','$RUND',NULL,false),
+
+  ('$D','$CM','up_sell'   ,'$PROD',0.1,'pendente','$RUND',1,true),
+  ('$D','$CM','up_sell'   ,'$P2'  ,0.1,'pendente','$RUND',2,true),
+
+  ('$D','$CN','up_sell'   ,'$PROD',0.1,'pendente','$RUND',1,NULL),
+  ('$D','$CN','up_sell'   ,'$P2'  ,0.1,'pendente','$RUND',2,NULL);
+SQL
+
+campo() { # <cliente> <campo>
+  Pq -c "SELECT j->>'$2' FROM jsonb_array_elements(
+           public.farmer_melhores_individuais_por_cliente('$D')) j
+          WHERE j->>'customer_user_id'='$1';"
+}
+nprod() { # <cliente> — quantos SKUs a tela vai NOMEAR
+  Pq -c "SELECT jsonb_array_length(j->'produtos') FROM jsonb_array_elements(
+           public.farmer_melhores_individuais_por_cliente('$D')) j
+          WHERE j->>'customer_user_id'='$1';"
+}
+
+# ── os cinco estados, e a PRECEDÊNCIA entre eles ────────────────────────────────
+eq "O1 topo único com ordem conhecida = eleito"         "$(campo "$CE" situacao)" "eleito"
+eq "O2 dois no rank mínimo = empatado"                  "$(campo "$CT" situacao)" "empatado"
+eq "O3 singleton SEM ordem = unico_registrado"          "$(campo "$CU" situacao)" "unico_registrado"
+# ⚠️ o assert que prende a precedência: sem ela este caso satisfaz 'unico_registrado'
+#    E 'topo único' ao mesmo tempo, e a versão anterior da spec exigia os DOIS.
+eq "O4 singleton COM ordem NÃO vira eleito"             "$(campo "$CS" situacao)" "unico_registrado"
+eq "O5 [1,2,NULL] = ordem_indisponivel (incompleta)"    "$(campo "$CP" situacao)" "ordem_indisponivel"
+eq "O6 flag=true vence topo único"                      "$(campo "$CM" situacao)" "referencia_ambigua"
+eq "O7 flag NULA com ordem preenchida é fail-closed"    "$(campo "$CN" situacao)" "referencia_ambigua"
+
+# ── identidade separada da eleição ──────────────────────────────────────────────
+eq "O8 empate nomeia só o TOPO"                         "$(nprod "$CT")" "2"
+eq "O9 candidatos conta o GRUPO, não o topo"            "$(campo "$CT" candidatos)" "3"
+eq "O10 ordem_indisponivel nomeia o grupo INTEIRO"      "$(nprod "$CP")" "3"
+eq "O11 eleito nomeia UM"                               "$(nprod "$CE")" "1"
+eq "O12 produto_eleito é o do rank mínimo"              "$(campo "$CE" produto_eleito)" "$PROD"
+eq "O13 produto_eleito não-nulo ⟺ eleito, na carteira inteira" \
+   "$(Pq -c "SELECT count(*) FROM jsonb_array_elements(
+               public.farmer_melhores_individuais_por_cliente('$D')) j
+              WHERE (j->>'produto_eleito' IS NOT NULL) <> (j->>'situacao'='eleito');")" "0"
+eq "O14 produtos NUNCA é vazio ou nulo" \
+   "$(Pq -c "SELECT count(*) FROM jsonb_array_elements(
+               public.farmer_melhores_individuais_por_cliente('$D')) j
+              WHERE coalesce(jsonb_array_length(j->'produtos'),0) < 1;")" "0"
+eq "O15 um objeto por (cliente,tipo) — 7 clientes, 7 objetos" \
+   "$(Pq -c "SELECT jsonb_array_length(public.farmer_melhores_individuais_por_cliente('$D'));")" "7"
+eq "O16 carteira vazia devolve [] e não NULL" \
+   "$(Pq -c "SELECT public.farmer_melhores_individuais_por_cliente('$VAZIO')::text;")" "[]"
+
+# ── o writer: as chaves novas ATRAVESSAM jsonb_to_recordset ─────────────────────
+# Sem as listas de colunas atualizadas nos DOIS blocos, a chave é ignorada em
+# SILÊNCIO — nada persiste e nada falha, que é o pior desfecho possível.
+LOTE_ORDEM="[{\"customer_user_id\":\"$C1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD\",\"affinity_score\":0.5,\"ordem\":1,\"referencia_ambigua\":false},
+             {\"customer_user_id\":\"$C1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$P2\",\"affinity_score\":0.5,\"ordem\":1,\"referencia_ambigua\":true}]"
+RUNW="99999999-0000-4000-8000-000000000012"
+# `$COMO_A` porque o writer é gateado por authz (FG-acesso): sem a identidade, o assert
+# reprovaria por motivo ERRADO e a falsificação viraria teatro.
+GERACAO_A=$(Pq -c "SELECT coalesce(quote_literal(run_id::text)||'::uuid','NULL')
+                     FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$A';")
+[ -n "$GERACAO_A" ] || GERACAO_A=NULL
+P -q -c "$COMO_A SELECT public.farmer_recomendacoes_substituir('$A','$RUNW',$GERACAO_A,
+           '$LOTE_ORDEM'::jsonb,'completa',NULL,NULL,NULL);" >/dev/null
+eq "O17 o writer PERSISTE a ordem densa" \
+   "$(Pq -c "SELECT string_agg(ordem::text,',' ORDER BY product_id) FROM public.farmer_recommendations
+              WHERE run_id='$RUNW';")" "1,1"
+eq "O18 o writer PERSISTE a flag, sem coalescer" \
+   "$(Pq -c "SELECT string_agg(referencia_ambigua::text,',' ORDER BY product_id) FROM public.farmer_recommendations
+              WHERE run_id='$RUNW';")" "false,true"
+
+# ── negativos: a SQLSTATE ESPERADA, re-lançando o resto ─────────────────────────
+neg_ordem() { # <json> <sqlstate> <rótulo>
+  local saida
+  local vista
+  # A geração vigente é lida A CADA chamada: com a capturada lá em cima o lote morreria no
+  # CAS — reprovaria pelo motivo ERRADO, sem nunca alcançar a validação sob teste.
+  vista=$(Pq -c "SELECT coalesce(quote_literal(run_id::text)||'::uuid','NULL')
+                   FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$A';")
+  [ -n "$vista" ] || vista=NULL
+  saida=$(P -tA -c "$COMO_A DO \$t\$ BEGIN
+      PERFORM public.farmer_recomendacoes_substituir('$A','99999999-0000-4000-8000-0000000000ff',
+                $vista,'$1'::jsonb,'completa',NULL,NULL,NULL);
+      RAISE NOTICE 'NAO-RECUSOU';
+    EXCEPTION WHEN SQLSTATE '$2' THEN RAISE NOTICE 'RECUSOU-COMO-ESPERADO';
+    END \$t\$;" 2>&1 || true)
+  case "$saida" in
+    *RECUSOU-COMO-ESPERADO*) ok "$3" ;;
+    *) bad "$3 — veio: $(printf '%s' "$saida" | tr '\n' ' ' | cut -c1-170)" ;;
+  esac
+}
+LB="\"customer_user_id\":\"$C1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD\",\"affinity_score\":0.5"
+neg_ordem "[{$LB,\"ordem\":0}]"                       FG007 "O19 ordem 0 recusada (0 não é posição)"
+neg_ordem "[{$LB,\"ordem\":-1}]"                      FG007 "O20 ordem negativa recusada"
+neg_ordem "[{$LB,\"referencia_ambigua\":\"talvez\"}]" 22P02 "O21 flag não-booleana morre no CAST, antes de expirar"
+eq "O22 lote recusado NÃO expirou a geração vigente" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUNW' AND status='pendente';")" "2"
+
+# ── a fronteira ────────────────────────────────────────────────────────────────
+# A RLS não é provada aqui (este harness não carrega a policy `frec_select_carteira`,
+# e provar contra uma policy stub provaria o stub). O que se prova é a afirmação do
+# DESENHO: a RPC não bypassa RLS — se virasse DEFINER, leria como owner.
+eq "O23 a RPC é SECURITY INVOKER (não bypassa RLS)" \
+   "$(Pq -c "SELECT prosecdef FROM pg_proc WHERE oid='public.farmer_melhores_individuais_por_cliente(uuid)'::regprocedure;")" "f"
+eq "O24 anon NÃO executa a RPC nova" \
+   "$(Pq -c "SELECT has_function_privilege('anon','public.farmer_melhores_individuais_por_cliente(uuid)','EXECUTE');")" "f"
+eq "O25 authenticated executa" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated','public.farmer_melhores_individuais_por_cliente(uuid)','EXECUTE');")" "t"
+
 echo "─── falsificação ───"
 P -q <<SQL
 ALTER TABLE public.farmer_client_scores DISABLE ROW LEVEL SECURITY;

--- a/db/test-farmer-escopo-carteira.sh
+++ b/db/test-farmer-escopo-carteira.sh
@@ -442,7 +442,7 @@ neg_ordem() { # <json> <sqlstate> <rótulo>
 LB="\"customer_user_id\":\"$C1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD\",\"affinity_score\":0.5"
 neg_ordem "[{$LB,\"ordem\":0}]"                       FG007 "O19 ordem 0 recusada (0 não é posição)"
 neg_ordem "[{$LB,\"ordem\":-1}]"                      FG007 "O20 ordem negativa recusada"
-neg_ordem "[{$LB,\"referencia_ambigua\":\"talvez\"}]" 22P02 "O21 flag não-booleana morre no CAST, antes de expirar"
+neg_ordem "[{$LB,\"referencia_ambigua\":\"talvez\"}]" FG007 "O21 flag não-booleana recusada por TIPO, antes do cast"
 eq "O22 lote recusado NÃO expirou a geração vigente" \
    "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUNW' AND status='pendente';")" "2"
 
@@ -456,6 +456,39 @@ eq "O24 anon NÃO executa a RPC nova" \
    "$(Pq -c "SELECT has_function_privilege('anon','public.farmer_melhores_individuais_por_cliente(uuid)','EXECUTE');")" "f"
 eq "O25 authenticated executa" \
    "$(Pq -c "SELECT has_function_privilege('authenticated','public.farmer_melhores_individuais_por_cliente(uuid)','EXECUTE');")" "t"
+
+
+# ── achados da rodada 4 do challenge ───────────────────────────────────────────
+CG="cccccccc-0000-4000-8000-0000000000c2"   # duas gerações pendentes no mesmo grupo
+P -q <<SQL
+INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id) VALUES ('$CG','$D');
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, affinity_score,
+   status, run_id, ordem, referencia_ambigua)
+VALUES
+  ('$D','$CG','cross_sell','$PROD',0.1,'pendente','$RUND',1,false),
+  ('$D','$CG','cross_sell','$P2'  ,0.1,'pendente','99999999-0000-4000-8000-0000000000dd',2,false);
+SQL
+# Rank de G1 contra rank de G2 são universos diferentes: `ordem 1` não venceu de ninguém.
+eq "O26 geração MISTURADA no grupo não elege"      "$(campo "$CG" situacao)" "ordem_indisponivel"
+eq "O27 grupo incoerente não transporta run_id"    "$(campo "$CG" run_id)"   ""
+eq "O28 grupo coerente TRANSPORTA o run_id"        "$(campo "$CE" run_id)"   "$RUND"
+
+# O cast NÃO recusa representação textual — `boolean_in` aceita "false"/"off"/"0" e `int2in`
+# aceita "3". Sem a checagem de jsonb_typeof, um produtor defeituoso gravaria uma NEGATIVA
+# explícita de ambiguidade, e o teste com "talvez" ficaria verde sem provar nada.
+neg_ordem "[{$LB,\"referencia_ambigua\":\"false\"}]" FG007 "O29 flag \"false\" (string) é RECUSADA, não convertida"
+neg_ordem "[{$LB,\"referencia_ambigua\":0}]"         FG007 "O30 flag 0 é RECUSADA, não convertida"
+neg_ordem "[{$LB,\"ordem\":\"2\"}]"                  FG007 "O31 ordem \"2\" (string) é RECUSADA"
+# E o controle do outro lado: o tipo CERTO continua passando (a checagem não fecha demais).
+eq "O32 ordem numérica e flag booleana continuam aceitas" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUNW';")" "2"
+
+# RLS: `prosecdef` diz que a RPC não bypassa; falta que ela LEIA de verdade sob a identidade.
+# Sem o assert positivo, uma resposta sempre-vazia aprovaria o negativo (achado do challenge).
+eq "O33 sob a identidade do DONO a carteira volta NÃO-vazia" \
+   "$(Pq -c "SET test.uid='$D'; SET test.role='authenticated';
+             SELECT jsonb_array_length(public.farmer_melhores_individuais_por_cliente('$D'));" | tail -1)" "8"
 
 echo "─── falsificação ───"
 P -q <<SQL

--- a/db/test-farmer-escopo-carteira.sh
+++ b/db/test-farmer-escopo-carteira.sh
@@ -109,6 +109,12 @@ CREATE TABLE public.farmer_geracao_vigente (
 CREATE FUNCTION private.cap_carteira_escrever(p uuid) RETURNS boolean
   LANGUAGE sql STABLE AS $f$ SELECT false $f$;
 
+CREATE TABLE public._insumos_vistos (run_id uuid PRIMARY KEY, insumos jsonb);
+-- O writer e SECURITY INVOKER, entao este INSERT roda com os privilegios de QUEM chamou
+-- — e o harness chama sob `authenticated`. Sem o GRANT, o caminho feliz reprovaria por
+-- permissao de uma tabela que so existe no stub: assert vermelho pelo motivo ERRADO.
+GRANT SELECT, INSERT, UPDATE ON public._insumos_vistos TO PUBLIC;
+
 CREATE FUNCTION public.farmer_geracao_registrar(
   p_motor text, p_farmer_id uuid, p_run_id uuid, p_tipo text, p_n integer,
   p_completude text, p_motivo text, p_insumos jsonb, p_head uuid)
@@ -117,6 +123,10 @@ BEGIN
   INSERT INTO public.farmer_geracao_vigente (motor, farmer_id, run_id)
   VALUES (p_motor, p_farmer_id, p_run_id)
   ON CONFLICT (motor, farmer_id) DO UPDATE SET run_id = EXCLUDED.run_id;
+  -- O stub GUARDA os insumos: o sensor da distribuicao sai por este parametro, e descarta-lo
+  -- faria o assert dele passar por vacuidade — verde sobre um numero que ninguem emitiu.
+  INSERT INTO public._insumos_vistos (run_id, insumos) VALUES (p_run_id, p_insumos)
+  ON CONFLICT (run_id) DO UPDATE SET insumos = EXCLUDED.insumos;
 END $f$;
 SQL
 
@@ -509,6 +519,27 @@ eq "O33 sob a identidade do DONO a carteira volta NÃO-vazia" \
    "$(Pq -c "SET test.uid='$D'; SET test.role='authenticated';
              SELECT jsonb_array_length(public.farmer_melhores_individuais_por_cliente('$D'));" | tail -1)" "8"
 
+
+# ── O SENSOR DA DISTRIBUIÇÃO (§6.1) ────────────────────────────────────────────
+# A distribuicao por situacao nao e derivavel do banco ANTES da entrega: D3 muda quais SKUs
+# sao persistidos, entao "empate entre os persistidos" nao demonstra ausencia de vencedor
+# entre os candidatos. Ela e MEDIDA no writer, sobre o que acabou de ser gravado.
+#
+# O writer do assert O17 gravou 2 linhas para $C1 com ordem 1,1 e uma delas com a flag ligada
+# — o grupo cai em `referencia_ambigua`, que e o estado de maior precedencia.
+eq "O34 o sensor grava a eleicao com DENOMINADOR" \
+   "$(Pq -c "SELECT (insumos->'individuais_eleicao'->>'n') || '/' ||
+                    (insumos->'individuais_eleicao'->>'esperado')
+             FROM public._insumos_vistos WHERE run_id='$RUNW';")" "0/1"
+eq "O35 a distribuicao nomeia TIPO e SITUACAO" \
+   "$(Pq -c "SELECT insumos->'individuais_eleicao'->'distribuicao'->>'cross_sell:referencia_ambigua'
+             FROM public._insumos_vistos WHERE run_id='$RUNW';")" "1"
+# Inerte por construcao: `ok:true` e sem piso. Uma evidencia que DEGRADA o head travaria a
+# fase 2 para sempre, porque `degradado` nunca autoriza expirar (money-path §13).
+eq "O36 o sensor e INERTE — mede sem julgar" \
+   "$(Pq -c "SELECT (insumos->'individuais_eleicao'->>'ok') || ':' ||
+                    coalesce(insumos->'individuais_eleicao'->>'pisoCobertura','sem-piso')
+             FROM public._insumos_vistos WHERE run_id='$RUNW';")" "true:sem-piso"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # FALSIFICAÇÃO DA ORDEM — uma camada por vez

--- a/db/test-farmer-escopo-carteira.sh
+++ b/db/test-farmer-escopo-carteira.sh
@@ -599,9 +599,12 @@ else
   restaura_ordem
 
   # F3 — `produtos` deixa de recortar o topo e nomeia o grupo inteiro no empate.
+  # O padrão seguiu a reescrita que tirou o quadrático (achado R5/1): `produtos` deixou de sair
+  # de subquery correlacionada e passa a escolher entre dois arrays montados uma vez só. O guard
+  # de "não casou o padrão" pegou a defasagem — sem ele este assert teria virado teatro.
   if sabota_ordem "produtos sem recorte de topo" \
-       "s/AND (f\.situacao NOT IN ('eleito', 'empatado') OR b\.ordem = f\.ordem_minima)/AND true/" \
-       'AND true'; then
+       "s/CASE WHEN f\.situacao IN ('eleito', 'empatado') THEN f\.topo_ids ELSE f\.todos_ids END/f.todos_ids/" \
+       'f.todos_ids$'; then
     vermelho "F3 empate nomeia só o topo" "$(nprod "$CT")" "2"
   fi
   restaura_ordem

--- a/docs/superpowers/plans/2026-09-07-rpc-melhor-individual-ordem.md
+++ b/docs/superpowers/plans/2026-09-07-rpc-melhor-individual-ordem.md
@@ -1,0 +1,889 @@
+# Conserto da ordem do "melhor individual" — plano de implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parar de apresentar como veredicto uma escolha feita por uuid — a RPC do melhor individual elege por `id` em 98,7% dos pares medidos — entregando ordem persistida, honestidade de estado e duas células rotuladas no cartão.
+
+**Architecture:** Uma coluna `ordem` (rank **denso**) e uma coluna `referencia_ambigua` passam a viajar no payload do writer; uma RPC nova devolve **um objeto por (cliente, tipo)** com identidade (`produtos`) separada da eleição (`produto_eleito`) e uma `situacao` de 5 estados avaliada por precedência; o leitor valida invariantes entre campos e o cartão mostra duas células rotuladas. A RPC antiga continua servindo o front antigo até o Publish ser adotado.
+
+**Tech Stack:** Postgres 17 (migration manual via SQL Editor do Lovable) · React 18 + TS 5.8 strict · vitest · `bash` + `psql` para o harness PG.
+
+## Global Constraints
+
+- **Spec autoritativa:** `docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md` (revisão 4). Divergência entre plano e spec = a spec vence, e o plano é corrigido.
+- **`supabase/migrations/` é DR — NUNCA aplicar de lá.** A migration é colada pelo founder no SQL Editor (skill `lovable-db-operator`). O arquivo no repo é registro.
+- **Escrita no banco só pelo founder.** Leitura/diagnóstico: `~/.config/afiacao/psql-ro`, sempre com `-v ON_ERROR_STOP=1` e marcador positivo de fim.
+- **`CREATE OR REPLACE` de função:** pré-flight obrigatório com `pg_get_functiondef` da PROD; a última a recriar vence.
+- **Nomenclatura pt-BR** em código, rotas e commits.
+- **Arquivo novo em `src/` precisa de dono** em `src/lib/modulos/manifesto.ts` (`codigo` e `testes`), senão `manifesto.gate` falha só no CI.
+- **Ausente ≠ zero:** nunca `Number(null)`, nunca default que afirme medição não feita.
+- **Rank DENSO** (empatados compartilham o valor). Posições distintas mudariam o endereço do bug de uuid para índice de array.
+- **Toda validação conta só com evidência positiva:** rodar o comando, ver terminar, capturar `exit 0` colado.
+
+---
+
+## Estrutura de arquivos
+
+| arquivo | responsabilidade |
+|---|---|
+| `supabase/migrations/2026…_farmer_ordem_e_referencia_ambigua.sql` *(criar)* | colunas novas + `CREATE OR REPLACE` do writer + `CREATE` da RPC nova |
+| `src/lib/farmer/rank-denso.ts` *(criar)* | rank denso genérico, sobre um comparador — usado pelos dois tipos |
+| `src/lib/farmer/melhor-individual.ts` *(criar)* | contrato do leitor: tipos dos 5 estados + validação com invariantes cruzados |
+| `src/lib/farmer/upsell-ordem.ts` *(modificar)* | exportar o predicado de empate para o rank denso |
+| `src/hooks/useCrossSellEngine.ts` *(modificar)* | flag por cliente · rank denso nos dois tipos · D3 · payload |
+| `src/hooks/useBundleEngine.ts` *(modificar)* | os 7 pontos de §3.6 |
+| `src/components/farmer/bundles/CustomerBundleCard.tsx` *(modificar)* | duas células rotuladas, 5 estados |
+| `db/test-farmer-head-geracao.sh` *(modificar)* | contrato do banco + falsificação |
+
+---
+
+### Task 1: Migration — colunas, writer e RPC nova
+
+**Files:**
+- Create: `supabase/migrations/20260907HHMMSS_farmer_ordem_e_referencia_ambigua.sql`
+
+**Interfaces:**
+- Produces: colunas `farmer_recommendations.ordem smallint NULL` e `.referencia_ambigua boolean NULL`; `farmer_recomendacoes_substituir` aceitando as duas chaves em `p_linhas`; `farmer_melhores_individuais_por_cliente(uuid) RETURNS jsonb`.
+- Consumes: definição de PROD de `farmer_recomendacoes_substituir` (8 parâmetros, o último `p_head_visto uuid DEFAULT NULL`).
+
+- [ ] **Step 1: Pré-flight contra a PROD**
+
+```bash
+~/.config/afiacao/psql-ro -v ON_ERROR_STOP=1 -c "
+SELECT pg_get_functiondef('public.farmer_recomendacoes_substituir(uuid,uuid,uuid,jsonb,text,text,jsonb,uuid)'::regprocedure);
+SELECT 'FIM-OK-PREFLIGHT';"
+```
+
+Esperado: a definição atual, terminando com o marcador. Se a assinatura não existir, **parar**: o apply manual divergiu do repo e o `CREATE OR REPLACE` do passo seguinte apagaria o que está em produção.
+
+- [ ] **Step 2: Escrever a migration**
+
+Três blocos, nesta ordem. O corpo do writer é a definição de PROD do Step 1 com **exatamente** estas mudanças:
+
+1. Colunas:
+
+```sql
+ALTER TABLE public.farmer_recommendations
+  ADD COLUMN IF NOT EXISTS ordem              smallint,
+  ADD COLUMN IF NOT EXISTS referencia_ambigua boolean;
+
+COMMENT ON COLUMN public.farmer_recommendations.ordem IS
+  'Rank DENSO dentro de (farmer_id, customer_user_id, recommendation_type, run_id): empatados compartilham o valor. NULL = geracao gravada por produtor que nao calcula rank. Posicoes distintas mudariam o endereco do bug de uuid para indice de array.';
+COMMENT ON COLUMN public.farmer_recommendations.referencia_ambigua IS
+  'up_sell: o preco de referencia do cliente saiu de um desempate por uuid (preco-referencia.ts). NULL = nao medido — NAO usar DEFAULT false, que afirmaria medicao sobre linha legada.';
+```
+
+2. No writer, a lista de colunas do bloco de **validação** (etapa 6) ganha as duas, e a validação ganha uma cláusula:
+
+```sql
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    affinity_score          numeric,
+    ordem                   smallint,
+    referencia_ambigua      boolean
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.product_id IS NULL
+     OR r.recommendation_type IS NULL
+     OR r.recommendation_type NOT IN ('cross_sell', 'up_sell')
+     OR r.affinity_score IS NULL
+     OR NOT (
+          r.affinity_score >= 0
+          AND r.affinity_score < 'Infinity'::numeric
+          AND r.affinity_score <> 'NaN'::numeric
+        )
+     -- `ordem` é opcional (produtor legado não a emite), mas quando vem tem de ser rank:
+     -- 0 e negativos não são posição, e um `smallint` fora de faixa já explodiu no cast.
+     OR (r.ordem IS NOT NULL AND r.ordem < 1);
+```
+
+⚠️ `jsonb_to_recordset` **falha** no cast quando a chave existe com tipo errado (`"x"` para `smallint`, `"talvez"` para `boolean`) — o erro vem do cast, não do `WHERE`, e é o comportamento desejado: o lote inteiro é recusado antes de expirar nada. O harness prova as duas portas.
+
+3. No `INSERT` do writer, as duas colunas entram na lista, no `SELECT` e na lista do `jsonb_to_recordset` do `FROM` (que é **outra** lista, separada da validação):
+
+```sql
+  INSERT INTO public.farmer_recommendations (
+    farmer_id, customer_user_id, recommendation_type, product_id, current_product_id,
+    p_ij, m_ij, lie, affinity_score, complexity_factor, cluster_volume_estimate,
+    ordem, referencia_ambigua,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.recommendation_type, r.product_id, r.current_product_id,
+    r.p_ij, NULL, NULL,
+    r.affinity_score, coalesce(r.complexity_factor, 1), coalesce(r.cluster_volume_estimate, 1),
+    r.ordem, r.referencia_ambigua,
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    current_product_id      uuid,
+    p_ij                    numeric,
+    affinity_score          numeric,
+    complexity_factor       numeric,
+    cluster_volume_estimate numeric,
+    ordem                   smallint,
+    referencia_ambigua      boolean
+  );
+```
+
+4. A RPC nova:
+
+```sql
+CREATE OR REPLACE FUNCTION public.farmer_melhores_individuais_por_cliente(p_farmer_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', pg_temp
+AS $fn$
+  WITH base AS (
+    SELECT r.customer_user_id, r.recommendation_type, r.product_id,
+           r.affinity_score, r.run_id, r.ordem, r.referencia_ambigua
+    FROM public.farmer_recommendations r
+    WHERE r.farmer_id = p_farmer_id
+      AND r.status = 'pendente'
+      AND r.affinity_score IS NOT NULL
+  ),
+  grupo AS (
+    SELECT customer_user_id, recommendation_type,
+           count(*)                                       AS candidatos,
+           count(*) FILTER (WHERE ordem IS NULL)           AS sem_ordem,
+           min(ordem)                                      AS ordem_minima,
+           -- fail-closed de §5.2: NULL na flag COM ordem preenchida conta como ambígua.
+           bool_or(coalesce(referencia_ambigua, ordem IS NOT NULL)) AS ambigua,
+           max(affinity_score)                             AS affinity_score,
+           (array_agg(run_id ORDER BY ordem NULLS LAST, id))[1] AS run_id
+    FROM base GROUP BY 1, 2
+  ),
+  situado AS (
+    SELECT g.*,
+      CASE
+        WHEN g.ambigua                        THEN 'referencia_ambigua'
+        WHEN g.candidatos >= 2
+         AND g.sem_ordem > 0                  THEN 'ordem_indisponivel'
+        WHEN g.candidatos = 1                 THEN 'unico_registrado'
+        ELSE NULL  -- decidido abaixo, precisa contar quantos estão no rank mínimo
+      END AS situacao_parcial
+    FROM grupo g
+  ),
+  topo AS (
+    SELECT s.customer_user_id, s.recommendation_type,
+           count(*) AS no_topo
+    FROM situado s
+    JOIN base b USING (customer_user_id, recommendation_type)
+    WHERE s.situacao_parcial IS NULL AND b.ordem = s.ordem_minima
+    GROUP BY 1, 2
+  ),
+  final AS (
+    SELECT s.customer_user_id, s.recommendation_type, s.candidatos,
+           s.affinity_score, s.run_id, s.ordem_minima,
+           coalesce(s.situacao_parcial,
+                    CASE WHEN t.no_topo > 1 THEN 'empatado' ELSE 'eleito' END) AS situacao
+    FROM situado s LEFT JOIN topo t USING (customer_user_id, recommendation_type)
+  ),
+  montado AS (
+    SELECT f.customer_user_id, f.recommendation_type, f.situacao, f.candidatos,
+           f.affinity_score, f.run_id,
+           (SELECT coalesce(jsonb_agg(b.product_id ORDER BY b.product_id), '[]'::jsonb)
+              FROM base b
+             WHERE b.customer_user_id = f.customer_user_id
+               AND b.recommendation_type = f.recommendation_type
+               -- `eleito`/`empatado` nomeiam o TOPO; os demais nomeiam o grupo inteiro.
+               AND (f.situacao NOT IN ('eleito','empatado') OR b.ordem = f.ordem_minima)
+           ) AS produtos,
+           CASE WHEN f.situacao = 'eleito' THEN
+             (SELECT b.product_id FROM base b
+               WHERE b.customer_user_id = f.customer_user_id
+                 AND b.recommendation_type = f.recommendation_type
+                 AND b.ordem = f.ordem_minima LIMIT 1)
+           END AS produto_eleito
+    FROM final f
+  )
+  SELECT coalesce(
+           jsonb_agg(to_jsonb(m) ORDER BY m.customer_user_id, m.recommendation_type),
+           '[]'::jsonb)
+  FROM montado m
+$fn$;
+
+REVOKE ALL ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) TO service_role;
+```
+
+⚠️ `SECURITY INVOKER` de propósito, como a RPC antiga: `frec_select_carteira` segue sendo a única fronteira e `p_farmer_id` é filtro, não autorização. ⚠️ A RPC antiga **não** é derrubada aqui (§3.4) — ela serve o front antigo até a adoção do Publish.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/ && git commit -m "feat(db): ordem densa e referencia_ambigua no melhor individual"
+```
+
+---
+
+### Task 2: Harness PG17 — o contrato do banco
+
+**Files:**
+- Modify: `db/test-farmer-head-geracao.sh`
+
+**Interfaces:**
+- Consumes: a migration da Task 1.
+- Produces: asserts nomeados `O*` (ordem) e `S*` (situação) reutilizados pelas sabotagens da Task 8.
+
+⚠️ **Este harness e não o `test-farmer-geracao-vigente.sh`**: aquele aplica só a `20260814223445` e exercita uma assinatura de `farmer_recomendacoes_substituir` **sem `p_head_visto`**, que não é a que o front chama (`useCrossSellEngine.ts:1205`).
+
+- [ ] **Step 1: Aplicar a migration nova na ZONA 2**
+
+Depois de `P -q -f "$MIG"` (linha ~185), acrescentar:
+
+```bash
+MIG_ORDEM="$REPO_ROOT/supabase/migrations/20260907HHMMSS_farmer_ordem_e_referencia_ambigua.sql"
+P -q -f "$MIG_ORDEM"
+P -q -f "$MIG_ORDEM"   # idempotência: o founder pode re-colar
+ok "I2 migration da ordem é idempotente (aplicada 2x sem erro)"
+```
+
+- [ ] **Step 2: Escrever os asserts de situação — os cinco estados e a precedência**
+
+Um grupo por estado, semeando via a RPC real (não `INSERT` direto — a gravação é parte do contrato):
+
+```bash
+sit() {  # sit <cliente> <tipo> -> a situacao que a RPC devolve
+  Pq -c "SELECT j->>'situacao' FROM jsonb_array_elements(
+           public.farmer_melhores_individuais_por_cliente('$FARMER_A')) j
+          WHERE j->>'customer_user_id' = '$1' AND j->>'recommendation_type' = '$2';"
+}
+eq "$(sit "$CLI_ELEITO" cross_sell)"      "eleito"              "S1 topo único com ordem conhecida"
+eq "$(sit "$CLI_EMPATE" cross_sell)"      "empatado"            "S2 dois no rank mínimo"
+eq "$(sit "$CLI_SINGLETON" up_sell)"      "unico_registrado"    "S3 singleton NUNCA é eleito"
+eq "$(sit "$CLI_PARCIAL" cross_sell)"     "ordem_indisponivel"  "S4 [1,2,null] é incompleta"
+eq "$(sit "$CLI_AMBIGUO" up_sell)"        "referencia_ambigua"  "S5 flag vence empate E eleição"
+eq "$(sit "$CLI_FLAG_NULA" up_sell)"      "referencia_ambigua"  "S6 flag NULL com ordem preenchida é fail-closed"
+```
+
+⚠️ `CLI_SINGLETON` é semeado com `ordem` **nula** e um único candidato. A revisão 3 do plano exigia `eleito` aqui **e** `unico_registrado` noutro assert — oráculo contraditório; a precedência de §3.3 resolve, e este assert é o que a prende.
+
+- [ ] **Step 3: Escrever os asserts de payload — `produtos`, `candidatos`, `produto_eleito`**
+
+O caso `[A:1, B:1, C:2]`, que é onde a revisão 3 mentia:
+
+```bash
+eq "$(Pq -c "SELECT jsonb_array_length(j->'produtos') FROM … WHERE cliente='$CLI_EMPATE' …")" \
+   "2" "O1 produtos nomeia só o TOPO no empate"
+eq "$(Pq -c "SELECT j->>'candidatos' FROM … WHERE cliente='$CLI_EMPATE' …")" \
+   "3" "O2 candidatos é o GRUPO inteiro, não o topo"
+eq "$(Pq -c "SELECT count(*) FROM jsonb_array_elements(public.farmer_melhores_individuais_por_cliente('$FARMER_A')) j
+              WHERE (j->>'produto_eleito' IS NOT NULL) <> (j->>'situacao' = 'eleito');")" \
+   "0" "O3 produto_eleito não-nulo ⟺ eleito, sem exceção na carteira"
+```
+
+- [ ] **Step 4: Escrever os negativos — SQLSTATE nomeada, re-lançando o resto**
+
+```bash
+neg() {  # neg <json-de-p_linhas> <sqlstate-esperada> <rotulo>
+  local saida; saida=$(P -tA -c "
+    DO \$\$ BEGIN
+      PERFORM public.farmer_recomendacoes_substituir('$FARMER_A', gen_random_uuid(), NULL, '$1'::jsonb);
+      RAISE EXCEPTION 'NAO-RECUSOU';
+    EXCEPTION WHEN SQLSTATE '$2' THEN RAISE NOTICE 'RECUSOU-COMO-ESPERADO';
+    END \$\$;" 2>&1 || true)
+  case "$saida" in *RECUSOU-COMO-ESPERADO*) ok "$3" ;; *) bad "$3 — veio: $(printf '%s' "$saida" | head -c 200)" ;; esac
+}
+neg '[{…,"ordem":0}]'                  FG007 "N1 ordem 0 recusada"
+neg '[{…,"ordem":-1}]'                 FG007 "N2 ordem negativa recusada"
+neg '[{…,"referencia_ambigua":"talvez"}]' 22P02 "N3 flag não-booleana morre no cast, antes de expirar"
+```
+
+⚠️ O `WHEN OTHERS THEN 'OK'` está proibido: a cláusula captura a SQLSTATE **esperada** e qualquer outra sobe. Um teste que aceita "lançou algo" aprovaria a exceção errada.
+
+- [ ] **Step 5: RLS e ACL**
+
+```bash
+eq "$(Pq -c "SET ROLE authenticated; SET request.jwt.claims TO '{\"sub\":\"$FARMER_B\"}';
+             SELECT jsonb_array_length(public.farmer_melhores_individuais_por_cliente('$FARMER_A'));")" \
+   "0" "R1 carteira alheia não volta sob RLS"
+eq "$(Pq -c "SELECT has_function_privilege('anon','public.farmer_melhores_individuais_por_cliente(uuid)','EXECUTE');")" \
+   "f" "R2 anon não executa"
+```
+
+- [ ] **Step 6: Rodar o harness e capturar o exit code colado**
+
+```bash
+bash db/test-farmer-head-geracao.sh; echo "EXIT=$?"
+```
+
+Esperado: todos os `ok`, `EXIT=0`. Ausência de vermelho **não** é aprovação: conferir que a contagem de asserts subiu na linha de resumo.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add db/ && git commit -m "test(db): contrato dos 5 estados do melhor individual"
+```
+
+---
+
+### Task 3: `rank-denso.ts` — o rank, isolado do motor
+
+**Files:**
+- Create: `src/lib/farmer/rank-denso.ts`
+- Create: `src/lib/farmer/__tests__/rank-denso.test.ts`
+- Modify: `src/lib/farmer/upsell-ordem.ts`
+- Modify: `src/lib/modulos/manifesto.ts`
+
+**Interfaces:**
+- Produces: `rankDenso<T>(itens: readonly T[], comparar: (a:T,b:T)=>number): number[]` — devolve, na ordem de `itens`, o rank 1-based **denso**; e `chavesEmpatam` exportado de `upsell-ordem.ts`.
+- Consumes: `compararCandidatosUpSell` de `upsell-ordem.ts`.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { rankDenso } from '../rank-denso';
+
+const num = (a: number, b: number) => a - b;
+
+describe('rankDenso', () => {
+  it('empatados COMPARTILHAM o rank, e o seguinte não pula', () => {
+    // Denso, não competition ranking: [1,1,2] e nunca [1,1,3] — e nunca [1,2,3],
+    // que é o bug trocando de endereço (uuid → índice do array).
+    expect(rankDenso([10, 10, 20], num)).toEqual([1, 1, 2]);
+  });
+
+  it('devolve os ranks na ordem de ENTRADA, não na ordenada', () => {
+    expect(rankDenso([30, 10, 20], num)).toEqual([3, 1, 2]);
+  });
+
+  it('não reordena a entrada', () => {
+    const entrada = [30, 10, 20];
+    rankDenso(entrada, num);
+    expect(entrada).toEqual([30, 10, 20]);
+  });
+
+  it('lista vazia devolve vazio', () => {
+    expect(rankDenso([], num)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+heavy bun run test src/lib/farmer/__tests__/rank-denso.test.ts; echo "EXIT=$?"
+```
+
+Esperado: FAIL — `Failed to resolve import "../rank-denso"`.
+
+- [ ] **Step 3: Implementar**
+
+```ts
+/**
+ * Rank DENSO 1-based sobre um comparador — a peça que faz a ordem sobreviver à persistência.
+ *
+ * DENSO e não posicional: candidatos indistinguíveis para o comparador recebem o MESMO
+ * número. Numerar 1,2,3 entre empatados seria trocar o endereço do defeito que esta entrega
+ * conserta — hoje o desempate é `id` uuid, e viraria "índice no array", que é a ordem de
+ * varredura do catálogo. Um empate compartilhado é a afirmação verdadeira: o sinal não
+ * separou estes dois.
+ *
+ * O empate é derivado do PRÓPRIO comparador (`comparar(a,b) === 0`) em vez de um predicado
+ * paralelo: dois critérios de igualdade divergem no dia em que um dos dois muda, e a
+ * divergência apareceria como eleição fabricada.
+ */
+export function rankDenso<T>(itens: readonly T[], comparar: (a: T, b: T) => number): number[] {
+  const indices = itens.map((_, i) => i);
+  indices.sort((x, y) => comparar(itens[x], itens[y]));
+
+  const ranks = new Array<number>(itens.length);
+  let rank = 0;
+  for (let p = 0; p < indices.length; p++) {
+    if (p === 0 || comparar(itens[indices[p - 1]], itens[indices[p]]) !== 0) rank++;
+    ranks[indices[p]] = rank;
+  }
+  return ranks;
+}
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+heavy bun run test src/lib/farmer/__tests__/rank-denso.test.ts; echo "EXIT=$?"
+```
+
+Esperado: 4 passed, `EXIT=0`.
+
+- [ ] **Step 5: Registrar no manifesto**
+
+Em `src/lib/modulos/manifesto.ts`, no módulo que já dona `src/lib/farmer/upsell-ordem.ts`, acrescentar `"src/lib/farmer/rank-denso.ts"` em `codigo` e `"src/lib/farmer/__tests__/rank-denso.test.ts"` em `testes`. Sem isso o `manifesto.gate` reprova **só no CI**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/farmer/ src/lib/modulos/manifesto.ts
+git commit -m "feat(farmer): rank denso, com o empate derivado do proprio comparador"
+```
+
+---
+
+### Task 4: Motor — a flag de referência ambígua, por CLIENTE
+
+**Files:**
+- Modify: `src/hooks/useCrossSellEngine.ts:695`
+- Test: `src/hooks/__tests__/cross-sell-referencia-ambigua.test.tsx`
+
+**Interfaces:**
+- Produces: `Set<string>` de clientes com referência ambígua, consumido pela Task 5 ao montar `recRows`.
+
+- [ ] **Step 1: Escrever o teste que falha — o contraexemplo do challenge**
+
+O caso que a revisão 3 não cobria: a flag tem de sobreviver à **deduplicação**, que escolhe outra base.
+
+```tsx
+it('marca o cliente mesmo quando a base ambígua PERDE a deduplicação', async () => {
+  // Base A: dois pedidos no MESMO instante, preços 100 e 200 → referência decidida por uuid.
+  // Base B: referência inequívoca de 150.
+  // Candidatos X=230 e Y=180, mesma família/unidade, mesma popularidade.
+  // Com referência 100, X e Y são ambos melhores via B — e nenhuma linha nasceria marcada
+  // se a flag fosse da RELAÇÃO. Ela é do CLIENTE, então sobrevive.
+  const { linhas } = await rodarMotor(cenarioDuasBases());
+  expect(linhas.filter((l) => l.recommendation_type === 'up_sell')).toSatisfyAll(
+    (l) => l.referencia_ambigua === true,
+  );
+});
+
+it('cross_sell recebe false explícito — o tipo não usa preço de referência', async () => {
+  const { linhas } = await rodarMotor(cenarioDuasBases());
+  expect(linhas.filter((l) => l.recommendation_type === 'cross_sell')).toSatisfyAll(
+    (l) => l.referencia_ambigua === false,
+  );
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+heavy bun run test src/hooks/__tests__/cross-sell-referencia-ambigua.test.tsx; echo "EXIT=$?"
+```
+
+Esperado: FAIL — `referencia_ambigua` é `undefined`.
+
+- [ ] **Step 3: Implementar — marcar no ponto onde a informação existe**
+
+Em `useCrossSellEngine.ts`, antes do laço de clientes, `const clientesComReferenciaAmbigua = new Set<string>();`. No laço de preços (L695), substituir:
+
+```ts
+            if (existing.precoEm === null || compararRecencia(marca, existing.precoEm) > 0) {
+```
+
+por:
+
+```ts
+            // A ambiguidade é do CLIENTE e é decidida AQUI — antes de elegibilidade, dedup e
+            // corte. Marcar a relação vencedora não bastaria: a dedup guarda, por SKU, só a
+            // melhor relação, e a razão de preço que decide essa "melhor" é justamente a que a
+            // referência sorteada altera. O challenge executou o contraexemplo em que os mesmos
+            // dois SKUs chegam à persistência nos dois mundos e a flag da relação some.
+            //
+            // Indistinguível = instantes iguais OU ambos ausentes (`compararRecencia` cai no
+            // `pedidoId` nos dois casos) entre pedidos DISTINTOS, com preços diferentes.
+            if (
+              existing.precoEm !== null &&
+              existing.precoEm.instante === marca.instante &&
+              existing.precoEm.pedidoId !== marca.pedidoId &&
+              existing.price !== precoItem
+            ) {
+              clientesComReferenciaAmbigua.add(cid);
+            }
+            if (existing.precoEm === null || compararRecencia(marca, existing.precoEm) > 0) {
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+heavy bun run test src/hooks/__tests__/cross-sell-referencia-ambigua.test.tsx; echo "EXIT=$?"
+```
+
+Esperado: 2 passed, `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/ && git commit -m "feat(farmer): ambiguidade da referencia marcada por CLIENTE, antes da dedup"
+```
+
+---
+
+### Task 5: Motor — rank denso nos dois tipos, D3, e o payload
+
+**Files:**
+- Modify: `src/hooks/useCrossSellEngine.ts:1032-1046` e o bloco que monta `recRows`
+- Test: `src/hooks/__tests__/cross-sell-rank-denso.test.tsx`
+
+**Interfaces:**
+- Consumes: `rankDenso` (Task 3), `clientesComReferenciaAmbigua` (Task 4).
+- Produces: linhas de `p_linhas` com `ordem: number` e `referencia_ambigua: boolean`.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+```tsx
+it('up-sell: empatados compartilham a ordem', async () => {
+  const { linhas } = await rodarMotor(cenarioUpSellEmpatado());
+  expect(linhas.map((l) => l.ordem)).toEqual([1, 1]);
+});
+
+it('cross-sell: D3 ordena pelo score NÃO arredondado', async () => {
+  // k=[9,9,9,10] colidem em 0,0001 depois do Math.round(score*10000)/10000.
+  // Pela ordem antiga o topo saía por ordem de inserção (uuid do catálogo).
+  const { linhas } = await rodarMotor(cenarioQuatroSkusQuaseEmpatados());
+  expect(linhas[0].product_id).toBe(SKU_K10);
+  expect(linhas[0].ordem).toBe(1);
+});
+
+it('recRows carrega os dois campos novos', async () => {
+  const { linhas } = await rodarMotor(cenarioMinimo());
+  expect(Object.keys(linhas[0])).toEqual(expect.arrayContaining(['ordem', 'referencia_ambigua']));
+});
+```
+
+⚠️ As fixtures de up-sell precisam de **múltiplas bases de compra com preços diferentes**: com uma base só, ordenar por `premium/referência` dá a mesma ordem que por `premium`, e a sabotagem da Task 8 passaria verde.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+heavy bun run test src/hooks/__tests__/cross-sell-rank-denso.test.tsx; echo "EXIT=$?"
+```
+
+Esperado: FAIL — `ordem` é `undefined`.
+
+- [ ] **Step 3: Implementar**
+
+Substituir o bloco de ordenação e corte (L1032-1046):
+
+```ts
+        const upSellOrdenado = [...upSellPorProduto.values()].sort((a, b) =>
+          compararCandidatosUpSell(a.chave, b.chave),
+        );
+        const topUpCand = upSellOrdenado.slice(0, VAGAS_UP_SELL);
+        const ordemUp = rankDenso(topUpCand.map((c) => c.chave), compararCandidatosUpSell);
+
+        // D3: o cross-sell ordenava por `affinityScore`, que é o score ARREDONDADO a 4 casas —
+        // 32 valores distintos em 714 linhas. Entre empatados o `sort` estável devolvia a ordem
+        // de inserção, que é a varredura do catálogo (`.order('id')`): o top-3 do vendedor era
+        // uuid. Passa a ordenar pelo score cru, que é o que o motor de fato calculou.
+        crossSellRecs.sort((a, b) => b.scoreCru - a.scoreCru);
+        const topCross = crossSellRecs.slice(0, 3);
+        const ordemCross = rankDenso(topCross.map((r) => r.scoreCru), (a, b) => b - a);
+```
+
+⚠️ `scoreCru` **não existe hoje** — `Recommendation` só carrega `affinityScore`, que já vem
+arredondado de `Math.round(affinityScore * 10000) / 10000`. Acrescentar o campo ao tipo interno e
+preenchê-lo com o `pij` cru **antes** do arredondamento; sem ele, D3 é impossível de escrever e o
+`sort` continua sendo o mesmo de hoje com outro nome.
+
+E, ao montar `recRows`, cada linha recebe:
+
+```ts
+          ordem: ordemDoCandidato,                                  // 1-based, denso
+          referencia_ambigua:
+            tipo === 'up_sell' ? clientesComReferenciaAmbigua.has(cid) : false,
+```
+
+⚠️ `false` explícito no cross-sell é **afirmação verdadeira** sobre o tipo (o `pij` do cross-sell não usa preço), não silêncio — e é o que impede o fail-closed da RPC de marcar o tipo inteiro como ambíguo.
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+heavy bun run test src/hooks/__tests__/; echo "EXIT=$?"
+```
+
+Esperado: toda a suíte do hook verde, `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/ && git commit -m "feat(farmer): rank denso persistido nos dois tipos, e D3 pelo score cru"
+```
+
+---
+
+### Task 6: Leitor — contrato, validação e os 7 pontos
+
+**Files:**
+- Create: `src/lib/farmer/melhor-individual.ts`
+- Create: `src/lib/farmer/__tests__/melhor-individual.test.ts`
+- Modify: `src/hooks/useBundleEngine.ts` (L57-95, 844, 1038-1080, 1163)
+- Modify: `src/lib/modulos/manifesto.ts`
+
+**Interfaces:**
+- Produces: `type SituacaoIndividual` (5 estados), `type LinhaMelhorIndividual`, `validarRespostaMelhorIndividual(data: unknown): LinhaMelhorIndividual[]` (lança em resposta inválida), e `ComparacaoIndividual` ampliada.
+- Consumes: a RPC da Task 1.
+
+- [ ] **Step 1: Escrever o teste que falha — a linha que a revisão 3 deixava passar**
+
+```ts
+it('rejeita empatado com um produto só — o validador de campo a campo aceitava', () => {
+  expect(() => validarRespostaMelhorIndividual([{
+    customer_user_id: '11111111-1111-4111-8111-111111111111',
+    recommendation_type: 'cross_sell',
+    situacao: 'empatado',
+    candidatos: 1,
+    produtos: [],
+    produto_eleito: null,
+  }])).toThrow(/empatado exige/);
+});
+
+it('rejeita produto_eleito fora de eleito', () => { /* … situacao:'empatado', produto_eleito:'…' */ });
+it('rejeita produto_eleito que não está em produtos', () => { /* … */ });
+it('rejeita produtos com duplicata', () => { /* … */ });
+it('rejeita length(produtos) > candidatos', () => { /* … */ });
+it('aceita o caso [A:1,B:1,C:2]: produtos 2, candidatos 3', () => { /* … não lança */ });
+```
+
+⚠️ `toThrow(/empatado exige/)` casa a **marca do ramo**, não "lançou algo": um `toThrow()` pelado aprovaria a exceção errada.
+
+- [ ] **Step 2: Rodar e ver falhar**
+
+```bash
+heavy bun run test src/lib/farmer/__tests__/melhor-individual.test.ts; echo "EXIT=$?"
+```
+
+Esperado: FAIL — módulo inexistente.
+
+- [ ] **Step 3: Implementar o contrato**
+
+```ts
+export type SituacaoIndividual =
+  | 'eleito' | 'empatado' | 'unico_registrado' | 'ordem_indisponivel' | 'referencia_ambigua';
+
+export interface LinhaMelhorIndividual {
+  customer_user_id: string;
+  recommendation_type: 'cross_sell' | 'up_sell';
+  situacao: SituacaoIndividual;
+  produtos: string[];
+  produto_eleito: string | null;
+  candidatos: number;
+  affinity_score: number | null;
+  run_id: string | null;
+}
+
+/**
+ * Valida a resposta INTEIRA — e lança, em vez de filtrar.
+ *
+ * Descartar as linhas inválidas transformaria falha em ausência: o Map ficaria parcial e
+ * seria apresentado como completo, e `nenhum` é um VEREDICTO na tela. O consumidor trata a
+ * exceção como `leitura_falhou`, que vale para a carteira inteira e é honesto.
+ *
+ * Os invariantes ENTRE campos são o ponto: campo a campo,
+ * `{situacao:'empatado', candidatos:1, produtos:[]}` passa em "tipo reconhecido", "inteiro ≥1"
+ * e "sem eleito fora de eleito" — e não representa empate nenhum.
+ */
+export function validarRespostaMelhorIndividual(data: unknown): LinhaMelhorIndividual[] {
+  if (!Array.isArray(data)) throw new Error(`resposta nao-array: ${data === null ? 'null' : typeof data}`);
+  const vistos = new Set<string>();
+  return data.map((bruta, i) => {
+    const l = bruta as Record<string, unknown>;
+    const onde = `linha ${i}`;
+    if (typeof l.customer_user_id !== 'string') throw new Error(`${onde}: customer_user_id ausente`);
+    if (l.recommendation_type !== 'cross_sell' && l.recommendation_type !== 'up_sell')
+      throw new Error(`${onde}: tipo desconhecido ${String(l.recommendation_type)}`);
+    const chave = `${l.customer_user_id}:${l.recommendation_type}`;
+    if (vistos.has(chave)) throw new Error(`${onde}: (cliente,tipo) duplicado`);
+    vistos.add(chave);
+
+    if (!SITUACOES.has(l.situacao as string)) throw new Error(`${onde}: situacao invalida`);
+    if (!Number.isInteger(l.candidatos) || (l.candidatos as number) < 1)
+      throw new Error(`${onde}: candidatos precisa ser inteiro >= 1`);
+    if (!Array.isArray(l.produtos) || l.produtos.length < 1 || !l.produtos.every((p) => typeof p === 'string'))
+      throw new Error(`${onde}: produtos precisa ser array nao-vazio de uuid`);
+    if (new Set(l.produtos).size !== l.produtos.length) throw new Error(`${onde}: produtos com duplicata`);
+    if (l.produtos.length > (l.candidatos as number))
+      throw new Error(`${onde}: produtos (${l.produtos.length}) excede candidatos (${l.candidatos})`);
+
+    const eleito = l.situacao === 'eleito';
+    if ((l.produto_eleito != null) !== eleito)
+      throw new Error(`${onde}: produto_eleito nao-nulo tem de ser exatamente o estado eleito`);
+    if (eleito && !l.produtos.includes(l.produto_eleito as string))
+      throw new Error(`${onde}: produto_eleito fora de produtos`);
+
+    // Cardinalidade POR estado — o invariante que a validacao campo-a-campo nao alcanca.
+    if (l.situacao === 'empatado' && (l.produtos.length < 2 || (l.candidatos as number) < 2))
+      throw new Error(`${onde}: empatado exige >=2 produtos e >=2 candidatos`);
+    if (l.situacao === 'ordem_indisponivel' && (l.produtos.length < 2 || (l.candidatos as number) < 2))
+      throw new Error(`${onde}: ordem_indisponivel exige >=2 produtos e >=2 candidatos`);
+    if (l.situacao === 'unico_registrado' && (l.produtos.length !== 1 || l.candidatos !== 1))
+      throw new Error(`${onde}: unico_registrado exige exatamente 1 produto e 1 candidato`);
+    if (eleito && (l.produtos.length !== 1 || (l.candidatos as number) < 2))
+      throw new Error(`${onde}: eleito exige 1 produto nomeado e >=2 candidatos`);
+
+    return l as unknown as LinhaMelhorIndividual;
+  });
+}
+```
+
+- [ ] **Step 4: Rodar e ver passar**
+
+```bash
+heavy bun run test src/lib/farmer/__tests__/melhor-individual.test.ts; echo "EXIT=$?"
+```
+
+- [ ] **Step 5: Aplicar os 7 pontos em `useBundleEngine.ts`**
+
+| # | onde | mudança |
+|---|---|---|
+| 1 | L844 | chave do Map vira `` `${linha.customer_user_id}:${linha.recommendation_type}` `` |
+| 2 | L1046-1055 | resolve nome de **todos** os SKUs de `produtos`, não só do eleito |
+| 3 | novo | nenhum resolve → `indisponivel/produto_nao_resolve`; **alguns** resolvem → mantém a `situacao` e reporta `naoIdentificados` |
+| 4 | L1163 | o sensor conta só SKU que não resolve — estado sem eleição não é falha de catálogo |
+| 5 | L1073 | omite o cliente só quando **ambos** os tipos são `nenhum` |
+| 6 | L823-843 | `validarRespostaMelhorIndividual` no lugar do cast; a exceção cai no `catch` que já existe |
+| 7 | L1057 | `geracoesExibidas.add` passa a acompanhar **todo estado exibido** |
+
+- [ ] **Step 6: Rodar a suíte inteira do leitor**
+
+```bash
+heavy bun run test src/hooks/__tests__/; echo "EXIT=$?"
+```
+
+- [ ] **Step 7: Registrar no manifesto e commitar**
+
+```bash
+git add src/lib/farmer/ src/hooks/ src/lib/modulos/manifesto.ts
+git commit -m "feat(farmer): leitor com invariantes cruzados e nome em todo estado"
+```
+
+---
+
+### Task 7: Cartão — duas células rotuladas
+
+**Files:**
+- Modify: `src/components/farmer/bundles/CustomerBundleCard.tsx` (L68, L107-108)
+- Test: `src/components/farmer/bundles/__tests__/customer-bundle-card-individuais.test.tsx`
+
+**Interfaces:**
+- Consumes: `ComparacaoIndividual` ampliada (Task 6).
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Um por estado, mais o que prende o achado R3/3:
+
+```tsx
+it('empatado com um nome faltando NÃO promove o outro a vencedor', () => {
+  render(<CustomerBundleCard data={comEmpateComUmSkuForaDoCatalogo()} />);
+  expect(screen.getByText(/Igualmente indicados/)).toBeInTheDocument();
+  expect(screen.getByText(/1 de 2 não identificado/)).toBeInTheDocument();
+  expect(screen.queryByText(/Melhor complementar: /)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar** — `heavy bun run test src/components/farmer/bundles/__tests__/; echo "EXIT=$?"`
+
+- [ ] **Step 3: Implementar as duas células**
+
+Rótulos: "Melhor complementar" (cross_sell) e "Melhor upgrade" (up_sell). Copy por estado, exatamente como a tabela de §3.6.
+
+- [ ] **Step 4: Rodar e ver passar** — mesma linha do Step 2, `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ && git commit -m "feat(farmer): cartao com duas celulas rotuladas e os cinco estados"
+```
+
+---
+
+### Task 8: Falsificação — uma camada por vez
+
+**Files:**
+- Modify: `db/test-farmer-head-geracao.sh` (bloco `--falsificar`)
+
+- [ ] **Step 1: Commitar TUDO antes de sabotar**
+
+`restaurar()` costuma ser `git checkout --`: sabotar com trabalho não commitado apaga o trabalho.
+
+```bash
+git status --porcelain; echo "EXIT=$?"
+```
+
+Esperado: **saída vazia**.
+
+- [ ] **Step 2: Linha de base VERDE na mesma invocação**
+
+O laço roda o controle **antes** do primeiro `sed` e aborta se ele não estiver verde. Sem isso, uma suíte sempre-vermelha aprova todas as sabotagens.
+
+- [ ] **Step 3: As seis sabotagens, conferindo contagem E nomes**
+
+| sabotagem | vermelho esperado |
+|---|---|
+| dedup guarda só a flag da relação vencedora | `S5` |
+| D3 volta ao score arredondado | `cross-sell: D3 ordena pelo score NÃO arredondado` |
+| `rankDenso` numera 1,2,3 entre empatados | `empatados COMPARTILHAM o rank` + `O1` + `S2` |
+| `recRows` omite `ordem` | `recRows carrega os dois campos novos` + `S1` |
+| leitor descarta linha inválida em vez da resposta | `rejeita empatado com um produto só` |
+| RPC avalia `empatado` antes de `referencia_ambigua` | `S5` |
+
+Cada uma tem de produzir **exatamente** o conjunto declarado. Uma sabotagem que fica verde significa camada redundante ou inalcançada; uma que fica vermelha demais significa que o assert não isola o ramo.
+
+- [ ] **Step 4: Rodar a falsificação inteira**
+
+```bash
+bash db/test-farmer-head-geracao.sh --falsificar; echo "EXIT=$?"
+```
+
+Esperado: cada sabotagem nomeada com seu conjunto de vermelhos, `EXIT=0`. ⚠️ Terminar rápido demais é sinal de que a suíte não rodou.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/ && git commit -m "test(db): falsificacao das seis camadas do conserto da ordem"
+```
+
+---
+
+### Task 9: Sensor da distribuição (§6.1) e entrega
+
+**Files:**
+- Modify: a edge/RPC que grava o log de execuções (`20260815181500_farmer_geracao_head_sensor.sql:446`)
+
+- [ ] **Step 1: Emitir a contagem por `situacao` e tipo no log de execuções**
+
+Server-side, porque o produtor legado não sabe emiti-la, e no log (que tem denominador) em vez de insumo do head (que é sobrescrito).
+
+- [ ] **Step 2: Health stack completo**
+
+```bash
+heavy bun run typecheck; echo "EXIT=$?"
+bun run lint; echo "EXIT=$?"
+heavy bun run test; echo "EXIT=$?"
+bunx knip; echo "EXIT=$?"
+bun run lint:shell; echo "EXIT=$?"
+```
+
+Cada um tem de terminar e mostrar `EXIT=0` colado.
+
+- [ ] **Step 3: RE-conferir a main imediatamente antes do PR**
+
+`useCrossSellEngine.ts` é arquivo QUENTE (mudou +64 linhas hoje, por outra sessão).
+
+```bash
+git fetch origin && git log --oneline origin/main -5 && gh pr list --state open
+git grep -l "farmer_melhores_individuais_por_cliente" origin/main || echo "artefato ainda nao esta na main"
+```
+
+- [ ] **Step 4: Escrever a sequência de implantação no corpo do PR**
+
+A ordem é obrigatória e cada passo é MANUAL (Lovable):
+**1. banco** (founder cola a migration no SQL Editor) → **2. Publish** → **3. recálculo**, que grava
+os primeiros ranks → **4. PR de limpeza** derruba a RPC antiga. Inverter 1 e 2 faz o
+`jsonb_to_recordset` ignorar as chaves novas **em silêncio**: nada persiste e nada falha.
+
+- [ ] **Step 5: Abrir o PR e armar o watch**
+
+```bash
+gh pr create --draft --title "…" --body "…"
+scripts/pr-watch.sh <nº> &
+```
+
+⚠️ **DRAFT**: o auto-merge squasha qualquer PR não-draft assim que o `validate` passa, e esta entrega depende de uma migration manual aplicada ANTES do Publish.

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -1,0 +1,235 @@
+# A RPC do "melhor individual" elege por moeda em 98,7% dos casos — desenho do conserto
+
+> Continuação de `docs/historico/affinity-score-duas-grandezas.md` (#2350), que mediu o defeito e
+> deixou a RPC de fora **de propósito**, com 5 critérios de aceite. Este é o desenho que os atende.
+> Re-medição em prod: 07/09/2026, `psql-ro`, geração de 21/08/2026, 1.083 recomendações pendentes.
+
+## 1. O que a re-medição acrescentou à fotografia do #2350
+
+A fotografia do doc **reproduziu exatamente** (714 cross-sell + 369 up-sell, mesmas faixas, 186/186
+up-sell vencendo entre pares com os dois tipos, 52 vencedores cross-sell = exatamente os pares sem
+up-sell). Duas coisas são novas, e as duas mudam o desenho.
+
+### 1.1 O defeito do desempate é maior do que o medido — e engole o outro
+
+O #2350 registrou que o `id` uuid decide dentro do up-sell (183/183) e ressalvou: *"não diz que o
+score nunca decide NADA — nos 52 pares sem up-sell ele ainda escolhe entre produtos cross-sell"*.
+
+**Medido: falso.**
+
+| eixo | grupos | topo empatado |
+|---|---|---|
+| empate no topo dentro do `cross_sell` | 238 | **198 (83,2%)** |
+| `cross_sell` que VENCE a RPC (pares sem up-sell) | 52 | **52 (100%)** |
+| `up_sell` que vence a RPC | 186 | **183** |
+
+`updated_at` não desempata nada (é o instante da transação de geração, igual para o lote inteiro).
+Somando: **235 dos 238 pares (98,7%) têm o produto eleito escolhido pelo `id` uuid v4.**
+
+Consequência de desenho: **declarar política entre tipos e parar aí consertaria ~0%** do que chega
+à tela. O eixo dominante é o desempate, não a precedência.
+
+Causa direta, no cross-sell: `affinityScore: Math.round(score * 10000) / 10000`. A `relevance`
+varia na casa de 1e-6 e o arredondamento é 1e-4 — restam **32 valores distintos em 714 linhas**.
+A ordem existe no cálculo e morre na gravação.
+
+### 1.2 Não é "artefato de escala" — é um limiar bem definido, e ele quase virou
+
+Os dois motores computam `P(conversão)` do MESMO cliente e compartilham os fatores `health/100` e
+`engagement`, que **cancelam** na comparação:
+
+```
+cross: pij = 0,15 × (health/100) × engagement × relevance    relevance = clamp(cA·0,4 + aB·0,6, 0,01, 1,0)
+up:    pij = 0,10 × (health/100) × engagement × 0,8
+
+up > cross  ⟺  0,08 > 0,15 × relevance  ⟺  relevance < 0,5333
+```
+
+**Teste falsificável** (o que separa isto de uma história plausível): se o cancelamento vale, a
+`relevance` implícita `(max_cross/max_up)/1,875` tem de cair dentro do `clamp` do código. Medido
+nos 186 pares com os dois tipos: mín **0,0148** · mediana **0,0338** · máx **0,5041** ·
+**0 de 186 fora de [0,01 , 1,0]**. Cair 186/186 dentro do intervalo exato seria coincidência
+absurda se a álgebra estivesse errada.
+
+Isto **corrige o vocabulário** do #2350 em dois pontos:
+
+- as grandezas não são incomensuráveis "por base histórica diferente" — os termos de cliente são
+  literalmente os mesmos e se cancelam;
+- a precedência não é **estrutural**, é **contingente**: o máximo observado (0,5041) ficou a **5,5%**
+  do limiar (0,5333). Uma carteira com `assocBoost` um pouco maior faz cross-sell vencer.
+
+A assimetria real é outra, e é a que importa para o produto: **o score do cross-sell é descontado
+por um termo de aderência ao PRODUTO; o do up-sell não tem termo de produto nenhum** (o `0,8` é
+constante para todo candidato). O número do up-sell não estima o produto — estima o cliente. Comparar
+os dois é comparar "P(compra ESTE complementar)" com "P(compra ALGO mais caro)": erro de categoria,
+não de escala.
+
+### 1.3 Substrato para "moeda comum" não existe hoje
+
+`lie` e `m_ij`: **0 de 17.316 linhas** populadas (colunas mortas, como `best_individual_lie`).
+Comparar em R$ exigiria reintroduzir margem no motor — removida do browser de propósito no #1837.
+Fica registrado como caminho possível, fora desta entrega.
+
+## 2. As decisões (do founder, 07/09/2026)
+
+| # | Decisão | Critério que atende |
+|---|---|---|
+| D1 | A RPC devolve o **melhor de CADA tipo**, sem compará-los | 1 e 5 |
+| D2 | Eleição não decidida por sinal → **não elege**; diz que empatou | 4 |
+| D3 | A ordem em MEMÓRIA do cross-sell entra na mesma entrega | — |
+| D4 | O cartão ganha **duas células rotuladas** | — |
+
+**D1 dissolve a comparação em vez de inventá-la.** É a única saída que não viola o critério 5:
+declarar `up_sell > cross_sell` reproduziria um viés observado, e nenhuma regra comercial autoriza
+a precedência. Não escolher é a resposta honesta quando não há critério — `precisão > recall`
+aplicado à ORDEM, não ao conteúdo.
+
+## 3. O desenho
+
+### 3.1 `farmer_recommendations.ordem smallint NULL`
+
+Rank **denso**, base 1, escopo `(farmer_id, customer_user_id, recommendation_type, run_id)`.
+
+**Candidatos empatados no sinal recebem o MESMO valor.** Esta é a peça que impede a entrega de
+trocar o endereço do bug: se empatados recebessem posições distintas, o vencedor passaria a ser
+decidido pelo índice do array — a ordem de varredura do catálogo, que é `.order('id')`, que é uuid
+**de novo**. Com rank denso, o empate vira **fato gravado** em vez de inferência de igualdade de
+float na leitura.
+
+Nulável porque as 1.083 linhas de 21/08 existem e não são recuperáveis (§3.5).
+
+### 3.2 Quem calcula o rank (critério 2 — ordem justificável DENTRO de cada tipo)
+
+- **`cross_sell`**: `pij` **não arredondado**, desc. O score já carrega `relevance`, que é termo do
+  produto — a ordem é legítima; só não sobrevive ao `Math.round`. Empate genuíno (mesmo
+  `buyerCount` e mesmo `assocBoost` ⇒ mesma `relevance`) permanece empatado e compartilha rank.
+- **`up_sell`**: `compararCandidatosUpSell` (menor razão de preço → maior popularidade), sobre a
+  referência **cronológica** que entrou na main em 07/09 (`preco-referencia.ts`). `upsell-ordem.ts`
+  já tem o comparador **e** o predicado de empate (`candidatosEmpatam`, hoje privado) — o rank denso
+  reusa os dois em vez de reimplementar a noção de empate.
+
+**Nada disto toca `affinity_score` nem `p_ij`.** A "% de conversão" que a tela mostra continua
+idêntica, e a armadilha que o #1837 nomeou (codificar ordem na magnitude é inventar score) fica
+fechada: a ordem vai para uma coluna que É ordem.
+
+### 3.3 RPC `farmer_melhores_individuais_por_cliente(uuid)` (nome novo — §3.4)
+
+Devolve `jsonb` com até **dois** objetos por cliente. Contrato por objeto:
+
+```
+customer_user_id · recommendation_type · product_id · affinity_score · run_id · empatados
+```
+
+`empatados` = quantos candidatos **poderiam** ser o melhor daquele tipo:
+
+- `ordem` conhecida em todo o grupo → quantos compartilham `min(ordem)`;
+- **qualquer** `ordem` nula no grupo → **todos** os candidatos do grupo. Ordem desconhecida
+  significa que nenhum candidato pode ser descartado — fail-closed, e é o que faz os registros
+  legados se declararem sozinhos sem backfill.
+
+`empatados = 1` é, por construção, "decidido por sinal". Um campo só, semântica exata, sem flag
+redundante que possa divergir dele.
+
+**Guard estrutural: `product_id` volta `NULL` sempre que `empatados > 1`.** Não existe "devolve o
+vencedor e confia que o consumidor respeite a flag" — sem eleição por sinal, não sai nome. Torna
+impossível renderizar a moeda por descuido, hoje ou num consumidor futuro (money-path §5: o guard
+mora na fronteira que toda via cruza).
+
+Preservados da RPC atual, e pelos mesmos motivos: `coalesce(…, '[]'::jsonb)` (`[]` = li e não há;
+`NULL` = falhou, e o caller lança), `SECURITY INVOKER` (a policy `frec_select_carteira` segue sendo
+a única fronteira), `REVOKE`/`GRANT` nomeando as roles.
+
+### 3.4 Por que nome NOVO em vez de substituir
+
+A RPC atual fica **intocada**. Isso elimina a janela de regressão entre os dois deploys manuais:
+entre a migration e o Publish, o front velho chama a RPC velha e nada muda.
+
+Se eu trocasse a assinatura da RPC existente, o front velho receberia **duas linhas por cliente** e
+o `melhorIndividual.set(linha.customer_user_id, linha)` guardaria a última — arbitrário outra vez,
+com o agravante de ser invisível. Também evita o `DROP`+`CREATE` que **reseta o ACL**
+(`database.md` §4).
+
+### 3.5 Registros existentes (critério 3) — sem backfill
+
+Os 1.083 pendentes de 21/08 nascem com `ordem` nula e, por §3.3, reportam `empatados = N`: a tela
+diz "N produtos igualmente indicados" em vez de eleger. **Isso já é o conserto**, e vale no dia da
+migration, antes de qualquer recálculo — para de apresentar moeda como veredicto para os 235 pares
+de hoje.
+
+Backfill foi descartado com motivo: a ordem não é recuperável das colunas existentes (o #2350 já
+mediu que `created_at` está empatado nos mesmos grupos), e re-derivar com preços de **hoje** sobre
+uma geração de **21/08** fabricaria número — exatamente o que `precisão > recall` proíbe.
+
+### 3.6 Leitor e tela (D4)
+
+`ComparacaoIndividual` passa a ser por tipo. O cartão ganha duas células rotuladas — "Melhor
+cross-sell" e "Melhor up-sell" — cada uma com quatro estados:
+
+| estado | quando | o que mostra |
+|---|---|---|
+| `encontrado` | `empatados = 1` e o SKU resolve no catálogo ativo | nome do produto |
+| `empatado` | `empatados > 1` | "N produtos igualmente indicados" |
+| `nenhum` | a RPC respondeu e não há oferta daquele tipo | — |
+| `indisponivel` | leitura falhou, ou o SKU eleito saiu do catálogo | rótulo + motivo |
+
+`empatado` e `indisponivel` ficam **separados de propósito**: "li e empatei" não é "não consegui
+ler". Colapsar os dois refaria, um nível abaixo, a fabricação de rótulo que o #1594 matou.
+
+Efeito colateral desejado: o vendedor passa a ver a **família** da oferta. Era justamente a
+invisibilidade do tipo (o cartão mostrava só o nome) que tornava a limitação indetectável para quem
+avalia o bundle — o "custo aceito" que o #2350 registrou deixa de ser aceito.
+
+### 3.7 Ordem em memória do cross-sell (D3)
+
+`crossSellRecs.sort((a,b) => b.affinityScore - a.affinityScore)` ordena pelo score **arredondado**;
+`Array.prototype.sort` é estável, então entre empatados vence a ordem de inserção — a varredura do
+catálogo, que vem de `fetchAllPages` com `.order('id')`. O top-3 do vendedor é uuid pelo mesmo
+mecanismo da RPC.
+
+Como o motor já vai calcular o rank denso para gravar, o `sort` passa a usar a mesma chave. Fechar
+só o lado persistido deixaria o mesmo defeito vivo com outra roupa.
+
+## 4. Sequência de implantação (critério 3)
+
+1. **Banco** — você cola no SQL Editor (`lovable-db-operator`):
+   `ALTER TABLE … ADD COLUMN ordem` · `CREATE OR REPLACE` de `farmer_recomendacoes_substituir`
+   (aceita e **valida** `ordem`: nula, ou inteiro ≥ 1) · `CREATE` da RPC nova.
+2. **Publish** — motores gravam `ordem`; leitor chama a RPC nova; cartão com duas células.
+3. **Recálculo** (um clique). Sem ele a tela diz "empatou" para os 238 clientes — honesto, mas é
+   janela: fazer no mesmo dia.
+4. **PR de limpeza** derruba a RPC antiga.
+
+A ordem 1→2 é obrigatória, não preferencial: o escritor novo grava `ordem`, e contra o schema velho
+o `jsonb_to_recordset` ignoraria a chave em silêncio — a coluna não existiria e **nenhum** rank
+seria persistido, sem erro nenhum. O `CREATE OR REPLACE` do writer é pré-flightado contra
+`pg_get_functiondef` da PROD (`database.md` §4: apply manual diverge do repo).
+
+## 5. Prova (money-path: plpgsql é late-bound)
+
+Harness PG17 estendendo `db/test-farmer-geracao-vigente.sh` (hoje 31 asserts + 4 falsificações):
+
+- **positivos**: rank denso grava empatados com o mesmo valor; `empatados` conta o topo;
+  `product_id` é `NULL` sob empate; grupo com `ordem` nula reporta `empatados = N`; `[]` na
+  carteira vazia; dois objetos por cliente quando há os dois tipos.
+- **negativos**: `ordem = 0` e `ordem` negativa recusadas com a SQLSTATE nomeada, re-lançando o
+  resto (`WHEN OTHERS THEN 'OK'` é teatro).
+- **RLS**: `SET ROLE authenticated` + GUC; carteira alheia não volta.
+- **falsificação**: sabotar uma camada por vez, com **linha de base verde na MESMA invocação**, e
+  conferir **contagem e NOMES** dos vermelhos — exit≠0 não distingue "pegou o bug" de "não rodou".
+
+⚠️ **Armadilha herdada, e ela é específica desta entrega**: o doc de 07/09
+(`preco-de-referencia-escolhido-por-uuid.md`) registra que o Codex removeu a referência da chave de
+ordenação do up-sell e **12 testes seguiram verdes**, porque a fixture tinha **uma** base comprada —
+com uma base só, `premium/ref` ordena igual a `premium`. As fixtures de up-sell aqui terão
+**múltiplas bases com preços diferentes**, e haverá uma sabotagem dedicada a provar que essa
+propriedade é medida.
+
+## 6. O que esta entrega NÃO fecha (declarado)
+
+- **A precedência entre tipos continua sem regra comercial.** D1 dissolve a comparação; não a
+  resolve. No dia em que houver regra (margem, mix, prazo), ela entra como política explícita — e
+  aí `empatados` já dá a base para dizer quando ela é aplicável.
+- **`p_ij` é 0 em 645 de 714 linhas cross-sell** (`Math.round(0,0002 × 1000)/10 = 0`): o vendedor lê
+  "0,0%" como probabilidade de conversão. Mesmo mecanismo de quantização, outra coluna, outro
+  consumidor. Fica como achado registrado, com medição própria pendente.
+- **Moeda comum em R$** (§1.3): sem substrato hoje.

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -162,16 +162,31 @@ São dois estados diferentes e passam a ter nomes diferentes:
 
 | `situacao` | condição | significado |
 |---|---|---|
-| `eleito` | ordem conhecida em todo o grupo **e** um único candidato no topo | decidido por sinal |
-| `empatado` | ordem conhecida em todo o grupo **e** ≥2 candidatos no topo | igualdade MEDIDA |
-| `ordem_desconhecida` | **qualquer** `ordem` nula no grupo com ≥2 candidatos | ninguém mediu |
+| `eleito` | ordem conhecida em TODO o grupo · máximo ÚNICO · referência não-ambígua | decidido por sinal |
+| `empatado` | ordem conhecida em TODO o grupo · ≥2 candidatos no máximo | igualdade MEDIDA |
+| `unico_registrado` | grupo de UM candidato | identificável, mas nada foi ordenado |
+| `ordem_indisponivel` | ≥2 candidatos e QUALQUER `ordem` nula | ordenação ausente ou incompleta |
 
-Um grupo de **um único candidato** é `eleito` mesmo com `ordem` nula: não há escolha a fazer, e
-chamar isso de empate seria a mentira simétrica. `candidatos` conta **SKUs distintos** (`count
-(DISTINCT product_id)`), não linhas — "N produtos" exige unicidade por produto.
+⚠️ **`unico_registrado` existe porque `eleito` mentiria** (achado R2/3). Um grupo de um candidato
+com `ordem` nula não é empate — mas também não foi decidido por sinal de ordenação nenhum. Ser a
+única recomendação registrada permite identificá-la; não diz nada sobre a qualidade da escolha que
+a produziu. Colapsar os dois em `eleito` seria a mentira simétrica à do campo único da revisão 1.
 
-O caso `[1, 2, null]` cai em `ordem_desconhecida` por fail-closed: as ordens conhecidas mantêm sua
-relação entre si, mas nada situa a linha nula, e afirmar o vencedor exigiria descartá-la.
+⚠️ **`ordem_indisponivel` cobre DOIS casos e o rótulo não afirma mais do que sabe**: `[null,null]`
+é ordenação **ausente**; `[1,2,null]` é ordenação **incompleta** — as ordens conhecidas mantêm sua
+relação, mas nada situa a linha nula, e eleger exigiria descartá-la. Nos dois a resposta honesta é
+a mesma ("não dá para ordenar este grupo"), então o estado é um só; o que não se pode é chamar
+qualquer um deles de "ninguém mediu", que era a redação anterior.
+
+**`candidatos` conta conjuntos DIFERENTES por estado**, e isso é explícito no contrato porque
+contar o grupo inteiro em `empatado` seria falso (achado R2/3): em `[A:1, B:1, C:2]` há **2**
+empatados, não 3.
+
+| estado | `candidatos` conta |
+|---|---|
+| `empatado` | SKUs distintos **no topo** |
+| `ordem_indisponivel` | SKUs distintos **registrados no grupo** |
+| `eleito` · `unico_registrado` | 1 |
 
 **Guard estrutural: `product_id` só é não-nulo quando `situacao = 'eleito'`.** Sem eleição por
 sinal, não sai vencedor — impossível renderizar a moeda por descuido.
@@ -199,8 +214,10 @@ Também evita o `DROP`+`CREATE` que **reseta o ACL** (`database.md` §4).
 
 ### 3.5 Registros existentes (critério 3) — sem backfill
 
-Os 1.083 pendentes de 21/08 nascem com `ordem` nula ⇒ `situacao = 'ordem_desconhecida'` e a tela diz
-"ordenação indisponível — N recomendações registradas".
+Os 1.083 pendentes de 21/08 nascem com `ordem` nula. Os grupos com **≥2** candidatos saem
+`ordem_indisponivel`; os de **um só** candidato saem `unico_registrado` e exibem o nome — e a
+distinção não é teórica: 369 linhas up-sell em 186 grupos implicam **pelo menos 3 grupos de uma
+linha** (achado R2/3, que derrubou o "todos sairão como ordem desconhecida" da revisão 2).
 
 ⚠️ **Correção da revisão 1**, que se contradizia: eu afirmava que isso "vale no dia da migration,
 antes de qualquer recálculo". **Não vale** — §3.4 mantém a RPC antiga servindo o front antigo, então
@@ -222,9 +239,22 @@ O leitor muda em cinco pontos, e quatro deles são armadilhas que o challenge ap
    deliberado como falha de catálogo — fabricaria deterioração.
 4. **O filtro de inclusão do cartão** (`useBundleEngine.ts:1073`) passa a omitir o cliente só quando
    **ambos** os tipos são `nenhum`.
-5. **Validação em runtime da resposta**: tipo reconhecido, `candidatos` inteiro ≥1, sem duplicata
-   `(cliente,tipo)`, combinação `situacao`×`product_id` válida. O cast atual para
-   `MelhorIndividualRow[]` não valida nada.
+5. **Validação em runtime da resposta**: `customer_user_id` presente, tipo reconhecido,
+   `candidatos` inteiro ≥1, sem duplicata `(cliente,tipo)`, combinação `situacao`×`product_id`
+   válida. O cast atual para `MelhorIndividualRow[]` não valida nada. **A resposta inválida é
+   rejeitada INTEIRA como `leitura_falhou`, preservando a causa** — validar-e-descartar linhas
+   transformaria falha em ausência e entregaria um Map parcial apresentado como completo (achado
+   R2/4). Sem a checagem de `customer_user_id` as demais passam e a linha some na consulta pela
+   chave, que é a mesma falha por outra porta.
+6. **`geracoesExibidas`** (`useBundleEngine.ts:1057`) só recebe `run_id` quando o produto resolve.
+   Com os estados novos, cartões exibiriam empates e ordens indisponíveis de gerações diferentes
+   sem alimentar o canário — a contagem passa a acompanhar **todo estado exibido**,
+   independentemente de o SKU resolver.
+
+**Preservar** (o challenge listou, e nenhum é consequência automática do desenho): o cartão
+continua aparecendo quando há bundle, mesmo com os dois individuais em `nenhum`; o aviso do cartão
+recolhido (`CustomerBundleCard.tsx:68`), hoje dependente do estado individual único; e a proibição
+de comparar `ordem` de `run_id` diferentes dentro de uma mesma eleição.
 
 O cartão ganha duas células rotuladas, cada uma com:
 
@@ -274,10 +304,18 @@ na origem. O challenge executou os helpers reais trocando só os uuids e o vence
 | clientes atingidos | 14 |
 | **∩ com os 186 clientes de up-sell vivo** | **2 (1,1%)** |
 
-É limite **superior**: nem todo par ambíguo troca vencedor. A 1,1% dos clientes, propagar a
-ambiguidade até o contrato da RPC não se paga nesta entrega — mas **declarar** é obrigatório, e a
-entrega inclui um sensor que conta pares ambíguos por execução, para que o número deixe de depender
-de alguém lembrar de medir. Se ele subir, a propagação vira trabalho próprio.
+É limite **superior**: nem todo par ambíguo troca vencedor. Mas **incidência medida não fecha
+falha de contrato** (achado R2/1): um único caso basta para que `eleito` — que afirma "decidido por
+sinal" — esteja errado, e o Codex executou os helpers reais trocando só os uuids, obtendo topo
+numericamente único nos DOIS mundos, com vencedores diferentes.
+
+**Por isso a ambiguidade entra no contrato, não num sensor agregado.** Um sensor não permite ao
+consumidor distinguir os casos afetados; a flag permite. O motor já tem o dado no instante em que
+escolhe a referência: quando o topo por `instante` está empatado entre pedidos DISTINTOS **com
+preços diferentes**, o candidato up-sell derivado dela nasce marcado, e o grupo não pode sair
+`eleito` — cai em `ordem_indisponivel`. Custo: um booleano por linha, decidido onde a informação
+já existe. A alternativa que o Codex também aceitava — rebaixar `eleito` para "topo único do rank
+persistido" — foi descartada: ela conserta o texto e deixa o consumidor sem como distinguir.
 
 ## 6. Implantação (critério 3)
 
@@ -303,9 +341,23 @@ A ordem 1→2 é obrigatória: contra o schema velho, o `jsonb_to_recordset` **i
 A última não é barrada pelo CAS: se a aba antiga lê o head **depois** da geração nova, ela apresenta
 o head correto e grava normalmente — o CAS controla concorrência causal, não versão do produtor. E
 `FarmerRecommendations.tsx:45` calcula **ao montar**, então não depende de clique consciente.
-⇒ a validação de `ordem` no writer **não pode** rejeitar o payload legado (quebraria a aba antiga
-inteira); o que a entrega adiciona é um **contador de gerações sem `ordem`** no head, para a janela
-ser observável em vez de suposta.
+**O que a entrega faz aqui, dito como o que é** (achado R2/5): um contador **não** torna o writer
+fail-closed. São garantias diferentes — o writer segue permitindo que uma geração sem rank
+substitua uma com rank; o leitor degrada honestamente para `ordem_indisponivel`; e o contador
+apenas torna a regressão **observável**. Isto é **aceitação declarada de perda de cobertura**, não
+proteção contra ela, e a revisão 2 a descrevia como se fosse proteção.
+
+⚠️ E a justificativa que eu dei — "rejeitar quebraria a aba antiga inteira" — **não está
+demonstrada**: em `useCrossSellEngine.ts:1208` a falha de persistência gera aviso e mantém o
+cálculo em memória. O comportamento do build legado efetivamente servido precisa ser **verificado
+antes** de a afirmação entrar no PR; até lá ela sai da spec.
+
+O fechamento de verdade, se a exigência for impedir regressão após a adoção, é um **guard de
+versão/capacidade do produtor**, verificado atomicamente **antes de expirar linhas** — um produtor
+legado não consegue removê-lo. E **nunca copiar ranks antigos para uma geração nova**. O sensor tem
+de ser calculado **no servidor** (o produtor legado não sabe emiti-lo) e viver no **log de
+execuções** (`20260815181500_farmer_geracao_head_sensor.sql:446`), que tem denominador — como
+insumo do head atual ele seria sobrescrito.
 
 ## 7. O que mudou da revisão 1 (challenge Codex)
 
@@ -318,7 +370,20 @@ ser observável em vez de suposta.
 | 5 | Janelas de implantação; §3.4 contradizia §3.5 | §3.5 corrigida; §6 lista as janelas e o risco da aba antiga |
 | 6 | Afirmações além da evidência | §1.1 (incidência ≠ dano) e §3.2 (recuperação medida: **104 de 198**, depois de o proxy global ter mentido 198/198) |
 
-## 8. Prova
+### 7.1 Rodada 2 do challenge
+
+A revisão 2 foi de novo reprovada, e com razão em tudo que era verificável:
+
+| # | Achado R2 | Resolução |
+|---|---|---|
+| 1 | Medir incidência não fecha o contrato: `eleito` ainda podia ser arbitrário na origem | §5: a ambiguidade da referência virou **flag por linha** e bloqueia `eleito` |
+| 2 | `k` global pode empatar/inverter na carteira; e heterogeneidade ≠ máximo único | §3.2 remedida: **9/198**, com 4 controles |
+| 3 | Singleton com ordem nula não é `eleito`; `[1,2,null]` é incompleta, não ausente; `candidatos` sem conjunto definido | §3.3: 4 estados, e `candidatos` conta conjunto DIFERENTE por estado |
+| 4 | Faltava `geracoesExibidas` e o destino da resposta inválida | §3.6: 6º ponto + rejeição INTEIRA + `customer_user_id` na validação |
+| 5 | Contador não é fail-closed; "quebraria a aba antiga" não demonstrado | §6: reescrito como aceitação declarada de perda, e a afirmação não demonstrada foi retirada |
+| 6 | Afirmações além do medido | §3.2, §5 e §6 corrigidas; §8 rotulada como PLANO de prova |
+
+## 8. Plano de prova (ainda NÃO executado)
 
 Harness PG17 estendendo `db/test-farmer-geracao-vigente.sh` (hoje 31 asserts + 4 falsificações):
 
@@ -327,6 +392,10 @@ Harness PG17 estendendo `db/test-farmer-geracao-vigente.sh` (hoje 31 asserts + 4
   `ordem` nula sai `eleito` · `[]` na carteira vazia · dois objetos por cliente.
 - **negativos**: `ordem = 0` e negativa recusadas com a SQLSTATE nomeada, re-lançando o resto.
 - **RLS**: `SET ROLE authenticated` + GUC; carteira alheia não volta.
+- **exigidos pelo R2**: máximo PARCIALMENTE empatado (`[A:1,B:1,C:2]`) · ordem parcialmente nula
+  (`[1,2,null]`) · singleton com ordem nula saindo `unico_registrado` · falha de validação chegando
+  ao cartão como `leitura_falhou` (e não como Map parcial) · o interleaving "novo grava → antigo lê
+  head novo → antigo tenta gravar" · referência ambígua bloqueando `eleito`.
 - **falsificação**: uma camada por vez, com linha de base **verde na mesma invocação**, conferindo
   **contagem e NOMES** dos vermelhos.
 
@@ -349,3 +418,7 @@ provar que essa propriedade é medida.
 - **`p_ij` é 0 em 645 de 714 linhas cross-sell** (`Math.round(0,0002 × 1000)/10 = 0`): o vendedor lê
   "0,0%". Mesma quantização, outra coluna, outro consumidor.
 - **Moeda comum em R$** (§1.3): sem substrato hoje.
+- **O sinal do motor de cross-sell é grosso, e agora há evidência dimensionada disso**: 189 de 198
+  grupos têm `relevance` EXATAMENTE igual entre os candidatos do topo. Dar sinal novo (margem,
+  giro, recência do SKU no cliente) é o conserto da CAUSA — spec própria, com esta medição como
+  ponto de partida. Esta entrega trata o sintoma: para de apresentar o sorteio como veredicto.

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -143,7 +143,7 @@ Devolve `jsonb` com até **dois** objetos por cliente:
 
 ```
 customer_user_id · recommendation_type · product_id · affinity_score · run_id
-                 · situacao · candidatos
+                 · situacao · candidatos · produtos_empatados
 ```
 
 ⚠️ **A revisão 1 tinha UM campo `empatados` e ele MENTIA.** Com `ordem` nula em todo o grupo, ele
@@ -165,7 +165,18 @@ O caso `[1, 2, null]` cai em `ordem_desconhecida` por fail-closed: as ordens con
 relação entre si, mas nada situa a linha nula, e afirmar o vencedor exigiria descartá-la.
 
 **Guard estrutural: `product_id` só é não-nulo quando `situacao = 'eleito'`.** Sem eleição por
-sinal, não sai nome — impossível renderizar a moeda por descuido.
+sinal, não sai vencedor — impossível renderizar a moeda por descuido.
+
+**`produtos_empatados` (array de SKUs) é preenchido SÓ em `empatado`** — e a assimetria com
+`ordem_desconhecida` é o ponto: só listamos produtos quando a igualdade foi **medida**. Em
+`ordem_desconhecida` sai apenas a contagem, porque afirmar "estes são igualmente indicados" sobre
+linhas cuja ordem ninguém conhece seria a mesma mentira do campo único que a revisão 1 tinha.
+
+Decisão de exibir a LISTA (delegada pelo founder, decidida por medição): os 94 empates reais têm
+**tamanho exatamente 2 — todos os 94**. Listar dois nomes ocupa o mesmo espaço que "2 produtos
+igualmente indicados" e é estritamente mais útil: o vendedor conhece o cliente e desempata com o
+que o motor não sabe. O teto é estrutural — o corte do motor persiste no máximo 3 cross-sell por
+cliente, então a lista nunca passa de 3.
 
 Preservados da RPC atual e pelos mesmos motivos: `coalesce(…, '[]'::jsonb)`, `SECURITY INVOKER`,
 `REVOKE`/`GRANT` nomeando as roles.
@@ -211,7 +222,7 @@ O cartão ganha duas células rotuladas, cada uma com:
 | estado | mostra |
 |---|---|
 | `eleito` + SKU resolve | nome do produto |
-| `empatado` | "N produtos igualmente indicados" |
+| `empatado` | "Igualmente indicados: A, B" (os nomes; sempre 2 hoje, teto 3) |
 | `ordem_desconhecida` | "Ordenação indisponível — N recomendações registradas" |
 | `nenhum` | — |
 | `indisponivel` | rótulo + motivo (leitura falhou · SKU fora do catálogo) |

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -500,6 +500,31 @@ O terceiro caminho que o challenge propôs — up-sell ordenado, cross-sell apre
 registradas sem prioridade afirmada** — é o que a §3.6 passa a fazer, agora que nomear deixou de
 depender de eleger.
 
+### 7.3 Rodada 4 do challenge — e o que a EXECUÇÃO acrescentou
+
+| # | achado | resposta na revisão 5 |
+|---|---|---|
+| 1 | o detector de ambiguidade erra dos DOIS lados: escapa (desempate intra-pedido pela posição) e marca demais (empate histórico já superado) | `referencia-ambigua.ts`: cada (cliente,SKU,pedido) é reduzido ao preço da regra intra-pedido, e só os pedidos empatados na recência MÁXIMA são comparados. 9 testes, incluindo os dois casos do challenge |
+| 2 | a RPC do plano não é executável (`id` não projetado em `base`) | já corrigido na implementação antes do parecer; o plano foi alinhado. E o challenge **confirma**, por enumeração de 22.620 combinações, que a precedência não tem buraco |
+| 3 | mistura de gerações: `ordem 1` de G1 contra `ordem 2` de G2 elege sem que nada os tenha comparado | a RPC detecta e cai em `ordem_indisponivel`, sem transportar `run_id`. `count(DISTINCT)` ignora NULL, então o NULL é contado à parte |
+| 4 | o validador aceita não-uuid, e faltava `length(produtos) = candidatos` nos estados que nomeiam o grupo | `melhor-individual.ts` com formato uuid e a igualdade; 22 testes |
+| 5 | o cast NÃO recusa `"false"`/`"off"`/`0` — `boolean_in` converte | validação de `jsonb_typeof` **antes** do cast, com controle do outro lado. A falsificação F6 prova: sem ela, `"false"` PASSA |
+| 6 | a matriz de falsificação mapeava sabotagem TS para assert SQL | falsificação do banco tem 6 sabotagens na camada certa, todas com dente; as de TS ficam com os testes de TS |
+| 7 | o sensor não tem entrega verificável | pendente — §6.1 define o quê, falta o onde (`farmer_geracao_registrar`, na migration nova) |
+
+**O que só apareceu EXECUTANDO** (e que nenhuma leitura tinha pego):
+
+- **O harness certo não era o `test-farmer-head-geracao.sh`.** O critério do challenge está certo
+  (a base precisa ter `p_head_visto`), mas aquela cadeia para na `20260815181500` e produz um
+  writer que produção já não tem — sem o gate de escopo de carteira que a `20260906164002`
+  acrescentou em 06/09. A base é essa: **a última a recriar o writer é a que vale**.
+- `pg_get_functiondef` não emite o `;` final, e o wrapper `psql-ro` ecoa dois `SET` para dentro do
+  arquivo. Os dois viram erro de sintaxe num apply manual.
+- Dentro de `$( )` o bash faz **brace expansion** em `{a,b}`: o payload JSON da falsificação era
+  partido em duas palavras, e o `22P02` resultante passava por vermelho legítimo.
+- `sabota_ordem` conferia que o PADRÃO casou, não que a migration APLICOU — sabotagem inerte é
+  lida como "sem dente" e manda o diagnóstico para o lugar errado.
+
 ## 8. Plano de prova (ainda NÃO executado)
 
 **Onde.** `db/test-farmer-head-geracao.sh`, **não** `db/test-farmer-geracao-vigente.sh` (achado

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -110,30 +110,39 @@ Nulável porque as 1.083 linhas de 21/08 existem e não são recuperáveis (§3.
   referência cronológica de `preco-referencia.ts`. `upsell-ordem.ts` já tem o comparador **e** o
   predicado de empate (`candidatosEmpatam`, hoje privado) — o rank denso reusa os dois.
 
-**Quanto isso recupera, medido — e o primeiro número estava errado.** Dentro de um cliente,
-`relevance = 0,4·k/N + 0,6·aB`, com `k` = compradores distintos do SKU **na carteira** (N=269
-clientes, medido). Eu primeiro usei `k` GLOBAL como proxy e obtive "198 de 198 recuperáveis". O `k`
-de carteira **inverte parte do resultado**:
+**Quanto isso recupera, medido — e eu errei DUAS vezes antes de acertar.** Dentro de um cliente,
+`relevance = clamp(0,4·k/N + 0,6·aB, 0,01, 1,0)`, com `k` = compradores do SKU **na carteira**
+(N=269, medido) e `aB` reconstruído das regras de associação. Recuperável ⟺ o **máximo é ÚNICO**.
+
+| tentativa | critério usado | resultado | por que estava errado |
+|---|---|---|---|
+| 1 | `k` GLOBAL distinto | 198/198 | a carteira é 269 de milhares; SKUs que se separam na base colidem no recorte |
+| 2 | `k` de carteira distinto | 104/198 | heterogeneidade ≠ máximo único — `k=[6,6,5]` tem valores distintos e nenhum vencedor |
+| **3** | **máximo único de `relevance`** | **9/198 (4,5%)** | — |
 
 | | n | % dos 198 |
 |---|---|---|
-| grupos cross-sell empatados no topo | 198 | 100% |
-| `k` de carteira DIFERE ⇒ recuperável pelo score não-arredondado | **104** | **52,5%** |
-| `k` de carteira IGUAL | 94 | 47,5% |
-| desses 94, salvos por `assocBoost` diferente | **0** | — |
-| **empate REAL** (mesmo `k` **e** mesmo `aB` ⇒ mesma `relevance`) | **94** | **47,5%** |
+| máximo ÚNICO ⇒ recuperável pelo rank | **9** | 4,5% |
+| **sem vencedor único (empate REAL)** | **189** | **95,5%** |
 
-⇒ Sobre os 238 grupos cross-sell: 40 já decididos pelo score · 104 recuperados pelo rank ·
-**94 (39,5%) vão exibir "N produtos igualmente indicados"**.
+**Controles** (por que acredito nesta versão e não nas duas anteriores): a fórmula
+`clamp(buyerCount/totalCustomers, 0, 1)` foi conferida no código (`useCrossSellEngine.ts:872`);
+682 de 714 linhas têm `k ≥ 9`, que é o gate `cA ≥ 0,03`, e as outras 32 entram por `aB > 0`;
+`k ∈ [1,22]` com N=269 dá `cA·12 ∈ [0,045 , 0,98]`, que reproduz `cluster_volume_estimate = 1` em
+714 de 714; e a `relevance` reconstruída (máx 0,0327 com `aB=0`) bate com a mediana 0,0338 obtida
+por um caminho **independente**, a razão entre os scores persistidos.
 
-Esses 94 são **indistinguíveis para o motor** — mesma aderência de carteira, nenhuma regra de
-associação. `empatado` é a resposta verdadeira, e consertá-los seria dar **sinal novo** ao motor,
-não ordenar melhor. Fica declarado em §9.
+⇒ Sobre os 238 grupos cross-sell: 40 já decididos pelo score + **9** recuperados = **49 eleitos
+(20,6%)**; **189 (79,4%) exibem empate**.
 
-⚠️ Lição de método, e ela quase passou: um proxy pode ser *fortemente* correlacionado e ainda
-inverter o veredicto. `k` global distinto NÃO implica `k` de carteira distinto — a carteira é 269
-de milhares de clientes, e SKUs que se separam na base inteira colidem no recorte.
-(`cluster_volume_estimate` também não serve: é `1` em 714 de 714 linhas, no piso do `max(1,…)`.)
+**O que isso muda na proposta de valor, dito sem maquiagem:** o rank do cross-sell quase não
+ELEGE — ele faz a tela **parar de mentir**. A causa é o sinal do motor ser grosso: `k ∈ [9,22]`
+sobre N=269, com `aB = 0` na maioria, produz colisão EXATA de `relevance`. Não é arredondamento,
+não é ordenação: é ausência de informação, e nenhuma mudança de `ORDER BY` a cria.
+
+O rank continua necessário — mas pelo **up-sell**, onde o score não carrega produto nenhum e a
+chave do #1837 (razão de preço, contínua) discrimina de verdade. Incluir o cross-sell na mesma
+coluna é quase de graça e remove a dependência do arredondamento como proxy de empate.
 
 **Nada disto toca `affinity_score` nem `p_ij`.**
 

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -132,78 +132,97 @@ Nulável porque as 1.083 linhas de 21/08 existem e não são recuperáveis (§3.
 714 de 714; e a `relevance` reconstruída (máx 0,0327 com `aB=0`) bate com a mediana 0,0338 obtida
 por um caminho **independente**, a razão entre os scores persistidos.
 
-⇒ Sobre os 238 grupos cross-sell: 40 já decididos pelo score + **9** recuperados = **49 eleitos
-(20,6%)**; **189 (79,4%) exibem empate**.
+⇒ Sobre os 238 grupos cross-sell **hoje persistidos**: 40 já decididos pelo score + **9**
+recuperados = 49 com vencedor; **189 sem**. ⚠️ Isto descreve o conjunto ATUAL — **não** é previsão
+da tela pós-entrega, e a revisão 3 apresentava como se fosse (achado R3/4). D3 muda a ordenação
+antes do corte, logo muda o próprio conjunto persistido: quem mede a tela é o sensor de §6.1.
 
-**O que isso muda na proposta de valor, dito sem maquiagem:** o rank do cross-sell quase não
-ELEGE — ele faz a tela **parar de mentir**. A causa é o sinal do motor ser grosso: `k ∈ [9,22]`
-sobre N=269, com `aB = 0` na maioria, produz colisão EXATA de `relevance`. Não é arredondamento,
-não é ordenação: é ausência de informação, e nenhuma mudança de `ORDER BY` a cria.
+**Dois recortes que o challenge exigiu, medidos agora:**
 
-O rank continua necessário — mas pelo **up-sell**, onde o score não carrega produto nenhum e a
-chave do #1837 (razão de preço, contínua) discrimina de verdade. Incluir o cross-sell na mesma
-coluna é quase de graça e remove a dependência do arredondamento como proxy de empate.
+| | resultado |
+|---|---|
+| tamanho dos grupos sem vencedor único (sobre os **189**, não os 94 da revisão 2) | **2 em 189 de 189** |
+| clientes **cross-only** (sem up-sell — os 52 em que o cross-sell é a ÚNICA indicação) | 52 |
+| …empatados no score arredondado | **52 de 52** |
+| …**recuperados pelo rank** | **0 de 52** |
+
+O segundo recorte é o que importa e é pior do que o agregado sugeria: **os 9 grupos que o rank
+recupera estão TODOS em clientes que também têm up-sell**, onde D1 já entrega o up-sell como a
+oferta do tipo dele. Nos 52 clientes em que a célula cross-sell é a única coisa que o vendedor tem,
+o rank não recupera **nenhuma** eleição.
+
+**O que isso muda na proposta de valor, dito sem maquiagem:** o rank do cross-sell não ELEGE — ele
+faz a tela **parar de mentir**. Hoje esses 52 clientes recebem um vencedor sorteado por uuid
+apresentado como veredicto; passam a receber **dois nomes rotulados como igualmente indicados**, e
+quem escolhe é o vendedor, que tem o contexto que o motor não tem. A causa é o sinal ser grosso:
+`k ∈ [9,22]` sobre N=269, com `aB = 0` na maioria, produz colisão EXATA de `relevance`. Não é
+arredondamento nem ordenação: é ausência de informação, e nenhuma mudança de `ORDER BY` a cria.
+
+O rank continua necessário pelo **up-sell**, onde o comparador do #1837 usa termos que **dependem do
+produto** — razão de preço e popularidade — enquanto o `pij` do cross-sell não usa nenhum. Essa é
+uma afirmação sobre o CÓDIGO, verificável em `upsell-ordem.ts:113`; **quanto** o up-sell discrimina
+em prod depois de referência, dedup e corte é a mesma pergunta não-derivável do banco de §6.1, e o
+sensor a responde. Incluir o cross-sell na mesma coluna é quase de graça e remove a dependência do
+arredondamento como proxy de empate.
 
 **Nada disto toca `affinity_score` nem `p_ij`.**
 
 ### 3.3 RPC `farmer_melhores_individuais_por_cliente(uuid)` (nome novo — §3.4)
 
-Devolve `jsonb` com até **dois** objetos por cliente:
+Devolve `jsonb` com até **dois** objetos por cliente (um por tipo):
 
 ```
-customer_user_id · recommendation_type · product_id · affinity_score · run_id
-                 · situacao · candidatos · produtos_empatados
+customer_user_id · recommendation_type · situacao · produtos · produto_eleito
+                 · candidatos · affinity_score · run_id
 ```
 
-⚠️ **A revisão 1 tinha UM campo `empatados` e ele MENTIA.** Com `ordem` nula em todo o grupo, ele
-diria "2 produtos igualmente indicados" — afirmando igualdade **medida** onde houve
-**desconhecimento**. É o `ausente ≠ zero` da casa reintroduzido dentro do conserto que veio matá-lo.
-São dois estados diferentes e passam a ter nomes diferentes:
+**Identidade e eleição são campos SEPARADOS** (achado R3/2). A revisão 3 tinha um único
+`product_id` preso ao guard "só é não-nulo em `eleito`" e, ao mesmo tempo, prometia exibir o nome
+do produto em `unico_registrado`. O nome não tinha de onde vir: o contrato eliminava o
+identificador exatamente nos estados em que a tela precisava dele. **Identificar produtos não exige
+afirmar prioridade entre eles** — e é essa separação que permite nomear sem eleger:
 
-| `situacao` | condição | significado |
-|---|---|---|
-| `eleito` | ordem conhecida em TODO o grupo · máximo ÚNICO · referência não-ambígua | decidido por sinal |
-| `empatado` | ordem conhecida em TODO o grupo · ≥2 candidatos no máximo | igualdade MEDIDA |
-| `unico_registrado` | grupo de UM candidato | identificável, mas nada foi ordenado |
-| `ordem_indisponivel` | ≥2 candidatos e QUALQUER `ordem` nula | ordenação ausente ou incompleta |
+- **`produtos`** — array de SKUs que a tela vai NOMEAR. Sempre ≥1 elemento.
+- **`produto_eleito`** — não-nulo **se e somente se** `situacao = 'eleito'`, e sempre um elemento de
+  `produtos`. É o guard estrutural que impede renderizar vencedor por descuido.
+- **`candidatos`** — **sempre** o tamanho do grupo registrado. Um número, um significado.
 
-⚠️ **`unico_registrado` existe porque `eleito` mentiria** (achado R2/3). Um grupo de um candidato
-com `ordem` nula não é empate — mas também não foi decidido por sinal de ordenação nenhum. Ser a
-única recomendação registrada permite identificá-la; não diz nada sobre a qualidade da escolha que
-a produziu. Colapsar os dois em `eleito` seria a mentira simétrica à do campo único da revisão 1.
+⚠️ A revisão 3 fazia `candidatos` contar um conjunto DIFERENTE por estado. Aquilo consertava a
+mentira do R2/3 (`[A:1, B:1, C:2]` tem **2** empatados, não 3) criando outra: um campo cujo
+denominador o consumidor precisa inferir do rótulo. Com `produtos` transportando quem é nomeado e
+`candidatos` medindo o grupo, o mesmo caso vira `produtos=[A,B]`, `candidatos=3` — e a tela diz
+"2 de 3", que é a frase verdadeira.
 
-⚠️ **`ordem_indisponivel` cobre DOIS casos e o rótulo não afirma mais do que sabe**: `[null,null]`
-é ordenação **ausente**; `[1,2,null]` é ordenação **incompleta** — as ordens conhecidas mantêm sua
-relação, mas nada situa a linha nula, e eleger exigiria descartá-la. Nos dois a resposta honesta é
-a mesma ("não dá para ordenar este grupo"), então o estado é um só; o que não se pode é chamar
-qualquer um deles de "ninguém mediu", que era a redação anterior.
+**Estados, em ordem de PRECEDÊNCIA** — a primeira condição que casar decide. Sem isso um singleton
+com ordem conhecida satisfaz duas linhas da tabela ao mesmo tempo (achado R3/2):
 
-**`candidatos` conta conjuntos DIFERENTES por estado**, e isso é explícito no contrato porque
-contar o grupo inteiro em `empatado` seria falso (achado R2/3): em `[A:1, B:1, C:2]` há **2**
-empatados, não 3.
+| # | `situacao` | condição | `produtos` | significado |
+|---|---|---|---|---|
+| 1 | `referencia_ambigua` | qualquer linha do grupo com a flag de §5 | todos os registrados | a ordem saiu de uma referência sorteada |
+| 2 | `ordem_indisponivel` | ≥2 candidatos e QUALQUER `ordem` nula | todos os registrados | ordenação ausente ou incompleta |
+| 3 | `unico_registrado` | exatamente 1 candidato | o único | identificável; nada foi ordenado |
+| 4 | `empatado` | ≥2 candidatos · ordens todas conhecidas · ≥2 no rank mínimo | os do topo | igualdade MEDIDA |
+| 5 | `eleito` | ≥2 candidatos · ordens todas conhecidas · 1 no rank mínimo | o vencedor | decidido por sinal |
 
-| estado | `candidatos` conta |
-|---|---|
-| `empatado` | SKUs distintos **no topo** |
-| `ordem_indisponivel` | SKUs distintos **registrados no grupo** |
-| `eleito` · `unico_registrado` | 1 |
+⚠️ **A precedência 1 é o que fecha o R3/1.** Ambiguidade a montante invalida qualquer afirmação de
+eleição **e** de empate: um empate calculado sobre uma referência sorteada não é igualdade medida,
+é coincidência de um sorteio. Colapsá-la em `ordem_indisponivel` também serviria à tela — mas
+apagaria a única distinção acionável entre "ninguém ordenou" (falta rank) e "ordenei sobre um dado
+arbitrário" (defeito a montante, em `preco-referencia.ts`). São causas diferentes com consertos
+diferentes, e um booleano paralelo ao lado do enum recriaria os dois-vocabulários-numa-coluna que
+o repo já pagou caro para desfazer.
 
-**Guard estrutural: `product_id` só é não-nulo quando `situacao = 'eleito'`.** Sem eleição por
-sinal, não sai vencedor — impossível renderizar a moeda por descuido.
+⚠️ **`unico_registrado` existe porque `eleito` mentiria** (achado R2/3). Um grupo de um candidato não
+foi decidido por sinal de ordenação nenhum: ser a única recomendação registrada permite
+identificá-la, e não diz nada sobre a qualidade da escolha que a produziu. Com a precedência, um
+singleton **nunca** sai `eleito`, tenha `ordem` ou não.
 
-**`produtos_empatados` (array de SKUs) é preenchido SÓ em `empatado`** — e a assimetria com
-`ordem_desconhecida` é o ponto: só listamos produtos quando a igualdade foi **medida**. Em
-`ordem_desconhecida` sai apenas a contagem, porque afirmar "estes são igualmente indicados" sobre
-linhas cuja ordem ninguém conhece seria a mesma mentira do campo único que a revisão 1 tinha.
+⚠️ **`ordem_indisponivel` cobre DOIS casos** e o rótulo não afirma mais do que sabe: `[null, null]`
+(ninguém ordenou) e `[1, 2, null]` (ordenação incompleta). A tela diz "ordenação indisponível", não
+"ninguém mediu" — a segunda frase seria falsa no segundo caso.
 
-Decisão de exibir a LISTA (delegada pelo founder, decidida por medição): os 94 empates reais têm
-**tamanho exatamente 2 — todos os 94**. Listar dois nomes ocupa o mesmo espaço que "2 produtos
-igualmente indicados" e é estritamente mais útil: o vendedor conhece o cliente e desempata com o
-que o motor não sabe. O teto é estrutural — o corte do motor persiste no máximo 3 cross-sell por
-cliente, então a lista nunca passa de 3.
-
-Preservados da RPC atual e pelos mesmos motivos: `coalesce(…, '[]'::jsonb)`, `SECURITY INVOKER`,
-`REVOKE`/`GRANT` nomeando as roles.
+O `affinity_score` continua no payload como **dado de diagnóstico do tipo**, nunca como critério
+entre tipos: D1 dissolveu a comparação, e §1.2 mostra por quê.
 
 ### 3.4 Por que nome NOVO
 
@@ -228,43 +247,71 @@ Backfill descartado: a ordem não é recuperável das colunas existentes, e re-d
 
 ### 3.6 Leitor e tela (D4)
 
-O leitor muda em cinco pontos, e quatro deles são armadilhas que o challenge apontou:
+O leitor muda em sete pontos; seis são armadilhas que o challenge apontou.
 
 1. **A chave do Map passa a incluir o tipo** (`useBundleEngine.ts:844`) — hoje é uma linha por
    cliente, e o segundo objeto sobrescreveria o primeiro.
-2. **A decisão sobre `situacao` acontece ANTES de consultar `productMap`.** Hoje `pid == null` cai
-   direto em `produto_nao_resolve` (`useBundleEngine.ts:1050`): sem esta ordem, todo empate viraria
-   "o SKU sumiu do catálogo". Só `eleito` tenta resolver SKU.
-3. **O sensor de resolução** (`useBundleEngine.ts:1163`) não pode contar `product_id` nulo
-   deliberado como falha de catálogo — fabricaria deterioração.
-4. **O filtro de inclusão do cartão** (`useBundleEngine.ts:1073`) passa a omitir o cliente só quando
+2. **Todo estado resolve nome no catálogo.** Hoje `pid == null` cai direto em `produto_nao_resolve`
+   (`useBundleEngine.ts:1050`). Com identidade separada de eleição (§3.3), o leitor resolve **todos**
+   os SKUs de `produtos`; `situacao` decide o que a apresentação SIGNIFICA, não se existe
+   apresentação. A regra da revisão 3 ("só `eleito` tenta resolver SKU") era o que tornava os nomes
+   prometidos irrecuperáveis.
+3. **SKU válido que não resolve ≠ leitura inválida** (achado R3/3). São dois defeitos distintos e a
+   tela não pode fundi-los:
+   - **nenhum** SKU de `produtos` resolve → célula `indisponivel · produto_nao_resolve`;
+   - **alguns** resolvem → mostra os que resolveram **e declara quantos não identificou**. Em
+     `empatado`, perder um nome **não** promove o outro a vencedor: a célula segue `empatado`, com
+     "1 de 2 não identificado". Esconder o participante que sumiu converteria uma falha de catálogo
+     em eleição — exatamente a fabricação que esta entrega existe para matar.
+4. **O sensor de resolução** (`useBundleEngine.ts:1163`) conta SKU que não resolve, e só isso —
+   estado sem eleição não é falha de catálogo e contá-lo fabricaria deterioração.
+5. **O filtro de inclusão do cartão** (`useBundleEngine.ts:1073`) passa a omitir o cliente só quando
    **ambos** os tipos são `nenhum`.
-5. **Validação em runtime da resposta**: `customer_user_id` presente, tipo reconhecido,
-   `candidatos` inteiro ≥1, sem duplicata `(cliente,tipo)`, combinação `situacao`×`product_id`
-   válida. O cast atual para `MelhorIndividualRow[]` não valida nada. **A resposta inválida é
-   rejeitada INTEIRA como `leitura_falhou`, preservando a causa** — validar-e-descartar linhas
-   transformaria falha em ausência e entregaria um Map parcial apresentado como completo (achado
-   R2/4). Sem a checagem de `customer_user_id` as demais passam e a linha some na consulta pela
-   chave, que é a mesma falha por outra porta.
-6. **`geracoesExibidas`** (`useBundleEngine.ts:1057`) só recebe `run_id` quando o produto resolve.
-   Com os estados novos, cartões exibiriam empates e ordens indisponíveis de gerações diferentes
-   sem alimentar o canário — a contagem passa a acompanhar **todo estado exibido**,
-   independentemente de o SKU resolver.
+6. **Validação em runtime, com invariantes ENTRE campos** (achado R3/3). Só validar campo a campo
+   deixa passar `{situacao:'empatado', candidatos:1, produtos:[]}` — que satisfaz "tipo reconhecido",
+   "inteiro ≥1" e "sem produto eleito fora de `eleito`", e não representa empate nenhum. O contrato
+   verificado:
 
-**Preservar** (o challenge listou, e nenhum é consequência automática do desenho): o cartão
-continua aparecendo quando há bundle, mesmo com os dois individuais em `nenhum`; o aviso do cartão
-recolhido (`CustomerBundleCard.tsx:68`), hoje dependente do estado individual único; e a proibição
-de comparar `ordem` de `run_id` diferentes dentro de uma mesma eleição.
+   | invariante | vale para |
+   |---|---|
+   | `customer_user_id` uuid presente · tipo reconhecido · `(cliente,tipo)` sem duplicata | todos |
+   | `situacao` ∈ enum de 5 · `candidatos` inteiro ≥1 | todos |
+   | `produtos` array de uuids válidos, **sem duplicatas**, `1 ≤ length ≤ candidatos` | todos |
+   | `produto_eleito` não-nulo **⟺** `situacao='eleito'`, e ∈ `produtos` | todos |
+   | `length(produtos) = 1` ∧ `candidatos ≥ 2` | `eleito` |
+   | `length(produtos) = 1` ∧ `candidatos = 1` | `unico_registrado` |
+   | `length(produtos) ≥ 2` ∧ `candidatos ≥ 2` | `empatado` · `ordem_indisponivel` |
 
-O cartão ganha duas células rotuladas, cada uma com:
+   **A resposta inválida é rejeitada INTEIRA como `leitura_falhou`, preservando a causa** —
+   validar-e-descartar linhas transformaria falha em ausência e entregaria um Map parcial
+   apresentado como completo (achado R2/4). Sem a checagem de `customer_user_id` as demais passam e
+   a linha some na consulta pela chave, que é a mesma falha por outra porta.
+7. **`geracoesExibidas`** (`useBundleEngine.ts:1057`) só recebe `run_id` quando o produto resolve.
+   Com os estados novos, cartões exibiriam empates e ordens indisponíveis de gerações diferentes sem
+   alimentar o canário — a contagem passa a acompanhar **todo estado exibido**.
+
+**Preservar** (o challenge listou, e nenhum é consequência automática do desenho): o cartão continua
+aparecendo quando há bundle, mesmo com os dois individuais em `nenhum`; o aviso do cartão recolhido
+(`CustomerBundleCard.tsx:68`), hoje dependente do estado individual único; e a proibição de comparar
+`ordem` de `run_id` diferentes dentro de uma mesma eleição.
+
+O cartão ganha **duas células rotuladas** ("Melhor complementar" · "Melhor upgrade"), cada uma com:
 
 | estado | mostra |
 |---|---|
-| `eleito` + SKU resolve | nome do produto |
-| `empatado` | "Igualmente indicados: A, B" (os nomes; sempre 2 hoje, teto 3) |
-| `ordem_desconhecida` | "Ordenação indisponível — N recomendações registradas" |
+| `eleito` | nome do produto |
+| `empatado` | "Igualmente indicados: A, B" (`candidatos` no rodapé quando > `length(produtos)`) |
+| `unico_registrado` | "Única registrada: A" |
+| `ordem_indisponivel` | "Ordenação indisponível — A, B (N registradas)" |
+| `referencia_ambigua` | "Sem ordem confiável — A, B" |
 | `nenhum` | — |
 | `indisponivel` | rótulo + motivo (leitura falhou · SKU fora do catálogo) |
+
+⚠️ **Nomear em todos os estados é o que evita trocar uma mentira por uma omissão.** A revisão 3
+mostrava contagem sem nomes quando a ordem era desconhecida, com o argumento de que listar produtos
+afirmaria igualdade. Não afirma: quem afirma é o RÓTULO, e o rótulo é o campo `situacao`. Retirar os
+nomes deixaria o vendedor sem nada acionável justamente nos 52 clientes cross-only, onde **nenhuma**
+eleição é recuperável (§3.2) — a célula viraria um aviso de indisponibilidade permanente.
 
 ### 3.7 Ordem em memória do cross-sell (D3)
 
@@ -287,14 +334,15 @@ demonstrou executando:
 A garantia fica restrita ao **cartão de bundles**. Estender à via do WhatsApp e ao corte é trabalho
 próprio, com medição própria.
 
-## 5. Ambiguidade a montante do rank — declarada e medida
+## 5. Ambiguidade a montante do rank — por CLIENTE, não por linha
 
-`compararRecencia` (`preco-referencia.ts:114`) desempata por `pedidoId` (uuid) quando as datas
-empatam. Isso escolhe o preço de **referência**, que é a chave primária da ordem do up-sell — logo
-um rank pode ser numericamente único (`situacao = 'eleito'`) e ainda carregar uma decisão arbitrária
-na origem. O challenge executou os helpers reais trocando só os uuids e o vencedor mudou de Y para X.
+`compararRecencia` (`preco-referencia.ts:108`) desempata por `pedidoId` (uuid) quando o instante é
+indistinguível — datas iguais **ou ambas ausentes**. Isso escolhe o preço de **referência**, que é a
+chave primária da ordem do up-sell: um rank pode ser numericamente único (`eleito`) e ainda carregar
+uma decisão arbitrária na origem. O challenge executou os helpers reais trocando só os uuids e o
+vencedor mudou.
 
-**Incidência, medida agora** (o challenge a declarou desconhecida):
+**Incidência, medida** (o challenge R1 a declarou desconhecida):
 
 | | n |
 |---|---|
@@ -304,30 +352,71 @@ na origem. O challenge executou os helpers reais trocando só os uuids e o vence
 | clientes atingidos | 14 |
 | **∩ com os 186 clientes de up-sell vivo** | **2 (1,1%)** |
 
-É limite **superior**: nem todo par ambíguo troca vencedor. Mas **incidência medida não fecha
-falha de contrato** (achado R2/1): um único caso basta para que `eleito` — que afirma "decidido por
-sinal" — esteja errado, e o Codex executou os helpers reais trocando só os uuids, obtendo topo
-numericamente único nos DOIS mundos, com vencedores diferentes.
+⚠️ Limite **superior** por um lado (nem todo par ambíguo troca vencedor) e possivelmente **inferior**
+pelo outro: a query casou empate de DATA, e o código também cai no uuid quando as duas marcas têm
+`instante` nulo — caso que a medição pode não ter contado. A regra do código não depende desta
+medição para estar certa; a medição serve para dimensionar o custo, e está declarada como
+aproximação.
 
-**Por isso a ambiguidade entra no contrato, não num sensor agregado.** Um sensor não permite ao
-consumidor distinguir os casos afetados; a flag permite. O motor já tem o dado no instante em que
-escolhe a referência: quando o topo por `instante` está empatado entre pedidos DISTINTOS **com
-preços diferentes**, o candidato up-sell derivado dela nasce marcado, e o grupo não pode sair
-`eleito` — cai em `ordem_indisponivel`. Custo: um booleano por linha, decidido onde a informação
-já existe. A alternativa que o Codex também aceitava — rebaixar `eleito` para "topo único do rank
-persistido" — foi descartada: ela conserta o texto e deixa o consumidor sem como distinguir.
+### 5.1 Por que por CLIENTE (achado R3/1)
+
+A revisão 3 marcava a LINHA derivada de uma base ambígua. **A flag desaparecia na deduplicação.** O
+motor guarda, por SKU, apenas sua melhor relação com uma base comprada (`useCrossSellEngine.ts:998`)
+— e a razão de preço que decide essa "melhor" é justamente a que a referência sorteada altera. O
+challenge executou o contraexemplo com os comparadores reais:
+
+| referência sorteada para a base A | melhor relação de X | melhor relação de Y | resultado |
+|---|---|---|---|
+| 100 | 230/150 = 1,5333 (base B) | 180/150 = 1,2 (base B) | **Y vence — nenhuma flag sobrevive** |
+| 200 | 230/200 = 1,15 (base A) | 180/150 = 1,2 (base B) | X vence — flag presente |
+
+Os **mesmos dois SKUs** chegam à persistência nos dois mundos. No primeiro, a RPC permitiria
+`eleito = Y` embora trocar exclusivamente os uuids altere o topo. Marcar só a relação que sobreviveu
+não basta: a ambiguidade tem de sobreviver às três decisões seguintes — **elegibilidade,
+deduplicação e corte**.
+
+**Regra:** a marca é do **cliente**, para o tipo `up_sell`, e é decidida **antes** dessas três
+decisões. Ao montar o mapa de preços por (cliente, SKU) — o laço de `useCrossSellEngine.ts:695` — o
+motor marca o cliente quando, ao comparar duas marcas do mesmo SKU, o instante é indistinguível
+entre `pedidoId` distintos **e os preços diferem**. Um cliente marcado tem TODAS as suas linhas
+`up_sell` gravadas com a flag, e o grupo sai `referencia_ambigua` (precedência 1 de §3.3).
+
+`cross_sell` **não** usa preço de referência: seu `pij` é `0,15 × health × engagement × relevance`,
+e `relevance` sai de aderência de cluster e regras de associação (`useCrossSellEngine.ts:882`). A
+flag é gravada `false` — afirmação verdadeira sobre o tipo, não silêncio.
+
+A alternativa mais seletiva que o challenge admite — marcar só quando o vencedor **não** é invariante
+entre as referências admissíveis — exigiria enumerar os mundos possíveis dentro do motor. Fica fora:
+mais caro, e a versão conservadora custa 2 clientes de 186.
+
+### 5.2 Coluna, validação e persistência
+
+- **Coluna:** `farmer_recommendations.referencia_ambigua boolean NULL`. **Não** `NOT NULL DEFAULT
+  false`: o default afirmaria "não ambígua" sobre 17.316 linhas legadas que ninguém mediu, que é o
+  `ausente ≠ zero` da casa dentro do conserto que veio matá-lo. `NULL` = não medido.
+- **Payload:** `p_linhas[].referencia_ambigua`, na mesma lista explícita de
+  `jsonb_to_recordset` que `ordem` (§6) — sem isso a chave é ignorada **em silêncio**.
+- **Validação no writer:** booleano ou ausente. Não-booleano recusa a gravação inteira com SQLSTATE
+  nomeada, no mesmo bloco que hoje valida `affinity_score`
+  (`farmer_recomendacoes_substituir`, L106-110 da definição de PROD).
+- **Leitura fail-closed:** a RPC agrega com `bool_or`, e **`NULL` com `ordem` preenchida conta como
+  ambígua**. Esse par só nasce de um produtor que grava rank sem gravar flag — impossível enquanto os
+  dois campos entram na mesma versão, e é exatamente por ser impossível que a falha tem de ser
+  fechada em vez de suposta. Linha legada (`ordem` nula) cai em `ordem_indisponivel` pela precedência
+  2 antes de a flag importar.
 
 ## 6. Implantação (critério 3)
 
-1. **Banco** (SQL Editor, `lovable-db-operator`): `ADD COLUMN ordem` · `CREATE OR REPLACE` de
-   `farmer_recomendacoes_substituir` (aceita e **valida** `ordem`: nula, ou inteiro ≥ 1) · `CREATE`
-   da RPC nova. Pré-flight contra `pg_get_functiondef` da PROD.
+1. **Banco** (SQL Editor, `lovable-db-operator`): `ADD COLUMN ordem smallint NULL` · `ADD COLUMN
+   referencia_ambigua boolean NULL` (§5.2) · `CREATE OR REPLACE` de `farmer_recomendacoes_substituir`
+   (aceita e **valida** os dois: `ordem` nula ou inteiro ≥ 1; `referencia_ambigua` booleana ou
+   ausente) · `CREATE` da RPC nova. Pré-flight contra `pg_get_functiondef` da PROD.
 2. **Publish**.
 3. **Recálculo**, que grava os ranks.
 4. **PR de limpeza** derruba a RPC antiga.
 
-A ordem 1→2 é obrigatória: contra o schema velho, o `jsonb_to_recordset` **ignoraria a chave
-`ordem` em silêncio** e nenhum rank seria persistido, sem erro nenhum.
+A ordem 1→2 é obrigatória: contra o schema velho, o `jsonb_to_recordset` **ignoraria as chaves
+novas em silêncio** e nem rank nem flag seriam persistidos, sem erro nenhum.
 
 **Janelas em que a tela segue errada** (o challenge listou, e são reais):
 
@@ -359,13 +448,27 @@ de ser calculado **no servidor** (o produtor legado não sabe emiti-lo) e viver 
 execuções** (`20260815181500_farmer_geracao_head_sensor.sql:446`), que tem denominador — como
 insumo do head atual ele seria sobrescrito.
 
+### 6.1 O sensor da distribuição — porque a tela pós-entrega NÃO está prevista
+
+§3.2 mede o conjunto **já persistido**. D3 (§3.7) muda a ordenação **antes** do `slice(0,3)`
+(`useCrossSellEngine.ts:1037`), logo muda **quais** SKUs são persistidos — e o challenge executou o
+contraexemplo: com N=269, `aB=0`, `k=[9,9,9,10]`, os quatro colidem no score arredondado
+(`0,0001`); a ordem antiga persiste A/B/C e a reconstrução encontra empate real, a ordem nova
+persiste D/A/B e encontra vencedor único. **"Empate entre os produtos persistidos" não demonstra
+ausência de vencedor entre os candidatos que o motor verá.** Prever a distribuição exigiria executar
+o pipeline TypeScript completo sobre um snapshot coerente — não é derivável do banco.
+
+Então a distribuição **não é prevista, é medida**: o produtor emite, no log de execuções (server-side,
+§6), a contagem de grupos por `situacao` e por tipo. Sem esse número, a fase seguinte — dar sinal
+novo ao motor de cross-sell — não tem denominador, e "ninguém reclamou" é ausência de dado.
+
 ## 7. O que mudou da revisão 1 (challenge Codex)
 
 | # | Achado | Resolução |
 |---|---|---|
 | 1 | O teste da `relevance` implícita não prova o cancelamento | §1.2 reescrita: evidência é o código; o teste foi retirado como prova e o método que distingue ficou registrado |
 | 2 | `empatados` mente com ordem nula | §3.3: `situacao` com 3 estados; `candidatos` conta SKUs distintos |
-| 3 | `product_id = NULL` colide com `produto_nao_resolve` | §3.6: cinco pontos do leitor, com a ordem das decisões explícita |
+| 3 | `product_id = NULL` colide com `produto_nao_resolve` | resolvido de vez na R4: identidade separada da eleição (§3.3), e o leitor resolve nome em todo estado (§3.6) |
 | 4 | Arbitrariedade a montante do rank | §5: medida (2/186) e declarada, com sensor |
 | 5 | Janelas de implantação; §3.4 contradizia §3.5 | §3.5 corrigida; §6 lista as janelas e o risco da aba antiga |
 | 6 | Afirmações além da evidência | §1.1 (incidência ≠ dano) e §3.2 (recuperação medida: **104 de 198**, depois de o proxy global ter mentido 198/198) |
@@ -383,42 +486,100 @@ A revisão 2 foi de novo reprovada, e com razão em tudo que era verificável:
 | 5 | Contador não é fail-closed; "quebraria a aba antiga" não demonstrado | §6: reescrito como aceitação declarada de perda, e a afirmação não demonstrada foi retirada |
 | 6 | Afirmações além do medido | §3.2, §5 e §6 corrigidas; §8 rotulada como PLANO de prova |
 
+### 7.2 Rodada 3 do challenge
+
+| # | achado | resposta na revisão 4 |
+|---|---|---|
+| 1 | a flag por linha **desaparece na dedup** — contraexemplo executado | §5.1: a marca é do CLIENTE, decidida antes de elegibilidade/dedup/corte; §5.2 especifica coluna, validação e persistência |
+| 2 | os 4 estados não formam contrato executável: `unico_registrado` exigia nome sem identificador; falta precedência; `ordem_desconhecida` ≠ enum | §3.3 reescrita: **identidade separada da eleição** (`produtos` + `produto_eleito`), 5 estados com PRECEDÊNCIA, nomenclatura única |
+| 3 | validador sem invariantes ENTRE campos aceita `empatado` com `candidatos:1` e array vazio; SKU que não resolve ≠ leitura inválida | §3.6.6: tabela de invariantes cruzados; §3.6.3 separa os dois defeitos |
+| 4 | 9/198 **não prevê** a tela pós-entrega (D3 muda o conjunto persistido); "todos os empates têm 2" vinha dos 94 | §3.2 rebaixada a descrição do conjunto atual + §6.1 (o sensor); histograma re-medido sobre os **189** (2 em 189/189) e o recorte cross-only (**0 de 52** recuperados) |
+| 5 | §8 podia ficar verde sem provar: oráculo contraditório, base SQL sem `p_head_visto`, ramos decisivos em TS | §8 reescrita em 3 camadas, sobre `test-farmer-head-geracao.sh`, com as sabotagens nomeadas e o esperado do interleaving escrito |
+
+O terceiro caminho que o challenge propôs — up-sell ordenado, cross-sell apresentado como **opções
+registradas sem prioridade afirmada** — é o que a §3.6 passa a fazer, agora que nomear deixou de
+depender de eleger.
+
 ## 8. Plano de prova (ainda NÃO executado)
 
-Harness PG17 estendendo `db/test-farmer-geracao-vigente.sh` (hoje 31 asserts + 4 falsificações):
+**Onde.** `db/test-farmer-head-geracao.sh`, **não** `db/test-farmer-geracao-vigente.sh` (achado
+R3/5). O segundo aplica só a `20260814223445` e testa uma assinatura de
+`farmer_recomendacoes_substituir` **sem `p_head_visto`** — que não é a que o front chama
+(`useCrossSellEngine.ts:1205`). O primeiro aplica a cadeia `20260814223445` + `20260815181500`, que é
+a assinatura real. Provar contra a antiga seria testar código que ninguém executa.
 
-- **positivos**: rank denso grava empatados com o mesmo valor · `situacao` nos três estados ·
-  `candidatos` conta SKUs distintos · `product_id` nulo fora de `eleito` · grupo de 1 candidato com
-  `ordem` nula sai `eleito` · `[]` na carteira vazia · dois objetos por cliente.
-- **negativos**: `ordem = 0` e negativa recusadas com a SQLSTATE nomeada, re-lançando o resto.
+**Três camadas, porque nenhuma cobre a outra.** Semear `ordem` e `referencia_ambigua` à mão no PG
+prova armazenamento e leitura — e é cega ao motor perder a flag na dedup, emitir posições distintas
+em vez de rank denso, ou omitir o campo ao montar `recRows`. Os ramos decisivos vivem em TypeScript.
+
+### 8.1 PG17 — contrato do banco
+
+- **positivos**: rank denso grava empatados com o mesmo valor · `situacao` nos **cinco** estados,
+  respeitando a PRECEDÊNCIA · `candidatos` = tamanho do grupo e `produtos` = quem é nomeado, no caso
+  `[A:1, B:1, C:2]` → `produtos=[A,B]`, `candidatos=3` · `produto_eleito` não-nulo **⟺** `eleito` ·
+  `[]` na carteira vazia · dois objetos por cliente · ordem parcialmente nula (`[1,2,null]`) →
+  `ordem_indisponivel` · **singleton com `ordem` nula → `unico_registrado`** (⚠️ a revisão 3 exigia
+  `eleito` nos positivos e `unico_registrado` nos casos do R2 — oráculo contraditório, achado R3/5;
+  a precedência de §3.3 resolve: singleton nunca é `eleito`) · `referencia_ambigua` vencendo
+  `empatado` **e** `eleito` · `NULL` na flag com `ordem` preenchida → `referencia_ambigua`.
+- **negativos**: `ordem = 0` e negativa recusadas com a SQLSTATE nomeada; `referencia_ambigua`
+  não-booleana idem — capturando a SQLSTATE esperada e **re-lançando o resto**.
 - **RLS**: `SET ROLE authenticated` + GUC; carteira alheia não volta.
-- **exigidos pelo R2**: máximo PARCIALMENTE empatado (`[A:1,B:1,C:2]`) · ordem parcialmente nula
-  (`[1,2,null]`) · singleton com ordem nula saindo `unico_registrado` · falha de validação chegando
-  ao cartão como `leitura_falhou` (e não como Map parcial) · o interleaving "novo grava → antigo lê
-  head novo → antigo tenta gravar" · referência ambígua bloqueando `eleito`.
-- **falsificação**: uma camada por vez, com linha de base **verde na mesma invocação**, conferindo
-  **contagem e NOMES** dos vermelhos.
+- **ACL**: `has_function_privilege` para `PUBLIC` e `anon` nas duas pontas.
 
-⚠️ **Armadilha herdada e específica**: `preco-de-referencia-escolhido-por-uuid.md` registra que o
-Codex removeu a referência da chave de ordenação e **12 testes seguiram verdes**, porque a fixture
-tinha **uma** base comprada — com uma base só, `premium/ref` ordena igual a `premium`. As fixtures
-de up-sell aqui terão **múltiplas bases com preços diferentes**, e haverá sabotagem dedicada a
-provar que essa propriedade é medida.
+### 8.2 Vitest — o produtor e o leitor
+
+- **produtor** (`useCrossSellEngine`): rank **denso** (empatados compartilham o valor; posições
+  distintas moveriam o bug do uuid para o índice do array) · a flag de §5.1 sobrevive a
+  elegibilidade, dedup e corte · `recRows` carrega os dois campos novos · D3 ordena pelo score **não
+  arredondado**.
+- **leitor** (`useBundleEngine`): os sete pontos de §3.6 · resposta inválida → `leitura_falhou`
+  **inteira** · SKU que não resolve em `empatado` → segue `empatado` com "1 de 2 não identificado",
+  **não** vira eleição.
+- **fixtures de up-sell com MÚLTIPLAS bases de compra com preços diferentes**: com uma base só, a
+  ordem por `premium/referência` coincide com a ordem por `premium` e uma sabotagem passa verde.
+
+### 8.3 Falsificação — uma camada por vez
+
+Linha de base **verde na mesma invocação** (cópia + `LC_ALL`, abortando antes do primeiro `sed`), e
+conferindo **contagem e NOMES** dos vermelhos. Sabotagens mínimas, cada uma mirando um ramo que só
+ela alcança:
+
+| sabotagem | o que fica vermelho se o teste vale |
+|---|---|
+| dedup guarda só a flag da relação vencedora | o cliente marcado sai `eleito` (R3/1) |
+| D3 volta a ordenar pelo score arredondado | o conjunto persistido muda |
+| rank vira posição sequencial em vez de denso | empate vira eleição por índice |
+| `recRows` omite `ordem` / `referencia_ambigua` | nada persiste, e o teste que "passava" era cego |
+| leitor descarta a linha inválida em vez da resposta | Map parcial apresentado como completo |
+| RPC perde a precedência (avalia `empatado` antes de `referencia_ambigua`) | grupo ambíguo afirma igualdade medida |
+
+### 8.4 O interleaving legado — o esperado escrito
+
+"Nova grava → antiga lê o head novo → antiga tenta gravar": sob a decisão de §6, **a gravação antiga
+é ACEITA**. O leitor degrada para `ordem_indisponivel` e o servidor registra a perda de cobertura no
+log de execuções. Um teste esperando recusa estaria provando outra decisão — e passaria a reprovar o
+código correto.
 
 ## 9. O que esta entrega NÃO fecha (declarado)
 
 - **A precedência entre tipos continua sem regra comercial.** D1 dissolve a comparação; não a
   resolve.
-- **Os 94 empates REAIS do cross-sell** (39,5% dos grupos) continuam sem vencedor — e é correto que
-  continuem: o motor não tem sinal que os distinga. Fechá-los exige **sinal novo** (margem, giro,
-  recência do SKU no cliente), que é trabalho de motor, não de ordenação. O que a entrega faz é
-  parar de **fingir** que há vencedor ali.
+- **Os 189 empates REAIS do cross-sell** (95,5% dos grupos empatados; **52 de 52** nos clientes
+  cross-only, §3.2) continuam sem vencedor — e é correto que continuem: o motor não tem sinal que os
+  distinga. Fechá-los exige **sinal novo** (margem, giro, recência do SKU no cliente), que é trabalho
+  de motor, não de ordenação. O que a entrega faz é parar de **fingir** que há vencedor ali.
+- **A distribuição da tela depois desta entrega não está prevista** (§6.1): D3 muda o conjunto
+  persistido, e prever exigiria executar o pipeline TS sobre um snapshot coerente. Quem responde é o
+  sensor server-side, e ele é entregue junto.
 - **A via do WhatsApp e o corte top-3/top-2** (§4).
-- **A ambiguidade da referência de preço** (§5) — declarada e sensoreada, não propagada.
+- **A ambiguidade da referência de preço não é CONSERTADA** (§5): ela passa a ser propagada por
+  cliente e a bloquear eleição — o conserto seria dar a `preco-referencia.ts` um critério que não
+  caia em uuid, e isso é spec própria.
 - **`p_ij` é 0 em 645 de 714 linhas cross-sell** (`Math.round(0,0002 × 1000)/10 = 0`): o vendedor lê
   "0,0%". Mesma quantização, outra coluna, outro consumidor.
 - **Moeda comum em R$** (§1.3): sem substrato hoje.
 - **O sinal do motor de cross-sell é grosso, e agora há evidência dimensionada disso**: 189 de 198
-  grupos têm `relevance` EXATAMENTE igual entre os candidatos do topo. Dar sinal novo (margem,
-  giro, recência do SKU no cliente) é o conserto da CAUSA — spec própria, com esta medição como
-  ponto de partida. Esta entrega trata o sintoma: para de apresentar o sorteio como veredicto.
+  grupos têm `relevance` EXATAMENTE igual entre os candidatos do topo, todos de tamanho 2. Dar sinal
+  novo é o conserto da CAUSA — spec própria, com esta medição como ponto de partida e o sensor de
+  §6.1 como denominador. Esta entrega trata o sintoma: para de apresentar o sorteio como veredicto.

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -525,7 +525,42 @@ depender de eleger.
 - `sabota_ordem` conferia que o PADRÃO casou, não que a migration APLICOU — sabotagem inerte é
   lida como "sem dente" e manda o diagnóstico para o lugar errado.
 
-## 8. Plano de prova (ainda NÃO executado)
+### 7.4 Rodada 5 — o leitor, a tela e o sensor
+
+Reprovou. Os quatro achados foram reproduzidos por ele **executando** os helpers reais e
+renderizando React em memória, não lendo o diff.
+
+| # | Achado | Resolução |
+|---|---|---|
+| 1 | Custo **quadrático** levado para dentro da transação de gravação: `produtos` saía de subquery correlacionada por grupo sobre `base`, e `produto_eleito` repetia a varredura — ~149M verificações com 7.716 grupos, segurando os locks do INSERT. `AS MATERIALIZED` não alcança subquery interna | arrays montados na varredura que `grupo`/`topo` já fazem; o SELECT externo só ESCOLHE qual, e em `eleito` o topo tem um elemento, logo `topo_ids->>0` |
+| 2 | `if (nome)` aceita `"   "`: célula com parágrafo em BRANCO, contada como resolvida, sem aviso. O schema permite a descrição | `trim()` antes de aceitar, com teste dos DOIS lados — aparar não pode virar recusa de produto que existe |
+| 4 | O `title` **diagnosticava** desativação ("não está no catálogo ativo"), mas produto ATIVO com `descricao` vazia produz o mesmo estado | texto passa a dizer o que o código sabe: não identificou pelo nome |
+| 5 | "Um motor novo quebra no compilador" era **falso**: o tipo gerado diz `recommendation_type: string`, e o vocabulário vivia em 3 lugares soltos. Validador aceitando um 3º tipo que a lista não conhece faz a linha entrar no Map e nunca virar célula — cliente só daquele tipo SOME | `TIPOS_INDIVIDUAIS` vira fonte única; união, iteração e `Record` derivam dela |
+
+Sobre o **sensor**, ele corrigiu sem exagerar: não há defeito de MVCC (o `INSERT` do writer
+`VOLATILE` termina antes do statement que chama a RPC `STABLE`) nem de RLS por aninhamento, e a
+definição estrita da §6.1 está cumprida. O que estava excessivo era a **promessa**: o universo é
+"grupos pendentes no instante da gravação", não "eleições exibidas" — um `eleito` cujo SKU saiu do
+catálogo conta aqui e vira `indisponivel` na tela, e o leitor pula cliente sem `profile`. Medir o
+exibido exige um sensor **depois** da projeção, que é outra entrega.
+
+Sobre a rejeição global da resposta inválida (§3.6.6), a posição dele: *"Não é a única alternativa
+honesta… Porém, isso exige outro contrato; simplesmente filtrar linhas inválidas continuaria
+errado. Não reprovo o fechamento global, por si só, nesta entrega."*
+
+### 7.5 O que só a FALSIFICAÇÃO encontrou
+
+A suíte de integração da leitura inválida passava **pelo motivo errado**. O helper deriva
+`produto_eleito` do array, e com um produto só ele saía não-nulo: a linha era recusada pela
+checagem de `produto_eleito`, nunca pela cardinalidade do `empatado` que o teste diz guardar.
+Sabotar a cardinalidade deixou o teste VERDE — e é assim que se descobre. Mesma classe dos
+negativos que morriam no CAS: verde por outra razão que não a prometida.
+
+E o alvo da sabotagem F7 apontava para o teste do cartão, que monta a célula à mão e é **imune por
+desenho** — ele testa renderização, não projeção. Escolher o alvo errado teria registrado como
+"camada frágil" o que era separação correta de responsabilidade.
+
+## 8. Plano de prova (EXECUTADO — ver §8.5)
 
 **Onde.** `db/test-farmer-head-geracao.sh`, **não** `db/test-farmer-geracao-vigente.sh` (achado
 R3/5). O segundo aplica só a `20260814223445` e testa uma assinatura de
@@ -585,6 +620,21 @@ ela alcança:
 é ACEITA**. O leitor degrada para `ordem_indisponivel` e o servidor registra a perda de cobertura no
 log de execuções. Um teste esperando recusa estaria provando outra decisão — e passaria a reprovar o
 código correto.
+
+### 8.5 O que a prova produziu (executado)
+
+| camada | evidência | resultado |
+|---|---|---|
+| banco | `db/test-farmer-escopo-carteira.sh` (PG17, a migration REAL) | **67 asserts, 0 falhas**, exit 0 |
+| banco — falsificação | 8 sabotagens SQL, controle verde na mesma invocação | todas com dente |
+| TS | 5 suítes (`melhor-individual`, `CustomerBundleCard`, `bulk`, `leitura-falha`, `head-vazio`) | **81 testes**, exit 0 |
+| TS — falsificação | `scripts/falsificar-individuais.sh` (8 sabotagens, alvo casado por NOME) | **8 de 8 com dente**, exit 0 |
+| tipos | `bun run typecheck` (src + scripts/db) | exit 0 |
+| shell | `bun run lint:shell` | 0 achados em 385 arquivos |
+
+O guard "a sabotagem NÃO casou o padrão" pagou por si duas vezes: a F3 do harness SQL apontava
+para o texto da subquery que a correção do quadrático removeu, e sem ele o assert teria seguido
+verde sobre uma sabotagem que nunca existiu.
 
 ## 9. O que esta entrega NÃO fecha (declarado)
 

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -4,6 +4,19 @@
 > deixou a RPC de fora **de propósito**, com 5 critérios de aceite. Este é o desenho que os atende.
 > Re-medição em prod: 07/09/2026, `psql-ro`, geração de 21/08/2026, 1.083 recomendações pendentes.
 
+> 🚧 **STATUS: REPROVADA NO CHALLENGE — não implementar esta versão.** Challenge Codex
+> (`gpt-6-astra`, `max`, 522 s, 159k tokens) derrubou quatro peças, todas confirmadas no código:
+> (a) o teste da `relevance` implícita é fraco — como o up-sell vence os 186 pares, o limite
+> superior do clamp passa por construção e não testa nada; (b) `empatados` **mente** quando a
+> `ordem` é nula: "N produtos igualmente indicados" afirma igualdade MEDIDA onde houve
+> desconhecimento (é `ausente ≠ zero` com outra roupa); (c) `product_id = NULL` colide com o ramo
+> `produto_nao_resolve` do leitor atual (`useBundleEngine.ts:1050`), virando "SKU sumiu" em vez de
+> "empatou"; (d) há escolha arbitrária **a montante** do rank — `compararRecencia` desempata por
+> `pedidoId` (uuid) quando as datas empatam, e o vencedor do up-sell muda sem que o rank deixe de
+> parecer inequívoco. Além disso a RPC **não** é fronteira que toda via cruza: o preview do
+> WhatsApp lê a tabela direto e reordena pelo score arredondado. Revisão em curso.
+
+
 ## 1. O que a re-medição acrescentou à fotografia do #2350
 
 A fotografia do doc **reproduziu exatamente** (714 cross-sell + 369 up-sell, mesmas faixas, 186/186

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -110,13 +110,30 @@ Nulável porque as 1.083 linhas de 21/08 existem e não são recuperáveis (§3.
   referência cronológica de `preco-referencia.ts`. `upsell-ordem.ts` já tem o comparador **e** o
   predicado de empate (`candidatosEmpatam`, hoje privado) — o rank denso reusa os dois.
 
-**Quanto isso recupera, medido** (o challenge cobrou o número): dentro de um cliente e com `aB=0`,
-`pij ∝ k`, sendo `k` os compradores distintos do SKU. Nos 198 grupos cross-sell empatados,
-**198 (100%) têm `k` distinto entre os empatados**, com spread de até 49 compradores — ou seja, o
-empate é **artefato do arredondamento** e o rank o desfaz. Zero grupos com `k` igual.
-⚠️ `k` aqui é a contagem GLOBAL de compradores, proxy do `k` restrito à carteira que o motor usa;
-`k` global distinto implica fortemente `k` de carteira distinto, mas não prova.
-(`cluster_volume_estimate` não serve de proxy: é `1` em 714 de 714 linhas, no piso do `max(1,…)`.)
+**Quanto isso recupera, medido — e o primeiro número estava errado.** Dentro de um cliente,
+`relevance = 0,4·k/N + 0,6·aB`, com `k` = compradores distintos do SKU **na carteira** (N=269
+clientes, medido). Eu primeiro usei `k` GLOBAL como proxy e obtive "198 de 198 recuperáveis". O `k`
+de carteira **inverte parte do resultado**:
+
+| | n | % dos 198 |
+|---|---|---|
+| grupos cross-sell empatados no topo | 198 | 100% |
+| `k` de carteira DIFERE ⇒ recuperável pelo score não-arredondado | **104** | **52,5%** |
+| `k` de carteira IGUAL | 94 | 47,5% |
+| desses 94, salvos por `assocBoost` diferente | **0** | — |
+| **empate REAL** (mesmo `k` **e** mesmo `aB` ⇒ mesma `relevance`) | **94** | **47,5%** |
+
+⇒ Sobre os 238 grupos cross-sell: 40 já decididos pelo score · 104 recuperados pelo rank ·
+**94 (39,5%) vão exibir "N produtos igualmente indicados"**.
+
+Esses 94 são **indistinguíveis para o motor** — mesma aderência de carteira, nenhuma regra de
+associação. `empatado` é a resposta verdadeira, e consertá-los seria dar **sinal novo** ao motor,
+não ordenar melhor. Fica declarado em §9.
+
+⚠️ Lição de método, e ela quase passou: um proxy pode ser *fortemente* correlacionado e ainda
+inverter o veredicto. `k` global distinto NÃO implica `k` de carteira distinto — a carteira é 269
+de milhares de clientes, e SKUs que se separam na base inteira colidem no recorte.
+(`cluster_volume_estimate` também não serve: é `1` em 714 de 714 linhas, no piso do `max(1,…)`.)
 
 **Nada disto toca `affinity_score` nem `p_ij`.**
 
@@ -279,7 +296,7 @@ ser observável em vez de suposta.
 | 3 | `product_id = NULL` colide com `produto_nao_resolve` | §3.6: cinco pontos do leitor, com a ordem das decisões explícita |
 | 4 | Arbitrariedade a montante do rank | §5: medida (2/186) e declarada, com sensor |
 | 5 | Janelas de implantação; §3.4 contradizia §3.5 | §3.5 corrigida; §6 lista as janelas e o risco da aba antiga |
-| 6 | Afirmações além da evidência | §1.1 (incidência ≠ dano) e §3.2 (recuperação medida: 198/198) |
+| 6 | Afirmações além da evidência | §1.1 (incidência ≠ dano) e §3.2 (recuperação medida: **104 de 198**, depois de o proxy global ter mentido 198/198) |
 
 ## 8. Prova
 
@@ -303,6 +320,10 @@ provar que essa propriedade é medida.
 
 - **A precedência entre tipos continua sem regra comercial.** D1 dissolve a comparação; não a
   resolve.
+- **Os 94 empates REAIS do cross-sell** (39,5% dos grupos) continuam sem vencedor — e é correto que
+  continuem: o motor não tem sinal que os distinga. Fechá-los exige **sinal novo** (margem, giro,
+  recência do SKU no cliente), que é trabalho de motor, não de ordenação. O que a entrega faz é
+  parar de **fingir** que há vencedor ali.
 - **A via do WhatsApp e o corte top-3/top-2** (§4).
 - **A ambiguidade da referência de preço** (§5) — declarada e sensoreada, não propagada.
 - **`p_ij` é 0 em 645 de 714 linhas cross-sell** (`Math.round(0,0002 × 1000)/10 = 0`): o vendedor lê

--- a/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
+++ b/docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md
@@ -1,29 +1,20 @@
-# A RPC do "melhor individual" elege por moeda em 98,7% dos casos — desenho do conserto
+# A RPC do "melhor individual" elege por uuid em 98,7% dos casos — desenho do conserto
 
 > Continuação de `docs/historico/affinity-score-duas-grandezas.md` (#2350), que mediu o defeito e
 > deixou a RPC de fora **de propósito**, com 5 critérios de aceite. Este é o desenho que os atende.
-> Re-medição em prod: 07/09/2026, `psql-ro`, geração de 21/08/2026, 1.083 recomendações pendentes.
-
-> 🚧 **STATUS: REPROVADA NO CHALLENGE — não implementar esta versão.** Challenge Codex
-> (`gpt-6-astra`, `max`, 522 s, 159k tokens) derrubou quatro peças, todas confirmadas no código:
-> (a) o teste da `relevance` implícita é fraco — como o up-sell vence os 186 pares, o limite
-> superior do clamp passa por construção e não testa nada; (b) `empatados` **mente** quando a
-> `ordem` é nula: "N produtos igualmente indicados" afirma igualdade MEDIDA onde houve
-> desconhecimento (é `ausente ≠ zero` com outra roupa); (c) `product_id = NULL` colide com o ramo
-> `produto_nao_resolve` do leitor atual (`useBundleEngine.ts:1050`), virando "SKU sumiu" em vez de
-> "empatou"; (d) há escolha arbitrária **a montante** do rank — `compararRecencia` desempata por
-> `pedidoId` (uuid) quando as datas empatam, e o vencedor do up-sell muda sem que o rank deixe de
-> parecer inequívoco. Além disso a RPC **não** é fronteira que toda via cruza: o preview do
-> WhatsApp lê a tabela direto e reordena pelo score arredondado. Revisão em curso.
-
+> Medições em prod: `psql-ro`, 07/09/2026, geração de 21/08/2026, 1.083 recomendações pendentes.
+>
+> **Revisão 2** — a revisão 1 foi REPROVADA pelo challenge Codex (`gpt-6-astra`, `max`, 522 s,
+> 159k tokens). Seis achados entraram; dois exigiram medição nova, e uma delas quase derrubou a
+> peça central. O que mudou está em §7.
 
 ## 1. O que a re-medição acrescentou à fotografia do #2350
 
 A fotografia do doc **reproduziu exatamente** (714 cross-sell + 369 up-sell, mesmas faixas, 186/186
 up-sell vencendo entre pares com os dois tipos, 52 vencedores cross-sell = exatamente os pares sem
-up-sell). Duas coisas são novas, e as duas mudam o desenho.
+up-sell).
 
-### 1.1 O defeito do desempate é maior do que o medido — e engole o outro
+### 1.1 O desempate por uuid alcança também o cross-sell
 
 O #2350 registrou que o `id` uuid decide dentro do up-sell (183/183) e ressalvou: *"não diz que o
 score nunca decide NADA — nos 52 pares sem up-sell ele ainda escolhe entre produtos cross-sell"*.
@@ -39,63 +30,65 @@ score nunca decide NADA — nos 52 pares sem up-sell ele ainda escolhe entre pro
 `updated_at` não desempata nada (é o instante da transação de geração, igual para o lote inteiro).
 Somando: **235 dos 238 pares (98,7%) têm o produto eleito escolhido pelo `id` uuid v4.**
 
-Consequência de desenho: **declarar política entre tipos e parar aí consertaria ~0%** do que chega
-à tela. O eixo dominante é o desempate, não a precedência.
+⚠️ **Limite desta afirmação** (challenge Codex): 98,7% é a **incidência do último critério usado**
+— não é dano comercial, nem taxa de produto errado. Ela não autoriza dizer que este defeito
+"engole" o da precedência entre tipos, nem que uma política entre tipos consertaria "~0%": trocar
+a política mudaria a FAMÍLIA da oferta em 186 clientes, que é outro efeito. Não há medição que
+ordene a importância dos dois. São defeitos separados (critério 4), e ficam separados.
 
-Causa direta, no cross-sell: `affinityScore: Math.round(score * 10000) / 10000`. A `relevance`
-varia na casa de 1e-6 e o arredondamento é 1e-4 — restam **32 valores distintos em 714 linhas**.
-A ordem existe no cálculo e morre na gravação.
+### 1.2 A precedência entre tipos é um limiar, não um artefato de escala
 
-### 1.2 Não é "artefato de escala" — é um limiar bem definido, e ele quase virou
-
-Os dois motores computam `P(conversão)` do MESMO cliente e compartilham os fatores `health/100` e
-`engagement`, que **cancelam** na comparação:
+Os dois motores computam `P(conversão)` do MESMO cliente. `healthScore` e `engagementFactor` são
+calculados **uma vez por cliente** e reusados nos dois (`useCrossSellEngine.ts:835`), então
+cancelam na comparação:
 
 ```
-cross: pij = 0,15 × (health/100) × engagement × relevance    relevance = clamp(cA·0,4 + aB·0,6, 0,01, 1,0)
+cross: pij = 0,15 × (health/100) × engagement × relevance   relevance = clamp(cA·0,4 + aB·0,6, 0,01, 1,0)
 up:    pij = 0,10 × (health/100) × engagement × 0,8
 
 up > cross  ⟺  0,08 > 0,15 × relevance  ⟺  relevance < 0,5333
 ```
 
-**Teste falsificável** (o que separa isto de uma história plausível): se o cancelamento vale, a
-`relevance` implícita `(max_cross/max_up)/1,875` tem de cair dentro do `clamp` do código. Medido
-nos 186 pares com os dois tipos: mín **0,0148** · mediana **0,0338** · máx **0,5041** ·
-**0 de 186 fora de [0,01 , 1,0]**. Cair 186/186 dentro do intervalo exato seria coincidência
-absurda se a álgebra estivesse errada.
+**A evidência do cancelamento é a leitura do código** — as mesmas variáveis, para fatores positivos
+e finitos —, não uma inferência sobre os dados.
 
-Isto **corrige o vocabulário** do #2350 em dois pontos:
+⚠️ **A revisão 1 alegava um teste empírico que não sustenta o que dizia.** Eu afirmei que a
+`relevance` implícita `(max_cross/max_up)/1,875` cair 186/186 dentro de `[0,01 , 1,0]` seria
+"coincidência absurda". Não é: como o up-sell vence os 186 pares, `max_cross/max_up < 1` **sempre**,
+logo a implícita é `< 0,5333` **por construção** e o limite superior nunca poderia falhar. Só o
+limite inferior testava algo, e frouxamente — fatores de cliente diferentes entre os motores também
+produziriam valores dentro do intervalo. O teste que **distingue** é reconstruir `relevance` a
+partir dos insumos e comparar `round4(previsto)` com o persistido, sabotando **um** motor com um
+fator extra; fica registrado como método, não executado aqui (reconstruir com insumos de hoje
+testaria o motor de hoje, não a geração de 21/08).
 
-- as grandezas não são incomensuráveis "por base histórica diferente" — os termos de cliente são
-  literalmente os mesmos e se cancelam;
-- a precedência não é **estrutural**, é **contingente**: o máximo observado (0,5041) ficou a **5,5%**
-  do limiar (0,5333). Uma carteira com `assocBoost` um pouco maior faz cross-sell vencer.
+⚠️ E o bicondicional vale no score **antes do arredondamento**. Com `relevance = 0,5332` o cross
+bruto é `0,011997` contra `0,012` do up, mas ambos gravam `0,012` — e aí a RPC pode eleger cross
+pelo desempate. A fronteira exata é do valor bruto; o persistido tem uma faixa cinza de largura
+1e-4.
 
-A assimetria real é outra, e é a que importa para o produto: **o score do cross-sell é descontado
-por um termo de aderência ao PRODUTO; o do up-sell não tem termo de produto nenhum** (o `0,8` é
-constante para todo candidato). O número do up-sell não estima o produto — estima o cliente. Comparar
-os dois é comparar "P(compra ESTE complementar)" com "P(compra ALGO mais caro)": erro de categoria,
-não de escala.
+A assimetria que importa para o produto é outra: **o score do cross-sell é descontado por um termo
+de aderência ao PRODUTO; o do up-sell não tem termo de produto nenhum** (o `0,8` é constante para
+todo candidato). O número do up-sell não estima o produto — estima o cliente. Comparar os dois é
+comparar "P(compra ESTE complementar)" com "P(compra ALGO mais caro)".
 
 ### 1.3 Substrato para "moeda comum" não existe hoje
 
 `lie` e `m_ij`: **0 de 17.316 linhas** populadas (colunas mortas, como `best_individual_lie`).
 Comparar em R$ exigiria reintroduzir margem no motor — removida do browser de propósito no #1837.
-Fica registrado como caminho possível, fora desta entrega.
 
 ## 2. As decisões (do founder, 07/09/2026)
 
-| # | Decisão | Critério que atende |
+| # | Decisão | Critério |
 |---|---|---|
 | D1 | A RPC devolve o **melhor de CADA tipo**, sem compará-los | 1 e 5 |
-| D2 | Eleição não decidida por sinal → **não elege**; diz que empatou | 4 |
+| D2 | Eleição não decidida por sinal → **não elege** | 4 |
 | D3 | A ordem em MEMÓRIA do cross-sell entra na mesma entrega | — |
 | D4 | O cartão ganha **duas células rotuladas** | — |
 
-**D1 dissolve a comparação em vez de inventá-la.** É a única saída que não viola o critério 5:
+**D1 dissolve a comparação em vez de inventá-la** — a única saída que não viola o critério 5:
 declarar `up_sell > cross_sell` reproduziria um viés observado, e nenhuma regra comercial autoriza
-a precedência. Não escolher é a resposta honesta quando não há critério — `precisão > recall`
-aplicado à ORDEM, não ao conteúdo.
+a precedência.
 
 ## 3. O desenho
 
@@ -103,146 +96,215 @@ aplicado à ORDEM, não ao conteúdo.
 
 Rank **denso**, base 1, escopo `(farmer_id, customer_user_id, recommendation_type, run_id)`.
 
-**Candidatos empatados no sinal recebem o MESMO valor.** Esta é a peça que impede a entrega de
-trocar o endereço do bug: se empatados recebessem posições distintas, o vencedor passaria a ser
-decidido pelo índice do array — a ordem de varredura do catálogo, que é `.order('id')`, que é uuid
-**de novo**. Com rank denso, o empate vira **fato gravado** em vez de inferência de igualdade de
-float na leitura.
+**Candidatos empatados no sinal recebem o MESMO valor.** É a peça que impede a entrega de trocar o
+endereço do bug: com posições distintas para empatados, o vencedor passaria a ser o índice do array
+— a varredura do catálogo, que é `.order('id')`, que é uuid **de novo**.
 
 Nulável porque as 1.083 linhas de 21/08 existem e não são recuperáveis (§3.5).
 
-### 3.2 Quem calcula o rank (critério 2 — ordem justificável DENTRO de cada tipo)
+### 3.2 Quem calcula o rank (critério 2)
 
-- **`cross_sell`**: `pij` **não arredondado**, desc. O score já carrega `relevance`, que é termo do
-  produto — a ordem é legítima; só não sobrevive ao `Math.round`. Empate genuíno (mesmo
-  `buyerCount` e mesmo `assocBoost` ⇒ mesma `relevance`) permanece empatado e compartilha rank.
+- **`cross_sell`**: `pij` **não arredondado**, desc. Empate genuíno (mesma `relevance`) compartilha
+  rank.
 - **`up_sell`**: `compararCandidatosUpSell` (menor razão de preço → maior popularidade), sobre a
-  referência **cronológica** que entrou na main em 07/09 (`preco-referencia.ts`). `upsell-ordem.ts`
-  já tem o comparador **e** o predicado de empate (`candidatosEmpatam`, hoje privado) — o rank denso
-  reusa os dois em vez de reimplementar a noção de empate.
+  referência cronológica de `preco-referencia.ts`. `upsell-ordem.ts` já tem o comparador **e** o
+  predicado de empate (`candidatosEmpatam`, hoje privado) — o rank denso reusa os dois.
 
-**Nada disto toca `affinity_score` nem `p_ij`.** A "% de conversão" que a tela mostra continua
-idêntica, e a armadilha que o #1837 nomeou (codificar ordem na magnitude é inventar score) fica
-fechada: a ordem vai para uma coluna que É ordem.
+**Quanto isso recupera, medido** (o challenge cobrou o número): dentro de um cliente e com `aB=0`,
+`pij ∝ k`, sendo `k` os compradores distintos do SKU. Nos 198 grupos cross-sell empatados,
+**198 (100%) têm `k` distinto entre os empatados**, com spread de até 49 compradores — ou seja, o
+empate é **artefato do arredondamento** e o rank o desfaz. Zero grupos com `k` igual.
+⚠️ `k` aqui é a contagem GLOBAL de compradores, proxy do `k` restrito à carteira que o motor usa;
+`k` global distinto implica fortemente `k` de carteira distinto, mas não prova.
+(`cluster_volume_estimate` não serve de proxy: é `1` em 714 de 714 linhas, no piso do `max(1,…)`.)
+
+**Nada disto toca `affinity_score` nem `p_ij`.**
 
 ### 3.3 RPC `farmer_melhores_individuais_por_cliente(uuid)` (nome novo — §3.4)
 
-Devolve `jsonb` com até **dois** objetos por cliente. Contrato por objeto:
+Devolve `jsonb` com até **dois** objetos por cliente:
 
 ```
-customer_user_id · recommendation_type · product_id · affinity_score · run_id · empatados
+customer_user_id · recommendation_type · product_id · affinity_score · run_id
+                 · situacao · candidatos
 ```
 
-`empatados` = quantos candidatos **poderiam** ser o melhor daquele tipo:
+⚠️ **A revisão 1 tinha UM campo `empatados` e ele MENTIA.** Com `ordem` nula em todo o grupo, ele
+diria "2 produtos igualmente indicados" — afirmando igualdade **medida** onde houve
+**desconhecimento**. É o `ausente ≠ zero` da casa reintroduzido dentro do conserto que veio matá-lo.
+São dois estados diferentes e passam a ter nomes diferentes:
 
-- `ordem` conhecida em todo o grupo → quantos compartilham `min(ordem)`;
-- **qualquer** `ordem` nula no grupo → **todos** os candidatos do grupo. Ordem desconhecida
-  significa que nenhum candidato pode ser descartado — fail-closed, e é o que faz os registros
-  legados se declararem sozinhos sem backfill.
+| `situacao` | condição | significado |
+|---|---|---|
+| `eleito` | ordem conhecida em todo o grupo **e** um único candidato no topo | decidido por sinal |
+| `empatado` | ordem conhecida em todo o grupo **e** ≥2 candidatos no topo | igualdade MEDIDA |
+| `ordem_desconhecida` | **qualquer** `ordem` nula no grupo com ≥2 candidatos | ninguém mediu |
 
-`empatados = 1` é, por construção, "decidido por sinal". Um campo só, semântica exata, sem flag
-redundante que possa divergir dele.
+Um grupo de **um único candidato** é `eleito` mesmo com `ordem` nula: não há escolha a fazer, e
+chamar isso de empate seria a mentira simétrica. `candidatos` conta **SKUs distintos** (`count
+(DISTINCT product_id)`), não linhas — "N produtos" exige unicidade por produto.
 
-**Guard estrutural: `product_id` volta `NULL` sempre que `empatados > 1`.** Não existe "devolve o
-vencedor e confia que o consumidor respeite a flag" — sem eleição por sinal, não sai nome. Torna
-impossível renderizar a moeda por descuido, hoje ou num consumidor futuro (money-path §5: o guard
-mora na fronteira que toda via cruza).
+O caso `[1, 2, null]` cai em `ordem_desconhecida` por fail-closed: as ordens conhecidas mantêm sua
+relação entre si, mas nada situa a linha nula, e afirmar o vencedor exigiria descartá-la.
 
-Preservados da RPC atual, e pelos mesmos motivos: `coalesce(…, '[]'::jsonb)` (`[]` = li e não há;
-`NULL` = falhou, e o caller lança), `SECURITY INVOKER` (a policy `frec_select_carteira` segue sendo
-a única fronteira), `REVOKE`/`GRANT` nomeando as roles.
+**Guard estrutural: `product_id` só é não-nulo quando `situacao = 'eleito'`.** Sem eleição por
+sinal, não sai nome — impossível renderizar a moeda por descuido.
 
-### 3.4 Por que nome NOVO em vez de substituir
+Preservados da RPC atual e pelos mesmos motivos: `coalesce(…, '[]'::jsonb)`, `SECURITY INVOKER`,
+`REVOKE`/`GRANT` nomeando as roles.
 
-A RPC atual fica **intocada**. Isso elimina a janela de regressão entre os dois deploys manuais:
-entre a migration e o Publish, o front velho chama a RPC velha e nada muda.
+### 3.4 Por que nome NOVO
 
-Se eu trocasse a assinatura da RPC existente, o front velho receberia **duas linhas por cliente** e
-o `melhorIndividual.set(linha.customer_user_id, linha)` guardaria a última — arbitrário outra vez,
-com o agravante de ser invisível. Também evita o `DROP`+`CREATE` que **reseta o ACL**
-(`database.md` §4).
+A RPC atual fica **intocada**: entre a migration e o Publish, o front velho chama a RPC velha e
+nada muda. Trocar a assinatura da atual faria o front velho receber duas linhas por cliente, e o
+`melhorIndividual.set(customer_user_id, …)` guardaria a última — arbitrário de novo, e invisível.
+Também evita o `DROP`+`CREATE` que **reseta o ACL** (`database.md` §4).
 
 ### 3.5 Registros existentes (critério 3) — sem backfill
 
-Os 1.083 pendentes de 21/08 nascem com `ordem` nula e, por §3.3, reportam `empatados = N`: a tela
-diz "N produtos igualmente indicados" em vez de eleger. **Isso já é o conserto**, e vale no dia da
-migration, antes de qualquer recálculo — para de apresentar moeda como veredicto para os 235 pares
-de hoje.
+Os 1.083 pendentes de 21/08 nascem com `ordem` nula ⇒ `situacao = 'ordem_desconhecida'` e a tela diz
+"ordenação indisponível — N recomendações registradas".
 
-Backfill foi descartado com motivo: a ordem não é recuperável das colunas existentes (o #2350 já
-mediu que `created_at` está empatado nos mesmos grupos), e re-derivar com preços de **hoje** sobre
-uma geração de **21/08** fabricaria número — exatamente o que `precisão > recall` proíbe.
+⚠️ **Correção da revisão 1**, que se contradizia: eu afirmava que isso "vale no dia da migration,
+antes de qualquer recálculo". **Não vale** — §3.4 mantém a RPC antiga servindo o front antigo, então
+nada muda até o Publish ser **adotado** pelo cliente. O conserto começa na adoção, não na migration.
+
+Backfill descartado: a ordem não é recuperável das colunas existentes, e re-derivar com preços de
+**hoje** sobre uma geração de **21/08** fabricaria número.
 
 ### 3.6 Leitor e tela (D4)
 
-`ComparacaoIndividual` passa a ser por tipo. O cartão ganha duas células rotuladas — "Melhor
-cross-sell" e "Melhor up-sell" — cada uma com quatro estados:
+O leitor muda em cinco pontos, e quatro deles são armadilhas que o challenge apontou:
 
-| estado | quando | o que mostra |
-|---|---|---|
-| `encontrado` | `empatados = 1` e o SKU resolve no catálogo ativo | nome do produto |
-| `empatado` | `empatados > 1` | "N produtos igualmente indicados" |
-| `nenhum` | a RPC respondeu e não há oferta daquele tipo | — |
-| `indisponivel` | leitura falhou, ou o SKU eleito saiu do catálogo | rótulo + motivo |
+1. **A chave do Map passa a incluir o tipo** (`useBundleEngine.ts:844`) — hoje é uma linha por
+   cliente, e o segundo objeto sobrescreveria o primeiro.
+2. **A decisão sobre `situacao` acontece ANTES de consultar `productMap`.** Hoje `pid == null` cai
+   direto em `produto_nao_resolve` (`useBundleEngine.ts:1050`): sem esta ordem, todo empate viraria
+   "o SKU sumiu do catálogo". Só `eleito` tenta resolver SKU.
+3. **O sensor de resolução** (`useBundleEngine.ts:1163`) não pode contar `product_id` nulo
+   deliberado como falha de catálogo — fabricaria deterioração.
+4. **O filtro de inclusão do cartão** (`useBundleEngine.ts:1073`) passa a omitir o cliente só quando
+   **ambos** os tipos são `nenhum`.
+5. **Validação em runtime da resposta**: tipo reconhecido, `candidatos` inteiro ≥1, sem duplicata
+   `(cliente,tipo)`, combinação `situacao`×`product_id` válida. O cast atual para
+   `MelhorIndividualRow[]` não valida nada.
 
-`empatado` e `indisponivel` ficam **separados de propósito**: "li e empatei" não é "não consegui
-ler". Colapsar os dois refaria, um nível abaixo, a fabricação de rótulo que o #1594 matou.
+O cartão ganha duas células rotuladas, cada uma com:
 
-Efeito colateral desejado: o vendedor passa a ver a **família** da oferta. Era justamente a
-invisibilidade do tipo (o cartão mostrava só o nome) que tornava a limitação indetectável para quem
-avalia o bundle — o "custo aceito" que o #2350 registrou deixa de ser aceito.
+| estado | mostra |
+|---|---|
+| `eleito` + SKU resolve | nome do produto |
+| `empatado` | "N produtos igualmente indicados" |
+| `ordem_desconhecida` | "Ordenação indisponível — N recomendações registradas" |
+| `nenhum` | — |
+| `indisponivel` | rótulo + motivo (leitura falhou · SKU fora do catálogo) |
 
 ### 3.7 Ordem em memória do cross-sell (D3)
 
 `crossSellRecs.sort((a,b) => b.affinityScore - a.affinityScore)` ordena pelo score **arredondado**;
-`Array.prototype.sort` é estável, então entre empatados vence a ordem de inserção — a varredura do
-catálogo, que vem de `fetchAllPages` com `.order('id')`. O top-3 do vendedor é uuid pelo mesmo
-mecanismo da RPC.
+o `sort` é estável, então entre empatados vence a ordem de inserção — a varredura do catálogo, que
+vem de `.order('id')`. O top-3 do vendedor é uuid pelo mesmo mecanismo. Passa a usar a chave densa.
 
-Como o motor já vai calcular o rank denso para gravar, o `sort` passa a usar a mesma chave. Fechar
-só o lado persistido deixaria o mesmo defeito vivo com outra roupa.
+## 4. Escopo da garantia — o que esta entrega NÃO cobre
 
-## 4. Sequência de implantação (critério 3)
+⚠️ **A revisão 1 chamou a RPC de "a fronteira que toda via cruza". É falso**, e o challenge
+demonstrou executando:
 
-1. **Banco** — você cola no SQL Editor (`lovable-db-operator`):
-   `ALTER TABLE … ADD COLUMN ordem` · `CREATE OR REPLACE` de `farmer_recomendacoes_substituir`
-   (aceita e **valida** `ordem`: nula, ou inteiro ≥ 1) · `CREATE` da RPC nova.
-2. **Publish** — motores gravam `ordem`; leitor chama a RPC nova; cartão com duas células.
-3. **Recálculo** (um clique). Sem ele a tela diz "empatou" para os 238 clientes — honesto, mas é
-   janela: fazer no mesmo dia.
+- **O preview do WhatsApp lê `farmer_recommendations` direto** (`usePropostaPreview.ts:104`) e
+  reordena pelo score arredondado (`cross-sell.ts:31`). Com três afinidades iguais, inverter a
+  entrada muda os produtos selecionados. Não passa pela RPC nem pela `ordem`.
+- **Os cortes top-3/top-2 do motor** (`useCrossSellEngine.ts:1045`) já descartam candidatos
+  empatados **antes** da persistência. `candidatos` conta recomendações persistidas, não todos os
+  candidatos que o motor viu.
+
+A garantia fica restrita ao **cartão de bundles**. Estender à via do WhatsApp e ao corte é trabalho
+próprio, com medição própria.
+
+## 5. Ambiguidade a montante do rank — declarada e medida
+
+`compararRecencia` (`preco-referencia.ts:114`) desempata por `pedidoId` (uuid) quando as datas
+empatam. Isso escolhe o preço de **referência**, que é a chave primária da ordem do up-sell — logo
+um rank pode ser numericamente único (`situacao = 'eleito'`) e ainda carregar uma decisão arbitrária
+na origem. O challenge executou os helpers reais trocando só os uuids e o vencedor mudou de Y para X.
+
+**Incidência, medida agora** (o challenge a declarou desconhecida):
+
+| | n |
+|---|---|
+| pares (cliente,SKU) com preço utilizável | 13.290 |
+| topo com empate de data entre pedidos DISTINTOS | 157 |
+| **desses, com preços distintos ⇒ o uuid muda a referência** | **23 (0,17%)** |
+| clientes atingidos | 14 |
+| **∩ com os 186 clientes de up-sell vivo** | **2 (1,1%)** |
+
+É limite **superior**: nem todo par ambíguo troca vencedor. A 1,1% dos clientes, propagar a
+ambiguidade até o contrato da RPC não se paga nesta entrega — mas **declarar** é obrigatório, e a
+entrega inclui um sensor que conta pares ambíguos por execução, para que o número deixe de depender
+de alguém lembrar de medir. Se ele subir, a propagação vira trabalho próprio.
+
+## 6. Implantação (critério 3)
+
+1. **Banco** (SQL Editor, `lovable-db-operator`): `ADD COLUMN ordem` · `CREATE OR REPLACE` de
+   `farmer_recomendacoes_substituir` (aceita e **valida** `ordem`: nula, ou inteiro ≥ 1) · `CREATE`
+   da RPC nova. Pré-flight contra `pg_get_functiondef` da PROD.
+2. **Publish**.
+3. **Recálculo**, que grava os ranks.
 4. **PR de limpeza** derruba a RPC antiga.
 
-A ordem 1→2 é obrigatória, não preferencial: o escritor novo grava `ordem`, e contra o schema velho
-o `jsonb_to_recordset` ignoraria a chave em silêncio — a coluna não existiria e **nenhum** rank
-seria persistido, sem erro nenhum. O `CREATE OR REPLACE` do writer é pré-flightado contra
-`pg_get_functiondef` da PROD (`database.md` §4: apply manual diverge do repo).
+A ordem 1→2 é obrigatória: contra o schema velho, o `jsonb_to_recordset` **ignoraria a chave
+`ordem` em silêncio** e nenhum rank seria persistido, sem erro nenhum.
 
-## 5. Prova (money-path: plpgsql é late-bound)
+**Janelas em que a tela segue errada** (o challenge listou, e são reais):
+
+| situação | efeito |
+|---|---|
+| migration aplicada, front antigo | continua na RPC antiga, elegendo por uuid |
+| Publish feito, cliente não adotou o build | o erro persiste até o clique de atualização (`pwa-update.ts:32`) |
+| ranks gravados, leitor antigo | a RPC antiga ignora `ordem` e pode eleger outro produto |
+| **aba antiga recalcula depois da nova** | grava payload **sem** `ordem`, apagando a cobertura |
+
+A última não é barrada pelo CAS: se a aba antiga lê o head **depois** da geração nova, ela apresenta
+o head correto e grava normalmente — o CAS controla concorrência causal, não versão do produtor. E
+`FarmerRecommendations.tsx:45` calcula **ao montar**, então não depende de clique consciente.
+⇒ a validação de `ordem` no writer **não pode** rejeitar o payload legado (quebraria a aba antiga
+inteira); o que a entrega adiciona é um **contador de gerações sem `ordem`** no head, para a janela
+ser observável em vez de suposta.
+
+## 7. O que mudou da revisão 1 (challenge Codex)
+
+| # | Achado | Resolução |
+|---|---|---|
+| 1 | O teste da `relevance` implícita não prova o cancelamento | §1.2 reescrita: evidência é o código; o teste foi retirado como prova e o método que distingue ficou registrado |
+| 2 | `empatados` mente com ordem nula | §3.3: `situacao` com 3 estados; `candidatos` conta SKUs distintos |
+| 3 | `product_id = NULL` colide com `produto_nao_resolve` | §3.6: cinco pontos do leitor, com a ordem das decisões explícita |
+| 4 | Arbitrariedade a montante do rank | §5: medida (2/186) e declarada, com sensor |
+| 5 | Janelas de implantação; §3.4 contradizia §3.5 | §3.5 corrigida; §6 lista as janelas e o risco da aba antiga |
+| 6 | Afirmações além da evidência | §1.1 (incidência ≠ dano) e §3.2 (recuperação medida: 198/198) |
+
+## 8. Prova
 
 Harness PG17 estendendo `db/test-farmer-geracao-vigente.sh` (hoje 31 asserts + 4 falsificações):
 
-- **positivos**: rank denso grava empatados com o mesmo valor; `empatados` conta o topo;
-  `product_id` é `NULL` sob empate; grupo com `ordem` nula reporta `empatados = N`; `[]` na
-  carteira vazia; dois objetos por cliente quando há os dois tipos.
-- **negativos**: `ordem = 0` e `ordem` negativa recusadas com a SQLSTATE nomeada, re-lançando o
-  resto (`WHEN OTHERS THEN 'OK'` é teatro).
+- **positivos**: rank denso grava empatados com o mesmo valor · `situacao` nos três estados ·
+  `candidatos` conta SKUs distintos · `product_id` nulo fora de `eleito` · grupo de 1 candidato com
+  `ordem` nula sai `eleito` · `[]` na carteira vazia · dois objetos por cliente.
+- **negativos**: `ordem = 0` e negativa recusadas com a SQLSTATE nomeada, re-lançando o resto.
 - **RLS**: `SET ROLE authenticated` + GUC; carteira alheia não volta.
-- **falsificação**: sabotar uma camada por vez, com **linha de base verde na MESMA invocação**, e
-  conferir **contagem e NOMES** dos vermelhos — exit≠0 não distingue "pegou o bug" de "não rodou".
+- **falsificação**: uma camada por vez, com linha de base **verde na mesma invocação**, conferindo
+  **contagem e NOMES** dos vermelhos.
 
-⚠️ **Armadilha herdada, e ela é específica desta entrega**: o doc de 07/09
-(`preco-de-referencia-escolhido-por-uuid.md`) registra que o Codex removeu a referência da chave de
-ordenação do up-sell e **12 testes seguiram verdes**, porque a fixture tinha **uma** base comprada —
-com uma base só, `premium/ref` ordena igual a `premium`. As fixtures de up-sell aqui terão
-**múltiplas bases com preços diferentes**, e haverá uma sabotagem dedicada a provar que essa
-propriedade é medida.
+⚠️ **Armadilha herdada e específica**: `preco-de-referencia-escolhido-por-uuid.md` registra que o
+Codex removeu a referência da chave de ordenação e **12 testes seguiram verdes**, porque a fixture
+tinha **uma** base comprada — com uma base só, `premium/ref` ordena igual a `premium`. As fixtures
+de up-sell aqui terão **múltiplas bases com preços diferentes**, e haverá sabotagem dedicada a
+provar que essa propriedade é medida.
 
-## 6. O que esta entrega NÃO fecha (declarado)
+## 9. O que esta entrega NÃO fecha (declarado)
 
 - **A precedência entre tipos continua sem regra comercial.** D1 dissolve a comparação; não a
-  resolve. No dia em que houver regra (margem, mix, prazo), ela entra como política explícita — e
-  aí `empatados` já dá a base para dizer quando ela é aplicável.
+  resolve.
+- **A via do WhatsApp e o corte top-3/top-2** (§4).
+- **A ambiguidade da referência de preço** (§5) — declarada e sensoreada, não propagada.
 - **`p_ij` é 0 em 645 de 714 linhas cross-sell** (`Math.round(0,0002 × 1000)/10 = 0`): o vendedor lê
-  "0,0%" como probabilidade de conversão. Mesmo mecanismo de quantização, outra coluna, outro
-  consumidor. Fica como achado registrado, com medição própria pendente.
+  "0,0%". Mesma quantização, outra coluna, outro consumidor.
 - **Moeda comum em R$** (§1.3): sem substrato hoje.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "lint:shell": "bash scripts/shellcheck-gate.sh",
+    "falsificar:individuais": "bash scripts/falsificar-individuais.sh",
     "preview": "vite preview",
     "test": "vitest run",
     "test:sonda-rollback": "deno test --no-remote --allow-read --allow-write --allow-run=deno,git,tar supabase/harness-sonda-rollback/",

--- a/scripts/falsificar-individuais.sh
+++ b/scripts/falsificar-individuais.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Falsificação das camadas TS do conserto da ordem do melhor individual.
+#
+# Uma suíte verde não prova que ela PRENDE alguma coisa: prova que passou. Este script sabota
+# uma camada por vez e exige VERMELHO — e exige que o vermelho seja o teste CERTO, pelo nome.
+# Sabotagem que fica verde denuncia teste inalcançado ou redundante; vermelho no teste errado
+# denuncia asserção que casa por acidente.
+#
+# ⚠️ O CONTROLE roda na MESMA invocação, ANTES do primeiro `sed`, e o script aborta se ele não
+# estiver verde. Sem isso a suíte poderia estar sempre-vermelha e todas as sabotagens
+# "aprovariam" — a armadilha catalogada em docs/historico/falsificacao-sem-linha-de-base.md.
+#
+# Uso:  bun run falsificar:individuais      (ou ./scripts/falsificar-individuais.sh)
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+FONTES=(
+  src/lib/farmer/melhor-individual.ts
+  src/hooks/useBundleEngine.ts
+  src/components/farmer/bundles/CustomerBundleCard.tsx
+)
+ALVOS=(
+  src/lib/farmer/__tests__/melhor-individual.test.ts
+  src/components/farmer/bundles/__tests__/CustomerBundleCard.test.tsx
+  src/hooks/__tests__/bundle-melhor-individual-bulk.test.tsx
+)
+
+TMP="$(mktemp -d)"
+restaurar() { git checkout -- "${FONTES[@]}" 2>/dev/null || true; }
+trap 'restaurar; rm -rf "$TMP"' EXIT
+
+# Estado limpo é PRÉ-REQUISITO: `restaurar()` é `git checkout --`, e ele descartaria edição não
+# commitada junto com a sabotagem. Falhar aqui é o certo — o contrário perde trabalho.
+if ! git diff --quiet -- "${FONTES[@]}"; then
+  echo "ABORTADO: há edição não commitada nas fontes. Commite antes de falsificar."
+  exit 2
+fi
+
+falhas_por_nome() {
+  local json="$TMP/r.json"
+  rm -f "$json"
+  bunx vitest run "${ALVOS[@]}" --reporter=json --outputFile="$json" >"$TMP/saida.txt" 2>&1
+  # Ausência de relatório NÃO é ausência de falha: sem este ramo, um vitest que nem subiu
+  # (import quebrado, sintaxe inválida) devolveria zero nomes e passaria por "verde".
+  if [ ! -s "$json" ]; then
+    echo "__SEM_RELATORIO__"
+    return 0
+  fi
+  python3 - "$json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+for arquivo in d.get('testResults', []):
+    for t in arquivo.get('assertionResults', []):
+        if t.get('status') == 'failed':
+            print(t.get('fullName', '(sem nome)'))
+PY
+}
+
+echo "── CONTROLE: a suíte tem de estar VERDE antes de qualquer sabotagem ──"
+base="$(falhas_por_nome)"
+if [ -n "$base" ]; then
+  echo "ABORTADO: a linha de base já está vermelha — nenhuma sabotagem provaria nada."
+  echo "$base"
+  exit 1
+fi
+echo "controle verde ✓"
+echo
+
+falhou=0
+sabotar() {
+  local rotulo="$1" arquivo="$2" velho="$3" novo="$4" esperado="$5"
+
+  # Aplicar tem de ser VERIFICADO: um padrão que não casa deixaria a fonte intacta, a suíte
+  # verde, e o script diria "sem dente" sobre uma sabotagem que nunca existiu.
+  if ! python3 - "$arquivo" "$velho" "$novo" <<'PY'
+import io, sys
+p, velho, novo = sys.argv[1], sys.argv[2], sys.argv[3]
+s = io.open(p, encoding='utf-8').read()
+if s.count(velho) != 1:
+    print('  padrão casou %d vez(es) — sabotagem NÃO aplicada' % s.count(velho))
+    sys.exit(1)
+io.open(p, 'w', encoding='utf-8').write(s.replace(velho, novo))
+PY
+  then
+    echo "✗ $rotulo — NÃO APLICOU"
+    falhou=1
+    restaurar
+    return
+  fi
+
+  local vermelhos n
+  vermelhos="$(falhas_por_nome)"
+  n="$(printf '%s' "$vermelhos" | grep -c . || true)"
+  restaurar
+
+  if [ "$n" -eq 0 ]; then
+    echo "✗ $rotulo — SEM DENTE: sabotei e a suíte seguiu verde"
+    falhou=1
+  elif ! printf '%s\n' "$vermelhos" | grep -qF "$esperado"; then
+    echo "✗ $rotulo — vermelho no teste ERRADO ($n falha(s)); esperava casar: $esperado"
+    printf '%s\n' "$vermelhos" | sed 's/^/    /'
+    falhou=1
+  else
+    echo "✓ $rotulo — $n vermelho(s), incluindo o esperado"
+  fi
+}
+
+# ── F1: a chave do Map perde o tipo ──────────────────────────────────────────────────────────
+# O defeito original: uma linha por cliente fazia a segunda rota sobrescrever a primeira, e a
+# rota perdida virava `nenhum` — um veredicto sobre o que ninguém verificou.
+# shellcheck disable=SC2016  # `${...}` aqui é o LITERAL do template TS a casar, não expansão de shell.
+sabotar 'F1 chave do Map sem o tipo' src/hooks/useBundleEngine.ts \
+  '`${linha.customer_user_id}:${linha.recommendation_type}`' \
+  '`${linha.customer_user_id}:cross_sell`' \
+  'as DUAS rotas do mesmo cliente coexistem'
+
+# ── F2: a projeção promove o sobrevivente a eleito ───────────────────────────────────────────
+# A fabricação central: `empatado` que perdeu um nome no catálogo virando eleição.
+sabotar 'F2 nome único vira eleição' src/lib/farmer/melhor-individual.ts \
+  '    situacao: linha.situacao,' \
+  "    situacao: nomes.length === 1 ? 'eleito' : linha.situacao," \
+  'o sobrevivente não vira vencedor'
+
+# ── F3: some o invariante cruzado do `empatado` ──────────────────────────────────────────────
+# Campo a campo, `{empatado, candidatos:1}` é uma linha válida — e não representa empate nenhum.
+sabotar 'F3 empatado sem cardinalidade' src/lib/farmer/melhor-individual.ts \
+  "    if (situacao === 'empatado' && (produtos.length < 2 || candidatos < 2)) {" \
+  "    if (false) {" \
+  'derruba a leitura INTEIRA'
+
+# ── F4: o sensor volta a contar célula ───────────────────────────────────────────────────────
+# Com denominador por célula, a deriva de catálogo some justamente no estado com mais nomes.
+sabotar 'F4 sensor por célula' src/hooks/useBundleEngine.ts \
+  'skusIndividuaisPedidos += linha.produtos.length;' \
+  'skusIndividuaisPedidos += 1;' \
+  'a resolução conta SKU, não célula'
+
+# ── F5: o filtro de inclusão exige as DUAS rotas ─────────────────────────────────────────────
+# Com `every`, o cliente que tem só uma rota some da lista — a omissão que afirma ausência.
+sabotar 'F5 filtro exige ambas as rotas' src/hooks/useBundleEngine.ts \
+  "TIPOS_INDIVIDUAIS.some((t) => individuais[t].status !== 'nenhum')" \
+  "TIPOS_INDIVIDUAIS.every((t) => individuais[t].status !== 'nenhum')" \
+  'DETECTOR: o cenário produz bundle'
+
+# ── F6: a célula perde o qualificador ────────────────────────────────────────────────────────
+# Sem ele os nomes aparecem sem dizer o que são: a tela volta a insinuar ranking onde não há.
+sabotar 'F6 célula sem qualificador' src/components/farmer/bundles/CustomerBundleCard.tsx \
+  '  const qualificador = QUALIFICADOR[celula.situacao];' \
+  '  const qualificador = null;' \
+  'nomeia os produtos E declara o que sabe'
+
+# ── F7: o total de produtos vira o de nomes resolvidos ───────────────────────────────────────
+# O rodapé "1 de 2 sem nome" some, e a célula passa a esconder que escondeu.
+sabotar 'F7 total de produtos = nomes resolvidos' src/lib/farmer/melhor-individual.ts \
+  '    produtos: linha.produtos.length,' \
+  '    produtos: nomes.length,' \
+  'sem nome'
+
+# ── F8: o nome deixa de ser aparado ──────────────────────────────────────────────────────────
+# Achado R5/2: `if (nome)` aceita `"   "`, e a célula renderiza um parágrafo em branco contado
+# como resolvido. Nome que não se lê não identifica produto nenhum.
+sabotar 'F8 nome sem trim' src/lib/farmer/melhor-individual.ts \
+  '    const nome = nomeDoSku(sku)?.trim();' \
+  '    const nome = nomeDoSku(sku);' \
+  'conta como não resolvido'
+
+echo
+if [ "$falhou" -eq 0 ]; then
+  echo "TODAS AS SABOTAGENS TÊM DENTE"
+  exit 0
+fi
+echo "HÁ SABOTAGEM SEM DENTE — veja acima"
+exit 1

--- a/scripts/falsificar-individuais.sh
+++ b/scripts/falsificar-individuais.sh
@@ -155,7 +155,7 @@ sabotar 'F6 célula sem qualificador' src/components/farmer/bundles/CustomerBund
 sabotar 'F7 total de produtos = nomes resolvidos' src/lib/farmer/melhor-individual.ts \
   '    produtos: linha.produtos.length,' \
   '    produtos: nomes.length,' \
-  'sem nome'
+  'perde UM nome no catálogo continua empatado'
 
 # ── F8: o nome deixa de ser aparado ──────────────────────────────────────────────────────────
 # Achado R5/2: `if (nome)` aceita `"   "`, e a célula renderiza um parágrafo em branco contado

--- a/src/components/farmer/bundles/CustomerBundleCard.tsx
+++ b/src/components/farmer/bundles/CustomerBundleCard.tsx
@@ -2,12 +2,109 @@
 // Extraído verbatim de src/pages/FarmerBundles.tsx (god-component split).
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { ChevronDown, ChevronUp, Layers, Zap } from 'lucide-react';
-import type { BundleRecommendation, CustomerBundles } from '@/hooks/useBundleEngine';
+import { ChevronDown, ChevronUp, Layers, TrendingUp, Zap } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { TIPOS_INDIVIDUAIS, type BundleRecommendation, type CustomerBundles } from '@/hooks/useBundleEngine';
+import type { CelulaIndividual, SituacaoIndividual } from '@/lib/farmer/melhor-individual';
 import { classifyCustomerProfile, profileLabels, type CustomerProfile, type BundleArgument } from '@/hooks/useBundleArguments';
 import type { useDiagnosticQuestions } from '@/hooks/useDiagnosticQuestions';
 import type { CustomerCtx } from './types';
 import { BundleCardFull } from './BundleCardFull';
+
+/**
+ * O que cada rota individual se chama na tela — e por que são DUAS.
+ *
+ * A célula única comparava `affinity_score` de dois motores cujas escalas não são
+ * comensuráveis, e o resultado era uma precedência de tipo que ninguém decidiu (up_sell venceu
+ * 186 de 186 pares em prod). Rotular as duas devolve a escolha a quem conhece o cliente.
+ */
+const ROTULOS: Record<(typeof TIPOS_INDIVIDUAIS)[number], { titulo: string; Icone: LucideIcon }> = {
+  cross_sell: { titulo: 'Melhor complementar', Icone: Zap },
+  up_sell: { titulo: 'Melhor upgrade', Icone: TrendingUp },
+};
+
+/**
+ * O QUALIFICADOR é quem afirma prioridade — não a lista de nomes.
+ *
+ * Foi o argumento que decidiu mostrar nomes em todo estado: listar dois produtos não diz que um
+ * vence o outro; quem diria isso é o rótulo, e o rótulo aqui declara exatamente o que se sabe.
+ * `eleito` não tem qualificador porque só ali houve eleição de verdade.
+ *
+ * `alerta` marca os dois estados em que a ordem NÃO é confiável — o aviso vai no qualificador e
+ * não nos nomes, que continuam acionáveis: o vendedor pode ofertar qualquer um dos dois.
+ */
+const QUALIFICADOR: Record<SituacaoIndividual, { texto: string; alerta: boolean } | null> = {
+  eleito: null,
+  empatado: { texto: 'Igualmente indicados', alerta: false },
+  unico_registrado: { texto: 'Única registrada', alerta: false },
+  ordem_indisponivel: { texto: 'Ordenação indisponível', alerta: true },
+  referencia_ambigua: { texto: 'Sem ordem confiável', alerta: true },
+};
+
+const CelulaDeRota = ({ titulo, Icone, celula }: { titulo: string; Icone: LucideIcon; celula: CelulaIndividual }) => {
+  const indisponivel = celula.status === 'indisponivel';
+  return (
+    <div className="rounded p-1.5 text-center bg-muted">
+      <Icone className={`w-3 h-3 mx-auto mb-0.5 ${indisponivel ? 'text-status-warning' : 'text-status-info'}`} />
+      <p className="text-[9px] text-muted-foreground">{titulo}</p>
+      {/* TRÊS ausências distintas, e o traço só serve a UMA. O `?? '—'` de antes dava o mesmo
+          sinal para "li e não há" e para "não consegui ler" — e, junto com o filtro que omitia
+          o cliente sem bundle, transformava a falha de leitura na afirmação "não há rota
+          individual para este cliente" (money-path §2 na forma de rótulo). */}
+      {celula.status === 'indisponivel' ? (
+        <p
+          className="text-[10px] font-bold text-status-warning leading-tight"
+          title={
+            celula.motivo === 'leitura_falhou'
+              ? "A leitura das recomendações individuais falhou nesta execução. Não é 'não existe' — é 'não sei'. Recalcule para tentar de novo."
+              : 'A recomendação existe, mas não foi possível identificar nenhum produto dela pelo nome — pode ser SKU fora do catálogo ativo ou cadastro sem descrição.'
+          }
+        >
+          Indisponível
+        </p>
+      ) : celula.status === 'nenhum' ? (
+        <p className="text-xs font-bold" title="Este cliente não tem oferta pendente desta rota.">
+          —
+        </p>
+      ) : (
+        <CelulaEncontrada celula={celula} />
+      )}
+    </div>
+  );
+};
+
+const CelulaEncontrada = ({ celula }: { celula: Extract<CelulaIndividual, { status: 'encontrado' }> }) => {
+  const qualificador = QUALIFICADOR[celula.situacao];
+  const semNome = celula.produtos - celula.nomes.length;
+  return (
+    <>
+      {qualificador && (
+        <p className={`text-[8px] leading-tight ${qualificador.alerta ? 'text-status-warning' : 'text-muted-foreground'}`}>
+          {qualificador.texto}
+        </p>
+      )}
+      <p className="text-xs font-bold leading-tight break-words">{celula.nomes.join(' · ')}</p>
+      {/* Declarar o que sumiu é o que impede a falha de catálogo de virar eleição: num
+          `empatado` que perdeu um nome, esconder o ausente promoveria o sobrevivente a
+          vencedor — a fabricação exata que esta tela existe para não cometer. */}
+      {semNome > 0 && (
+        <p
+          className="text-[8px] text-status-warning leading-tight"
+          title="Estes SKUs foram recomendados e não foi possível identificá-los pelo nome — SKU fora do catálogo ativo, ou cadastro sem descrição."
+        >
+          {semNome} de {celula.produtos} sem nome
+        </p>
+      )}
+      {/* Só em `empatado`: nos estados que nomeiam o grupo inteiro `produtos = candidatos` por
+          invariante, e em `eleito` os demais candidatos PERDERAM — não estão escondidos. */}
+      {celula.situacao === 'empatado' && celula.candidatos > celula.produtos && (
+        <p className="text-[8px] text-muted-foreground leading-tight">
+          empate entre {celula.produtos} de {celula.candidatos}
+        </p>
+      )}
+    </>
+  );
+};
 
 interface CustomerBundleCardProps {
   data: CustomerBundles;
@@ -30,7 +127,12 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
   // isso são milhares de cartões anunciando uma taxa de conversão que ninguém calculou.
   // (Achado 4 do challenge Codex — consequência direta de consertar a omissão.)
   const melhorProbabilidade = data.bundles[0]?.pBundle ?? null;
-  const comparacaoIndisponivel = data.bestIndividual.status === 'indisponivel';
+  // Quantas das DUAS rotas ninguém consegue afirmar. Vale como aviso no cartão RECOLHIDO: sem
+  // ele, o cliente que só entrou na lista por causa da falha se apresenta como um cartão comum,
+  // e o operador teria de expandir um a um para descobrir que não sabemos nada dele.
+  const rotasIndisponiveis = TIPOS_INDIVIDUAIS.filter(
+    (tipo) => data.individuais[tipo].status === 'indisponivel',
+  ).length;
 
   // grossMarginPct passa SEM `|| 0`: o guard dentro de classifyCustomerProfile só funciona se o
   // null chegar até lá. Coagir aqui tornaria a correção inerte (a armadilha do #1508).
@@ -68,8 +170,12 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
               {/* O estado indisponível precisa aparecer COLAPSADO: sem isto, o cliente que só
                   entrou na lista por causa da falha se apresenta como um cartão comum, e o
                   operador teria de expandir um a um para descobrir que não sabemos nada dele. */}
-              {comparacaoIndisponivel && (
-                <span className="text-[10px] font-semibold text-status-warning">comparação indisponível</span>
+              {rotasIndisponiveis > 0 && (
+                <span className="text-[10px] font-semibold text-status-warning">
+                  {rotasIndisponiveis === TIPOS_INDIVIDUAIS.length
+                    ? 'comparação indisponível'
+                    : `${rotasIndisponiveis} rota indisponível`}
+                </span>
               )}
               <Badge variant="outline" className={`text-[7px] ${profileInfo.color}`}>{profileInfo.label}</Badge>
             </div>
@@ -79,15 +185,20 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
 
         {expanded && (
           <div className="mt-3 space-y-3">
-            {/* Duas rotas de oferta — SEM declarar vencedor.
+            {/* TRÊS rotas de oferta — SEM declarar vencedor entre nenhuma delas.
                 O card antes coroava 🏆 quem tivesse o maior LIE em R$. Isso não sobrevive a duas
                 coisas: (1) sem custo no browser não há lucro esperado para comparar; (2) mesmo os
                 scores de afinidade não são comensuráveis entre si — `pBundle` multiplica por
                 `lift/2` e não é limitado a 1, enquanto o score individual é uma probabilidade.
-                Eleger vencedor entre as duas escalas era um número inventado. */}
+                Eleger vencedor entre as duas escalas era um número inventado.
+
+                A terceira célula nasceu do MESMO defeito um nível abaixo: complementar e upgrade
+                dividiam uma célula e disputavam por `affinity_score`, escalas igualmente
+                incomensuráveis. Separá-las não é enfeite de layout — é parar de responder por
+                artefato de escala uma pergunta que ninguém fez. */}
             <div className="bg-muted/50 rounded-lg p-2">
               <p className="text-[9px] font-semibold mb-1">📊 Rotas de oferta</p>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                 <div className="rounded p-1.5 text-center bg-muted">
                   <Layers className="w-3 h-3 mx-auto mb-0.5 text-status-success" />
                   <p className="text-[9px] text-muted-foreground">Melhor bundle</p>
@@ -95,34 +206,14 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
                     {melhorProbabilidade == null ? 'Sem bundle' : `${melhorProbabilidade.toFixed(1)}%`}
                   </p>
                 </div>
-                <div className="rounded p-1.5 text-center bg-muted">
-                  <Zap className={`w-3 h-3 mx-auto mb-0.5 ${comparacaoIndisponivel ? 'text-status-warning' : 'text-status-info'}`} />
-                  <p className="text-[9px] text-muted-foreground">Melhor individual</p>
-                  {/* TRÊS estados, não dois. O `?? '—'` de antes lia a união colapsada em
-                      `IndividualComparison | null` e dava o MESMO traço para "li e não há" e
-                      para "não consegui ler" — e, junto com o filtro que omitia da lista o
-                      cliente sem bundle, transformava a falha de leitura na afirmação "não há
-                      rota individual para este cliente" (money-path §2 na forma de rótulo).
-                      O traço continua sendo o certo para `nenhum`: ali a leitura ACONTECEU. */}
-                  {data.bestIndividual.status === 'encontrado' ? (
-                    <p className="text-xs font-bold">{data.bestIndividual.value.productName}</p>
-                  ) : data.bestIndividual.status === 'indisponivel' ? (
-                    <p
-                      className="text-[10px] font-bold text-status-warning leading-tight"
-                      title={
-                        data.bestIndividual.motivo === 'leitura_falhou'
-                          ? "A leitura das recomendações individuais falhou nesta execução. Não é 'não existe' — é 'não sei'. Recalcule para tentar de novo."
-                          : 'A recomendação existe, mas o produto dela não está no catálogo ativo — não dá para dizer qual é.'
-                      }
-                    >
-                      Comparação indisponível
-                    </p>
-                  ) : (
-                    <p className="text-xs font-bold" title="Este cliente não tem oferta individual pendente.">
-                      —
-                    </p>
-                  )}
-                </div>
+                {TIPOS_INDIVIDUAIS.map((tipo) => (
+                  <CelulaDeRota
+                    key={tipo}
+                    titulo={ROTULOS[tipo].titulo}
+                    Icone={ROTULOS[tipo].Icone}
+                    celula={data.individuais[tipo]}
+                  />
+                ))}
               </div>
             </div>
 

--- a/src/components/farmer/bundles/__tests__/CustomerBundleCard.test.tsx
+++ b/src/components/farmer/bundles/__tests__/CustomerBundleCard.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CustomerBundleCard } from "../CustomerBundleCard";
-import type { CustomerBundles } from "@/hooks/useBundleEngine";
+import type { CustomerBundles, IndividuaisDoCliente } from "@/hooks/useBundleEngine";
+import type { CelulaIndividual } from "@/lib/farmer/melhor-individual";
 import type { useDiagnosticQuestions } from "@/hooks/useDiagnosticQuestions";
 
+const NENHUM: CelulaIndividual = { status: "nenhum" };
 const data = {
   customerId: "c1",
   customerName: "Cliente X",
@@ -16,7 +18,7 @@ const data = {
   customerType: null,
   recentProducts: null,
   bundles: [],
-  bestIndividual: { status: "nenhum" },
+  individuais: { cross_sell: NENHUM, up_sell: NENHUM },
 } as unknown as CustomerBundles;
 
 const diagHook = {
@@ -43,6 +45,20 @@ function setup(overrides: Partial<React.ComponentProps<typeof CustomerBundleCard
   return props;
 }
 
+/** Expande o cartão com as células dadas — o resto do cliente fica igual em todos os casos. */
+const comCelulas = (individuais: Partial<IndividuaisDoCliente>) =>
+  setup({
+    data: {
+      ...data,
+      individuais: { cross_sell: NENHUM, up_sell: NENHUM, ...individuais },
+    } as unknown as CustomerBundles,
+    expanded: true,
+  });
+
+const ELEITO: CelulaIndividual = {
+  status: "encontrado", situacao: "eleito", nomes: ["Verniz PU 900"], produtos: 1, candidatos: 3,
+};
+
 describe("CustomerBundleCard", () => {
   it("mostra cabeçalho com nome, health score e contagem de bundles", () => {
     setup();
@@ -59,41 +75,115 @@ describe("CustomerBundleCard", () => {
 
   it("não renderiza a comparação quando colapsado", () => {
     setup();
-    expect(screen.queryByText("📊 Comparação Inteligente")).toBeNull();
+    expect(screen.queryByText("Melhor complementar")).toBeNull();
   });
 
-  // ── Os TRÊS estados da comparação individual ────────────────────────────────────────────
+  // ── As DUAS rotas, rotuladas ─────────────────────────────────────────────────────────────
   //
-  // O card renderizava `data.bestIndividual?.productName ?? '—'`, e o tipo era
-  // `IndividualComparison | null`: "li e não existe" e "não consegui ler" davam o MESMO traço.
-  // Um traço não fabrica número, mas — somado ao filtro que omitia da lista o cliente sem
-  // bundle próprio — fabricava a AFIRMAÇÃO "não há rota individual para este cliente". É o §2
-  // do money-path (ausente ≠ zero) na forma de rótulo. O tipo agora discrimina, e a tela tem
-  // de mostrar a diferença: se os dois estados renderizassem igual, a união seria decorativa.
-  const comData = (bestIndividual: unknown) =>
-    setup({ data: { ...data, bestIndividual } as unknown as CustomerBundles, expanded: true });
+  // Havia UMA célula "Melhor individual", e o que ela mostrava saía de comparar
+  // `affinity_score` entre dois motores cujas escalas não são comensuráveis: up_sell venceu
+  // 186 de 186 pares medidos em prod (07/09/2026), uma precedência de tipo que ninguém decidiu.
+  // Duas células entregam as duas ofertas e devolvem a escolha a quem conhece o cliente.
+  it("expandido, mostra as duas rotas com rótulos distintos", () => {
+    comCelulas({});
+    expect(screen.getByText("Melhor complementar")).toBeTruthy();
+    expect(screen.getByText("Melhor upgrade")).toBeTruthy();
+  });
 
-  it("expandido, `encontrado` mostra o nome do produto", () => {
-    comData({
-      status: "encontrado",
-      value: { productId: "p1", productName: "Verniz PU 900", affinity: 0.42, type: "cross_sell" },
+  it("cada rota mostra a SUA oferta — uma não vaza para a outra", () => {
+    // O discriminador da chave de Map por `(cliente, tipo)`: com a chave antiga uma das duas
+    // linhas sobrescrevia a outra, e a rota perdida virava `nenhum` — um veredicto.
+    comCelulas({
+      cross_sell: ELEITO,
+      up_sell: { status: "encontrado", situacao: "unico_registrado", nomes: ["Selador 500"], produtos: 1, candidatos: 1 },
     });
     expect(screen.getByText("Verniz PU 900")).toBeTruthy();
-    expect(screen.queryByText("Comparação indisponível")).toBeNull();
+    expect(screen.getByText("Selador 500")).toBeTruthy();
+    expect(screen.getByText("Única registrada")).toBeTruthy();
+    // `eleito` é o ÚNICO estado sem qualificador — ali houve eleição de verdade.
+    expect(screen.queryByText("Igualmente indicados")).toBeNull();
   });
 
-  it("expandido, `nenhum` mostra o traço — a leitura ACONTECEU e não há oferta", () => {
-    comData({ status: "nenhum" });
-    expect(screen.getByText("—")).toBeTruthy();
-    expect(screen.queryByText("Comparação indisponível")).toBeNull();
+  // ── Os estados: o RÓTULO é quem afirma prioridade, não a lista de nomes ──────────────────
+  it.each([
+    ["empatado", "Igualmente indicados"],
+    ["unico_registrado", "Única registrada"],
+    ["ordem_indisponivel", "Ordenação indisponível"],
+    ["referencia_ambigua", "Sem ordem confiável"],
+  ] as const)("estado `%s` nomeia os produtos E declara o que sabe (%s)", (situacao, qualificador) => {
+    const doisNomes = situacao === "unico_registrado" ? ["Fundo PU"] : ["Fundo PU", "Massa 700"];
+    comCelulas({
+      cross_sell: {
+        status: "encontrado", situacao, nomes: doisNomes,
+        produtos: doisNomes.length, candidatos: Math.max(doisNomes.length, 1),
+      },
+    });
+    expect(screen.getByText(qualificador)).toBeTruthy();
+    // Nomear em TODO estado é o que evita trocar uma mentira por uma omissão: sem os nomes, os
+    // 52 clientes cross-only — onde nenhuma eleição é recuperável — ficariam com uma célula
+    // que só avisa indisponibilidade permanente, sem nada acionável.
+    expect(screen.getByText(new RegExp("Fundo PU"))).toBeTruthy();
   });
 
-  it("expandido, `indisponivel` diz que não sabe — e NÃO usa o mesmo traço do `nenhum`", () => {
-    comData({ status: "indisponivel", motivo: "leitura_falhou" });
-    expect(screen.getByText("Comparação indisponível")).toBeTruthy();
+  it("`empatado` que perdeu um nome segue empatado — o sobrevivente NÃO vira vencedor", () => {
+    // Esconder o participante que o catálogo não soube nomear converteria falha de catálogo em
+    // eleição — a fabricação exata que esta tela existe para não cometer (achado R3/3).
+    comCelulas({
+      cross_sell: { status: "encontrado", situacao: "empatado", nomes: ["Fundo PU"], produtos: 2, candidatos: 2 },
+    });
+    expect(screen.getByText("Igualmente indicados")).toBeTruthy();
+    expect(screen.getByText("1 de 2 sem nome")).toBeTruthy();
+  });
+
+  it("`empatado` cujo topo é menor que o grupo declara os dois números", () => {
+    comCelulas({
+      cross_sell: { status: "encontrado", situacao: "empatado", nomes: ["Fundo PU", "Massa 700"], produtos: 2, candidatos: 5 },
+    });
+    expect(screen.getByText("empate entre 2 de 5")).toBeTruthy();
+  });
+
+  it("`eleito` NÃO declara os candidatos que perderam — eles não estão escondidos", () => {
+    // `candidatos: 3` com 1 nome é o normal do estado eleito: os outros dois foram VENCIDOS.
+    // Um rodapé "1 de 3" ali sugeriria informação sonegada onde houve decisão.
+    comCelulas({ cross_sell: ELEITO });
+    expect(screen.getByText("Verniz PU 900")).toBeTruthy();
+    expect(screen.queryByText(/de 3/)).toBeNull();
+    expect(screen.queryByText(/sem nome/)).toBeNull();
+  });
+
+  // ── As TRÊS ausências, que não podem renderizar igual ────────────────────────────────────
+  //
+  // O card renderizava `bestIndividual?.productName ?? '—'`: "li e não existe" e "não consegui
+  // ler" davam o MESMO traço. Um traço não fabrica número, mas — somado ao filtro que omitia
+  // da lista o cliente sem bundle próprio — fabricava a AFIRMAÇÃO "não há rota individual para
+  // este cliente". É o §2 do money-path (ausente ≠ zero) na forma de rótulo.
+  it("`nenhum` mostra o traço — a leitura ACONTECEU e não há oferta", () => {
+    comCelulas({});
+    expect(screen.getAllByText("—").length).toBe(2);
+    expect(screen.queryByText("Indisponível")).toBeNull();
+  });
+
+  it("`indisponivel` diz que não sabe — e NÃO usa o mesmo traço do `nenhum`", () => {
+    comCelulas({
+      cross_sell: { status: "indisponivel", motivo: "leitura_falhou" },
+      up_sell: { status: "indisponivel", motivo: "produto_nao_resolve" },
+    });
+    expect(screen.getAllByText("Indisponível").length).toBe(2);
     // O discriminador: se o traço aparecesse aqui também, a falha de leitura seguiria
     // indistinguível da ausência verificada — que é exatamente o defeito corrigido.
     expect(screen.queryByText("—")).toBeNull();
+  });
+
+  it("os dois motivos de `indisponivel` explicam coisas DIFERENTES", () => {
+    // Mesmo rótulo, `title` distinto: "não consegui ler" pede recálculo, "o SKU sumiu do
+    // catálogo" não. Fundir os textos apagaria a única pista de o que fazer a seguir.
+    comCelulas({
+      cross_sell: { status: "indisponivel", motivo: "leitura_falhou" },
+      up_sell: { status: "indisponivel", motivo: "produto_nao_resolve" },
+    });
+    const titulos = screen.getAllByText("Indisponível").map((e) => e.getAttribute("title") ?? "");
+    expect(titulos.some((t) => t.includes("falhou nesta execução"))).toBe(true);
+    expect(titulos.some((t) => t.includes("identificar nenhum produto"))).toBe(true);
   });
 
   // ── O zero fabricado que a própria correção tornou comum (achado 4 do challenge Codex) ────
@@ -104,7 +194,7 @@ describe("CustomerBundleCard", () => {
   // passam a entrar de propósito, e na maior carteira isso são milhares de cartões anunciando
   // uma taxa que ninguém calculou. É `Number(null) === 0` na forma de rótulo.
   it("sem bundle NÃO vira `0,0% de conversão` — nem colapsado, nem expandido", () => {
-    comData({ status: "nenhum" });
+    comCelulas({});
     expect(screen.queryByText(/0\.0% de conversão/)).toBeNull();
     expect(screen.queryByText("0.0%")).toBeNull();
     expect(screen.getAllByText(/[Ss]em bundle/).length).toBeGreaterThan(0);
@@ -125,11 +215,40 @@ describe("CustomerBundleCard", () => {
     expect(screen.queryByText(/[Ss]em bundle/)).toBeNull();
   });
 
-  it("colapsado, `indisponivel` já se anuncia — sem precisar expandir cartão por cartão", () => {
+  // ── O aviso do cartão RECOLHIDO ──────────────────────────────────────────────────────────
+  //
+  // Sem ele, o cliente que só entrou na lista por causa da falha se apresenta como um cartão
+  // comum, e o operador teria de expandir um a um para descobrir que não sabemos nada dele.
+  it("colapsado, as DUAS rotas indisponíveis anunciam a comparação inteira", () => {
     setup({
       expanded: false,
-      data: { ...data, bestIndividual: { status: "indisponivel", motivo: "leitura_falhou" } } as unknown as CustomerBundles,
+      data: {
+        ...data,
+        individuais: {
+          cross_sell: { status: "indisponivel", motivo: "leitura_falhou" },
+          up_sell: { status: "indisponivel", motivo: "leitura_falhou" },
+        },
+      } as unknown as CustomerBundles,
     });
     expect(screen.getByText("comparação indisponível")).toBeTruthy();
+  });
+
+  it("colapsado, UMA rota indisponível não é apresentada como a comparação toda", () => {
+    // A célula que sobrou tem informação acionável. Dizer "comparação indisponível" com uma
+    // oferta legível na tela exageraria a falha — e exagerar também é descrever errado.
+    setup({
+      expanded: false,
+      data: {
+        ...data,
+        individuais: { cross_sell: ELEITO, up_sell: { status: "indisponivel", motivo: "produto_nao_resolve" } },
+      } as unknown as CustomerBundles,
+    });
+    expect(screen.getByText("1 rota indisponível")).toBeTruthy();
+    expect(screen.queryByText("comparação indisponível")).toBeNull();
+  });
+
+  it("colapsado e tudo íntegro: nenhum aviso — senão o operador aprende a ignorá-lo", () => {
+    setup({ expanded: false, data: { ...data, individuais: { cross_sell: ELEITO, up_sell: NENHUM } } as unknown as CustomerBundles });
+    expect(screen.queryByText(/indisponível/)).toBeNull();
   });
 });

--- a/src/hooks/__tests__/bundle-custo-fora-do-browser.test.tsx
+++ b/src/hooks/__tests__/bundle-custo-fora-do-browser.test.tsx
@@ -108,7 +108,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcsChamadas.push(nome);

--- a/src/hooks/__tests__/bundle-escopo-carteira.test.tsx
+++ b/src/hooks/__tests__/bundle-escopo-carteira.test.tsx
@@ -122,7 +122,7 @@ vi.mock('@/integrations/supabase/client', () => ({
       // O motor EXIGE array desta RPC (`devolveu null em vez de array` aborta o cálculo).
       // Vazio é o caso honesto aqui: nenhum cliente tem rota individual concorrente, então o
       // que sobra na tela é o bundle — que é o observável deste arquivo.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return { then: (resolve: (v: unknown) => void) => resolve({ data: [], error: null }) };
       }
       if (nome === 'get_skus_margem_positiva') {

--- a/src/hooks/__tests__/bundle-head-degradado-todos-insumos.test.tsx
+++ b/src/hooks/__tests__/bundle-head-degradado-todos-insumos.test.tsx
@@ -51,7 +51,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, params?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       // Paginada desde o #1782 — precisa de builder, não Promise crua.

--- a/src/hooks/__tests__/bundle-head-nao-mente-apos-linhas.test.tsx
+++ b/src/hooks/__tests__/bundle-head-nao-mente-apos-linhas.test.tsx
@@ -79,7 +79,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       // Paginada desde o #1782 — builder com `.order().range()`, não Promise crua.

--- a/src/hooks/__tests__/bundle-head-registra-vazio-sem-linha.test.tsx
+++ b/src/hooks/__tests__/bundle-head-registra-vazio-sem-linha.test.tsx
@@ -9,7 +9,7 @@ import { renderHook, act } from '@testing-library/react';
  *
  *     linhasProduzidas = allCustomerBundles.some((cb) => cb.bundles.length > 0)
  *
- * Um cliente entra em `allCustomerBundles` com `bundles: []` quando só tem `bestIndividual`
+ * Um cliente entra em `allCustomerBundles` com `bundles: []` quando só tem oferta individual
  * — e essa comparação não vira linha nenhuma no `p_linhas` da RPC de substituição. Contando
  * CLIENTES (`allCustomerBundles.length > 0`, como era antes), esse caso travava o
  * `registrarVazio()` do `catch` sobre uma execução que não produziu nada: o head parava de se
@@ -72,9 +72,11 @@ function dadosDa(tabela: string): unknown[] {
     case 'omie_products': return PRODUTOS;
     case 'profiles': return ['c9', 'c8'].map(perfil);
     case 'sales_orders': return PEDIDOS;
-    // O ingrediente do caso: com `bestIndividual` o cliente ENTRA em `allCustomerBundles`
-    // mesmo com `topBundles` vazio (`if (topBundles.length > 0 || bestIndividual)`) — e é
-    // exatamente esse cliente que a contagem antiga confundia com uma linha gravável.
+    // O ingrediente do caso: com uma célula individual não-`nenhum` o cliente ENTRA em
+    // `allCustomerBundles` mesmo com `topBundles` vazio — e é exatamente esse cliente que a
+    // contagem antiga confundia com uma linha gravável. Aqui quem o faz entrar é o
+    // `indisponivel`: a RPC das individuais cai no default do mock (`data: null` sem erro),
+    // que é FALHA de leitura, e falha não autoriza omitir ninguém.
     case 'farmer_recommendations':
       return [{ product_id: 'P4', affinity_score: 0.9, recommendation_type: 'cross_sell' }];
     default: return [];
@@ -147,7 +149,7 @@ beforeEach(() => {
 });
 
 describe('useBundleEngine — head registra o vazio quando não houve linha', () => {
-  it('FG-VAZIO-SEM-LINHA: cliente só com bestIndividual não conta como linha produzida', async () => {
+  it('FG-VAZIO-SEM-LINHA: cliente só com oferta individual não conta como linha produzida', async () => {
     const { result } = renderHook(() => useBundleEngine());
     await act(async () => { await result.current.calculateBundles(); });
 

--- a/src/hooks/__tests__/bundle-identidade-account.test.tsx
+++ b/src/hooks/__tests__/bundle-identidade-account.test.tsx
@@ -129,7 +129,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcArgs.push({ nome, args: args ?? {} });

--- a/src/hooks/__tests__/bundle-melhor-individual-bulk.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-bulk.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 /**
- * A comparação "bundle × melhor produto individual" em UMA leitura — e os três estados dela.
+ * A comparação "bundle × ofertas individuais" em UMA leitura — e os estados dela.
  *
  * ERA N+1: um `.from('farmer_recommendations')` por cliente, dentro do laço. O #1800 consertou
  * a HONESTIDADE daquela leitura (o `error` resolvido e a Promise rejeitada passaram a ser
@@ -28,35 +28,60 @@ import { renderHook, act } from '@testing-library/react';
  *      na forma de rótulo: `IndividualComparison | null` colapsava "li e não há" com "não
  *      consegui ler", e o filtro `if (topBundles.length > 0 || bestIndividual)` transformava o
  *      colapso na afirmação "não há rota individual para este cliente".
+ *   4. As DUAS rotas chegam SEPARADAS. A célula única comparava `affinity_score` de motores com
+ *      escalas incomensuráveis, e o vencedor saía por artefato de escala — up_sell venceu 186 de
+ *      186 pares em prod (07/09/2026). Uma chave de Map por cliente fazia a segunda linha
+ *      sobrescrever a primeira em silêncio; a chave passou a incluir o tipo.
  *
- * CENÁRIO: seis cestas fazem o Apriori achar P1→P2 e P1→P3; `c7` comprou só P1 e recebe o par
- * P2+P3 como bundle. `c8` NÃO recebe bundle nenhum — é ele quem revela a omissão.
+ * CENÁRIO: seis cestas fazem o Apriori achar P1→P2 e P1→P3; `C7` comprou só P1 e recebe o par
+ * P2+P3 como bundle. `C8` NÃO recebe bundle nenhum — é ele quem revela a omissão.
+ *
+ * ⚠️ Os ids são uuids DE VERDADE porque o validador de resposta exige formato (achado R2/4):
+ * um `customer_user_id` fora de formato some na consulta pela chave do Map, e sumir é
+ * indistinguível de "este cliente não tem oferta" — a falha entrando pela porta dos fundos.
  */
-const FARMER = 'farmer-bulk';
+const uuid = (n: number) => `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+const FARMER = uuid(1);
+const C7 = uuid(7);
+const C8 = uuid(8);
+const C9 = uuid(9);
+const P1 = uuid(101);
+const P2 = uuid(102);
+const P3 = uuid(103);
+const P4 = uuid(104);
+const RUN_UNICO = uuid(200);
+const RUN_A = uuid(201);
+const RUN_B = uuid(202);
+/** SKU válido em FORMA que o catálogo ativo não conhece — a deriva, não a resposta malformada. */
+const SKU_FANTASMA = uuid(999);
+
 let falhaBulk: 'nao' | 'erro' | 'rejeita' | 'null_mudo' | 'nao_array' | 'string_json' = 'nao';
 /** RPC íntegra devolvendo `[]` — o vazio LEGÍTIMO, que não é falha de leitura nenhuma. */
 let semPendentes = false;
 /** `true` = a carteira devolvida tem 1.500 entradas — mais que o antigo cap de 1.000. */
 let carteiraGrande = false;
-/** `true` = o SKU eleito não está no catálogo ATIVO (`productMap` não resolve). */
+/** `true` = o SKU nomeado não está no catálogo ATIVO (`productMap` não resolve). */
 let produtoForaDoCatalogo = false;
 /** `true` = a tabela tem DUAS gerações pendentes vivas ao mesmo tempo. */
 let duasGeracoes = false;
+/** Linhas extras injetadas no payload — os estados que o cenário base não produz. */
+let linhasExtras: Array<Record<string, unknown>> = [];
 
 const chamadasBulk: number[] = [];
 /** Args da RPC que persiste os bundles — é por ela que o head (completude) é movido. */
 const argsSubstituir: Array<Record<string, unknown>> = [];
 
 const PEDIDOS = [
-  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-01T00:00:00Z' },
-  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-02T00:00:00Z' },
-  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-03T00:00:00Z' },
-  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-04T00:00:00Z' },
-  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-05T00:00:00Z' },
-  { customer_user_id: 'c7', items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-06T00:00:00Z' },
+  { customer_user_id: C9, items: [{ product_id: P1 }, { product_id: P2 }, { product_id: P3 }], total: 300, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: C9, items: [{ product_id: P1 }, { product_id: P2 }, { product_id: P3 }], total: 300, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: C8, items: [{ product_id: P4 }], total: 50, created_at: '2026-07-03T00:00:00Z' },
+  { customer_user_id: C8, items: [{ product_id: P4 }], total: 50, created_at: '2026-07-04T00:00:00Z' },
+  { customer_user_id: C8, items: [{ product_id: P4 }], total: 50, created_at: '2026-07-05T00:00:00Z' },
+  { customer_user_id: C7, items: [{ product_id: P1 }], total: 100, created_at: '2026-07-06T00:00:00Z' },
 ];
-const PRODUTOS = ['P1', 'P2', 'P3', 'P4'].map((id) => ({
-  id, codigo: id, descricao: `Produto ${id}`, valor_unitario: 100,
+const NOMES: Record<string, string> = { [P1]: 'Produto P1', [P2]: 'Produto P2', [P3]: 'Produto P3', [P4]: 'Produto P4' };
+const PRODUTOS = [P1, P2, P3, P4].map((id) => ({
+  id, codigo: id, descricao: NOMES[id], valor_unitario: 100,
   metadata: null, ativo: true, omie_codigo_produto: null,
 }));
 const score = (cid: string) => ({
@@ -68,27 +93,47 @@ const perfil = (cid: string) => ({ user_id: cid, name: `Cliente ${cid}`, custome
 
 function dadosDa(tabela: string): unknown[] {
   switch (tabela) {
-    case 'farmer_client_scores': return ['c9', 'c8', 'c7'].map(score);
+    case 'farmer_client_scores': return [C9, C8, C7].map(score);
     case 'omie_products': return PRODUTOS;
-    case 'profiles': return ['c9', 'c8', 'c7'].map(perfil);
+    case 'profiles': return [C9, C8, C7].map(perfil);
     case 'sales_orders': return PEDIDOS;
     default: return [];
   }
 }
 
-const linhaBulk = (cid: string, pid: string, run = 'run-unico') => ({
-  customer_user_id: cid, product_id: pid, affinity_score: 0.42,
-  recommendation_type: 'cross_sell', run_id: run,
+/**
+ * Uma linha da RPC. `situacao` e `candidatos` são DERIVADOS do array por padrão para que o
+ * cenário base não escreva combinação que o validador rejeitaria — quem quer um estado
+ * específico o declara em `extras`, e é exatamente aí que o teste fica explícito.
+ */
+const linhaIndividual = (
+  cid: string,
+  produtos: string[],
+  extras: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  customer_user_id: cid,
+  recommendation_type: 'cross_sell',
+  situacao: produtos.length === 1 ? 'eleito' : 'empatado',
+  produtos,
+  produto_eleito: produtos.length === 1 ? produtos[0] : null,
+  candidatos: Math.max(2, produtos.length),
+  affinity_score: 0.42,
+  run_id: RUN_UNICO,
+  ...extras,
 });
+
 /** 1.500 clientes de enchimento: 50% acima do cap de linhas que a versão paginada sofria. */
-const CARTEIRA_GRANDE = Array.from({ length: 1500 }, (_, i) => linhaBulk(`extra-${i}`, 'P4'));
+const CARTEIRA_GRANDE = Array.from({ length: 1500 }, (_, i) => linhaIndividual(uuid(1000 + i), [P4]));
 
 function linhasBulk(): Array<Record<string, unknown>> {
   const uteis = duasGeracoes
-    ? [linhaBulk('c8', 'P4', 'run-A'), linhaBulk('c9', 'P2', 'run-B')]
-    : [linhaBulk('c8', produtoForaDoCatalogo ? 'SKU-QUE-NAO-EXISTE' : 'P4')];
+    ? [
+        linhaIndividual(C8, [P4], { run_id: RUN_A }),
+        linhaIndividual(C9, [P2], { run_id: RUN_B }),
+      ]
+    : [linhaIndividual(C8, [produtoForaDoCatalogo ? SKU_FANTASMA : P4])];
   // O cliente útil vai no FIM: na versão paginada ele cairia fora do cap e viraria `nenhum`.
-  return carteiraGrande ? [...CARTEIRA_GRANDE, ...uteis] : uteis;
+  return [...(carteiraGrande ? CARTEIRA_GRANDE : []), ...uteis, ...linhasExtras];
 }
 
 function chain(table: string): unknown {
@@ -118,7 +163,7 @@ vi.mock('@/integrations/supabase/client', () => ({
         };
         return c;
       }
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         chamadasBulk.push(1);
         if (falhaBulk === 'rejeita') return Promise.reject(new Error('Failed to fetch'));
         if (falhaBulk === 'erro') {
@@ -156,6 +201,8 @@ async function calcular() {
   await act(async () => { await result.current.calculateBundles(); });
   return result;
 }
+const acharCliente = (result: Awaited<ReturnType<typeof calcular>>, cid: string) =>
+  result.current.customerBundles.find((c) => c.customerId === cid);
 
 beforeEach(() => {
   falhaBulk = 'nao';
@@ -163,25 +210,81 @@ beforeEach(() => {
   carteiraGrande = false;
   duasGeracoes = false;
   produtoForaDoCatalogo = false;
+  linhasExtras = [];
   chamadasBulk.length = 0;
   argsSubstituir.length = 0;
   vi.clearAllMocks();
 });
 
-describe('useBundleEngine — o melhor individual em UMA leitura, com os três estados', () => {
+describe('useBundleEngine — as ofertas individuais em UMA leitura, com os estados separados', () => {
   it('DETECTOR: o cenário produz bundle e a comparação chega ao cliente certo', async () => {
     // Sem este controle positivo, tudo abaixo passaria por vacuidade — "nenhum bundle" é o
     // desfecho de QUALQUER insumo faltando.
     const result = await calcular();
-    const c7 = result.current.customerBundles.find((c) => c.customerId === 'c7');
-    const c8 = result.current.customerBundles.find((c) => c.customerId === 'c8');
+    const c7 = acharCliente(result, C7);
+    const c8 = acharCliente(result, C8);
 
-    expect(c7?.bundles.length, 'c7 devia receber o par P2+P3').toBeGreaterThan(0);
-    expect(c7?.bestIndividual.status).toBe('nenhum');
-    expect(c8?.bestIndividual).toEqual({
+    expect(c7?.bundles.length, 'C7 devia receber o par P2+P3').toBeGreaterThan(0);
+    expect(c7?.individuais.cross_sell.status).toBe('nenhum');
+    expect(c8?.individuais.cross_sell).toEqual({
       status: 'encontrado',
-      value: { productId: 'P4', productName: 'Produto P4', affinity: 0.42, type: 'cross_sell' },
+      situacao: 'eleito',
+      nomes: ['Produto P4'],
+      produtos: 1,
+      candidatos: 2,
     });
+    // O tipo que o cenário NÃO produziu não vira falha nem invenção — vira `nenhum`.
+    expect(c8?.individuais.up_sell.status).toBe('nenhum');
+  });
+
+  it('as DUAS rotas do mesmo cliente coexistem — a de cima não engole a de baixo', async () => {
+    // Com a chave do Map em `customer_user_id` puro, a segunda linha sobrescrevia a primeira e
+    // uma das rotas sumia da tela como `nenhum` — um veredicto, e o defeito que a célula única
+    // escondia por construção. A chave passou a ser `${cliente}:${tipo}`.
+    linhasExtras = [
+      linhaIndividual(C8, [P2], { recommendation_type: 'up_sell', situacao: 'unico_registrado', produto_eleito: null, candidatos: 1 }),
+    ];
+    const result = await calcular();
+    const c8 = acharCliente(result, C8);
+
+    expect(c8?.individuais.cross_sell.status, 'a rota complementar sumiu').toBe('encontrado');
+    expect(c8?.individuais.up_sell).toEqual({
+      status: 'encontrado',
+      situacao: 'unico_registrado',
+      nomes: ['Produto P2'],
+      produtos: 1,
+      candidatos: 1,
+    });
+  });
+
+  it('`empatado` que perde UM nome no catálogo continua empatado — não promove o sobrevivente', async () => {
+    // O achado R3/3, e a razão de `nomes` e `produtos` serem campos separados: esconder o
+    // participante que o catálogo não soube nomear converteria uma falha de catálogo em
+    // ELEIÇÃO. A célula segue `empatado`, declarando 1 de 2 não identificado.
+    linhasExtras = [
+      linhaIndividual(C9, [P2, SKU_FANTASMA], { situacao: 'empatado', candidatos: 2 }),
+    ];
+    const result = await calcular();
+
+    expect(acharCliente(result, C9)?.individuais.cross_sell).toEqual({
+      status: 'encontrado',
+      situacao: 'empatado',
+      nomes: ['Produto P2'],
+      produtos: 2,
+      candidatos: 2,
+    });
+  });
+
+  it('linha que viola invariante ENTRE campos derruba a leitura INTEIRA, não só a linha', async () => {
+    // `{empatado, candidatos:1, produtos:[X]}` passa em toda checagem campo a campo — tipo
+    // reconhecido, inteiro ≥1, sem eleito fora de `eleito` — e não representa empate nenhum.
+    // Descartar só a linha ruim daria um Map parcial apresentado como completo: o cliente
+    // afetado viraria `nenhum`, que é um veredicto. Rejeitar tudo é a saída honesta.
+    linhasExtras = [linhaIndividual(C9, [P2], { situacao: 'empatado', candidatos: 1 })];
+    const result = await calcular();
+
+    expect(acharCliente(result, C8)?.individuais.cross_sell.status).toBe('indisponivel');
+    expect(acharCliente(result, C9)?.individuais.cross_sell.status).toBe('indisponivel');
   });
 
   it('a leitura é UMA — não uma por cliente (o N+1 morreu)', async () => {
@@ -198,8 +301,7 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
     carteiraGrande = true;
     const result = await calcular();
 
-    const c8 = result.current.customerBundles.find((c) => c.customerId === 'c8');
-    expect(c8?.bestIndividual.status).toBe('encontrado');
+    expect(acharCliente(result, C8)?.individuais.cross_sell.status).toBe('encontrado');
     expect(chamadasBulk.length, 'voltou a fatiar a leitura em mais de um request').toBe(1);
   });
 
@@ -211,8 +313,7 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
     falhaBulk = 'null_mudo';
     const result = await calcular();
 
-    const c8 = result.current.customerBundles.find((c) => c.customerId === 'c8');
-    expect(c8?.bestIndividual.status).toBe('indisponivel');
+    expect(acharCliente(result, C8)?.individuais.cross_sell.status).toBe('indisponivel');
   });
 
   it.each(['nao_array', 'string_json'] as const)(
@@ -226,41 +327,43 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
       // isto: com só o caso do objeto, desligar o guard passava VERDE.
       falhaBulk = modo;
       const result = await calcular();
-      expect(
-        result.current.customerBundles.find((c) => c.customerId === 'c8')?.bestIndividual.status,
-      ).toBe('indisponivel');
+      expect(acharCliente(result, C8)?.individuais.cross_sell.status).toBe('indisponivel');
       expect(toast.success, 'anunciou sucesso sobre uma leitura que não aconteceu').not.toHaveBeenCalled();
     },
   );
 
-  it('SKU eleito fora do catálogo ativo vira `indisponivel`, não um nome inventado', async () => {
+  it('SKU fora do catálogo ativo vira `indisponivel`, não um nome inventado', async () => {
     // Era `productName: prod?.descricao || 'Produto'`: a tela dizia ter ENCONTRADO o melhor
     // individual e mostrava um literal. É a mesma fabricação de rótulo que esta união veio
-    // matar, um nível abaixo — e `product_id` é nullable no schema, então há duas portas.
+    // matar, um nível abaixo. Aqui NENHUM nome resolve — só então a célula perde a identidade.
     produtoForaDoCatalogo = true;
     const result = await calcular();
 
-    const c8 = result.current.customerBundles.find((c) => c.customerId === 'c8');
-    expect(c8?.bestIndividual).toEqual({ status: 'indisponivel', motivo: 'produto_nao_resolve' });
+    expect(acharCliente(result, C8)?.individuais.cross_sell).toEqual({
+      status: 'indisponivel', motivo: 'produto_nao_resolve',
+    });
   });
 
   it.each(['erro', 'rejeita'] as const)(
     'a leitura falhando (%s) marca INDISPONÍVEL e NÃO omite o cliente da lista',
     async (modo) => {
-      // O coração desta entrega. Antes, `c8` (sem bundle próprio) sumia da lista quando a
+      // O coração desta entrega. Antes, `C8` (sem bundle próprio) sumia da lista quando a
       // leitura dele falhava — e sumir é afirmar, pelo silêncio, que não há rota individual
       // para ele. As duas portas contam: `{ error }` resolvido e Promise rejeitada.
       falhaBulk = modo;
       const result = await calcular();
 
-      const c8 = result.current.customerBundles.find((c) => c.customerId === 'c8');
+      const c8 = acharCliente(result, C8);
       expect(c8, 'o cliente sem bundle sumiu da lista quando a leitura falhou').toBeDefined();
-      expect(c8?.bestIndividual.status).toBe('indisponivel');
+      // AS DUAS rotas ficam indisponíveis: a falha de leitura é da carteira inteira, e deixar
+      // uma delas em `nenhum` afirmaria ausência sobre o que ninguém leu.
+      expect(c8?.individuais.cross_sell).toEqual({ status: 'indisponivel', motivo: 'leitura_falhou' });
+      expect(c8?.individuais.up_sell).toEqual({ status: 'indisponivel', motivo: 'leitura_falhou' });
 
       // E o cliente COM bundle não perde o bundle por causa da leitura acessória.
-      const c7 = result.current.customerBundles.find((c) => c.customerId === 'c7');
+      const c7 = acharCliente(result, C7);
       expect(c7?.bundles.length).toBeGreaterThan(0);
-      expect(c7?.bestIndividual.status).toBe('indisponivel');
+      expect(c7?.individuais.cross_sell.status).toBe('indisponivel');
     },
   );
 
@@ -272,27 +375,16 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
     // RPC de substituição do cross-sell, e mover a decisão para cá poria o gate longe da causa.
     duasGeracoes = true;
     await calcular();
-
     const avisos = vi.mocked(toast.warning).mock.calls.map((c) => String(c[0]));
     expect(avisos.some((m) => m.includes('gerações diferentes'))).toBe(true);
   });
 
   it('CONTRAPROVA: com UMA geração o aviso não aparece (senão seria ruído constante)', async () => {
-    // Sem esta, um `toast.warning` disparado sempre passaria no teste acima e o canário seria
-    // indistinguível de um alarme quebrado — o "rótulo com DEFAULT constante não é fato".
     await calcular();
     const avisos = vi.mocked(toast.warning).mock.calls.map((c) => String(c[0]));
     expect(avisos.some((m) => m.includes('gerações diferentes'))).toBe(false);
   });
 
-  // ── A reavaliação: `melhor_individual` NÃO entra no `InsumosSnapshot` ─────────────────────
-  //
-  // A tarefa pedia para reavaliar, porque o fundamento antigo (o RUÍDO de N consultas por
-  // execução) caiu com a leitura em bloco. Cheguei a declarar o insumo; o challenge Codex
-  // mostrou que o argumento certo é outro e aponta para o lado oposto: "'não obrigatório' só
-  // vale para `n===0`; `ok:false` SEMPRE degrada. Portanto `melhor_individual` passa a bloquear
-  // a expiração de bundles embora seja comprovadamente invariante para `p_linhas`."
-  //
   // A completude julga UMA coisa — se o zero de BUNDLES veio de snapshot íntegro — e esta
   // leitura não participa dela. Declará-la faria uma leitura acessória travar para sempre o
   // mecanismo de aposentadoria da fase 2, porque `degradado` nunca autoriza expirar.
@@ -305,7 +397,7 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
     expect(head.p_completude).toBe('completo');
 
     // ⚠️ Era `not.toContain('melhor_individual')` — asserção pelo NOME, e o nome é a parte
-    // frágil: as chaves mudaram para `comparacao_individual_*` neste PR e aquela linha teria
+    // frágil: as chaves mudaram para `comparacao_individual_*` naquele PR e aquela linha teria
     // seguido VERDE por coincidência, com a decisão que ela guarda invertida. O que precisa
     // valer é a FORMA: a comparação não prega NADA no veredicto — nem `ok:false` (que degrada
     // SEMPRE, obrigatório ou não) nem `pisoCobertura` (que faria `esperado` voltar a julgar).
@@ -318,11 +410,14 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
     }
   });
 
-  // ── Os 4 estados da evidência inerte (money-path §13) ────────────────────────────────────
+  // ── Os estados da evidência inerte (money-path §13) ──────────────────────────────────────
   //
   // A tabela existe porque UMA chave só não distingue os casos: "clientes com veredicto"
   // gravaria 237/238 num cenário em que a resolução real é 0/1 — o `nenhum`, que é fato
   // comercial legítimo, mascarando a deriva que o sensor existe para expor.
+  //
+  // A unidade da resolução é o SKU PEDIDO, não a célula: uma célula `empatado` promete dois
+  // nomes e pede duas resoluções, e contá-la como uma esconderia metade da deriva.
   function evidencias() {
     const i = argsSubstituir[0].p_insumos as Record<string, { n: number; esperado?: number }>;
     const par = (k: string) => (i[k] ? `${i[k].n}/${i[k].esperado}` : 'AUSENTE');
@@ -352,41 +447,41 @@ describe('useBundleEngine — o melhor individual em UMA leitura, com os três e
   });
 
   it('produto fora do catálogo ativo: leitura 1/1 e resolução 0/1 — a deriva aparece', async () => {
-    // O estado que HOJE é invisível em toda parte: não está no toast, e sem esta chave não
-    // estaria no head. É a deriva que o cross-sell só enxergou quando ganhou série (934/939).
     produtoForaDoCatalogo = true;
     await calcular();
     expect(evidencias()).toEqual({ leitura: '1/1', resolucao: '0/1' });
   });
 
+  it('a resolução conta SKU, não célula — o empate parcial aparece como 1/2', async () => {
+    // Se o denominador fosse a célula, esta linha contaria 1/1 e a deriva do SKU que sumiu do
+    // catálogo ficaria invisível justamente no estado em que há mais nomes para perder.
+    linhasExtras = [linhaIndividual(C9, [P2, SKU_FANTASMA], { situacao: 'empatado', candidatos: 2 })];
+    await calcular();
+    expect(evidencias()).toEqual({ leitura: '1/1', resolucao: '2/3' });
+  });
+
   it('o denominador é o LAÇO, não o payload da RPC', async () => {
-    // 1.500 linhas de clientes que não estão em `farmer_client_scores`: a RPC devolve, o laço
-    // nunca os avalia, e `productMap` nunca é exercitado para eles. Contá-los inflaria o
-    // denominador com trabalho que não aconteceu — e é por isso que o contador vive no laço em
-    // vez de reaproveitar `insumos.clientes_com_profile`, que conta sobre outro universo
-    // (`ativos`) e só EMPATA com este em produção por acaso.
+    // 1.500 linhas de clientes que não estão em `farmer_client_scores` — o laço nunca as
+    // exercita contra o catálogo. Contá-las inflaria o denominador com trabalho que não houve.
     carteiraGrande = true;
     await calcular();
     expect(evidencias()).toEqual({ leitura: '1/1', resolucao: '1/1' });
   });
 
   it('mas a falha TAMBÉM não vira sucesso — ela sai pelo aviso, que é onde ela pertence', async () => {
-    // O par indispensável do teste acima: sem ele, "não degrada o head" se leria como "a falha
-    // sumiu". Ela não some — muda de canal.
     falhaBulk = 'erro';
     await calcular();
-
     expect(toast.success).not.toHaveBeenCalled();
     const avisos = vi.mocked(toast.warning).mock.calls.map((c) => String(c[0]));
     expect(avisos.some((m) => m.includes('não pôde ser lida'))).toBe(true);
   });
 
   it('"li e não há" continua sendo `nenhum` — a falha não contamina o zero legítimo', async () => {
-    // A contraprova do caso acima: sem falha, `c7` (que de fato não tem recomendação pendente)
-    // sai `nenhum`, não `indisponivel`. Um `indisponivel` universal seria fail-closed demais e
-    // apagaria a informação que o motor de fato tem.
+    semPendentes = true;
     const result = await calcular();
-    const c7 = result.current.customerBundles.find((c) => c.customerId === 'c7');
-    expect(c7?.bestIndividual.status).toBe('nenhum');
+    const c7 = acharCliente(result, C7);
+    expect(c7?.bundles.length, 'o bundle sumiu junto — o cenário perdeu o detector').toBeGreaterThan(0);
+    expect(c7?.individuais.cross_sell.status).toBe('nenhum');
+    expect(c7?.individuais.up_sell.status).toBe('nenhum');
   });
 });

--- a/src/hooks/__tests__/bundle-melhor-individual-bulk.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-bulk.test.tsx
@@ -280,7 +280,12 @@ describe('useBundleEngine — as ofertas individuais em UMA leitura, com os esta
     // reconhecido, inteiro ≥1, sem eleito fora de `eleito` — e não representa empate nenhum.
     // Descartar só a linha ruim daria um Map parcial apresentado como completo: o cliente
     // afetado viraria `nenhum`, que é um veredicto. Rejeitar tudo é a saída honesta.
-    linhasExtras = [linhaIndividual(C9, [P2], { situacao: 'empatado', candidatos: 1 })];
+    // `produto_eleito: null` EXPLÍCITO: sem ele o helper o deriva do array de um elemento, a
+    // linha é recusada pela checagem de `produto_eleito` e este teste ficaria verde mesmo com a
+    // cardinalidade do `empatado` desligada — provando outra coisa que não a que promete.
+    linhasExtras = [
+      linhaIndividual(C9, [P2], { situacao: 'empatado', produto_eleito: null, candidatos: 1 }),
+    ];
     const result = await calcular();
 
     expect(acharCliente(result, C8)?.individuais.cross_sell.status).toBe('indisponivel');

--- a/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
@@ -15,7 +15,7 @@ import { captureException } from '@/lib/analytics';
  * defeitos de gravidade bem diferente:
  *
  *  1. `{ data: null, error }` resolvido — a falha vira "não há recomendação pendente":
- *     `bestIndividual` fica `null`, o cliente sem bundle próprio é OMITIDO da lista inteira, e
+ *     as células individuais ficam `null`, o cliente sem bundle próprio é OMITIDO da lista, e
  *     ao fim a execução ainda emite `toast.success`. É o §2 (ausente ≠ zero) na forma de
  *     rótulo: uma leitura que não aconteceu apresentada como veredicto.
  *
@@ -109,8 +109,8 @@ vi.mock('@/integrations/supabase/client', () => ({
         };
         return c;
       }
-      // A leitura do melhor individual — UMA tupla jsonb. As duas falhas entram por aqui.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      // A leitura das ofertas individuais — UMA tupla jsonb. As duas falhas entram por aqui.
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         // A REJEIÇÃO é o caminho perigoso: escapa para o `catch` externo com todos os
         // insumos obrigatórios já íntegros. O `{ error }` resolvido é o silencioso.
         if (falhaMelhorIndividual === 'rejeita') return Promise.reject(new Error('Failed to fetch'));

--- a/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
@@ -9,7 +9,7 @@ import { captureException } from '@/lib/analytics';
  *
  * O motor lê o melhor individual da carteira e monta a comparação "bundle × melhor produto
  * individual". A leitura era um `.from('farmer_recommendations')` POR CLIENTE, dentro do laço,
- * e hoje é a RPC em bloco `farmer_melhor_individual_por_cliente` — a PORTA mudou, os dois
+ * e hoje é a RPC em bloco `farmer_melhores_individuais_por_cliente` — a PORTA mudou, os dois
  * defeitos abaixo são os mesmos e continuam sendo o que este arquivo guarda. O `error` era
  * DESCARTADO na desestruturação (`const { data: existingRecs } = await ...`), e daí saíam dois
  * defeitos de gravidade bem diferente:

--- a/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
+++ b/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
@@ -138,7 +138,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcs.push({ nome, args });

--- a/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
+++ b/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
@@ -89,7 +89,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcs.push({ nome, args });

--- a/src/hooks/__tests__/bundle-universo-pedidos.test.tsx
+++ b/src/hooks/__tests__/bundle-universo-pedidos.test.tsx
@@ -193,7 +193,7 @@ vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: (tabela: string) => stubChain(tabela),
     rpc: (nome: string, args?: Record<string, unknown>) => {
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcArgs.push({ nome, args: args ?? {} });

--- a/src/hooks/__tests__/bundle-vendaveis-erro-de-codigo.test.tsx
+++ b/src/hooks/__tests__/bundle-vendaveis-erro-de-codigo.test.tsx
@@ -122,7 +122,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       if (nome === 'farmer_geracao_registrar') registros.push(args ?? {});

--- a/src/hooks/__tests__/bundle-vendaveis-erro-honesto.test.tsx
+++ b/src/hooks/__tests__/bundle-vendaveis-erro-honesto.test.tsx
@@ -58,7 +58,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       if (nome === 'get_skus_margem_positiva') {

--- a/src/hooks/__tests__/bundle-vendaveis-paginacao.test.tsx
+++ b/src/hooks/__tests__/bundle-vendaveis-paginacao.test.tsx
@@ -123,7 +123,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string, args?: Record<string, unknown>) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       rpcsChamadas.push(nome);

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -16,6 +16,14 @@ import { lerHeadVigente, registrarGeracaoFarmer } from '@/lib/farmer/registrar-g
 import { indexarCatalogoAtivo, resolverItemNoCatalogo } from '@/lib/farmer/identidade-item';
 import { STATUS_NAO_VENDA_POSTGREST } from '@/lib/farmer/universo-pedidos';
 import { medirBundlesDeContaUnica } from '@/lib/farmer/cobertura-conta-oferta';
+import {
+  montarCelulaIndividual,
+  TIPOS_INDIVIDUAIS,
+  validarRespostaMelhorIndividual,
+  type CelulaIndividual,
+  type LinhaMelhorIndividual,
+  type TipoIndividual,
+} from '@/lib/farmer/melhor-individual';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AssociationRule {
@@ -54,60 +62,32 @@ export interface BundleRecommendation {
   status: string;
 }
 
-// Não exportado: os consumidores falam em `ComparacaoIndividual` (a união), e só alcançam
-// isto pelo ramo `encontrado`. Export sem consumidor externo reprova no knip — que roda no
-// health stack, não no `bun run test` (mesma armadilha anotada em completude-snapshot.ts).
-interface IndividualComparison {
-  productId: string;
-  productName: string;
-  /**
-   * Score de AFINIDADE (adimensional) da melhor recomendação individual — NÃO é dinheiro.
-   * Era `lie: number` lendo `farmer_recommendations.lie`, que agora é sempre NULL: `Number(null)`
-   * daria 0 e fabricaria "nenhuma afinidade" onde o certo é "não medida" (money-path §2).
-   */
-  affinity: number | null;
-  type: 'cross_sell' | 'up_sell';
-}
-
 /**
- * O resultado da comparação com o melhor produto individual — TRÊS estados, não dois.
+ * As DUAS rotas individuais de um cliente, uma por tipo de motor.
  *
- * `IndividualComparison | null` colapsava "li e não existe" com "não consegui ler", e o
- * conjunto UI+filtro transformava o colapso numa AFIRMAÇÃO: a tela renderizava
- * `bestIndividual?.productName ?? '—'` e, pior, o cliente sem bundle próprio era OMITIDO da
- * lista inteira (`if (topBundles.length > 0 || bestIndividual)`). O traço não fabricava
- * número, mas a dupla fabricava o rótulo "não há rota individual para este cliente" — é o
- * §2 do money-path (ausente ≠ zero) na forma de rótulo, o mesmo defeito que o #1800 tirou
- * do `error` descartado e que sobrevivia um passo adiante, no tipo.
+ * Era um `bestIndividual` só, e o único era uma PRECEDÊNCIA de tipo não declarada: os dois
+ * motores gravam em `affinity_score` escalas incomensuráveis, e comparar entre elas elegia
+ * up_sell em 186 de 186 pares medidos em prod (07/09/2026) — sem que ninguém tivesse decidido
+ * que upgrade vale mais que complemento. Duas células ROTULADAS entregam as duas ofertas e
+ * devolvem a escolha a quem conhece o cliente, em vez de resolvê-la por artefato de escala.
  *
- * `indisponivel` existe porque a leitura é ACESSÓRIA e não derruba a carteira: ela não entra
- * em `p_linhas`, então falhar nela não pode custar os bundles já descobertos — mas também não
- * pode desaparecer.
+ * O `Record` deriva de `TIPOS_INDIVIDUAIS`, que é a fonte ÚNICA do vocabulário. A versão
+ * anterior declarava a união literal aqui e prometia que "um motor novo quebra no compilador";
+ * o challenge (R5/5) mostrou que não: o tipo gerado do Supabase diz `recommendation_type:
+ * string`, e com os vocabulários soltos um terceiro motor aceito pelo validador entrava no Map
+ * sem nunca virar célula — cliente só daquele tipo sumindo da lista em silêncio.
  */
-export type ComparacaoIndividual =
-  | { status: 'encontrado'; value: IndividualComparison }
-  | { status: 'nenhum' }
-  | {
-      status: 'indisponivel';
-      /**
-       * `leitura_falhou` — a RPC não respondeu; vale para a carteira inteira.
-       * `produto_nao_resolve` — a RPC respondeu, mas o SKU eleito não está no catálogo ATIVO
-       *   (ou veio sem `product_id`, que é nullable no schema). Antes isto caía em
-       *   `productName: prod?.descricao || 'Produto'` e a tela afirmava ter encontrado o
-       *   melhor individual exibindo um nome INVENTADO — a mesma fabricação de rótulo que esta
-       *   união veio matar, um nível abaixo. Medido em prod (20/08/2026): 0 de 671 pendentes
-       *   com score caem aqui hoje, mas `product_id` é nullable e o SKU pode ser desativado
-       *   DEPOIS da geração. (Achado 3 do challenge Codex.)
-       */
-      motivo: 'leitura_falhou' | 'produto_nao_resolve';
-    };
+export type IndividuaisDoCliente = Record<TipoIndividual, CelulaIndividual>;
+
+/** Reexportado para a tela não precisar conhecer o módulo do contrato. A fonte é UMA só. */
+export { TIPOS_INDIVIDUAIS };
 
 export interface CustomerBundles {
   customerId: string;
   customerName: string;
   healthScore: number;
   bundles: BundleRecommendation[];
-  bestIndividual: ComparacaoIndividual;
+  individuais: IndividuaisDoCliente;
   avgMonthlySpend: number;
   /** `null` = margem não apurada. NÃO trocar por 0: 0 classifica o cliente como "sensível a
    *  preço" via `classifyCustomerProfile`, um veredito que a ausência de dado não sustenta. */
@@ -165,21 +145,6 @@ interface SalesOrderRow {
 }
 
 /** Uma linha da RPC `farmer_melhor_individual_por_cliente` — já é O melhor do cliente. */
-interface MelhorIndividualRow {
-  customer_user_id: string;
-  /**
-   * NULLABLE no schema (`information_schema`, conferido 21/08/2026) — e o tipo dizia `string`.
-   * Era uma mentira BARATA de manter enquanto ninguém media: `productMap.get(null)` só dá miss
-   * e cai no mesmo ramo do SKU inativo. Com o sensor de resolução abaixo os dois passam a
-   * CONTAR, e um tipo que esconde uma das portas faz o número nascer torto. (Achado do
-   * challenge Codex gpt-5.6-sol/xhigh, 21/08.)
-   */
-  product_id: string | null;
-  affinity_score: number | string | null;
-  recommendation_type: 'cross_sell' | 'up_sell';
-  /** Geração a que a linha pertence. Todas deveriam trazer a MESMA — ver o aviso no toast. */
-  run_id: string | null;
-}
 
 // ─── Premissa do LIE do bundle (NÃO é aprendida) ─────────────────────
 // Constante ARBITRADA, não medição. Até 2026-07-21 o hook lia
@@ -804,7 +769,10 @@ export const useBundleEngine = () => {
       // PAGINADA como as outras: a capa de 1.000 do PostgREST vale para `.rpc()` igual a
       // `.from()` e já zerou este motor duas vezes (#1782, #1801). `customer_user_id` é
       // único no resultado do `DISTINCT ON`, logo é ordem TOTAL — paginar não pula linha.
-      const melhorIndividual = new Map<string, MelhorIndividualRow>();
+      // Chave `${cliente}:${tipo}`, não o cliente: a RPC devolve ATÉ DUAS linhas por cliente
+      // (uma por motor) e, com a chave antiga, a segunda sobrescreveria a primeira em silêncio —
+      // uma das duas rotas sumiria da tela apresentada como "não há".
+      const melhorIndividual = new Map<string, LinhaMelhorIndividual>();
       /**
        * A leitura acessória falhou — UMA vez, para a execução inteira. Era um CONTADOR de
        * clientes porque a consulta era por-cliente; com a leitura em bloco a falha deixou de
@@ -826,23 +794,23 @@ export const useBundleEngine = () => {
         // coerência deixa de ser probabilística, e o cap de 1.000 some por construção (ele
         // conta LINHAS, e agora há uma) — o caminho sai da classe #1782/#1801 em vez de se
         // defender dela.
-        const { data, error } = await supabase.rpc('farmer_melhor_individual_por_cliente', {
-          p_farmer_id: effectiveUserId,
-        });
+        // `as never` no nome porque `types.ts` é gerado pelo Lovable e ainda não conhece esta
+        // RPC — mesmo idioma do `farmer_bundle_recomendacoes_substituir` logo abaixo. O contrato
+        // de verdade não é o tipo gerado e sim `validarRespostaMelhorIndividual`, que roda em
+        // RUNTIME: um tipo estático não teria detido resposta malformada de qualquer forma.
+        const { data, error } = await supabase.rpc(
+          'farmer_melhores_individuais_por_cliente' as never,
+          { p_farmer_id: effectiveUserId } as never,
+        );
         if (error) throw error;
-        // `data` não-array é resposta MALFORMADA, nunca "vazio": a RPC faz
-        // `coalesce(…, '[]'::jsonb)` justamente para o vazio legítimo chegar como `[]`. Sem
-        // esta linha, `null` viraria `nenhum` para a carteira inteira — a leitura que não
-        // aconteceu apresentada como veredicto, que é o §6 do money-path (o contrato tem de
-        // EXPOR a falha, senão o caller não pode detectar). A prova SQL do outro lado deste
-        // par é o assert A3 do harness; mexer num sem o outro reabre o buraco.
-        if (!Array.isArray(data)) {
-          throw new Error(
-            `farmer_melhor_individual_por_cliente devolveu ${data === null ? 'null' : typeof data} em vez de array`,
-          );
-        }
-        for (const linha of data as unknown as MelhorIndividualRow[]) {
-          melhorIndividual.set(linha.customer_user_id, linha);
+        // Valida a resposta INTEIRA e LANÇA — nunca filtra. Descartar linha inválida daria um
+        // Map parcial apresentado como completo, e a linha ausente vira `nenhum` na tela, que é
+        // um VEREDICTO ("não há rota individual para este cliente"). Rejeitar tudo como
+        // `leitura_falhou` é a única saída honesta: vale para a carteira e não afirma nada.
+        // A checagem de formato uuid do `customer_user_id` faz parte disso — sem ela a linha
+        // some na consulta pela chave, que é a mesma falha entrando por outra porta.
+        for (const linha of validarRespostaMelhorIndividual(data)) {
+          melhorIndividual.set(`${linha.customer_user_id}:${linha.recommendation_type}`, linha);
         }
       } catch (erroIndividual) {
         console.error('Falha ao ler o melhor individual da carteira:', erroIndividual);
@@ -923,17 +891,22 @@ export const useBundleEngine = () => {
        */
       const geracoesExibidas = new Set<string>();
       /**
-       * Denominador do sensor de RESOLUÇÃO: registros que a RPC devolveu E que o laço de fato
-       * exercitou contra o `productMap` (depois do gate `if (!profile) continue`).
+       * Denominador do sensor de RESOLUÇÃO: SKUs que a resposta pediu para NOMEAR e que o laço
+       * de fato exercitou contra o `productMap` (depois do gate `if (!profile) continue`).
+       *
+       * A unidade passou de registro para SKU porque `produtos` virou array: uma célula
+       * `empatado` com 2 nomes pede duas resoluções, e contá-la como uma esconderia metade da
+       * deriva de catálogo. E o sensor mede SÓ catálogo — estado sem eleição não é falha de
+       * resolução, e somá-lo aqui fabricaria deterioração onde só há empate legítimo.
        *
        * Contado AQUI, não reaproveitado de `insumos.clientes_com_profile`: aquele conta sobre
        * `ativos` (carteira ∩ quem tem pedido) e este laço percorre TODO `clientScores` — em
        * prod os dois empatam, mas não é invariante, e um denominador que coincide por acaso é
        * o "rótulo com DEFAULT constante" do §5 esperando a base mudar.
        */
-      let comparacoesAvaliadas = 0;
-      /** Quantas delas resolveram para SKU do catálogo ATIVO — o numerador. */
-      let comparacoesResolvidas = 0;
+      let skusIndividuaisPedidos = 0;
+      /** Quantos deles o catálogo ATIVO soube nomear — o numerador. */
+      let skusIndividuaisResolvidos = 0;
 
       for (const score of clientScores) {
         const cid = score.customer_user_id;
@@ -1035,46 +1008,45 @@ export const useBundleEngine = () => {
         // `nenhum` = a RPC respondeu e este cliente não tem oferta individual pendente;
         // `indisponivel` = ninguém pode afirmar nada sobre este cliente (e o `motivo` diz por
         // quê: a leitura falhou, ou o SKU eleito não existe mais no catálogo ativo).
-        let bestIndividual: ComparacaoIndividual;
-        const rec = melhorIndividual.get(cid);
-        if (comparacaoIndisponivel) {
-          bestIndividual = { status: 'indisponivel', motivo: 'leitura_falhou' };
-        } else if (rec) {
-          comparacoesAvaliadas++;
-          // `product_id` separado ANTES do Map: com `string | null` o compilador passa a EXIGIR
-          // o tratamento, em vez de a chave `null` virar um miss indistinguível de SKU inativo.
-          const pid = rec.product_id;
-          const prod = pid == null ? undefined : productMap.get(pid);
-          // Ausente ≠ zero: `Number(null)` é 0 e afirmaria afinidade nula MEDIDA.
-          const afinidade = rec.affinity_score == null ? NaN : Number(rec.affinity_score);
-          if (pid == null || !prod?.descricao) {
-            // Era `productName: prod?.descricao || 'Produto'`: a tela dizia ter ENCONTRADO o
-            // melhor individual e mostrava um nome inventado. O `productMap` só tem SKU
-            // ATIVO, e `product_id` é nullable no schema — as duas portas caem aqui.
-            // "Encontrei algo que não sei identificar" é `não sei`, não `encontrei`.
-            bestIndividual = { status: 'indisponivel', motivo: 'produto_nao_resolve' };
-          } else {
-            geracoesExibidas.add(rec.run_id ?? 'sem-run');
-            comparacoesResolvidas++;
-            bestIndividual = {
-              status: 'encontrado',
-              value: {
-                productId: pid,
-                productName: prod.descricao,
-                affinity: Number.isFinite(afinidade) ? afinidade : null,
-                type: rec.recommendation_type,
-              },
-            };
+        // As duas rotas individuais, uma por motor — nomeadas, nunca comparadas entre si.
+        // O nome resolve em TODO estado: `situacao` decide o que a apresentação SIGNIFICA, não
+        // se existe apresentação. A regra anterior ("só o eleito tem identidade") era o que
+        // tornava irrecuperáveis os nomes dos 52 clientes cross-only, onde nenhuma eleição é
+        // possível — ali a célula viraria um aviso de indisponibilidade permanente.
+        const celulaDe = (tipo: TipoIndividual): CelulaIndividual => {
+          if (comparacaoIndisponivel) return { status: 'indisponivel', motivo: 'leitura_falhou' };
+
+          const linha = melhorIndividual.get(`${cid}:${tipo}`);
+          const celula = montarCelulaIndividual(
+            linha,
+            // `|| undefined`: descrição vazia é tão inútil quanto ausente, e deixá-la passar
+            // renderizaria uma célula com nome em branco — a versão silenciosa de inventar nome.
+            (sku) => productMap.get(sku)?.descricao || undefined,
+          );
+          if (linha) {
+            skusIndividuaisPedidos += linha.produtos.length;
+            skusIndividuaisResolvidos += celula.status === 'encontrado' ? celula.nomes.length : 0;
+            // Toda linha EXIBIDA alimenta o canário, não só a que elegeu alguém: com os estados
+            // novos o cartão mostra empates e ordens indisponíveis, e restringir a contagem ao
+            // eleito deixaria cartões misturando gerações sem ninguém avisar.
+            geracoesExibidas.add(linha.run_id ?? 'sem-run');
           }
-        } else {
-          bestIndividual = { status: 'nenhum' };
-        }
+          return celula;
+        };
+        // Literal COMPLETO em vez de `{} as IndividuaisDoCliente` preenchido num laço: o cast
+        // era o único ponto do caminho em que o tipo era AFIRMADO e não verificado, e um motor
+        // novo amanhã deixaria o campo `undefined` — a tela quebrando em runtime por uma
+        // omissão que o compilador tinha como pegar. Agora ele pega.
+        const individuais: IndividuaisDoCliente = {
+          cross_sell: celulaDe('cross_sell'),
+          up_sell: celulaDe('up_sell'),
+        };
 
         // `nenhum` é a ÚNICA ausência que autoriza omitir o cliente da lista, porque é a
         // única que foi de fato verificada. Com `indisponivel` o cliente entra mesmo sem
         // bundle: sumi-lo seria afirmar, pelo silêncio, que não há rota individual para
         // ele — a afirmação que nenhuma leitura sustentou.
-        if (topBundles.length > 0 || bestIndividual.status !== 'nenhum') {
+        if (topBundles.length > 0 || TIPOS_INDIVIDUAIS.some((t) => individuais[t].status !== 'nenhum')) {
           const purchasedProducts = [...purchased]
             .map((pid) => productMap.get(pid)?.descricao)
             .filter((d): d is string => Boolean(d));
@@ -1083,7 +1055,7 @@ export const useBundleEngine = () => {
             customerName: profile.name ?? '',
             healthScore,
             bundles: topBundles,
-            bestIndividual,
+            individuais,
             avgMonthlySpend: Number(score.avg_monthly_spend_180d || 0),
             grossMarginPct: margemConhecida(score.gross_margin_pct),
             categoryCount: Number(score.category_count || 0),
@@ -1162,12 +1134,13 @@ export const useBundleEngine = () => {
       };
       insumos.comparacao_individual_produto_resolvido = {
         ok: true,
-        // Por REGISTRO PENDENTE, que é a unidade da deriva: SKU desativado depois da geração do
-        // cross-sell, ou `product_id` null. As duas portas caem no ramo `produto_nao_resolve`,
-        // que hoje é o ÚNICO estado do motor invisível em toda parte — não está no toast, e sem
-        // esta chave não estaria no head.
-        n: comparacoesResolvidas,
-        esperado: comparacoesAvaliadas,
+        // Por SKU PEDIDO, que é a unidade da deriva: produto desativado depois da geração do
+        // cross-sell. Uma célula pede tantas resoluções quantos nomes promete, e é por isso que
+        // o denominador não é "células avaliadas" — em `empatado` isso contaria 1 onde há 2.
+        // A célula que perde TODOS os nomes cai em `produto_nao_resolve`, o único estado do
+        // motor invisível em toda parte: não está no toast, e sem esta chave não estaria no head.
+        n: skusIndividuaisResolvidos,
+        esperado: skusIndividuaisPedidos,
       };
 
       aplicarBundles(allCustomerBundles);
@@ -1178,7 +1151,7 @@ export const useBundleEngine = () => {
       // gravação — e é este flag que impede a tela de culpar a leitura por ela.
       setCalculado(true);
       // Linhas PERSISTÍVEIS, não clientes: um cliente entra em `allCustomerBundles` só com
-      // `bestIndividual` (`encontrado` ou `indisponivel`) e nenhum bundle, e essa comparação
+      // uma célula individual (`encontrado` ou `indisponivel`) e nenhum bundle, e ela
       // não vira linha nenhuma no payload da RPC. Contando clientes, esse caso travava o `registrarVazio()` do `catch` sobre uma
       // execução que de fato não produziu nada — o head parava de se mover e "nenhum registro
       // novo" voltava a significar duas coisas opostas (challenge Codex xhigh).

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -24,6 +24,13 @@ import {
 } from '@/lib/farmer/upsell-ordem';
 import { acumularContaDeCompra, medirCoberturaContaDaOferta, ofertaNaContaDoCliente } from '@/lib/farmer/cobertura-conta-oferta';
 import { compararRecencia, instanteDoPedido, type MarcaDeCompra } from '@/lib/farmer/preco-referencia';
+import { rankDenso } from '@/lib/farmer/rank-denso';
+import {
+  referenciaEhAmbigua,
+  registrarPrecoDoPedido,
+  topoVazio,
+  type TopoDeReferencia,
+} from '@/lib/farmer/referencia-ambigua';
 import { toast } from 'sonner';
 import { precoUtilizavel } from '@/lib/format';
 
@@ -57,6 +64,23 @@ export interface Recommendation {
    * que é o único sinal personalizado por cliente.
    */
   affinityScore: number;
+  /**
+   * O mesmo score SEM o arredondamento a 4 casas — o que o motor de fato calculou.
+   *
+   * `affinityScore` é `Math.round(x * 10000) / 10000`, e em prod isso colapsa 714 linhas de
+   * cross-sell em 32 valores distintos: ordenar por ele deixa o `sort` estável decidir entre
+   * empatados, e a ordem de inserção é a varredura do catálogo (`.order('id')`) — uuid outra
+   * vez. A ordenação e o rank usam ESTE campo; a tela e a coluna persistida seguem com o
+   * arredondado, que é o que sempre foi mostrado.
+   */
+  scoreCru: number;
+  /**
+   * Rank DENSO 1-based dentro de (cliente, tipo) — empatados compartilham o valor.
+   * Persistido em `farmer_recommendations.ordem`; é o que faz a ordem sobreviver à gravação.
+   */
+  ordem?: number;
+  /** O preço de referência deste CLIENTE saiu de um desempate por uuid (só up-sell). */
+  referenciaAmbigua?: boolean;
   complexityFactor: number;
   /**
    * `round(clusterAdherence × 12)` no cross-sell — uma REESCALA da fração de clientes do
@@ -126,6 +150,11 @@ interface HistoricoDoSku {
   price: number;
   /** Procedência do `price` vigente; `null` enquanto nenhum item informou preço utilizável. */
   precoEm: MarcaDeCompra | null;
+  /**
+   * Os pedidos que disputam a recência máxima, já reduzidos a um preço cada. É o que permite
+   * dizer se `price` foi escolhido por uuid — ver `referencia-ambigua.ts`.
+   */
+  topo: TopoDeReferencia;
 }
 
 interface SalesOrderRow {
@@ -673,7 +702,8 @@ export const useCrossSellEngine = () => {
           const productId = r.productId;
           itensResolvidos++;
 
-          const existing: HistoricoDoSku = cp.get(productId) || { qty: 0, price: 0, precoEm: null };
+          const existing: HistoricoDoSku =
+            cp.get(productId) || { qty: 0, price: 0, precoEm: null, topo: topoVazio() };
           existing.qty += Number(item.quantity || item.quantidade || 1);
           // O preço de referência é o do pedido MAIS RECENTE, não o do "último lido". Duas
           // correções empilhadas aqui, e as duas são de money-path:
@@ -692,6 +722,11 @@ export const useCrossSellEngine = () => {
           const precoItem = precoUtilizavel(item.unit_price) ?? precoUtilizavel(item.valor_unitario);
           if (precoItem !== null && precoItem > 0) {
             const marca: MarcaDeCompra = { instante: instantePedido, pedidoId, ordemDeLeitura, posicao };
+            // Registrado ANTES da escolha: o detector precisa dos pedidos que DISPUTAM o topo,
+            // não só do que venceu. Reduzir cada pedido ao seu preço intra-pedido (determinístico)
+            // e comparar só os empatados na recência máxima é o que separa "o uuid decidiu" de
+            // "a posição decidiu" — ver `referencia-ambigua.ts`.
+            registrarPrecoDoPedido(existing.topo, instantePedido, pedidoId, precoItem);
             if (existing.precoEm === null || compararRecencia(marca, existing.precoEm) > 0) {
               existing.price = precoItem;
               existing.precoEm = marca;
@@ -909,6 +944,7 @@ export const useCrossSellEngine = () => {
               productName: product.descricao,
               pij: Math.round(pij * 1000) / 10,
               affinityScore: Math.round(affinityScore * 10000) / 10000,
+              scoreCru: affinityScore,
               complexityFactor,
               clusterVolume,
               estoque: product.estoque ?? null,
@@ -1020,6 +1056,7 @@ export const useCrossSellEngine = () => {
                 currentProductName: currentProduct?.descricao || 'Produto atual',
                 pij: Math.round(pij * 1000) / 10,
                 affinityScore: Math.round(affinityScore * 10000) / 10000,
+              scoreCru: affinityScore,
                 complexityFactor,
                 clusterVolume: purchaseData.qty,
                 estoque: product.estoque ?? null,
@@ -1036,7 +1073,14 @@ export const useCrossSellEngine = () => {
 
         // Cross-sell ordena por AFINIDADE (desc) — lá o `pij` carrega `relevance`, que é
         // termo do PRODUTO, então o score realmente discrimina candidatos.
-        crossSellRecs.sort((a, b) => b.affinityScore - a.affinityScore);
+        //
+        // ⚠️ Pelo score CRU, não pelo arredondado. `affinityScore` é `round(x*10000)/10000`, e
+        // medido em prod isso colapsa 714 linhas em 32 valores: o `sort` é estável, então entre
+        // empatados vencia a ordem de inserção — a varredura do catálogo, ordenada por `id`. O
+        // top-3 do vendedor era uuid pelo mesmo mecanismo que a RPC. Ordenar pelo que o motor
+        // calculou não CRIA sinal (189 de 198 grupos empatam de verdade), mas para de fabricar
+        // uma ordem que ninguém mediu.
+        crossSellRecs.sort((a, b) => b.scoreCru - a.scoreCru);
 
         // Up-sell NÃO reordena aqui, e a ausência é o conserto: `upSellRecs` já chega
         // ordenado por `compararCandidatosUpSell`. Um `sort` por afinidade seria um no-op
@@ -1044,6 +1088,37 @@ export const useCrossSellEngine = () => {
         // afinidade decide. Foi essa declaração falsa que escondeu o defeito até aqui.
         const topCross = crossSellRecs.slice(0, 3);
         const topUp = upSellRecs.slice(0, VAGAS_UP_SELL);
+
+        // ── O RANK, que é o que sobrevive à persistência ──────────────────────────────────
+        // DENSO: empatados compartilham o número. Posições distintas apenas mudariam o
+        // endereço do defeito — de "vence o menor uuid" para "vence o menor índice do array",
+        // e o array vem do catálogo ordenado por `id`.
+        //
+        // Calculado sobre o TOP já cortado, não sobre a lista inteira: `ordem` é a posição
+        // DENTRO do que foi persistido, e é assim que a RPC a lê (o mínimo do grupo é o topo).
+        const ordemCross = rankDenso(topCross, (a, b) => b.scoreCru - a.scoreCru);
+        topCross.forEach((rec, i) => { rec.ordem = ordemCross[i]; });
+        const ordemUp = rankDenso(
+          topUp.map((rec) => upSellPorProduto.get(rec.productId)!.chave),
+          compararCandidatosUpSell,
+        );
+        topUp.forEach((rec, i) => { rec.ordem = ordemUp[i]; });
+
+        // ── A ambiguidade, do CLIENTE ─────────────────────────────────────────────────────
+        // Marca do cliente e não da linha: a dedup guarda por SKU só a melhor relação com uma
+        // base comprada, e a razão que decide essa "melhor" é justamente a que a referência
+        // sorteada altera — a flag da linha sumiria junto com a relação descartada. Basta UMA
+        // base comprada com referência arbitrária para que a ordem do up-sell inteiro deste
+        // cliente possa ter sido outra.
+        //
+        // `cross_sell` recebe `false` EXPLÍCITO: seu `pij` não usa preço nenhum
+        // (`0,15 × health × engagement × relevance`), então a afirmação é verdadeira sobre o
+        // tipo — e é o que impede o fail-closed da RPC de marcar o tipo inteiro como ambíguo.
+        const clienteComReferenciaAmbigua = [...customerPurchased.values()].some((h) =>
+          referenciaEhAmbigua(h.topo),
+        );
+        topUp.forEach((rec) => { rec.referenciaAmbigua = clienteComReferenciaAmbigua; });
+        topCross.forEach((rec) => { rec.referenciaAmbigua = false; });
 
         // SENSOR da ordem do up-sell — o entregável mínimo quando o sinal não decide.
         // Uma posição só conta como decidida se nenhum candidato DESCARTADO tem a chave
@@ -1161,6 +1236,12 @@ export const useCrossSellEngine = () => {
           current_product_id: rec.currentProductId || null,
           p_ij: rec.pij,
           affinity_score: rec.affinityScore,
+          // Sem `?? null` e sem `?? false`: um default aqui afirmaria medição que não houve, e
+          // a coluna é `NULL`-able justamente para distinguir "não medido" de "medido e falso".
+          // A RPC fecha a falha do outro lado (flag nula COM ordem preenchida conta como
+          // ambígua), e é o par das duas pontas que torna o contrato honesto.
+          ordem: rec.ordem,
+          referencia_ambigua: rec.referenciaAmbigua,
           complexity_factor: rec.complexityFactor,
           cluster_volume_estimate: rec.clusterVolume,
         })),

--- a/src/lib/farmer/__tests__/melhor-individual.test.ts
+++ b/src/lib/farmer/__tests__/melhor-individual.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { validarRespostaMelhorIndividual, type LinhaMelhorIndividual } from '../melhor-individual';
+import {
+  montarCelulaIndividual,
+  validarRespostaMelhorIndividual,
+  type LinhaMelhorIndividual,
+} from '../melhor-individual';
 
 const CLI = '11111111-1111-4111-8111-111111111111';
 const A = 'aaaaaaaa-1111-4111-8111-111111111111';
@@ -138,5 +142,80 @@ describe('validarRespostaMelhorIndividual — invariantes ENTRE campos', () => {
     // virariam `nenhum` — falha convertida em ausência.
     expect(() => validarRespostaMelhorIndividual([linha(), linha({ customer_user_id: 'x' })]))
       .toThrow(/linha 1/);
+  });
+});
+
+describe('montarCelulaIndividual — a projeção para a tela', () => {
+  /** Catálogo que conhece A e B. Qualquer outro SKU é a deriva (desativado depois da geração). */
+  const catalogo = (id: string) => ({ [A]: 'Verniz PU', [B]: 'Selador 500' })[id];
+  const valida = (over: Partial<Record<string, unknown>> = {}) =>
+    validarRespostaMelhorIndividual([linha(over)])[0];
+
+  it('linha ausente é `nenhum` — a RPC respondeu e este cliente não tem oferta deste tipo', () => {
+    expect(montarCelulaIndividual(undefined, catalogo)).toEqual({ status: 'nenhum' });
+  });
+
+  it('nome que resolve vira célula com a situação PRESERVADA', () => {
+    expect(montarCelulaIndividual(valida(), catalogo)).toEqual({
+      status: 'encontrado', situacao: 'eleito', nomes: ['Verniz PU'], produtos: 1, candidatos: 2,
+    });
+  });
+
+  it('NENHUM nome resolvendo vira `produto_nao_resolve` — não uma célula vazia', () => {
+    // Era `productName: prod?.descricao || 'Produto'`: a tela dizia ter encontrado o melhor
+    // individual exibindo um literal. Perder a identidade inteira é `não sei`, não `encontrei`.
+    const fora = 'cccccccc-1111-4111-8111-111111111111';
+    const l = valida({ produtos: [fora], produto_eleito: fora });
+    expect(montarCelulaIndividual(l, catalogo)).toEqual({
+      status: 'indisponivel', motivo: 'produto_nao_resolve',
+    });
+  });
+
+  it.each([['vazio', ''], ['só espaços', '   '], ['tabulação', '\t\n']])(
+    'nome %s conta como não resolvido — a alternativa é uma célula em branco',
+    (_rotulo, descricao) => {
+      // `só espaços` é o achado R5/2, reproduzido pelo challenge executando os helpers reais:
+      // `if (nome)` deixava passar `"   "`, a célula renderizava um parágrafo em BRANCO, o
+      // sensor contava 1/1, e a tela não avisava nada. O schema permite essa descrição.
+      expect(montarCelulaIndividual(valida(), () => descricao)).toEqual({
+        status: 'indisponivel', motivo: 'produto_nao_resolve',
+      });
+    },
+  );
+
+  it('nome com espaços em volta é APARADO, não descartado — o produto existe', () => {
+    // O outro lado do R5/2: aparar não pode virar recusa. `"  Verniz PU  "` identifica um
+    // produto de verdade, e transformá-lo em `indisponivel` trocaria um defeito por outro.
+    const celula = montarCelulaIndividual(valida(), () => '  Verniz PU  ');
+    expect(celula.status === 'encontrado' && celula.nomes).toEqual(['Verniz PU']);
+  });
+
+  it('resolvendo ALGUNS, a situação sobrevive — o sobrevivente não vira vencedor', () => {
+    // O achado R3/3, e a razão de `nomes` e `produtos` serem campos separados: colapsar para o
+    // único nome legível converteria uma falha de catálogo em ELEIÇÃO. `produtos: 2` com um
+    // nome só é o que deixa a tela dizer "1 de 2 sem nome" em vez de fingir decisão.
+    const fora = 'cccccccc-1111-4111-8111-111111111111';
+    const l = valida({ situacao: 'empatado', produtos: [A, fora], produto_eleito: null, candidatos: 2 });
+    const celula = montarCelulaIndividual(l, catalogo);
+
+    expect(celula).toEqual({
+      status: 'encontrado', situacao: 'empatado', nomes: ['Verniz PU'], produtos: 2, candidatos: 2,
+    });
+    // O discriminador explícito: um `empatado` que perde metade dos nomes NUNCA é `eleito`.
+    expect(celula.status === 'encontrado' && celula.situacao).not.toBe('eleito');
+  });
+
+  it('a ordem dos nomes é a de `produtos` — a resposta já vem ordenada e a tela não reordena', () => {
+    const l = valida({ situacao: 'ordem_indisponivel', produtos: [B, A], produto_eleito: null, candidatos: 2 });
+    const celula = montarCelulaIndividual(l, catalogo);
+    expect(celula.status === 'encontrado' && celula.nomes).toEqual(['Selador 500', 'Verniz PU']);
+  });
+
+  it('`candidatos` maior que `produtos` sobrevive à projeção — é o grupo, não o topo', () => {
+    // Em `[A:1, B:1, C:2]` saem `produtos=[A,B]` e `candidatos=3`, e a tela diz "2 de 3" — a
+    // frase verdadeira. Perder o número aqui apagaria a existência do terceiro registro.
+    const l = valida({ situacao: 'empatado', produtos: [A, B], produto_eleito: null, candidatos: 3 });
+    const celula = montarCelulaIndividual(l, catalogo);
+    expect(celula.status === 'encontrado' && celula.candidatos).toBe(3);
   });
 });

--- a/src/lib/farmer/__tests__/melhor-individual.test.ts
+++ b/src/lib/farmer/__tests__/melhor-individual.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { validarRespostaMelhorIndividual, type LinhaMelhorIndividual } from '../melhor-individual';
+
+const CLI = '11111111-1111-4111-8111-111111111111';
+const A = 'aaaaaaaa-1111-4111-8111-111111111111';
+const B = 'bbbbbbbb-1111-4111-8111-111111111111';
+const RUN = '99999999-1111-4111-8111-111111111111';
+
+/** Uma linha válida `eleito`, com os campos que cada teste sobrescreve. */
+const linha = (over: Partial<Record<string, unknown>> = {}) => ({
+  customer_user_id: CLI,
+  recommendation_type: 'cross_sell',
+  situacao: 'eleito',
+  produtos: [A],
+  produto_eleito: A,
+  candidatos: 2,
+  affinity_score: 0.5,
+  run_id: RUN,
+  ...over,
+});
+
+const valida = (over = {}) => validarRespostaMelhorIndividual([linha(over)]);
+
+describe('validarRespostaMelhorIndividual — invariantes ENTRE campos', () => {
+  it('aceita a linha bem formada', () => {
+    const [l] = valida() as LinhaMelhorIndividual[];
+    expect(l.situacao).toBe('eleito');
+    expect(l.produto_eleito).toBe(A);
+  });
+
+  it('aceita o caso [A:1, B:1, C:2]: 2 nomeados de 3 candidatos', () => {
+    expect(() =>
+      valida({ situacao: 'empatado', produtos: [A, B], produto_eleito: null, candidatos: 3 }),
+    ).not.toThrow();
+  });
+
+  // ── o que a validação campo a campo deixava passar ────────────────────────────
+  it('rejeita empatado com UM produto — cada campo passa, o conjunto não representa empate', () => {
+    expect(() =>
+      valida({ situacao: 'empatado', produtos: [A], produto_eleito: null, candidatos: 2 }),
+    ).toThrow(/empatado exige/);
+  });
+
+  it('rejeita ordem_indisponivel que esconde um registrado', () => {
+    // Promete transportar TODOS os registrados; com 2 de 3 a tela diria "3 registradas"
+    // mostrando 2 — esconder uma oferta sem dizer que escondeu.
+    expect(() =>
+      valida({ situacao: 'ordem_indisponivel', produtos: [A, B], produto_eleito: null, candidatos: 3 }),
+    ).toThrow(/produtos \(2\) = candidatos \(3\)/);
+  });
+
+  it('rejeita referencia_ambigua com um produto e dois candidatos', () => {
+    expect(() =>
+      valida({ situacao: 'referencia_ambigua', produtos: [A], produto_eleito: null, candidatos: 2 }),
+    ).toThrow(/produtos \(1\) = candidatos \(2\)/);
+  });
+
+  it('rejeita produto_eleito fora do estado eleito', () => {
+    expect(() =>
+      valida({ situacao: 'empatado', produtos: [A, B], produto_eleito: A, candidatos: 2 }),
+    ).toThrow(/exatamente o estado eleito/);
+  });
+
+  it('rejeita eleito sem produto_eleito', () => {
+    expect(() => valida({ produto_eleito: null })).toThrow(/exatamente o estado eleito/);
+  });
+
+  it('rejeita produto_eleito que não está em produtos', () => {
+    expect(() => valida({ produtos: [A], produto_eleito: B })).toThrow(/fora de produtos/);
+  });
+
+  it('rejeita eleito com um único candidato — não venceu de ninguém', () => {
+    expect(() => valida({ candidatos: 1 })).toThrow(/eleito exige/);
+  });
+
+  // ── formato: `typeof === 'string'` não basta ──────────────────────────────────
+  it('rejeita customer_user_id que não é uuid', () => {
+    // Uma string qualquer some na consulta pela chave do Map, e sumir é indistinguível de
+    // "este cliente não tem oferta" — que é um veredicto.
+    expect(() => valida({ customer_user_id: 'nao-e-uuid' })).toThrow(/customer_user_id não é uuid/);
+  });
+
+  it('rejeita SKU que não é uuid', () => {
+    expect(() => valida({ produtos: ['produto-sem-uuid'], produto_eleito: 'produto-sem-uuid' }))
+      .toThrow(/produtos contém item que não é uuid/);
+  });
+
+  it('rejeita produtos com duplicata', () => {
+    expect(() =>
+      valida({ situacao: 'empatado', produtos: [A, A], produto_eleito: null, candidatos: 2 }),
+    ).toThrow(/duplicata/);
+  });
+
+  it('rejeita produtos maior que candidatos', () => {
+    expect(() =>
+      valida({ situacao: 'empatado', produtos: [A, B], produto_eleito: null, candidatos: 1 }),
+    ).toThrow(/excede candidatos/);
+  });
+
+  it('rejeita candidatos zero, fracionário e não-numérico', () => {
+    expect(() => valida({ candidatos: 0 })).toThrow(/inteiro >= 1/);
+    expect(() => valida({ candidatos: 1.5 })).toThrow(/inteiro >= 1/);
+    expect(() => valida({ candidatos: '2' })).toThrow(/inteiro >= 1/);
+  });
+
+  it('rejeita situacao fora do enum e tipo desconhecido', () => {
+    expect(() => valida({ situacao: 'ordem_desconhecida' })).toThrow(/situacao inválida/);
+    expect(() => valida({ recommendation_type: 'bundle' })).toThrow(/tipo desconhecido/);
+  });
+
+  it('rejeita (cliente,tipo) duplicado', () => {
+    expect(() => validarRespostaMelhorIndividual([linha(), linha()])).toThrow(/duplicado/);
+  });
+
+  it('aceita os DOIS tipos do mesmo cliente — é o desenho', () => {
+    expect(() =>
+      validarRespostaMelhorIndividual([linha(), linha({ recommendation_type: 'up_sell' })]),
+    ).not.toThrow();
+  });
+
+  it('aceita run_id nulo (geração incoerente não transporta) e recusa run_id malformado', () => {
+    expect(() => valida({ run_id: null })).not.toThrow();
+    expect(() => valida({ run_id: 'x' })).toThrow(/run_id presente mas não é uuid/);
+  });
+
+  // ── a resposta inteira ────────────────────────────────────────────────────────
+  it('rejeita não-array, distinguindo null de outros tipos', () => {
+    expect(() => validarRespostaMelhorIndividual(null)).toThrow(/devolveu null/);
+    expect(() => validarRespostaMelhorIndividual({})).toThrow(/devolveu object/);
+  });
+
+  it('aceita [] — "li e não há" é resposta legítima', () => {
+    expect(validarRespostaMelhorIndividual([])).toEqual([]);
+  });
+
+  it('LANÇA em vez de filtrar: uma linha ruim derruba a resposta INTEIRA', () => {
+    // Filtrar entregaria um Map parcial apresentado como completo, e os clientes ausentes
+    // virariam `nenhum` — falha convertida em ausência.
+    expect(() => validarRespostaMelhorIndividual([linha(), linha({ customer_user_id: 'x' })]))
+      .toThrow(/linha 1/);
+  });
+});

--- a/src/lib/farmer/__tests__/rank-denso.test.ts
+++ b/src/lib/farmer/__tests__/rank-denso.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { rankDenso } from '../rank-denso';
+import { compararCandidatosUpSell, type ChaveUpSell } from '../upsell-ordem';
+
+const num = (a: number, b: number) => a - b;
+
+describe('rankDenso', () => {
+  it('empatados COMPARTILHAM o rank, e o seguinte não pula', () => {
+    // Denso, não "competition ranking": [1,1,2], nunca [1,1,3] — e nunca [1,2,3], que seria o
+    // bug trocando de endereço (uuid → índice do array).
+    expect(rankDenso([10, 10, 20], num)).toEqual([1, 1, 2]);
+  });
+
+  it('devolve os ranks na ordem de ENTRADA, não na ordenada', () => {
+    expect(rankDenso([30, 10, 20], num)).toEqual([3, 1, 2]);
+  });
+
+  it('não muta a entrada', () => {
+    const entrada = [30, 10, 20];
+    rankDenso(entrada, num);
+    expect(entrada).toEqual([30, 10, 20]);
+  });
+
+  it('lista vazia devolve vazio, e um item devolve [1]', () => {
+    expect(rankDenso([], num)).toEqual([]);
+    expect(rankDenso([7], num)).toEqual([1]);
+  });
+
+  it('tudo empatado é tudo rank 1 — o caso que a tela mostra como "igualmente indicados"', () => {
+    expect(rankDenso([5, 5, 5], num)).toEqual([1, 1, 1]);
+  });
+
+  it('usa o comparador REAL do up-sell, incluindo o desempate por popularidade', () => {
+    const c = (razaoPreco: number, popularidade: number): ChaveUpSell => ({ razaoPreco, popularidade });
+    // razão 1,2 (pop 9 e 9 → empatam) · razão 1,2 pop 3 (perde) · razão 1,1 (ganha de todos)
+    expect(
+      rankDenso([c(1.2, 9), c(1.2, 9), c(1.2, 3), c(1.1, 1)], compararCandidatosUpSell),
+    ).toEqual([2, 2, 3, 1]);
+  });
+});

--- a/src/lib/farmer/__tests__/referencia-ambigua.test.ts
+++ b/src/lib/farmer/__tests__/referencia-ambigua.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  referenciaEhAmbigua,
+  registrarPrecoDoPedido,
+  topoVazio,
+  type TopoDeReferencia,
+} from '../referencia-ambigua';
+
+/** Registra uma sequência `[instante, pedidoId, preço]` como o laço do motor faria. */
+function comprar(...compras: Array<[number | null, string, number]>): TopoDeReferencia {
+  const t = topoVazio();
+  for (const [i, p, v] of compras) registrarPrecoDoPedido(t, i, p, v);
+  return t;
+}
+
+describe('referenciaEhAmbigua', () => {
+  it('um pedido só nunca é ambíguo', () => {
+    expect(referenciaEhAmbigua(comprar([10, 'P', 100]))).toBe(false);
+  });
+
+  it('dois pedidos no MESMO instante com preços diferentes = ambíguo', () => {
+    expect(referenciaEhAmbigua(comprar([10, 'P', 100], [10, 'Q', 200]))).toBe(true);
+  });
+
+  it('dois pedidos empatados com o MESMO preço NÃO é ambíguo', () => {
+    // O uuid escolhe qual pedido, mas o valor resultante é idêntico: não há decisão contaminada.
+    expect(referenciaEhAmbigua(comprar([10, 'P', 100], [10, 'Q', 100]))).toBe(false);
+  });
+
+  it('EXCESSO: empate HISTÓRICO superado por um pedido mais recente não marca', () => {
+    // Sem o descarte dos mais antigos, o par (P,Q) ligaria a flag e o custo medido não
+    // dimensionaria o detector — foi um dos dois lados do achado do challenge.
+    expect(referenciaEhAmbigua(comprar([10, 'P', 100], [10, 'Q', 200], [20, 'R', 150]))).toBe(false);
+  });
+
+  it('ESCAPE: dois pedidos com o SKU repetido dentro de cada um', () => {
+    // P=[100,200] e Q=[200,100] no mesmo instante. Comparando item a item com a referência
+    // corrente, NENHUM disparo acontece — e a referência final vira 100 ou 200 pelo uuid.
+    // Reduzindo cada pedido ao seu preço intra-pedido (a última posição vence, determinístico),
+    // o topo fica {P:200, Q:100} e a ambiguidade aparece.
+    const t = comprar([10, 'P', 100], [10, 'P', 200], [10, 'Q', 200], [10, 'Q', 100]);
+    expect(t.precosPorPedido.get('P')).toBe(200);
+    expect(t.precosPorPedido.get('Q')).toBe(100);
+    expect(referenciaEhAmbigua(t)).toBe(true);
+  });
+
+  it('um pedido DATADO expulsa os sem data — null não empata com data', () => {
+    // `compararRecencia` é fail-closed no instante ausente: marca sem data nunca supera uma com
+    // data. Se o sem-data empatasse, a flag acenderia sobre um pedido que perdeu.
+    expect(referenciaEhAmbigua(comprar([null, 'P', 100], [10, 'Q', 200]))).toBe(false);
+    expect(referenciaEhAmbigua(comprar([10, 'Q', 200], [null, 'P', 100]))).toBe(false);
+  });
+
+  it('quando NENHUM pedido tem data, o desempate cai no uuid e é ambíguo', () => {
+    // `a.instante !== b.instante` é falso para (null, null), então o comparador real desce
+    // direto para o `pedidoId`. Este é o caso que a medição por "empate de DATA" pode não ter
+    // contado — e é por isso que o custo de 2/186 está declarado como aproximação.
+    expect(referenciaEhAmbigua(comprar([null, 'P', 100], [null, 'Q', 200]))).toBe(true);
+  });
+
+  it('três pedidos empatados, dois com o mesmo preço: ainda é ambíguo', () => {
+    expect(referenciaEhAmbigua(comprar([5, 'P', 100], [5, 'Q', 100], [5, 'R', 300]))).toBe(true);
+  });
+
+  it('topo vazio não é ambíguo', () => {
+    expect(referenciaEhAmbigua(topoVazio())).toBe(false);
+  });
+});

--- a/src/lib/farmer/melhor-individual.ts
+++ b/src/lib/farmer/melhor-individual.ts
@@ -16,6 +16,22 @@
  * `produtos=[A,B]` e `candidatos=3`, e a tela diz "2 de 3" — a frase verdadeira.
  */
 
+/**
+ * Os motores que disputavam a mesma coluna de score — e a ÚNICA fonte desse vocabulário.
+ *
+ * Ele vivia em três lugares independentes (a união em `LinhaMelhorIndividual`, a lista que o
+ * leitor itera, e o `Record` da tela), e o challenge (R5/5) enumerou o caso que não quebrava em
+ * lugar nenhum: validador passando a aceitar um terceiro tipo que a lista não conhece faz a
+ * linha entrar no Map e nunca virar célula — um cliente só daquele tipo, sem bundle, SOME da
+ * lista sem erro nenhum. Derivando os três daqui, estender um obriga a estender os outros.
+ *
+ * ⚠️ O tipo GERADO do Supabase diz `recommendation_type: string` — ele não guarda este
+ * vocabulário e nunca guardou. Quem o guarda no banco é o CHECK da coluna; aqui, esta linha.
+ */
+export const TIPOS_INDIVIDUAIS = ['cross_sell', 'up_sell'] as const;
+
+export type TipoIndividual = (typeof TIPOS_INDIVIDUAIS)[number];
+
 export type SituacaoIndividual =
   | 'eleito'
   | 'empatado'
@@ -40,7 +56,7 @@ const NOMEIAM_O_GRUPO = new Set<string>([
 
 export interface LinhaMelhorIndividual {
   customer_user_id: string;
-  recommendation_type: 'cross_sell' | 'up_sell';
+  recommendation_type: TipoIndividual;
   situacao: SituacaoIndividual;
   produtos: string[];
   produto_eleito: string | null;
@@ -83,7 +99,7 @@ export function validarRespostaMelhorIndividual(data: unknown): LinhaMelhorIndiv
     if (typeof l.customer_user_id !== 'string' || !UUID.test(l.customer_user_id)) {
       throw new Error(`${onde}: customer_user_id não é uuid`);
     }
-    if (l.recommendation_type !== 'cross_sell' && l.recommendation_type !== 'up_sell') {
+    if (!TIPOS_INDIVIDUAIS.includes(l.recommendation_type as TipoIndividual)) {
       throw new Error(`${onde}: tipo desconhecido ${String(l.recommendation_type)}`);
     }
     const chave = `${l.customer_user_id}:${l.recommendation_type}`;
@@ -149,4 +165,66 @@ export function validarRespostaMelhorIndividual(data: unknown): LinhaMelhorIndiv
 
     return l as unknown as LinhaMelhorIndividual;
   });
+}
+
+/**
+ * Uma rota individual do cliente já projetada para a tela — o que a célula do cartão renderiza.
+ *
+ * `nomes` são os que RESOLVERAM no catálogo ativo, e `produtos` é o tamanho do array na resposta:
+ * a diferença entre os dois é quantos SKUs a resposta pediu para nomear e o catálogo não soube.
+ * Guardar a diferença em vez de um campo `naoIdentificados` evita dois números que podem
+ * discordar — e a tela precisa dos dois lados para dizer "1 de 2 não identificado" sem promover
+ * o sobrevivente a vencedor.
+ *
+ * `candidatos` pode exceder `produtos` (em `eleito` e `empatado`, onde `produtos` é só o topo);
+ * nos três estados que nomeiam o grupo inteiro os dois são iguais por invariante do validador.
+ */
+export type CelulaIndividual =
+  | {
+      status: 'encontrado';
+      situacao: SituacaoIndividual;
+      /** Sempre ≥ 1 — nenhum nome resolvido vira `indisponivel`, não uma célula vazia. */
+      nomes: string[];
+      produtos: number;
+      candidatos: number;
+    }
+  | { status: 'nenhum' }
+  | { status: 'indisponivel'; motivo: 'leitura_falhou' | 'produto_nao_resolve' };
+
+/**
+ * Projeta uma linha da RPC na célula da tela, resolvendo os nomes no catálogo ATIVO.
+ *
+ * ⚠️ SKU que não resolve NÃO é leitura inválida, e os dois defeitos não podem se fundir: só
+ * quando NENHUM dos nomes resolve a célula perde a identidade e vira `produto_nao_resolve`.
+ * Resolvendo alguns, a `situacao` é PRESERVADA — um `empatado` que perdeu um nome continua
+ * empatado, com a tela declarando o que não identificou. Colapsar para o sobrevivente
+ * converteria uma falha de catálogo em eleição, que é a fabricação que esta entrega mata.
+ *
+ * `linha` ausente é `nenhum`: a RPC respondeu e este cliente não tem oferta pendente deste tipo.
+ * Quem distingue isso de "não consegui ler" é o chamador, que já sabe se a leitura falhou.
+ */
+export function montarCelulaIndividual(
+  linha: LinhaMelhorIndividual | undefined,
+  nomeDoSku: (id: string) => string | undefined,
+): CelulaIndividual {
+  if (!linha) return { status: 'nenhum' };
+
+  const nomes: string[] = [];
+  for (const sku of linha.produtos) {
+    // `trim()` antes de aceitar: `if (nome)` deixava passar `"   "` — a célula renderizava um
+    // parágrafo em BRANCO, contado como resolvido no sensor e sem nenhum aviso na tela. O
+    // schema permite essa descrição e o sincronizador preserva os espaços (achado R5/2). Nome
+    // que não se lê não identifica produto nenhum: é a mesma ausência do SKU que sumiu.
+    const nome = nomeDoSku(sku)?.trim();
+    if (nome) nomes.push(nome);
+  }
+  if (nomes.length === 0) return { status: 'indisponivel', motivo: 'produto_nao_resolve' };
+
+  return {
+    status: 'encontrado',
+    situacao: linha.situacao,
+    nomes,
+    produtos: linha.produtos.length,
+    candidatos: linha.candidatos,
+  };
 }

--- a/src/lib/farmer/melhor-individual.ts
+++ b/src/lib/farmer/melhor-individual.ts
@@ -1,0 +1,152 @@
+/**
+ * O contrato da RPC `farmer_melhores_individuais_por_cliente` — e a validação que impede a
+ * resposta malformada de virar veredicto na tela.
+ *
+ * IDENTIDADE E ELEIÇÃO SÃO CAMPOS SEPARADOS, e essa é a peça central do desenho:
+ *
+ *   `produtos`       — os SKUs que a tela vai NOMEAR. Sempre ≥ 1.
+ *   `produto_eleito` — não-nulo **se e somente se** `situacao === 'eleito'`.
+ *
+ * Um campo único obrigava a escolher entre "só o eleito tem identidade" — e aí a tela não tem
+ * nome para mostrar quando não houve eleição, que é a maioria dos casos medidos — e "todo estado
+ * carrega product_id", que faz a tela renderizar um vencedor por descuido. Identificar produtos
+ * não exige afirmar prioridade entre eles.
+ *
+ * `candidatos` tem UM significado: o tamanho do grupo registrado. Em `[A:1, B:1, C:2]` saem
+ * `produtos=[A,B]` e `candidatos=3`, e a tela diz "2 de 3" — a frase verdadeira.
+ */
+
+export type SituacaoIndividual =
+  | 'eleito'
+  | 'empatado'
+  | 'unico_registrado'
+  | 'ordem_indisponivel'
+  | 'referencia_ambigua';
+
+const SITUACOES = new Set<string>([
+  'eleito',
+  'empatado',
+  'unico_registrado',
+  'ordem_indisponivel',
+  'referencia_ambigua',
+]);
+
+/** Os três estados que nomeiam o GRUPO INTEIRO — para eles `produtos` tem de cobrir tudo. */
+const NOMEIAM_O_GRUPO = new Set<string>([
+  'unico_registrado',
+  'ordem_indisponivel',
+  'referencia_ambigua',
+]);
+
+export interface LinhaMelhorIndividual {
+  customer_user_id: string;
+  recommendation_type: 'cross_sell' | 'up_sell';
+  situacao: SituacaoIndividual;
+  produtos: string[];
+  produto_eleito: string | null;
+  candidatos: number;
+  affinity_score: number | null;
+  run_id: string | null;
+}
+
+/**
+ * Formato uuid. Checar `typeof === 'string'` NÃO basta (achado do challenge): um
+ * `customer_user_id` inválido some silenciosamente na consulta pela chave do Map — e sumir é
+ * indistinguível de "este cliente não tem oferta", que é um VEREDICTO na tela. Um SKU inválido
+ * viraria `produto_nao_resolve`, culpando o catálogo por um defeito da resposta.
+ */
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Valida a resposta INTEIRA — e lança, em vez de filtrar.
+ *
+ * Descartar as linhas inválidas transformaria falha em ausência: o Map ficaria parcial e seria
+ * apresentado como completo. O consumidor trata a exceção como `leitura_falhou`, que vale para a
+ * carteira inteira e é honesto sobre o que não se sabe.
+ *
+ * Os invariantes ENTRE campos são o ponto. Campo a campo,
+ * `{situacao:'empatado', candidatos:1, produtos:[]}` passa em "tipo reconhecido", "inteiro ≥ 1" e
+ * "sem eleito fora de eleito" — e não representa empate nenhum.
+ */
+export function validarRespostaMelhorIndividual(data: unknown): LinhaMelhorIndividual[] {
+  if (!Array.isArray(data)) {
+    throw new Error(
+      `farmer_melhores_individuais_por_cliente devolveu ${data === null ? 'null' : typeof data} em vez de array`,
+    );
+  }
+
+  const vistos = new Set<string>();
+  return data.map((bruta, i) => {
+    const l = (bruta ?? {}) as Record<string, unknown>;
+    const onde = `linha ${i}`;
+
+    if (typeof l.customer_user_id !== 'string' || !UUID.test(l.customer_user_id)) {
+      throw new Error(`${onde}: customer_user_id não é uuid`);
+    }
+    if (l.recommendation_type !== 'cross_sell' && l.recommendation_type !== 'up_sell') {
+      throw new Error(`${onde}: tipo desconhecido ${String(l.recommendation_type)}`);
+    }
+    const chave = `${l.customer_user_id}:${l.recommendation_type}`;
+    if (vistos.has(chave)) throw new Error(`${onde}: (cliente,tipo) duplicado`);
+    vistos.add(chave);
+
+    const situacao = l.situacao;
+    if (typeof situacao !== 'string' || !SITUACOES.has(situacao)) {
+      throw new Error(`${onde}: situacao inválida ${String(situacao)}`);
+    }
+    const candidatos = l.candidatos;
+    if (typeof candidatos !== 'number' || !Number.isInteger(candidatos) || candidatos < 1) {
+      throw new Error(`${onde}: candidatos precisa ser inteiro >= 1`);
+    }
+    const produtos = l.produtos;
+    if (!Array.isArray(produtos) || produtos.length < 1) {
+      throw new Error(`${onde}: produtos precisa ser array não-vazio`);
+    }
+    if (!produtos.every((p) => typeof p === 'string' && UUID.test(p))) {
+      throw new Error(`${onde}: produtos contém item que não é uuid`);
+    }
+    if (new Set(produtos).size !== produtos.length) {
+      throw new Error(`${onde}: produtos com duplicata`);
+    }
+    if (produtos.length > candidatos) {
+      throw new Error(`${onde}: produtos (${produtos.length}) excede candidatos (${candidatos})`);
+    }
+
+    const eleito = situacao === 'eleito';
+    const temEleito = l.produto_eleito != null;
+    if (temEleito !== eleito) {
+      throw new Error(`${onde}: produto_eleito não-nulo tem de ser exatamente o estado eleito`);
+    }
+    if (eleito && !produtos.includes(l.produto_eleito as string)) {
+      throw new Error(`${onde}: produto_eleito fora de produtos`);
+    }
+
+    // Cardinalidade POR estado — o que a validação campo a campo não alcança.
+    if (eleito && (produtos.length !== 1 || candidatos < 2)) {
+      throw new Error(`${onde}: eleito exige 1 produto nomeado e >= 2 candidatos`);
+    }
+    if (situacao === 'empatado' && (produtos.length < 2 || candidatos < 2)) {
+      throw new Error(`${onde}: empatado exige >= 2 produtos e >= 2 candidatos`);
+    }
+    // Os três estados sem ordenação confiável prometem transportar TODOS os registrados. Sem
+    // esta igualdade, `ordem_indisponivel` com candidatos=3 e produtos=[A,B] passaria — e a
+    // tela diria "3 registradas" mostrando 2, escondendo uma oferta sem dizer que escondeu.
+    if (NOMEIAM_O_GRUPO.has(situacao) && produtos.length !== candidatos) {
+      throw new Error(
+        `${onde}: ${situacao} exige produtos (${produtos.length}) = candidatos (${candidatos})`,
+      );
+    }
+    if (situacao === 'unico_registrado' && candidatos !== 1) {
+      throw new Error(`${onde}: unico_registrado exige exatamente 1 candidato`);
+    }
+
+    if (l.run_id != null && (typeof l.run_id !== 'string' || !UUID.test(l.run_id))) {
+      throw new Error(`${onde}: run_id presente mas não é uuid`);
+    }
+    if (l.affinity_score != null && typeof l.affinity_score !== 'number' && typeof l.affinity_score !== 'string') {
+      throw new Error(`${onde}: affinity_score em formato inesperado`);
+    }
+
+    return l as unknown as LinhaMelhorIndividual;
+  });
+}

--- a/src/lib/farmer/rank-denso.ts
+++ b/src/lib/farmer/rank-denso.ts
@@ -1,0 +1,31 @@
+/**
+ * Rank DENSO 1-based sobre um comparador — a peça que faz a ordem sobreviver à persistência.
+ *
+ * O motor calculava a ordem em memória e a jogava fora ao gravar: `farmer_recommendations` não
+ * tinha coluna de rank, e a leitura desempatava por `affinity_score` → `updated_at` → `id`. Os
+ * dois primeiros empatam (medido em prod, 07/09/2026: 183 de 183 pares up-sell), então quem
+ * elegia era o `id` uuid v4. Persistir o rank é o que fecha esse caminho.
+ *
+ * ⚠️ DENSO e não posicional. Candidatos que o comparador não separa recebem o MESMO número.
+ * Numerar 1, 2, 3 entre empatados apenas trocaria o ENDEREÇO do defeito: em vez de "vence o menor
+ * uuid" passaria a ser "vence o menor índice do array" — e o array vem da varredura do catálogo,
+ * que é ordenada por `id`. Mesmo sorteio, com um nome mais respeitável.
+ *
+ * ⚠️ O empate é derivado do PRÓPRIO comparador (`comparar(a, b) === 0`), nunca de um predicado
+ * paralelo. Dois critérios de igualdade divergem no dia em que um dos dois muda, e a divergência
+ * apareceria como eleição fabricada — o comparador diria "empataram" e o rank diria "este venceu".
+ */
+export function rankDenso<T>(itens: readonly T[], comparar: (a: T, b: T) => number): number[] {
+  // Ordena ÍNDICES, não os itens: o chamador precisa dos ranks alinhados à entrada, e ordenar a
+  // entrada perderia essa correspondência (além de mutar o array de quem chamou).
+  const indices = itens.map((_, i) => i);
+  indices.sort((x, y) => comparar(itens[x], itens[y]));
+
+  const ranks = new Array<number>(itens.length);
+  let rank = 0;
+  for (let p = 0; p < indices.length; p++) {
+    if (p === 0 || comparar(itens[indices[p - 1]], itens[indices[p]]) !== 0) rank++;
+    ranks[indices[p]] = rank;
+  }
+  return ranks;
+}

--- a/src/lib/farmer/referencia-ambigua.ts
+++ b/src/lib/farmer/referencia-ambigua.ts
@@ -1,0 +1,94 @@
+/**
+ * Quando o preço de REFERÊNCIA de um cliente foi decidido por uuid — e por que a marca é do
+ * cliente, não da linha.
+ *
+ * `compararRecencia` (`preco-referencia.ts`) ordena por instante → pedido → ordem de leitura →
+ * posição. O primeiro critério é observado; o SEGUNDO é o `pedidoId`, um uuid v4. Quando dois
+ * pedidos DISTINTOS empatam no instante — datas iguais, ou ambas ausentes — quem define o preço
+ * de referência é o sorteio do uuid. E `razaoPreco = preçoDoCandidato / referência` é a chave
+ * PRIMÁRIA da ordem do up-sell desde o #1837: a referência sorteada troca o vencedor.
+ *
+ * ⚠️ POR QUE POR CLIENTE, e não pela linha derivada. O motor guarda, por SKU, apenas a melhor
+ * relação com uma base comprada — e a razão que decide essa "melhor" é justamente a que a
+ * referência sorteada altera. O challenge executou o contraexemplo: base A com dois pedidos no
+ * mesmo instante (preços 100 e 200) e base B inequívoca em 150; candidatos X=230 e Y=180. Com
+ * referência 100, X e Y são ambos melhores via B e a linha marcada é DESCARTADA na dedup —
+ * nenhuma flag sobrevive, e a RPC elegeria Y embora trocar só os uuids mude o topo. A marca
+ * precisa sobreviver a elegibilidade, deduplicação e corte, e só o cliente vive mais que as três.
+ *
+ * ⚠️ POR QUE REDUZIR POR PEDIDO ANTES DE COMPARAR. Comparar cada item com a referência corrente,
+ * par a par, erra dos DOIS lados (achado da rodada 4 do challenge):
+ *
+ *   ESCAPE  · o comparador também desempata DENTRO do mesmo pedido, pela posição. Dois pedidos P
+ *             e Q no mesmo instante, P com preços [100, 200] e Q com [200, 100]: o primeiro item
+ *             de Q tem o mesmo preço da referência corrente (não dispara), e o segundo muda o
+ *             preço mas pertence ao MESMO pedido (não dispara). A referência final é 100 ou 200
+ *             conforme o uuid, com a flag `false` nos dois mundos.
+ *   EXCESSO · um empate HISTÓRICO ligaria a marca antes de aparecer um pedido estritamente mais
+ *             recente e inequívoco, que torna o empate antigo irrelevante.
+ *
+ * Por isso: primeiro cada (cliente, SKU, pedido) é reduzido ao preço que a regra INTRA-pedido
+ * escolhe — determinística, sem uuid —; depois só os pedidos empatados na recência MÁXIMA são
+ * comparados entre si. Ambiguidade é dois pedidos distintos, no topo, com preços diferentes.
+ */
+
+/** Os pedidos que disputam o topo de um (cliente, SKU), já reduzidos a um preço cada. */
+export interface TopoDeReferencia {
+  /**
+   * O instante máximo visto. `null` é o MENOS recente (o fail-closed de `compararRecencia`: sem
+   * data não se afirma recência) — e um `null` só chega ao topo quando nenhum pedido tem data.
+   */
+  instante: number | null;
+  /** pedidoId → o preço que a regra intra-pedido escolheu naquele pedido. */
+  precosPorPedido: Map<string, number>;
+}
+
+export function topoVazio(): TopoDeReferencia {
+  return { instante: null, precosPorPedido: new Map() };
+}
+
+/**
+ * Registra um preço observado, mantendo só os pedidos que disputam a recência máxima.
+ *
+ * Dentro de um MESMO pedido a última ocorrência vence, porque o laço do motor percorre as
+ * posições em ordem crescente e `compararRecencia` faz posição maior = mais recente. Isso é
+ * determinístico e por isso NÃO é ambiguidade — reduzir o pedido a um preço antes de comparar é
+ * o que separa "o uuid decidiu" de "a posição decidiu".
+ */
+export function registrarPrecoDoPedido(
+  topo: TopoDeReferencia,
+  instante: number | null,
+  pedidoId: string,
+  preco: number,
+): void {
+  const vazio = topo.precosPorPedido.size === 0;
+  // `null` perde de qualquer data. Sem isto um pedido sem `created_at` competiria de igual para
+  // igual com um datado, que é exatamente a afirmação que o fail-closed recusa fazer.
+  const maisRecente =
+    vazio ||
+    (instante !== null && topo.instante === null) ||
+    (instante !== null && topo.instante !== null && instante > topo.instante);
+  const empata =
+    !vazio && ((instante === null && topo.instante === null) || instante === topo.instante);
+
+  if (maisRecente) {
+    topo.instante = instante;
+    topo.precosPorPedido.clear();
+    topo.precosPorPedido.set(pedidoId, preco);
+    return;
+  }
+  if (empata) topo.precosPorPedido.set(pedidoId, preco);
+  // Mais antigo: descartado. Um empate histórico não torna a referência atual arbitrária.
+}
+
+/**
+ * A referência deste (cliente, SKU) foi decidida por uuid?
+ *
+ * Exige DOIS pedidos distintos no topo E preços diferentes entre eles. Dois pedidos empatados com
+ * o MESMO preço não geram ambiguidade: o uuid escolhe qual, e o valor resultante é o mesmo — não
+ * há decisão a contaminar.
+ */
+export function referenciaEhAmbigua(topo: TopoDeReferencia): boolean {
+  if (topo.precosPorPedido.size < 2) return false;
+  return new Set(topo.precosPorPedido.values()).size >= 2;
+}

--- a/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
@@ -111,7 +111,7 @@ vi.mock('@/integrations/supabase/client', () => ({
     rpc: (nome: string) => {
       // Leitura ATÔMICA do melhor individual: UMA tupla jsonb (array), não linhas paginadas.
       // `[]` = li e não há — que é o estado deste cenário. `null` seria FALHA, não vazio.
-      if (nome === 'farmer_melhor_individual_por_cliente') {
+      if (nome === 'farmer_melhores_individuais_por_cliente') {
         return Promise.resolve({ data: [], error: null });
       }
       // Paginada desde o #1782 — builder com `.order().range()`, não Promise crua.

--- a/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
+++ b/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
@@ -357,6 +357,12 @@ BEGIN
   -- o que acabou de ser gravado — e com DENOMINADOR, porque sem ele a fase seguinte volta a se
   -- decidir por "ninguém reclamou", que é ausência de dado.
   --
+  -- ⚠️ O universo é "grupos PENDENTES no instante da gravação", NÃO "eleições exibidas". Os dois
+  -- divergem sem concorrência nenhuma: um grupo `eleito` cujo único SKU saiu do catálogo ativo
+  -- conta como eleito aqui e vira `indisponivel` na tela, e o leitor pula cliente sem `profile`.
+  -- Chamar isto de "distribuição da tela" seria afirmar além do que ele mede (achado R5/1);
+  -- medir o exibido exige um sensor DEPOIS da projeção, que é outra entrega.
+  --
   -- ⚠️ Reusa a RPC de LEITURA em vez de reimplementar a precedência dos 5 estados. Duas cópias
   -- da mesma regra divergem no primeiro conserto que só uma recebe, e aí o sensor passa a medir
   -- uma tela que não existe. A ordem em que as duas funções aparecem NESTE arquivo não importa:
@@ -480,13 +486,21 @@ AS $fn$
            count(DISTINCT b.run_id)
              + (count(*) FILTER (WHERE b.run_id IS NULL) > 0)::int      AS geracoes,
            max(b.affinity_score)                                        AS affinity_score,
-           (array_agg(b.run_id ORDER BY b.run_id))[1]                   AS run_id_qualquer
+           (array_agg(b.run_id ORDER BY b.run_id))[1]                   AS run_id_qualquer,
+           -- Os NOMES do grupo inteiro, montados na varredura que ja acontece. Eles saiam de
+           -- uma subquery CORRELACIONADA por grupo la embaixo, e o challenge (rodada 5) contou
+           -- o custo: 3.858 clientes x 5 recomendacoes = 7.716 grupos varrendo `base` uma vez
+           -- cada, ~149 milhoes de verificacoes — e o sensor arrastou isso para DENTRO da
+           -- transacao de gravacao, segurando os locks. `AS MATERIALIZED` no CTE externo nao
+           -- alcanca subquery interna: quem paga o correlacionado e o plano, nao o CTE.
+           jsonb_agg(DISTINCT b.product_id ORDER BY b.product_id)        AS todos_ids
     FROM base b
     GROUP BY 1, 2
   ),
   topo AS (
     SELECT g.customer_user_id, g.recommendation_type,
-           count(DISTINCT b.product_id) AS no_topo
+           count(DISTINCT b.product_id) AS no_topo,
+           jsonb_agg(DISTINCT b.product_id ORDER BY b.product_id) AS topo_ids
     FROM grupo g
     JOIN base b USING (customer_user_id, recommendation_type)
     WHERE g.ordem_minima IS NOT NULL AND b.ordem = g.ordem_minima
@@ -512,6 +526,13 @@ AS $fn$
            END AS situacao
     FROM grupo g
     LEFT JOIN topo t USING (customer_user_id, recommendation_type)
+  ),
+  -- Os arrays chegam PRONTOS ao SELECT externo — ele so escolhe QUAL, pelo estado.
+  nomeado AS (
+    SELECT f.*, g.todos_ids, t.topo_ids
+    FROM final f
+    JOIN grupo g USING (customer_user_id, recommendation_type)
+    LEFT JOIN topo t USING (customer_user_id, recommendation_type)
   )
   SELECT coalesce(
            jsonb_agg(to_jsonb(m) ORDER BY m.customer_user_id, m.recommendation_type),
@@ -521,20 +542,12 @@ AS $fn$
            f.affinity_score, f.run_id,
            -- `eleito` e `empatado` nomeiam o TOPO; os tres estados sem ordenacao confiavel
            -- nomeiam o grupo INTEIRO — la nao existe topo que signifique alguma coisa.
-           (SELECT jsonb_agg(DISTINCT b.product_id ORDER BY b.product_id)
-              FROM base b
-             WHERE b.customer_user_id    = f.customer_user_id
-               AND b.recommendation_type = f.recommendation_type
-               AND (f.situacao NOT IN ('eleito', 'empatado') OR b.ordem = f.ordem_minima)
-           ) AS produtos,
-           CASE WHEN f.situacao = 'eleito' THEN
-             (SELECT (array_agg(b.product_id ORDER BY b.product_id))[1]
-                FROM base b
-               WHERE b.customer_user_id    = f.customer_user_id
-                 AND b.recommendation_type = f.recommendation_type
-                 AND b.ordem               = f.ordem_minima)
-           END AS produto_eleito
-    FROM final f
+           CASE WHEN f.situacao IN ('eleito', 'empatado') THEN f.topo_ids ELSE f.todos_ids END
+             AS produtos,
+           -- Em `eleito` o topo tem exatamente UM elemento (é o que o estado significa), entao
+           -- o primeiro do array E o eleito — sem segunda varredura para descobrir isso.
+           CASE WHEN f.situacao = 'eleito' THEN f.topo_ids->>0 END AS produto_eleito
+    FROM nomeado f
   ) m
 $fn$;
 

--- a/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
+++ b/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
@@ -72,6 +72,7 @@ DECLARE
   v_expiradas      integer;
   v_inseridas      integer;
   v_head_atual     uuid;
+  v_tipo_errado    integer;
 BEGIN
   -- 1) Gate de MENSAGEM (a RLS é quem autoriza — ver cabeçalho).
   IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
@@ -146,6 +147,21 @@ BEGIN
     RAISE EXCEPTION 'geração vigente mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
       coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
       USING ERRCODE = 'FG006';
+  END IF;
+
+  -- 6-pre) TIPO JSON BRUTO das chaves novas — antes do cast, porque o cast NÃO recusa.
+  -- `jsonb_to_recordset` encaminha o valor para a função de entrada do tipo, e `boolean_in`
+  -- aceita "false", "off" e "0"; `int2in` aceita "3". Um produtor defeituoso gravaria uma
+  -- NEGATIVA EXPLÍCITA de ambiguidade — ou uma ordem — em vez de ser recusado, e um teste
+  -- que só experimenta "talvez" fica verde sem provar a exigência (achado do challenge).
+  SELECT count(*) INTO v_tipo_errado
+  FROM jsonb_array_elements(p_linhas) AS e(linha)
+  WHERE (e.linha ? 'ordem'              AND jsonb_typeof(e.linha->'ordem')              NOT IN ('number','null'))
+     OR (e.linha ? 'referencia_ambigua' AND jsonb_typeof(e.linha->'referencia_ambigua') NOT IN ('boolean','null'));
+
+  IF v_tipo_errado > 0 THEN
+    RAISE EXCEPTION '% linha(s) com ordem não-numérica ou referencia_ambigua não-booleana — nada foi expirado',
+      v_tipo_errado USING ERRCODE = 'FG007';
   END IF;
 
   -- 6) VALIDAÇÃO ANTES DE MEXER (nada é expirado se o lote tem lixo).
@@ -401,8 +417,15 @@ AS $fn$
            count(*) FILTER (WHERE b.ordem IS NULL)                      AS sem_ordem,
            min(b.ordem)                                                 AS ordem_minima,
            bool_or(coalesce(b.referencia_ambigua, b.ordem IS NOT NULL)) AS ambigua,
+           -- Geracoes DISTINTAS no grupo. O `+ (… IS NULL)` nao e decoracao: `count(DISTINCT)`
+           -- IGNORA NULL, entao [G1, NULL] passaria por coerente. A trigger trg_frec_exige_run_id
+           -- torna run_id nulo impossivel em `pendente` hoje — e e justamente por isso que a
+           -- checagem tem de ser explicita: quando a trigger cair, a falha tem de aparecer aqui
+           -- em vez de virar uma eleicao entre universos diferentes.
+           count(DISTINCT b.run_id)
+             + (count(*) FILTER (WHERE b.run_id IS NULL) > 0)::int      AS geracoes,
            max(b.affinity_score)                                        AS affinity_score,
-           (array_agg(b.run_id ORDER BY b.run_id))[1]                   AS run_id
+           (array_agg(b.run_id ORDER BY b.run_id))[1]                   AS run_id_qualquer
     FROM base b
     GROUP BY 1, 2
   ),
@@ -416,10 +439,18 @@ AS $fn$
   ),
   final AS (
     SELECT g.customer_user_id, g.recommendation_type, g.candidatos, g.ordem_minima,
-           g.affinity_score, g.run_id,
+           g.affinity_score,
+           -- Geracao INCOERENTE nao transporta run_id: mandar um dos dois esconderia a mistura
+           -- do proprio canario do leitor, que conta geracoes distintas EXIBIDAS.
+           CASE WHEN g.geracoes = 1 THEN g.run_id_qualquer END AS run_id,
            CASE
              WHEN g.ambigua                              THEN 'referencia_ambigua'
-             WHEN g.candidatos >= 2 AND g.sem_ordem > 0  THEN 'ordem_indisponivel'
+             -- Rank so e comparavel DENTRO de uma geracao: `ordem 1` de G1 contra `ordem 2` de
+             -- G2 sao universos diferentes, e elegeria o primeiro sem que nada os tenha
+             -- comparado. O writer normal nao produz isso (ele substitui a geracao inteira),
+             -- mas NAO e invariante da tabela — a trigger exige run_id, nao geracao unica.
+             WHEN g.geracoes > 1
+               OR (g.candidatos >= 2 AND g.sem_ordem > 0) THEN 'ordem_indisponivel'
              WHEN g.candidatos = 1                       THEN 'unico_registrado'
              WHEN coalesce(t.no_topo, 2) > 1             THEN 'empatado'
              ELSE                                             'eleito'

--- a/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
+++ b/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
@@ -73,6 +73,9 @@ DECLARE
   v_inseridas      integer;
   v_head_atual     uuid;
   v_tipo_errado    integer;
+  v_eleitos        integer;
+  v_grupos         integer;
+  v_distribuicao   jsonb;
 BEGIN
   -- 1) Gate de MENSAGEM (a RLS é quem autoriza — ver cabeçalho).
   IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
@@ -344,9 +347,61 @@ BEGIN
     v_head_atual := p_head_visto;
   END IF;
 
+  -- ── O SENSOR DA DISTRIBUIÇÃO ───────────────────────────────────────────────────────────
+  --
+  -- A distribuição por situação NÃO é derivável do banco antes da entrega: a mudança de ordem
+  -- em memória (D3) altera QUAIS SKUs são persistidos, e o challenge executou o contraexemplo
+  -- (N=269, k=[9,9,9,10]: a ordem antiga persiste A/B/C e encontra empate, a nova persiste
+  -- D/A/B e encontra vencedor único). "Empate entre os produtos persistidos" não demonstra
+  -- ausência de vencedor entre os candidatos que o motor verá. Então ela é MEDIDA, aqui, sobre
+  -- o que acabou de ser gravado — e com DENOMINADOR, porque sem ele a fase seguinte volta a se
+  -- decidir por "ninguém reclamou", que é ausência de dado.
+  --
+  -- ⚠️ Reusa a RPC de LEITURA em vez de reimplementar a precedência dos 5 estados. Duas cópias
+  -- da mesma regra divergem no primeiro conserto que só uma recebe, e aí o sensor passa a medir
+  -- uma tela que não existe. A ordem em que as duas funções aparecem NESTE arquivo não importa:
+  -- plpgsql resolve a chamada em RUNTIME, e o harness prova a chamada EXECUTANDO.
+  --
+  -- Ela é SECURITY INVOKER e este writer também, então a `frec_select_carteira` continua sendo
+  -- a fronteira: o sensor conta exatamente o que este usuário poderia ver.
+  --
+  -- `AS MATERIALIZED` não é estilo: sem ele o planner pode INLINE o CTE e executar a RPC uma
+  -- vez por referência — três varreduras da carteira inteira (3.858 clientes na maior) para
+  -- produzir um número. Com ele a chamada acontece UMA vez e as três leituras são do resultado.
+  WITH grupos AS MATERIALIZED (
+    SELECT
+      j->>'recommendation_type' AS tipo,
+      j->>'situacao'            AS situacao
+    FROM jsonb_array_elements(public.farmer_melhores_individuais_por_cliente(p_farmer_id)) j
+  ),
+  por_chave AS (
+    SELECT tipo || ':' || situacao AS chave, count(*) AS n
+    FROM grupos GROUP BY 1
+  )
+  SELECT
+    (SELECT count(*) FROM grupos WHERE situacao = 'eleito'),
+    (SELECT count(*) FROM grupos),
+    -- `coalesce` para `{}`: carteira sem grupo nenhum devolve NULL do agregado, e NULL aqui
+    -- seria indistinguível de "o sensor não rodou" — a mesma confusão que o `[]` da RPC evita.
+    coalesce((SELECT jsonb_object_agg(chave, n) FROM por_chave), '{}'::jsonb)
+  INTO v_eleitos, v_grupos, v_distribuicao;
+
   PERFORM public.farmer_geracao_registrar(
     'cross_sell', p_farmer_id, p_run_id, 'linhas', v_inseridas,
-    p_completude, p_motivo, p_insumos, v_head_atual
+    p_completude, p_motivo,
+    -- `||` do lado DIREITO: a chave do sensor nunca sobrescreve o que o produtor mediu, e um
+    -- `p_insumos` nulo vira `{}` para que a evidência nova não se perca junto com a ausência.
+    coalesce(p_insumos, '{}'::jsonb) || jsonb_build_object(
+      'individuais_eleicao', jsonb_build_object(
+        -- Inerte por construção (`ok:true`, sem `pisoCobertura`): mede sem julgar, como as
+        -- demais evidências do §13 — degradar o head por causa dela travaria a fase 2.
+        'ok', true,
+        'n', v_eleitos,
+        'esperado', v_grupos,
+        'distribuicao', v_distribuicao
+      )
+    ),
+    v_head_atual
   );
 
   RETURN jsonb_build_object(

--- a/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
+++ b/supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql
@@ -1,0 +1,466 @@
+-- A ordem do "melhor individual" para de ser uuid — e a tela para de chamar sorteio de veredicto
+--
+-- O DEFEITO, medido em prod (psql-ro, 07/09/2026, 1.083 recomendacoes pendentes). Sao DOIS,
+-- independentes, e consertar um nao fecha o outro:
+--
+--   ENTRE TIPOS · `affinity_score` recebe valor de dois motores incomensuraveis. cross-sell faz
+--     `0,15 x health x engagement x relevance`; up-sell faz `0,10 x health x engagement x 0,8`.
+--     health e engagement CANCELAM, entao up vence <=> relevance < 0,5333 — e up venceu 186 de
+--     186 pares. Nao e "artefato de escala": e um limiar bem definido que o cross-sell chegou a
+--     0,5041 de cruzar. Precedencia de tipo NAO DECLARADA, nascida de uma coincidencia numerica.
+--
+--   DENTRO DO up_sell · para 183 dos 186 clientes com 2 ofertas, `affinity_score`, `updated_at` e
+--     `created_at` empatam nos 183. Quem elege e o `id` (uuid v4). A ordem que o #1837 calculou
+--     em memoria e DESCARTADA na persistencia. E `created_at` nao a recupera: desde a
+--     20260814223445 a geracao inteira entra num INSERT so, e `now()` e o instante da TRANSACAO.
+--
+--   Somados: 235 de 238 pares (98,7%) tem o produto eleito escolhido pelo uuid.
+--
+-- O QUE ESTA MIGRATION FAZ (spec: docs/superpowers/specs/2026-09-07-rpc-melhor-individual-ordem-design.md):
+--   1. `ordem` — rank DENSO, para a ordem sobreviver a persistencia;
+--   2. `referencia_ambigua` — a ambiguidade a montante do rank vira dado, nao suposicao;
+--   3. o writer aceita e VALIDA as duas;
+--   4. `farmer_melhores_individuais_por_cliente` — nome NOVO, um objeto por (cliente, TIPO).
+--
+-- ⚠️ NAO derruba `farmer_melhor_individual_por_cliente`. Ela serve o front antigo ate o Publish
+--    ser ADOTADO pelo cliente (o SW so troca de build no clique). Derrubar aqui quebraria a aba
+--    aberta de quem ainda nao atualizou. A limpeza e um PR posterior.
+--
+-- ⚠️ NAO faz backfill. A ordem nao e recuperavel das colunas existentes, e re-derivar com precos
+--    de HOJE sobre uma geracao de 21/08 fabricaria numero. Os 1.083 pendentes nascem com `ordem`
+--    nula e a RPC os apresenta como `ordem_indisponivel` — que e a verdade.
+-- ============================================================================================
+
+-- GUARD DE ORDEM DE APPLY: sem o writer de 8 parametros (20260815181500, o que tem `p_head_visto`)
+-- o CREATE OR REPLACE abaixo CRIARIA uma funcao nova em vez de substituir a existente, deixando
+-- duas sobrecargas e um `.rpc()` ambiguo. Abortar nomeando a dependencia e mais barato que isso.
+DO $guard$
+BEGIN
+  IF to_regprocedure('public.farmer_recomendacoes_substituir(uuid,uuid,uuid,jsonb,text,text,jsonb,uuid)') IS NULL THEN
+    RAISE EXCEPTION 'DEPENDENCIA FALTANDO: aplique antes a 20260815181500_farmer_geracao_head_sensor.sql (writer com p_head_visto)';
+  END IF;
+END
+$guard$;
+
+-- ── 1) AS COLUNAS ───────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.farmer_recommendations
+  ADD COLUMN IF NOT EXISTS ordem              smallint,
+  ADD COLUMN IF NOT EXISTS referencia_ambigua boolean;
+
+COMMENT ON COLUMN public.farmer_recommendations.ordem IS
+  'Rank DENSO dentro de (farmer_id, customer_user_id, recommendation_type, run_id): candidatos que o sinal nao separou COMPARTILHAM o valor. NULL = geracao gravada por produtor que nao calcula rank (aceitacao declarada de perda de cobertura, spec §6). Numerar 1,2,3 entre empatados trocaria o endereco do defeito: de uuid para indice do array, que e a ordem de varredura do catalogo.';
+
+COMMENT ON COLUMN public.farmer_recommendations.referencia_ambigua IS
+  'up_sell: o preco de referencia deste CLIENTE saiu de um desempate por uuid em preco-referencia.ts (instante indistinguivel entre pedidos distintos, com precos diferentes). Marca do CLIENTE e nao da linha: a deduplicacao guarda por SKU so a melhor relacao, e a razao de preco que decide essa "melhor" e justamente a que a referencia sorteada altera — a flag da linha sumiria com a relacao descartada. cross_sell grava false explicito (o tipo nao usa preco). NULL = nao medido; NAO usar DEFAULT false, que afirmaria medicao sobre 17.316 linhas legadas.';
+
+-- ── 2) O WRITER, com as duas chaves no payload ──────────────────────────────────────────────
+-- CREATE OR REPLACE (nao DROP+CREATE): preserva o ACL. Corpo extraido de pg_get_functiondef da
+-- PROD em 07/09/2026 23:0x e alterado em 6 pontos — as duas listas de jsonb_to_recordset que
+-- importam (validacao e INSERT), a clausula de `ordem < 1`, a mensagem do FG007, e as colunas
+-- no INSERT. As outras duas listas de recordset (escopo de carteira) leem so `customer_user_id`
+-- e ficam intocadas.
+CREATE OR REPLACE FUNCTION public.farmer_recomendacoes_substituir(p_farmer_id uuid, p_run_id uuid, p_geracao_vista uuid, p_linhas jsonb, p_completude text DEFAULT NULL::text, p_motivo text DEFAULT NULL::text, p_insumos jsonb DEFAULT NULL::jsonb, p_head_visto uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_total          integer;
+  v_invalidas      integer;
+  v_fora_escopo        integer;
+  v_geracao_atual  uuid;
+  v_expiradas      integer;
+  v_inseridas      integer;
+  v_head_atual     uuid;
+BEGIN
+  -- 1) Gate de MENSAGEM (a RLS é quem autoriza — ver cabeçalho).
+  IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG001';
+  END IF;
+  -- ⚠️ `IS NOT TRUE`, não `NOT (...)`. Numa sessão SEM JWT (pg_cron, psql) `auth.uid()`
+  -- devolve NULL, então `p_farmer_id = auth.uid()` é NULL e a disjunção inteira vira
+  -- NULL — e `IF NOT NULL THEN` NÃO dispara em PL/pgSQL. Medido em prod:
+  --   NOT (false OR NULL OR false)          => NULL   (o RAISE nunca acontece)
+  --   (false OR NULL OR false) IS NOT TRUE  => true   (barra, como se quer)
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever substitui recomendações'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 2) FORMATO.
+  IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
+    RAISE EXCEPTION 'p_linhas deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_linhas), 'null') USING ERRCODE = 'FG002';
+  END IF;
+
+  v_total := jsonb_array_length(p_linhas);
+
+  -- 3) LOTE VAZIO = RECUSA, não "expira tudo e deixa o farmer sem oferta".
+  -- Zero recomendação quase sempre é dado faltando a montante (catálogo, scores,
+  -- get_skus_margem_positiva), não "este farmer não tem o que oferecer" — mesmo
+  -- raciocínio que farmer_association_rules_substituir aplica ao lote vazio.
+  -- ⚠️ Isto SEGUE valendo depois do head: quem tem geração legitimamente vazia
+  -- chama `farmer_geracao_registrar` (que move o head e não toca em linha nenhuma),
+  -- e não esta função. Afrouxar aqui religaria a expiração — que está FORA do escopo
+  -- desta fase por decisão explícita.
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: as % recomendação(ões) pendentes deste farmer foram preservadas',
+      (SELECT count(*) FROM public.farmer_recommendations
+        WHERE farmer_id = p_farmer_id AND status = 'pendente')
+      USING ERRCODE = 'FG003';
+  END IF;
+
+  -- Teto defensivo: a maior geração medida em prod tem ~1.000 linhas
+  -- (3 cross + 2 up por cliente). 50k é ~50x isso — folga sem ficar ilimitado.
+  IF v_total > 50000 THEN
+    RAISE EXCEPTION 'lote de % linhas excede o teto de 50000', v_total USING ERRCODE = 'FG004';
+  END IF;
+
+  -- 4) SERIALIZAÇÃO por FARMER (não global: duas vendedoras recalculando ao mesmo
+  -- tempo mexem em escopos disjuntos e não têm por que esperar uma pela outra).
+  -- `xact` = o lock sai sozinho no commit/rollback.
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext('farmer_recomendacoes_substituir'), hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo deste farmer está em andamento — nada foi alterado'
+      USING ERRCODE = 'FG005';
+  END IF;
+
+  -- 5) GUARD CAUSAL (compare-and-swap).
+  -- O advisory lock acima só cobre a TRANSAÇÃO da RPC — ele não cobre a janela
+  -- longa entre "o motor leu o snapshot" e "o motor chamou esta função". Sem este
+  -- guard, dois recálculos sobrepostos terminam com o MAIS LENTO vencendo, e o
+  -- mais lento é justamente o que leu o snapshot mais VELHO (money-path §10: o
+  -- degradado terminar depois do saudável é o desfecho esperado, não o azar).
+  -- NULL casa NULL: primeira execução, e as linhas legadas (run_id NULL).
+  SELECT run_id INTO v_geracao_atual
+  FROM public.farmer_recommendations
+  WHERE farmer_id = p_farmer_id AND status = 'pendente'
+  ORDER BY created_at DESC, id DESC
+  LIMIT 1;
+
+  IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN
+    RAISE EXCEPTION 'geração vigente mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
+      coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
+      USING ERRCODE = 'FG006';
+  END IF;
+
+  -- 6) VALIDAÇÃO ANTES DE MEXER (nada é expirado se o lote tem lixo).
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    affinity_score          numeric,
+    ordem                   smallint,
+    referencia_ambigua      boolean
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.product_id IS NULL
+     OR r.recommendation_type IS NULL
+     OR r.recommendation_type NOT IN ('cross_sell', 'up_sell')
+     -- Finitude nos TRÊS lados. `>= 0` sozinho NÃO sanea: medido em prod,
+     -- `'NaN' >= 0` é TRUE e `'Infinity' >= 0` é TRUE (money-path §2).
+     OR r.affinity_score IS NULL
+     OR NOT (
+          r.affinity_score >= 0
+          AND r.affinity_score < 'Infinity'::numeric
+          AND r.affinity_score <> 'NaN'::numeric
+        )
+     -- `ordem` e OPCIONAL (o produtor legado nao a emite, e §6 aceita essa perda de
+     -- cobertura), mas quando VEM tem de ser rank: 0 e negativo nao sao posicao.
+     -- Nao ha teto aqui — `smallint` ja explodiu no cast antes desta linha.
+     OR (r.ordem IS NOT NULL AND r.ordem < 1);
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % linha(s) inválidas (cliente/produto/tipo ausente, afinidade nula/negativa/NaN/Infinita, ou ordem < 1) — nada foi expirado',
+      v_invalidas, v_total USING ERRCODE = 'FG007';
+  END IF;
+  -- 6-bis) ESCOPO DE CARTEIRA — o cliente do lote precisa ser DESTE farmer.
+  --
+  -- `farmer_client_scores` tem UNIQUE (customer_user_id): o dono de um cliente é uma
+  -- FUNÇÃO, computável aqui dentro. Até esta versão a RPC aceitava qualquer cliente e
+  -- carimbava `p_farmer_id` por cima — foi por essa porta que o fallback do browser
+  -- ("carteira vazia ⇒ carregue TODOS os scores") gravou 2.676 linhas com `farmer_id` ≠
+  -- dono do cliente. Medido em prod (psql-ro, 21/08/2026): o lote de abril sob o farmer
+  -- 33f59dc7 cobria 166 clientes e só 25,9% eram dele, contra os 18,8% da base que ele
+  -- detém — a assinatura de quem sorteou da base inteira, não de quem leu a própria carteira.
+  --
+  -- O gate tinha que ser AQUI, não só no browser: o cliente não pode ser a autoridade
+  -- sobre o próprio escopo (#1840 — o browser reescrevia as regras do servidor por cima).
+  --
+  -- E o dano SOBREVIVE ao conserto do browser porque a etapa 7 expira
+  -- `WHERE farmer_id = p_farmer_id`: a linha do cliente C gravada sob A, quando o dono é B,
+  -- é INVISÍVEL ao recálculo de B — o dono real recalcula e ela segue pendente, dando ao
+  -- mesmo cliente duas gerações vivas ao mesmo tempo.
+  --
+  -- `IS DISTINCT FROM`, não `<>`: o cliente SEM linha de score precisa cair do MESMO lado.
+  -- `<>` com NULL devolve NULL, o `WHERE` descarta, e o cliente de dono desconhecido passaria
+  -- — exatamente o caso mais suspeito. Dono desconhecido é recusa, nunca "grave assim mesmo".
+  --
+  -- Isto é FAIL-CLOSED sob a RLS: a função é SECURITY INVOKER e `farmer_client_scores` só
+  -- se deixa ler por `cap_carteira_ler(uid) OR carteira_visivel_para(cliente, uid)`. Se a RLS
+  -- esconder do chamador a linha de um cliente alheio, o LEFT JOIN devolve NULL — e NULL é
+  -- recusado. A cegueira da RLS vira RECUSA, não passagem.
+  -- 6-ter) LOCK CAUSAL DO ESCOPO — a metade que a trigger de troca de dono NÃO cobre.
+  -- O guard do #1850 compara o lote com o dono LIDO aqui; a trigger nova
+  -- (private.farmer_expirar_pendentes_do_dono_anterior) expira o que já existia quando o
+  -- dono muda. Nenhum dos dois cobre a janela ENTRE eles:
+  --
+  --   T1 (esta RPC, farmer A)          T2 (reatribuição do cliente C para B)
+  --   ------------------------         -------------------------------------
+  --   FG009 lê score de C = A
+  --                                    UPDATE farmer_client_scores: C -> B
+  --                                    trigger expira as pendentes de C que existiam
+  --   INSERT da oferta C sob A         (a linha NOVA nasce depois da varredura)
+  --   COMMIT                           COMMIT
+  --
+  -- A oferta nova sobrevive fora de escopo. O advisory lock do passo 4 não ajuda: ele é
+  -- por FARMER, e quem reatribui não o toma. Travar as linhas de score do lote até o
+  -- COMMIT resolve nos dois sentidos — se a troca chega antes, ela espera e a trigger
+  -- alcança a linha nova; se chega depois, esta RPC já lê o dono novo e o FG009 recusa.
+  --
+  -- `FOR SHARE`, não `FOR KEY SHARE`: um UPDATE que não mexe em chave toma
+  -- `FOR NO KEY UPDATE`, que NÃO conflita com `FOR KEY SHARE` — o lock mais fraco
+  -- deixaria a corrida exatamente como estava, e o teste do caminho feliz seguiria verde.
+  -- `FOR SHARE` conflita, e é compartilhado: duas vendedoras com lotes disjuntos não se
+  -- esperam (só quem tenta REATRIBUIR espera).
+  --
+  -- O `ORDER BY` é best-effort contra deadlock (o PG não garante ordem de travamento sob
+  -- ORDER BY). A garantia real é a ordem de RECURSOS, que esta fatia mantém única em todo
+  -- o domínio: farmer_client_scores -> farmer_recommendations. A trigger segue a mesma
+  -- ordem (é disparada POR um UPDATE em scores e só então toca recomendações), então não
+  -- há ciclo a inverter.
+  --
+  -- Cliente do lote SEM linha de score não trava nada — não há linha. Não é buraco: o
+  -- FG009 logo abaixo recusa o lote inteiro nesse caso (dono desconhecido é recusa).
+  PERFORM 1
+    FROM public.farmer_client_scores s
+   WHERE s.customer_user_id IN (
+           SELECT DISTINCT c.customer_user_id
+             FROM jsonb_to_recordset(p_linhas) AS c(customer_user_id uuid)
+            WHERE c.customer_user_id IS NOT NULL
+         )
+   ORDER BY s.customer_user_id
+     FOR SHARE;
+
+  SELECT count(*) INTO v_fora_escopo
+  FROM jsonb_to_recordset(p_linhas) AS r(customer_user_id uuid)
+  LEFT JOIN public.farmer_client_scores s ON s.customer_user_id = r.customer_user_id
+  WHERE s.farmer_id IS DISTINCT FROM p_farmer_id;
+
+  -- FG009, não FG008: o 008 JÁ É de outra defesa deste mesmo domínio — a trigger que barra
+  -- INSERT direto de pendente sem `run_id` (migration 20260814223445). Reusar o código
+  -- tornaria dois erros distintos indistinguíveis pela SQLSTATE, que é justamente o que um
+  -- chamador usa para decidir o que fazer. Verificado em prod: FG001–FG008 e FG101–FG107
+  -- ocupados; 009 livre.
+  IF v_fora_escopo > 0 THEN
+    RAISE EXCEPTION '% de % linha(s) são de cliente fora da carteira deste farmer — nada foi expirado',
+      v_fora_escopo, v_total USING ERRCODE = 'FG009';
+  END IF;
+
+  -- 7) A TROCA — os dois statements na MESMA transação.
+  -- Só 'pendente' é tocado: linha com desfecho ('ofertado'/'aceito'/'rejeitado')
+  -- é histórico e fica imutável. E é UPDATE, nunca DELETE.
+  UPDATE public.farmer_recommendations
+     SET status         = 'expirado',
+         expired_at     = clock_timestamp(),
+         expired_by_run = p_run_id,
+         updated_at     = clock_timestamp()
+   WHERE farmer_id = p_farmer_id
+     AND status = 'pendente';
+  GET DIAGNOSTICS v_expiradas = ROW_COUNT;
+
+  INSERT INTO public.farmer_recommendations (
+    farmer_id, customer_user_id, recommendation_type, product_id, current_product_id,
+    p_ij, m_ij, lie, affinity_score, complexity_factor, cluster_volume_estimate,
+    ordem, referencia_ambigua,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.recommendation_type, r.product_id, r.current_product_id,
+    r.p_ij,
+    -- m_ij e lie são DINHEIRO e saíram de cena no #1520 (o custo não chega mais ao
+    -- browser). Fixados em NULL aqui, não copiados do payload: o cliente não tem
+    -- como fabricá-los de volta.
+    NULL, NULL,
+    r.affinity_score, coalesce(r.complexity_factor, 1), coalesce(r.cluster_volume_estimate, 1),
+    -- Sem coalesce NENHUM nos dois: NULL aqui significa "o produtor nao mediu", e um
+    -- default afirmaria medicao que ninguem fez (money-path §2). Quem le fecha a falha
+    -- (a RPC trata flag NULL com ordem preenchida como ambigua).
+    r.ordem, r.referencia_ambigua,
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    current_product_id      uuid,
+    p_ij                    numeric,
+    affinity_score          numeric,
+    complexity_factor       numeric,
+    cluster_volume_estimate numeric,
+    ordem                   smallint,
+    referencia_ambigua      boolean
+  );
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+
+  -- 8) O HEAD, na MESMA transação — com o head que o CHAMADOR viu ANTES do cálculo.
+  --
+  -- ⚠️ A 1ª versão lia o head AQUI DENTRO e o passava adiante, o que satisfazia o CAS por
+  -- construção e abria a assimetria que o challenge Codex xhigh encontrou: um run VAZIO
+  -- que commita entre a leitura e a escrita de um run COM LINHAS não é visto pelo CAS da
+  -- etapa 5 (ele compara LINHAS, e o vazio não mexeu em linha nenhuma), então o run antigo
+  -- sobrescrevia um vazio mais novo. O sistema misturava duas ordens: frescor causal para
+  -- o vazio e ordem-de-commit para as linhas. Comparar o head ORIGINAL alinha as duas.
+  --
+  -- `p_completude IS NULL` é o marcador de chamador ANTERIOR ao sensor (assinatura de 4
+  -- args, bundle velho em cache): ele não tem head para declarar, então cai no head
+  -- corrente em vez de ser recusado por não saber de algo que não existia quando foi
+  -- escrito. Os dois sinais de "cliente antigo" são o mesmo, de propósito.
+  IF p_completude IS NULL THEN
+    SELECT run_id INTO v_head_atual
+    FROM public.farmer_geracao_vigente
+    WHERE motor = 'cross_sell' AND farmer_id = p_farmer_id;
+  ELSE
+    v_head_atual := p_head_visto;
+  END IF;
+
+  PERFORM public.farmer_geracao_registrar(
+    'cross_sell', p_farmer_id, p_run_id, 'linhas', v_inseridas,
+    p_completude, p_motivo, p_insumos, v_head_atual
+  );
+
+  RETURN jsonb_build_object(
+    'run_id',    p_run_id,
+    'expiradas', v_expiradas,
+    'inseridas', v_inseridas
+  );
+END;
+$function$;
+
+
+-- ── 3) A RPC NOVA ───────────────────────────────────────────────────────────────────────────
+-- Nome NOVO porque o CONTRATO mudou: uma linha por cliente virou uma por (cliente, TIPO), e o
+-- campo unico de produto virou identidade + eleicao separadas. Reusar o nome faria o front antigo
+-- receber uma resposta que ele interpreta errado em silencio.
+--
+-- ⚠️ IDENTIDADE E ELEICAO SAO CAMPOS SEPARADOS, e essa e a peca central:
+--   `produtos`       — os SKUs que a tela vai NOMEAR. Sempre >= 1.
+--   `produto_eleito` — nao-nulo se e somente se `situacao = 'eleito'`. Guard estrutural.
+-- Um campo unico obrigava a escolher entre "so o eleito tem identidade" (e ai a tela nao tem nome
+-- para mostrar quando nao ha eleicao) e "todo estado tem product_id" (e ai a tela renderiza um
+-- vencedor por descuido). Identificar produtos NAO exige afirmar prioridade entre eles.
+--
+-- ⚠️ `candidatos` tem UM significado: o tamanho do grupo registrado. Uma versao anterior fazia o
+-- campo contar conjunto diferente por estado — o consumidor teria de inferir o denominador do
+-- rotulo. Com `produtos` transportando quem e nomeado, `[A:1, B:1, C:2]` sai como
+-- produtos=[A,B], candidatos=3, e a tela pode dizer "2 de 3", que e a frase verdadeira.
+--
+-- ⚠️ PRECEDENCIA, nao tabela de condicoes soltas: a primeira que casa decide. Sem ela um grupo de
+-- um candidato COM ordem satisfaz "unico_registrado" e "topo unico" ao mesmo tempo.
+--   1 referencia_ambigua · 2 ordem_indisponivel · 3 unico_registrado · 4 empatado · 5 eleito
+-- Ambiguidade a montante invalida eleicao E empate: empate calculado sobre referencia sorteada
+-- nao e igualdade medida, e coincidencia de um sorteio.
+--
+-- ⚠️ FAIL-CLOSED em dois lugares: `coalesce(referencia_ambigua, ordem IS NOT NULL)` trata flag
+-- nula COM ordem preenchida como ambigua (par que so nasce de produtor que grava rank sem flag —
+-- impossivel enquanto os dois entram na mesma versao, e e por ser impossivel que a falha tem de
+-- ser fechada); e `coalesce(t.no_topo, 2) > 1` faz um topo nao-contado cair em `empatado`, nunca
+-- em `eleito`.
+--
+-- ⚠️ LIMITE DECLARADO: `run_id` e um por grupo. Se um grupo misturar geracoes — o que so acontece
+-- se o writer falhar —, esta RPC nao detecta; o canario do leitor conta geracoes ENTRE grupos,
+-- nao DENTRO de um.
+--
+-- SECURITY INVOKER de proposito, como a RPC que ela sucede: `frec_select_carteira` segue sendo a
+-- unica fronteira, e `p_farmer_id` e FILTRO, nao autorizacao. `coalesce(..., '[]')` mantem o par
+-- do contrato: `[]` = li e nao ha; NULL = a leitura falhou, e o caller LANCA.
+CREATE OR REPLACE FUNCTION public.farmer_melhores_individuais_por_cliente(p_farmer_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', pg_temp
+AS $fn$
+  WITH base AS (
+    SELECT r.customer_user_id, r.recommendation_type, r.product_id,
+           r.affinity_score, r.run_id, r.ordem, r.referencia_ambigua
+    FROM public.farmer_recommendations r
+    WHERE r.farmer_id = p_farmer_id
+      AND r.status = 'pendente'
+      -- fail-closed do #1800: sem score nao ha oferta, e ordenar por coluna toda-nula elegeria
+      -- um vencedor ARBITRARIO que a tela apresentaria como veredicto.
+      AND r.affinity_score IS NOT NULL
+  ),
+  grupo AS (
+    SELECT b.customer_user_id, b.recommendation_type,
+           count(DISTINCT b.product_id)                                 AS candidatos,
+           count(*) FILTER (WHERE b.ordem IS NULL)                      AS sem_ordem,
+           min(b.ordem)                                                 AS ordem_minima,
+           bool_or(coalesce(b.referencia_ambigua, b.ordem IS NOT NULL)) AS ambigua,
+           max(b.affinity_score)                                        AS affinity_score,
+           (array_agg(b.run_id ORDER BY b.run_id))[1]                   AS run_id
+    FROM base b
+    GROUP BY 1, 2
+  ),
+  topo AS (
+    SELECT g.customer_user_id, g.recommendation_type,
+           count(DISTINCT b.product_id) AS no_topo
+    FROM grupo g
+    JOIN base b USING (customer_user_id, recommendation_type)
+    WHERE g.ordem_minima IS NOT NULL AND b.ordem = g.ordem_minima
+    GROUP BY 1, 2
+  ),
+  final AS (
+    SELECT g.customer_user_id, g.recommendation_type, g.candidatos, g.ordem_minima,
+           g.affinity_score, g.run_id,
+           CASE
+             WHEN g.ambigua                              THEN 'referencia_ambigua'
+             WHEN g.candidatos >= 2 AND g.sem_ordem > 0  THEN 'ordem_indisponivel'
+             WHEN g.candidatos = 1                       THEN 'unico_registrado'
+             WHEN coalesce(t.no_topo, 2) > 1             THEN 'empatado'
+             ELSE                                             'eleito'
+           END AS situacao
+    FROM grupo g
+    LEFT JOIN topo t USING (customer_user_id, recommendation_type)
+  )
+  SELECT coalesce(
+           jsonb_agg(to_jsonb(m) ORDER BY m.customer_user_id, m.recommendation_type),
+           '[]'::jsonb)
+  FROM (
+    SELECT f.customer_user_id, f.recommendation_type, f.situacao, f.candidatos,
+           f.affinity_score, f.run_id,
+           -- `eleito` e `empatado` nomeiam o TOPO; os tres estados sem ordenacao confiavel
+           -- nomeiam o grupo INTEIRO — la nao existe topo que signifique alguma coisa.
+           (SELECT jsonb_agg(DISTINCT b.product_id ORDER BY b.product_id)
+              FROM base b
+             WHERE b.customer_user_id    = f.customer_user_id
+               AND b.recommendation_type = f.recommendation_type
+               AND (f.situacao NOT IN ('eleito', 'empatado') OR b.ordem = f.ordem_minima)
+           ) AS produtos,
+           CASE WHEN f.situacao = 'eleito' THEN
+             (SELECT (array_agg(b.product_id ORDER BY b.product_id))[1]
+                FROM base b
+               WHERE b.customer_user_id    = f.customer_user_id
+                 AND b.recommendation_type = f.recommendation_type
+                 AND b.ordem               = f.ordem_minima)
+           END AS produto_eleito
+    FROM final f
+  ) m
+$fn$;
+
+COMMENT ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) IS
+  'Motor de bundles: a melhor oferta individual de cada cliente POR TIPO (cross_sell e up_sell disputavam a mesma coluna de score sem regra comercial — up vencia 186 de 186). Uma tupla jsonb = um snapshot MVCC, e o cap de 1.000 do PostgREST some por construcao. Identidade (`produtos`) e separada de eleicao (`produto_eleito`, nao-nulo <=> situacao eleito): a tela nomeia sempre, e afirma prioridade so quando o sinal decidiu. `situacao` tem 5 estados avaliados por PRECEDENCIA (referencia_ambigua > ordem_indisponivel > unico_registrado > empatado > eleito). `[]` = li e nao ha; NULL nunca sai daqui, e o caller trata NULL como FALHA. SECURITY INVOKER: frec_select_carteira segue sendo a unica fronteira.';
+
+-- Privilegios: CREATE OR REPLACE preserva o ACL, mas na PRIMEIRA criacao nao ha ACL para
+-- preservar e vale o default do Supabase. Reemitidos NOMEANDO as roles (REVOKE de PUBLIC nao tira
+-- anon/authenticated, que sao concedidos por nome). Sob INVOKER o EXECUTE e so o direito de
+-- CHAMAR — quem decide quais linhas voltam e a RLS; `anon` sai porque chamada que nao pode
+-- devolver nada nao deve existir.
+REVOKE ALL ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.farmer_melhores_individuais_por_cliente(uuid) TO service_role;


### PR DESCRIPTION
## O defeito, medido em prod (07/09/2026, 1.083 recomendações pendentes)

`farmer_recommendations.affinity_score` recebe valores de **dois motores com escalas
incomensuráveis**, e a RPC ordenava por `(affinity_score DESC, updated_at DESC, id DESC)` **sem
filtrar tipo**. Dois defeitos independentes — consertar um não fecha o outro:

**Entre tipos.** up_sell venceu **186 de 186** pares. Não é regra comercial: health e engagement
se cancelam, e up vence ⟺ `relevance < 0,5333`; a relevance implícita máxima observada foi
`0,5041`. É precedência de tipo não declarada, nascida de artefato de escala.

**Dentro de up_sell.** Para 183 clientes com 2 ofertas, `affinity_score`, `updated_at` **e**
`created_at` empatam 183/183. Quem decide é o `id` (uuid v4), e a ordem que o motor calculou em
memória é descartada na persistência. `created_at` **não** recupera a ordem de inserção — desde a
`20260814223445` a geração inteira entra num INSERT só, e `now()` é o instante da transação. Não
havia conserto de graça por coluna existente.

E a tela mostrava só o nome do produto, então a limitação era **invisível para quem avalia o
bundle**.

## O que muda

**Banco** — colunas `ordem smallint` (rank **denso**: empatados compartilham o valor, em vez de
posições distintas que só mudariam o endereço do bug de uuid para índice de array) e
`referencia_ambigua boolean`. O writer valida `jsonb_typeof` **antes** do cast, porque
`boolean_in` aceita `"false"`/`"off"`/`0` e `int2in` aceita `"3"` — sem isso um produtor
defeituoso gravaria uma negativa explícita de ambiguidade.

**RPC nova** — uma linha por `(cliente, TIPO)`, com **identidade separada da eleição**:
`produtos` (array, sempre ≥1, o que a tela NOMEIA) e `produto_eleito` (não-nulo **se e somente
se** `situacao = 'eleito'`). Cinco estados por **precedência**: `referencia_ambigua` >
`ordem_indisponivel` > `unico_registrado` > `empatado` > `eleito`.

**Tela** — duas células rotuladas, "Melhor complementar" e "Melhor upgrade". A escolha entre elas
volta para quem conhece o cliente. **O rótulo é quem afirma prioridade, não a lista de nomes** —
por isso os produtos são nomeados em todo estado: sem isso, os **52 clientes cross-only**, onde
nenhuma eleição é recuperável, ficariam com uma célula que só avisa indisponibilidade permanente.

**Sensor server-side** — a distribuição por situação **não é previsível** antes da entrega (a
mudança de ordem em memória altera *quais* SKUs são persistidos), então ela é medida no writer,
com denominador. Sem isso a fase seguinte volta a se decidir por "ninguém reclamou".

## O que NÃO fiz

Não declarei `up_sell > cross_sell` para reproduzir o comportamento atual. O viés observado não
estabelece regra comercial — é justamente o que esta entrega existe para parar de fabricar.

## Prova

| camada | evidência | resultado |
|---|---|---|
| banco | `db/test-farmer-escopo-carteira.sh` (PG17, a migration REAL) | **67 asserts, 0 falhas** |
| banco — falsificação | 8 sabotagens SQL | todas com dente |
| TS | 5 suítes | **81 testes**, exit 0 |
| TS — falsificação | `bun run falsificar:individuais` | **8 de 8 com dente** |
| tipos · shell | `typecheck` · `lint:shell` | exit 0 · 0 achados |

**5 rodadas de challenge Codex, todas reprovando.** A 5ª reproduziu por execução: custo
quadrático que o sensor arrastou para dentro da transação de gravação (~149M verificações
segurando os locks do INSERT); `if (nome)` aceitando `"   "` e renderizando um parágrafo em
branco contado como resolvido; um `title` que diagnosticava desativação quando a causa podia ser
descrição vazia de produto ativo; e uma afirmação minha de que um motor novo quebraria no
compilador — não quebrava, e o cliente daquele tipo sumiria da lista em silêncio.

**E o que só a falsificação encontrou:** a suíte de integração da leitura inválida passava **pelo
motivo errado** — sabotar a cardinalidade do `empatado` a deixava verde, porque a linha era
recusada por outra checagem. Detalhe em §7.5 da spec.

## ⚠️ Deploy manual (3 camadas)

1. **Migration** — colar `supabase/migrations/20260907230000_farmer_ordem_e_referencia_ambigua.sql`
   no SQL Editor do Lovable. Ela **não** dropa a RPC antiga: o front atual segue servido até o
   Publish ser adotado.
2. **Publish** — o leitor novo só chega ao vendedor quando o cliente troca de build.
3. Sem backfill: `ordem` nasce `NULL` nas linhas existentes, o que as põe em
   `ordem_indisponivel` — o estado honesto para elas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)