### PR TITLE
feat(deploy): a canária ganha modo no `sonda:sql` — e o veredito passa a separar BUNDLE VELHO de CANÁRIA VERMELHA

### DIFF
--- a/db/test-canaria-veredito.sh
+++ b/db/test-canaria-veredito.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# test-canaria-veredito.sh — prova, EXECUTANDO, que o veredito do modo canária
+# (`bun run sonda:sql --canaria`) separa BUNDLE VELHO de CANÁRIA VERMELHA.
+#
+# POR QUE EXISTE: as duas classes têm desfechos OPOSTOS — bundle velho pede DEPLOY, canária
+# vermelha pede investigar a regressão — e o SQL que as separava era escrito à mão a cada
+# verificação (fecho do #2367: o bloco saiu do `sonda:sql` trocando `'probe'` por `'canary'` e
+# reescrevendo o CASE). Um CASE reescrito à mão erra a ORDEM dos ramos com facilidade, e o erro
+# mais caro é silencioso: a `generate-tactical-plan` responde HTTP **500** quando a canária dela
+# REPROVA, então julgar pelo status antes do eco `canary` lê regressão como bundle velho e manda
+# redeployar. Doc não ordena ramo de CASE: só teste que RODA a query prova a ordem.
+#
+# O SQL não é copiado — é GERADO pelo `scripts/sonda-versao-sql.ts` do repo, e o marcador esperado
+# é lido de volta DO PRÓPRIO SQL emitido. Assim um bump legítimo de `contrato` não quebra o teste,
+# e o teste continua provando o julgamento, não a constante.
+#
+# Uso:
+#   bash db/test-canaria-veredito.sh              # verde = os ramos discriminam
+#   bash db/test-canaria-veredito.sh --falsificar # controle verde + sabota o SQL e EXIGE vermelho
+set -uo pipefail
+
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT=5441
+export LC_ALL=C LANG=C  # sem isto o postmaster morre com "became multithreaded during startup"
+export PGVER=17   # consumido pelo db/lib/pg-harness.sh via source
+# Resolve o PGBIN do PG17 pelo harness (laptop, PGDG, `PGBIN_OVERRIDE`) em vez de cravar o
+# caminho do Homebrew: prova que só roda numa máquina é prova que ninguém repete.
+# shellcheck disable=SC1091  # o gate roda sem -x; o helper e versionado ao lado, em db/lib/
+. "$RAIZ/db/lib/pg-harness.sh"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pgtest-canaria.XXXXXX")"
+DATA="$TMP/data"; SOCK="$TMP"
+# shellcheck disable=SC2329  # invocada pelo `trap` abaixo
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# ------------------------------------------------- o SQL REAL, gerado pelo script ---
+# As três canárias BARATAS cobrem os três formatos de resposta que existem: topo (`copilot-analyze`),
+# envelope `data` (`omie-analytics-sync`) e topo com `success` (`omie-financeiro`). A CARA
+# (`generate-tactical-plan`) entra porque é a única cujo marcador mora no campo `versao` — e a única
+# que responde 500 numa canária vermelha.
+BARATAS="copilot-analyze omie-analytics-sync:doc_ambiguo_probe omie-financeiro"
+CARA="generate-tactical-plan"
+GERADO="$TMP/gerado.sql"
+# shellcheck disable=SC2086  # a lista de nomes é intencionalmente dividida em argumentos
+if ! (cd "$RAIZ" && bun scripts/sonda-versao-sql.ts --canaria $BARATAS "$CARA" --sem-rede) > "$GERADO" 2>"$TMP/gen.err"; then
+  echo "VERMELHO — o gerador falhou:"; cut -c1-400 "$TMP/gen.err"; exit 1
+fi
+# Sonda POSITIVA: geração vazia/silenciosa viraria suíte verde sobre SQL nenhum.
+grep -q 'AS veredito' "$GERADO" || { echo "VERMELHO — SQL gerado não tem CASE de veredito"; exit 1; }
+grep -q 'net.http_post' "$GERADO" || { echo "VERMELHO — SQL gerado não dispara nada"; exit 1; }
+
+# extrai_leitura <ordinal> <arquivo_sql> — o corpo do n-ésimo `format($sonda$…$sonda$`, que é o
+# bloco de LEITURA que o passo de disparo devolve. O `%1$L` (placeholder do mapa) e o `%%` (escape
+# do format) são desfeitos aqui, exatamente como o Postgres faria ao executar o passo 1 — que este
+# banco não pode rodar, porque não tem `net.http_post`.
+extrai_leitura() {
+  local n="$1" arq="$2"
+  awk -v alvo="$n" '
+    /^SELECT format\(\$sonda\$$/ { blocos++; if (blocos == alvo) { dentro = 1; next } }
+    /^\$sonda\$, m\.ids\)/      { if (dentro) exit }
+    dentro { print }
+  ' "$arq"
+}
+
+MAPA_BARATAS='{"copilot-analyze": 1001, "omie-analytics-sync:doc_ambiguo_probe": 1002, "omie-financeiro": 1003}'
+MAPA_CARA='{"generate-tactical-plan": 2001}'
+
+monta_leitura() { # <ordinal> <mapa-json> <arquivo_sql> -> stdout
+  extrai_leitura "$1" "$3" \
+    | sed "s|%1\$L|'$2'|" \
+    | sed 's|%%|%|g'
+}
+
+# ------------------------------------------ marcadores lidos DE VOLTA do SQL emitido ---
+# Digitá-los aqui recriaria, no teste, exatamente o defeito que a ferramenta fecha.
+marcador_de() { # <nome-da-canaria>
+  grep -o "('$1', '[a-z]*', '[^']*'" "$GERADO" | head -1 | sed "s/.*, '\([^']*\)'\$/\1/"
+}
+M_COPILOT="$(marcador_de 'copilot-analyze')"
+M_ANALYTICS="$(marcador_de 'omie-analytics-sync:doc_ambiguo_probe')"
+M_FINANCEIRO="$(marcador_de 'omie-financeiro')"
+M_TACTICAL="$(marcador_de 'generate-tactical-plan')"
+for par in "copilot:$M_COPILOT" "analytics:$M_ANALYTICS" "financeiro:$M_FINANCEIRO" "tactical:$M_TACTICAL"; do
+  [ -n "${par#*:}" ] || { echo "VERMELHO — não li o marcador de ${par%%:*} no SQL emitido"; exit 1; }
+done
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null 2>&1
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k $SOCK -c listen_addresses=" -l "$TMP/pg.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h "$SOCK" -U postgres canaria_verify
+P() { "$PGBIN/psql" -p "$PORT" -h "$SOCK" -U postgres -d canaria_verify "$@"; }
+
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE SCHEMA net;
+CREATE TABLE net._http_response (
+  id bigint PRIMARY KEY, status_code int, content text, created timestamptz NOT NULL
+);
+SQL
+
+# ------------------------------------------------------------------- asserções ---
+fail=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+
+# veredito <id-da-canaria> <arquivo-de-leitura> -> imprime o veredito daquela linha
+veredito() {
+  P -t -A -F'|' -f "$2" 2>/dev/null | awk -F'|' -v n="$1" '$1 == n { print $8 }'
+}
+
+# espera <descricao> <nome> <arquivo> <marca-esperada>
+# Casa a MARCA do ramo (ASCII, caixa fixa, sem -i), não "deu erro": um veredito que mudasse de
+# INDETERMINADO para CANARIA VERMELHA passaria num teste que só exigisse "não é verde".
+espera() {
+  local desc="$1" nome="$2" arq="$3" marca="$4" v
+  v="$(veredito "$nome" "$arq")"
+  case "$v" in
+    "$marca"*) ok "$desc" ;;
+    "")        bad "$desc — nenhuma linha para '$nome' (a leitura não parte de \`esperado\`?)" ;;
+    *)         bad "$desc — esperava '$marca…', veio '${v:0:90}'" ;;
+  esac
+}
+
+suite() {
+  local LB LC_ARQ
+  LB="$TMP/leitura-baratas.sql"; LC_ARQ="$TMP/leitura-cara.sql"
+  monta_leitura 1 "$MAPA_BARATAS" "$ALVO" > "$LB"
+  monta_leitura 2 "$MAPA_CARA"    "$ALVO" > "$LC_ARQ"
+  # Sonda POSITIVA do recorte: awk que não casa devolveria arquivo vazio e TODA asserção sairia
+  # "nenhuma linha" — que é vermelho, mas pelo motivo errado. Aqui ele é nomeado.
+  grep -q 'AS veredito' "$LB" || { bad "recorte do PASSO 2 saiu sem CASE de veredito"; return; }
+  grep -q 'AS veredito' "$LC_ARQ" || { bad "recorte do PASSO 4 saiu sem CASE de veredito"; return; }
+
+  # ---------------------------------------------------------- (A) o caso VERDE ---
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT","ok":true,"casos":{}}', now()),
+  -- envelope \`data\`: é assim que a omie-analytics-sync responde, e sem descer nele a canária
+  -- dela sairia como "sem eco" — bundle velho fabricado a partir de um bundle correto.
+  (1002, 200, '{"success":true,"data":{"canary":true,"contrato":"$M_ANALYTICS","ok":true}}', now()),
+  (1003, 200, '{"success":true,"action":"paginacao_probe","canary":true,"contrato":"$M_FINANCEIRO","ok":true}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT 9000 + g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 40) g;
+SQL
+  espera "verde: canary+contrato+ok os TRÊS presentes" 'copilot-analyze' "$LB" 'CANARIA VERDE'
+  espera "verde ATRAVÉS do envelope \`data\` (omie-analytics-sync)" 'omie-analytics-sync:doc_ambiguo_probe' "$LB" 'CANARIA VERDE'
+  espera "verde no topo com \`success\` (omie-financeiro)" 'omie-financeiro' "$LB" 'CANARIA VERDE'
+
+  # ------------------------------------------------------- (B) canária VERMELHA ---
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT","ok":false,"casos":{}}', now());
+SQL
+  espera "ok:false COM marcador batendo = CANARIA VERMELHA (regressão, não deploy)" \
+    'copilot-analyze' "$LB" 'CANARIA VERMELHA'
+
+  # A cara, no PASSO 4, com o marcador no campo \`versao\` E HTTP 500 — o par que a ordem dos
+  # ramos existe para separar. Status 500 antes do eco leria isto como recusa de bundle velho.
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (2001, 500, '{"canary":true,"versao":"$M_TACTICAL","ok":false,"resultados":[]}', now());
+SQL
+  espera "HTTP 500 COM eco canary é VERMELHA, não 'recusou o request'" \
+    'generate-tactical-plan' "$LC_ARQ" 'CANARIA VERMELHA'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (2001, 200, '{"canary":true,"versao":"$M_TACTICAL","ok":true,"resultados":[]}', now());
+SQL
+  espera "marcador no campo \`versao\` (generate-tactical-plan) fecha VERDE" \
+    'generate-tactical-plan' "$LC_ARQ" 'CANARIA VERDE'
+
+  # ------------------------------------------------ (C) contrato DIVERGENTE ---
+  # A armadilha 2 do deploy.md: o bundle velho carrega o expected VELHO e compara velho×velho,
+  # então responde ok:true. Julgar pelo `ok` sem o marcador leria isto como VERDE.
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"fatia-anterior-v0","ok":true,"casos":{}}', now());
+SQL
+  espera "contrato de OUTRA fatia com ok:true NÃO é verde" \
+    'copilot-analyze' "$LB" 'CANARIA DE OUTRA FATIA'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"ok":true,"casos":{}}', now());
+SQL
+  espera "canary:true SEM o campo do marcador = SEM MARCADOR (pré-versionamento)" \
+    'copilot-analyze' "$LB" 'CANARIA SEM MARCADOR'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT"}', now());
+SQL
+  espera "marcador batendo e SEM \`ok\` é fail-closed, não verde" \
+    'copilot-analyze' "$LB" 'CANARIA SEM VEREDITO'
+
+  # `ok` que não é booleano: os ramos de `IS NULL` e de `'false'` não o pegam, então é AQUI que a
+  # exigência de `ok = 'true'` no ramo verde vira carga. Sem esta linha essa conjunção seria
+  # inalcançável e a sabotagem que a remove ficaria VERDE — falsificação vazia disfarçada de teste.
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT","ok":"sim"}', now());
+SQL
+  espera "\`ok\` não-booleano não vira verde por omissão" \
+    'copilot-analyze' "$LB" 'INDETERMINADO'
+
+  # ------------------------------------------------------ (D) BUNDLE VELHO ---
+  # Nenhum destes é "canária vermelha": é canária AUSENTE, e o desfecho é deploy.
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"analysis":{"intent":"orcamento"},"tokens":812}', now());
+SQL
+  espera "200 SEM eco canary = rodou o FLUXO REAL (não é vermelha)" \
+    'copilot-analyze' "$LB" 'SEM CANARIA NO AR'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 401, '{"code":401,"message":"Unauthorized"}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT 9000 + g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 40) g;
+SQL
+  espera "401 com CRON_SECRET provado bom = SEM CANARIA NO AR" \
+    'copilot-analyze' "$LB" 'SEM CANARIA NO AR'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 401, '{"code":401}', now());
+SQL
+  espera "401 SEM controle de credencial é INDETERMINADO, nunca veredito" \
+    'copilot-analyze' "$LB" 'INDETERMINADO'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 404, '{"code":404}', now());
+SQL
+  espera "4xx sem eco = recusou o request, NADA executou" \
+    'copilot-analyze' "$LB" 'SEM CANARIA NO AR'
+
+  # ------------------------------------------------- (E) ausência de dado ---
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, NULL, NULL, now());
+SQL
+  espera "resposta ainda a caminho (status NULL) = AGUARDE" 'copilot-analyze' "$LB" 'AGUARDE'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  espera "id no mapa sem linha nenhuma = AGUARDE (não veredito negativo)" \
+    'copilot-analyze' "$LB" 'AGUARDE'
+
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT","ok":true}', now() - interval '95 minutes');
+SQL
+  espera "resposta FORA da janela não vira veredito de agora" \
+    'copilot-analyze' "$LB" 'INDETERMINADO'
+
+  # A linha que NÃO está no mapa: parte de `esperado`, então existe e diz o que falta.
+  local LSEM="$TMP/leitura-sem-mapa.sql"
+  monta_leitura 1 '{"copilot-analyze": 1001}' "$ALVO" > "$LSEM"
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<SQL
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 200, '{"canary":true,"contrato":"$M_COPILOT","ok":true}', now());
+SQL
+  espera "canária fora do mapa embutido = INDETERMINADO nomeando o passo" \
+    'omie-financeiro' "$LSEM" 'INDETERMINADO'
+}
+
+# ------------------------------------------------------------------- execução ---
+if [ "${1:-}" != "--falsificar" ]; then
+  printf '== canaria: BUNDLE VELHO x CANARIA VERMELHA ==\n'
+  ALVO="$GERADO"; suite
+  if [ "$fail" -eq 0 ]; then printf '\nVEREDITO DE CANARIA OK\n'; exit 0; fi
+  printf '\nVERMELHO\n'; exit 1
+fi
+
+# ---------------------------------------------------------------- falsificação ---
+printf '== falsificacao (sabota o SQL e EXIGE vermelho) ==\n'
+falhou=0
+utf8=""
+for cand in pt_BR.UTF-8 pt_BR.utf8 en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+  if [ "$(LC_ALL="$cand" locale charmap 2>/dev/null)" = "UTF-8" ]; then utf8="$cand"; break; fi
+done
+[ -n "$utf8" ] || { printf '  \033[31mFALHA\033[0m nenhum locale UTF-8 — metade da cobertura fingindo ser inteira\n'; exit 1; }
+
+# CONTROLE VERDE na MESMA invocação do laço, ANTES do primeiro sed — e pelo MESMO caminho que as
+# sabotagens usam (cópia em $TMP, os dois locales, `ALVO` sobrescrito). Sem ele, uma suíte
+# sempre-vermelha (por locale, por psql morto, por recorte quebrado) aprovaria TODA sabotagem, e a
+# suíte crua do modo normal é OUTRA invocação — não prova nada sobre este laço.
+CONTROLE="$TMP/controle.sql"
+cp "$GERADO" "$CONTROLE"
+controle_verde=0
+# shellcheck disable=SC2030  # o LC_ALL local ao subshell e o DESENHO: cada rodada da suite ve um
+#                              locale, e o pai continua em C. Idem SC2031 no laco de sabotagem.
+for loc in C "$utf8"; do
+  if ( export LC_ALL="$loc"; ALVO="$CONTROLE"; fail=0; suite >/dev/null 2>&1; [ "$fail" -eq 0 ] ); then
+    controle_verde=$((controle_verde + 1))
+  fi
+done
+if [ "$controle_verde" -ne 2 ]; then
+  printf '  \033[31mFALHA\033[0m controle NAO ficou verde (%d/2) — laco sempre-vermelho aprovaria toda sabotagem\n' "$controle_verde"
+  exit 1
+fi
+printf '  \033[32mok\033[0m   controle verde nos 2 locales (o laco distingue verde de vermelho)\n'
+
+sabota() { # <descricao> <expressao-sed>
+  local desc="$1" expr="$2" copia="$TMP/sabotado.sql" erro
+  erro="$(sed -E "$expr" "$GERADO" 2>&1 >"$copia")"
+  if [ -n "$erro" ]; then
+    printf '  \033[31mFALHA\033[0m "%s": sed invalido (%s) — falsificacao vazia\n' "$desc" "${erro:0:60}"; falhou=1; return
+  fi
+  if cmp -s "$GERADO" "$copia"; then
+    printf '  \033[31mFALHA\033[0m "%s": padrao nao casou, SQL intacto — falsificacao vazia\n' "$desc"; falhou=1; return
+  fi
+  local viu_vermelho=0 loc
+  # shellcheck disable=SC2031  # ver a nota do laco de controle: o escopo por subshell e o desenho
+  for loc in C "$utf8"; do
+    if ! ( export LC_ALL="$loc"; ALVO="$copia"; fail=0; suite >/dev/null 2>&1; [ "$fail" -eq 0 ] ); then
+      viu_vermelho=$((viu_vermelho + 1))
+    fi
+  done
+  if [ "$viu_vermelho" -eq 2 ]; then
+    printf '  \033[32mok\033[0m   "%s" -> suite vermelha nos 2 locales\n' "$desc"
+  else
+    printf '  \033[31mFALHA\033[0m "%s": suite ficou VERDE (%d/2 vermelhos) — assercao frouxa\n' "$desc" "$viu_vermelho"; falhou=1
+  fi
+}
+
+# ⚠️ Sabota-se UMA CAMADA POR VEZ, e a ordem abaixo é a lição: a primeira tentativa mirou as
+#    conjunções do ramo VERDE (`AND ... ok = 'true'`, `AND ... marcador = esperado`) e a suíte ficou
+#    VERDE nas duas — porque os ramos ESPECÍFICOS acima já interceptam esses casos. Não era asserção
+#    frouxa, era conjunção INALCANÇÁVEL pelos fixtures que existiam. Duas correções, ambas honestas:
+#    o fixture de `ok` não-booleano (acima) tornou a primeira alcançável, e a segunda é atacada onde
+#    ela decide de verdade — no ramo que NOMEIA a divergência.
+
+# (a1) O ramo que dá sentido ao arquivo: sem ele, "está no ar" vira "está correto".
+sabota "sem o ramo de ok:false (a vermelha perde o nome)" \
+  "s/WHEN l\.corpo ->> 'ok' = 'false'/WHEN false/"
+# (a2) A conjunção do ramo verde, agora ALCANÇÁVEL pelo fixture de \`ok\` não-booleano.
+sabota "verde deixa de exigir ok:true (ok nao-booleano vira verde)" \
+  "s/AND l\.corpo ->> 'ok' = 'true'//"
+# (b1) O ramo que nomeia a divergência de marcador.
+sabota "sem o ramo de marcador divergente (a outra fatia perde o nome)" \
+  "s/WHEN l\.corpo ->> l\.campo_marcador IS DISTINCT FROM l\.marcador_esperado/WHEN false/"
+# (b2) A armadilha 2 do deploy.md RECONSTRUÍDA: nada no CASE julga o marcador. O bundle velho
+#      compara velho x velho, responde ok:true, e o veredito sai CANARIA VERDE — mentindo verde.
+sabota "o CASE inteiro deixa de julgar o marcador (bundle velho MENTE VERDE)" \
+  "s/WHEN l\.corpo ->> l\.campo_marcador IS DISTINCT FROM l\.marcador_esperado/WHEN false/; s/AND l\.corpo ->> l\.campo_marcador = l\.marcador_esperado//"
+# (b3) O marcador esperado que sai do REPO vira um digitado qualquer: a canária no ar deixa de bater.
+sabota "marcador esperado fabricado no VALUES (repo deixa de mandar)" \
+  "s/(\('copilot-analyze', 'contrato', ')[^']*/\1marcador-fabricado-v0/"
+# (b4) O campo do marcador deixa de ser POR CANÁRIA: quem serve em \`versao\` some.
+sabota "marcador lido sempre de 'contrato' (a generate-tactical-plan some)" \
+  "s/l\.corpo ->> l\.campo_marcador/l.corpo ->> 'contrato'/g"
+# (c) A ORDEM dos ramos: julgar o status ANTES do eco faz a vermelha de HTTP 500 da
+#     generate-tactical-plan sair como 'recusou o request'.
+sabota "status julgado antes do eco (500 vermelha vira bundle velho)" \
+  "s/WHEN l\.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l\.status_code >= 400/WHEN l.status_code >= 400/"
+# (d) O envelope \`data\`: sem descer nele, as canárias da omie-analytics-sync somem para
+#     'sem eco' — um bundle correto classificado como velho.
+sabota "sem o COALESCE do envelope data (analytics vira 'sem eco')" \
+  "s/COALESCE\(x\.content::jsonb -> 'data', x\.content::jsonb\)/x.content::jsonb/"
+# (e) NULL-blind: trocar IS DISTINCT FROM por <> faz a chave AUSENTE devolver NULL, o ramo do
+#     eco não casa, e a resposta sem `canary` cai adiante no CASE.
+sabota "eco testado por <> (NULL-blind: chave ausente devolve NULL)" \
+  "s/l\.corpo ->> 'canary' IS DISTINCT FROM 'true'/l.corpo ->> 'canary' <> 'true'/g"
+# (f) A janela: sem ela, uma resposta de outra sessão vira veredito de agora.
+sabota "sem o guard de janela (resposta velha vira veredito de agora)" \
+  "/WHEN l\.created <= now\(\) - interval/,+3d"
+
+if [ "$falhou" -eq 0 ]; then printf '\nFALSIFICACAO OK — todo verde tem vermelho alcancavel\n'; exit 0; fi
+printf '\nVERMELHO\n'; exit 1

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -176,6 +176,25 @@ canary === true   E   contrato === '<marcador da fatia>'   E   ok === true
 | `omie-financeiro` | `paginacao_probe` | `paginacao-guards-v1` | guards de paginação do #1598: piso NÃO encolhe (vazia antes do fim = anomalia; velho: `\|\| 1` → "fim"), reversa só completa com sonda vazia (velho: `pagina < 1` → complete), fingerprint sem colisão (velho: `1ºcódigo:count`), resposta sem array LANÇA (velho: `\|\| []` → "página vazia" = fim) |
 | `copilot-analyze` | `{"canary":true}` | `tudo-ou-nada-normalizar-v1` | o tudo-ou-nada de `normalizarAnalise` (#2367): meia análise é `null`, confiança fora de 0–100 é `null`, enum inválido é `null` — e, nas duas direções, string numérica vira número e motivo não-string sai da lista sem derrubar a análise. **6 fixtures que se falsificam mutuamente** (helper sempre-`null` morre em 3, helper relaxado morre nos outros 3). ⚠️ Ela nasceu para o buraco que o #2362 NÃO fecha: aquele prova o que ENTRA no deploy (sha256 por arquivo, de `origin/main`), esta prova o que SAI |
 
+### Como DISPARAR (`bun run sonda:sql --canaria`)
+
+O SQL sai pronto do mesmo gerador da sonda — **não escreva `net.http_post` à mão**:
+
+```bash
+bun run sonda:sql --canaria                     # todas as alcançáveis pelo SQL Editor
+bun run sonda:sql --canaria copilot-analyze omie-financeiro
+```
+
+O que ele fecha, e por que cada um importa:
+
+- **O corpo é POR CANÁRIA** (a tabela acima tem quatro formas). Corpo errado não é "canária que não respondeu": a edge cai no **fluxo real** — na `carteira-rebuild` isso é o rebuild inteiro (lease + upserts), na `generate-tactical-plan` é token de LLM sem gate de auth na frente. Quem cai nessa classe sai em bloco **com trava**, e a trava vem do REGISTRO (`fluxoRealSeVelho`), não da memória de quem chama.
+- **O marcador esperado é DERIVADO do repo** pelo mesmo extrator do gate `canaria:bump` (`localizarCanarias`), nunca digitado — nas **duas** formas que ele conhece desde o #2374: `contrato: "<literal>"` (7 canárias) e `versao: VERSAO`, por referência ao símbolo do `versao.ts` (a `generate-tactical-plan`). O `campoMarcador` do registro é conferido contra a forma que o repo usa **nos dois sentidos**: canária que troque de forma RECUSA a geração até o registro acompanhar — sem isso, o sentido `versao`→`contrato` diria "sem marcador" (causa errada) e o inverso leria o marcador da SONDA achando que é o da canária.
+- **A `analyze-unified-order` é recusada**: a canária dela vive depois do gate de staff (JWT), o SQL Editor recebe 401, e 401 se lê como bundle velho. Ela é do APP LOGADO. (A **sonda** dela é alcançável.)
+- **PASSO 1 é do founder** (vault + INSERT) e devolve o **PASSO 2 já escrito, com o mapa `nome → request_id` dentro** — aqui isso não é conveniência: a resposta da canária **não ecoa o slug**, então sem o mapa nenhuma linha é atribuível. Por isso `--so-leitura` é recusado.
+- **BUNDLE VELHO ≠ CANÁRIA VERMELHA**, e o veredito diz qual é: ausência do eco `canary` (401 com controle de credencial, outro 4xx, ou **200 que rodou o fluxo real**) sai como `SEM CANARIA NO AR` — desfecho DEPLOY. Marcador divergente sai como `CANARIA DE OUTRA FATIA` (a armadilha 2 abaixo: o bundle velho compara velho×velho e responde `ok:true`). Só `ok:false` **com o marcador batendo** é `CANARIA VERMELHA` — desfecho investigar a regressão. ⚠️ O eco é julgado **antes** do status: a `generate-tactical-plan` responde **HTTP 500** quando a canária dela reprova.
+
+Prova executada (PG17 local, 18 asserções + 10 sabotagens com controle verde): `bash db/test-canaria-veredito.sh [--falsificar]`. Não entra no `nucleo-ci.txt` porque precisa de `bun` para gerar o SQL, e o job `provas-sql` é deliberadamente sem bun.
+
 ⚠️ **O `canaria:bump` só enxerga o `contrato` emitido como LITERAL no `index.ts`** (`RE_EMISSAO`, regex de `contrato: "..."`) — canária cujo marcador more num módulo da edge, ou saia por identificador, nasce FORA do único gate que vigia o bump dela, e o gate segue verde: MEDIDO no #2367, "6 canária(s) conferida(s)" antes e depois de a 7ª existir. Por isso a `copilot-analyze` duplica o marcador de propósito — literal no `index.ts` para o gate, constante em `canaria.ts` para o teste Deno — com a igualdade vigiada por `scripts/canaria-contrato-espelhado.test.ts`, que traz também o controle positivo da cegueira.
 
 

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -5,17 +5,25 @@ import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
+import { localizarCanarias } from './canaria-contrato-bump-gate';
+import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+
 import {
+  CANARIAS,
   escaparParaFormat,
   fatiaDaVerdade,
   gerarSqlDaLeva,
+  gerarSqlDasCanarias,
   gitReal,
   guardEfeitoLegado,
   main,
   parsearArgs,
+  resolverCanarias,
   resolverLeva,
   SENTINELA_MAPA,
+  type CanariaRegistrada,
   type ExecutorGit,
+  type LeitorCanariasDoRepo,
 } from './sonda-versao-sql';
 
 const RAIZ_REPO = join(import.meta.dirname, '..');
@@ -1232,5 +1240,503 @@ describe('parsearArgs — a flag do efeito legado', () => {
   });
   it('sem a flag, o campo fica indefinido (o guard trata como NÃO permitido)', () => {
     expect(parsearArgs(['monthly-report']).permitirEfeitoLegado).toBeUndefined();
+  });
+});
+
+// ==========================================================================================
+// MODO CANÁRIA
+// ==========================================================================================
+
+/** O leitor REAL — o mesmo que a CLI injeta. Testar com um leitor de mentira provaria o dublê. */
+const lerCanariasReal: LeitorCanariasDoRepo = (raiz, edge) =>
+  localizarCanarias(
+    removerComentarios(readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8')),
+  );
+
+/**
+ * Um `index.ts` de mentira que hospeda a canária no arm que a `chave` do registro nomeia.
+ *
+ * `forma: 'versao'` reproduz a `generate-tactical-plan`: o marcador não é literal, vem por
+ * REFERÊNCIA ao símbolo `VERSAO` — e é a forma que o `canaria:bump` só passou a enxergar no #2374.
+ */
+function corpoDaEdge(chave: string, marcador: string, forma: 'contrato' | 'versao' = 'contrato'): string {
+  if (forma === 'versao') {
+    return (
+      'Deno.serve(async (req) => {\n' +
+      '  if (body.canary === true) {\n' +
+      '    return json({ canary: true, versao: VERSAO, ok: true });\n' +
+      '  }\n' +
+      '});\n'
+    );
+  }
+  if (chave.startsWith('case:')) {
+    const rota = chave.slice('case:'.length);
+    return (
+      'Deno.serve(async (req) => {\n' +
+      '  const { action } = await req.json();\n' +
+      '  switch (action) {\n' +
+      `      case "${rota}": {\n` +
+      `        result = { canary: true, contrato: "${marcador}", ok: true };\n` +
+      '        break;\n' +
+      '      }\n' +
+      '  }\n' +
+      '});\n'
+    );
+  }
+  return (
+    'Deno.serve(async (req) => {\n' +
+    '  if (ehCanaria(req)) {\n' +
+    `    return json({ canary: true, contrato: "${marcador}", ok: true });\n` +
+    '  }\n' +
+    '});\n'
+  );
+}
+
+/**
+ * Repo de mentira com TODAS as edges do registro `CANARIAS`, cada uma emitindo o marcador que
+ * `sobrepor` disser (ou um derivado do nome). Um teste sabota UMA coisa a partir daqui.
+ */
+function fixtureCanarias(sobrepor: Record<string, string> = {}): string {
+  const raiz = mkdtempSync(join(tmpdir(), 'canaria-sql-'));
+  criadas.push(raiz);
+  mkdirSync(join(raiz, 'supabase', 'functions'), { recursive: true });
+  writeFileSync(join(raiz, 'supabase', 'config.toml'), 'project_id = "refdementira000000ab"\n');
+  const porEdge = new Map<string, CanariaRegistrada[]>();
+  for (const c of CANARIAS) porEdge.set(c.edge, [...(porEdge.get(c.edge) ?? []), c]);
+  for (const [edge, lista] of porEdge) {
+    const dir = join(raiz, 'supabase', 'functions', edge);
+    mkdirSync(dir, { recursive: true });
+    const corpo = lista
+      .map((c) => corpoDaEdge(c.chave, sobrepor[c.nome] ?? `marcador-de-${c.nome}-v1`, c.campoMarcador))
+      .join('\n');
+    writeFileSync(join(dir, 'index.ts'), corpo);
+    writeFileSync(
+      join(dir, 'versao.ts'),
+      `export const VERSAO = "${sobrepor[edge] ?? `versao-de-${edge}`}";\n`,
+    );
+  }
+  return raiz;
+}
+
+/**
+ * Um `git` que ESPELHA o disco: `show origin/main:<x>` devolve o próprio arquivo, então a fatia
+ * sai "em dia". O guard de sincronia é assunto do último bloco, e lá o espelho é quebrado de
+ * propósito — um fake que devolvesse string vazia diria "em dia" por acidente, não por desenho.
+ */
+function gitEspelho(raiz: string, divergir: string | null = null): ExecutorGit {
+  return (args) => {
+    if (args[0] === 'fetch') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'rev-parse') return { status: 0, stdout: 'abc123456789\n', stderr: '' };
+    if (args[0] === 'show') {
+      const caminho = args[1].slice(args[1].indexOf(':') + 1);
+      if (divergir !== null && caminho.includes(divergir)) {
+        return { status: 0, stdout: '// outro conteúdo\n', stderr: '' };
+      }
+      try {
+        return { status: 0, stdout: readFileSync(join(raiz, caminho), 'utf8'), stderr: '' };
+      } catch {
+        return { status: 1, stdout: '', stderr: 'no such path' };
+      }
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}
+
+describe('registro de canárias — o marcador SAI do repo, nunca do registro', () => {
+  it('contra o repo REAL: toda canária alcançável resolve, e o marcador é o que o index.ts emite', () => {
+    const alcancaveis = CANARIAS.filter((c) => c.inalcancavel === null).map((c) => c.nome);
+    const leva = resolverCanarias(RAIZ_REPO, alcancaveis, lerCanariasReal);
+    expect(leva).toHaveLength(alcancaveis.length);
+    for (const c of leva) {
+      expect(c.marcador, `${c.nome} sem marcador`).not.toBe('');
+      const emitido = lerCanariasReal(RAIZ_REPO, c.edge).find((e) => e.chave === c.chave);
+      expect(emitido, `${c.nome} não está no index.ts em ${c.chave}`).toBeDefined();
+      if (c.campoMarcador === 'contrato') {
+        expect(emitido?.contrato, `${c.nome} não bate com o index.ts`).toBe(c.marcador);
+      } else {
+        // Forma por REFERÊNCIA: o index.ts serve o símbolo, e o literal mora no `versao.ts`.
+        expect(emitido?.contrato, `${c.nome} deveria servir por referência`).toBeNull();
+        expect(emitido?.simbolo).toBe('VERSAO');
+        const versaoTs = readFileSync(
+          join(RAIZ_REPO, 'supabase', 'functions', c.edge, 'versao.ts'),
+          'utf8',
+        );
+        expect(versaoTs).toContain(`"${c.marcador}"`);
+      }
+    }
+  });
+
+  it('sabotar o index.ts muda o SQL — o marcador velho não sobrevive', () => {
+    const raiz = fixtureCanarias({ 'copilot-analyze': 'marcador-SABOTADO-v9' });
+    const sql = gerarSqlDasCanarias({
+      raiz,
+      nomes: ['copilot-analyze'],
+      ler: lerCanariasReal,
+    });
+    expect(sql).toContain("'marcador-SABOTADO-v9'");
+    expect(sql).not.toContain('marcador-de-copilot-analyze-v1');
+  });
+
+  it('cada canária leva o SEU marcador, não o da vizinha', () => {
+    const raiz = fixtureCanarias();
+    const sql = gerarSqlDasCanarias({
+      raiz,
+      nomes: ['copilot-analyze', 'omie-financeiro'],
+      ler: lerCanariasReal,
+    });
+    expect(sql).toContain("('copilot-analyze', 'contrato', 'marcador-de-copilot-analyze-v1'");
+    expect(sql).toContain("('omie-financeiro', 'contrato', 'marcador-de-omie-financeiro-v1'");
+  });
+
+  it('index.ts que não emite o `contrato` da chave registrada falha ALTO — nada é emitido', () => {
+    const raiz = fixtureCanarias();
+    writeFileSync(
+      join(raiz, 'supabase', 'functions', 'omie-financeiro', 'index.ts'),
+      'Deno.serve(() => json({ ok: true }));\n',
+    );
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz, nomes: ['omie-financeiro'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/marcador ILEGÍVEL/);
+    expect(msg).toMatch(/case:paginacao_probe/);
+    expect(msg).toMatch(/Nenhum SQL foi emitido/);
+  });
+
+  it('acusa TODAS as canárias tortas de uma vez, não só a primeira', () => {
+    const raiz = fixtureCanarias();
+    for (const edge of ['omie-financeiro', 'omie-vendas-sync']) {
+      writeFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'Deno.serve(() => {});\n');
+    }
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({
+        raiz,
+        nomes: ['omie-financeiro', 'omie-vendas-sync'],
+        ler: lerCanariasReal,
+      }),
+    );
+    expect(msg).toMatch(/omie-financeiro/);
+    expect(msg).toMatch(/omie-vendas-sync/);
+  });
+});
+
+describe('registro COMPLETO — canária fora dele nunca seria disparada', () => {
+  it('contra o repo REAL: nenhuma canária emitida está fora do registro', () => {
+    expect(() =>
+      resolverCanarias(RAIZ_REPO, ['copilot-analyze'], lerCanariasReal),
+    ).not.toThrow();
+  });
+
+  it('uma 2ª canária na MESMA edge, sem entrada no registro, derruba a geração', () => {
+    const raiz = fixtureCanarias();
+    const dir = join(raiz, 'supabase', 'functions', 'omie-financeiro');
+    writeFileSync(
+      join(dir, 'index.ts'),
+      readFileSync(join(dir, 'index.ts'), 'utf8') +
+        '\nDeno.serve(async (req) => {\n' +
+        '  const { action } = await req.json();\n' +
+        '  switch (action) {\n' +
+        '      case "nova_probe": {\n' +
+        '        result = { canary: true, contrato: "nasceu-fora-da-tabela-v1", ok: true };\n' +
+        '        break;\n' +
+        '      }\n' +
+        '  }\n' +
+        '});\n',
+    );
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz, nomes: ['copilot-analyze'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/FORA do registro CANARIAS/);
+    expect(msg).toMatch(/case:nova_probe/);
+    expect(msg).toMatch(/nasceu-fora-da-tabela-v1/);
+  });
+
+  it('a `generate-tactical-plan` que PASSAR a emitir `contrato` cobra o registro', () => {
+    const raiz = fixtureCanarias();
+    writeFileSync(
+      join(raiz, 'supabase', 'functions', 'generate-tactical-plan', 'index.ts'),
+      corpoDaEdge('if:1', 'agora-emite-contrato-v1', 'contrato'),
+    );
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz, nomes: ['generate-tactical-plan'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/trocou de FORMA/);
+    expect(msg).toMatch(/agora-emite-contrato-v1/);
+    expect(msg).toMatch(/Nenhum SQL foi emitido/);
+  });
+
+  it('a que emite LITERAL e PASSAR a servir por referência também cobra — nos dois sentidos', () => {
+    const raiz = fixtureCanarias();
+    writeFileSync(
+      join(raiz, 'supabase', 'functions', 'copilot-analyze', 'index.ts'),
+      corpoDaEdge('if:1', 'irrelevante', 'versao'),
+    );
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz, nomes: ['copilot-analyze'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/trocou de FORMA/);
+    expect(msg).toMatch(/REFERÊNCIA/);
+    // Sem esta conferência o registro leria `contrato` (ausente) e diria SEM MARCADOR — causa
+    // errada: o bundle está no ar, quem envelheceu foi o registro.
+    expect(msg).not.toMatch(/marcador ILEGÍVEL/);
+  });
+
+  it('símbolo que não é o `VERSAO` fica FORA do alcance, e o gerador DIZ isso', () => {
+    const raiz = fixtureCanarias();
+    writeFileSync(
+      join(raiz, 'supabase', 'functions', 'generate-tactical-plan', 'index.ts'),
+      'Deno.serve(async (req) => {\n' +
+        '  if (body.canary === true) {\n' +
+        '    return json({ canary: true, versao: OUTRO_SIMBOLO, ok: true });\n' +
+        '  }\n' +
+        '});\n',
+    );
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz, nomes: ['generate-tactical-plan'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/OUTRO_SIMBOLO/);
+    expect(msg).toMatch(/só `VERSAO` é resolvível/);
+  });
+});
+
+describe('o CORPO do disparo é POR CANÁRIA — corpo errado cai no FLUXO REAL', () => {
+  const sqlReal = () =>
+    gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: [], ler: lerCanariasReal });
+
+  it('as quatro formas da tabela do deploy.md saem no VALUES, cada uma na sua linha', () => {
+    const sql = sqlReal();
+    expect(sql).toContain(`('copilot-analyze', 'copilot-analyze', '{"canary": true}'::jsonb, '')`);
+    expect(sql).toContain(
+      `('omie-vendas-sync', 'omie-vendas-sync', '{"action": "identidade_probe"}'::jsonb, '')`,
+    );
+    expect(sql).toContain(
+      `('omie-analytics-sync:transferencia_probe', 'omie-analytics-sync', '{"action": "transferencia_probe"}'::jsonb, '')`,
+    );
+    expect(sql).toContain(`('carteira-rebuild', 'carteira-rebuild', '{}'::jsonb, '?canary=1')`);
+  });
+
+  it('a URL concatena o sufixo — sem isso a carteira-rebuild roda o rebuild REAL', () => {
+    expect(sqlReal()).toContain("/functions/v1/' || a.edge || a.sufixo");
+  });
+
+  it('o corpo vem da LINHA, não de um jsonb_build_object fixo', () => {
+    const sql = sqlReal();
+    expect(sql).toContain('body := a.corpo');
+    expect(sql).not.toContain("body := jsonb_build_object('canary'");
+  });
+
+  it('timeout_milliseconds é EXPLÍCITO e acima do default de 5s, que mata silencioso', () => {
+    expect(sqlReal()).toContain('timeout_milliseconds := 20000');
+  });
+
+  it('o segredo sai do vault, nunca do texto colado', () => {
+    expect(sqlReal()).toContain('vault.decrypted_secrets');
+  });
+});
+
+describe('a trava das CARAS vem do registro, não da memória de quem chama', () => {
+  it('as que caem em fluxo real caro saem em bloco COM trava, e as baratas sem', () => {
+    const sql = gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: [], ler: lerCanariasReal });
+    const [passo1, passo3] = sql.split('-- PASSO 3');
+    expect(passo1).not.toContain('confirmei_o_deploy');
+    expect(passo1).toContain("('copilot-analyze'");
+    expect(passo3).toContain("confirmei_o_deploy = 'sim'");
+    expect(passo3).toContain("('carteira-rebuild'");
+    expect(passo3).toContain("('generate-tactical-plan'");
+    expect(passo3).not.toContain("('copilot-analyze', 'copilot-analyze'");
+  });
+
+  it('o bloco caro NOMEIA o efeito de cada canária, não diz só "é caro"', () => {
+    const sql = gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: [], ler: lerCanariasReal });
+    expect(sql).toMatch(/carteira-rebuild: rebuild REAL da carteira/);
+    expect(sql).toMatch(/generate-tactical-plan: plano tatico com LLM/);
+  });
+
+  it('a trava é CASE, não filtro — filtro deixaria o http_post sair igual', () => {
+    const sql = gerarSqlDasCanarias({
+      raiz: RAIZ_REPO,
+      nomes: ['carteira-rebuild'],
+      ler: lerCanariasReal,
+    });
+    expect(sql).toContain("CASE WHEN g.confirmei_o_deploy = 'sim'");
+    expect(sql).not.toContain("WHERE g.confirmei_o_deploy = 'sim'");
+  });
+});
+
+describe('a canária inalcançável pelo SQL Editor é RECUSADA, não sondada', () => {
+  it('pedir a analyze-unified-order explica o gate e manda para o app logado', () => {
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({
+        raiz: RAIZ_REPO,
+        nomes: ['analyze-unified-order'],
+        ler: lerCanariasReal,
+      }),
+    );
+    expect(msg).toMatch(/gate de staff/);
+    expect(msg).toMatch(/Governança → Auditoria/);
+    expect(msg).toMatch(/Nenhum SQL foi emitido/);
+  });
+
+  it('a leva PADRÃO (sem nomes) não a inclui — 401 dela se leria como bundle velho', () => {
+    const sql = gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: [], ler: lerCanariasReal });
+    expect(sql).not.toContain("('analyze-unified-order'");
+  });
+});
+
+describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
+  const sql = () => gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: [], ler: lerCanariasReal });
+
+  it('a leitura NASCE dentro do format() do disparo — não existe versão sem mapa', () => {
+    const s = sql();
+    expect(s).toContain('SELECT format($sonda$');
+    // `jsonb_each_text('{}')` é o modo ECO da sonda; aqui ele significaria toda linha
+    // INDETERMINADA, porque a resposta da canária não ecoa o slug.
+    expect(s).not.toContain("jsonb_each_text('{}'::jsonb)");
+    expect(s).toContain('jsonb_each_text(%1$L::jsonb)');
+  });
+
+  it('CANARIA VERDE exige canary + marcador + ok, os três', () => {
+    const ramo = ramoDe(sql(), 'CANARIA VERDE');
+    const antes = sql().slice(0, sql().indexOf("THEN 'CANARIA VERDE"));
+    const cond = antes.slice(antes.lastIndexOf("WHEN l.corpo ->> 'canary' = 'true'"));
+    expect(cond).toContain("l.corpo ->> 'canary' = 'true'");
+    expect(cond).toContain('l.corpo ->> l.campo_marcador = l.marcador_esperado');
+    expect(cond).toContain("l.corpo ->> 'ok' = 'true'");
+    expect(ramo).toContain('CANARIA VERDE');
+  });
+
+  it('a leitura parte da lista CANÔNICA — zero linhas não pode virar "nada a reportar"', () => {
+    expect(sql()).toContain('WITH esperado(nome, campo_marcador, marcador_esperado, efeito) AS (VALUES');
+    expect(sql()).toContain('FROM esperado e');
+  });
+
+  it('desce no envelope `data` — a omie-analytics-sync responde aninhado', () => {
+    expect(sql()).toContain("COALESCE(x.content::jsonb -> 'data', x.content::jsonb)");
+  });
+
+  it('os ramos que separam BUNDLE VELHO de CANARIA VERMELHA estão todos nomeados', () => {
+    const s = sql();
+    for (const marca of [
+      'INDETERMINADO',
+      'AGUARDE',
+      'SEM CANARIA NO AR',
+      'CANARIA SEM MARCADOR',
+      'CANARIA DE OUTRA FATIA',
+      'CANARIA SEM VEREDITO',
+      'CANARIA VERMELHA',
+      'CANARIA VERDE',
+    ]) {
+      expect(s, `ramo ausente: ${marca}`).toContain(`THEN '${marca}`);
+    }
+  });
+
+  it('o 200 sem eco DIZ que rodou o fluxo real, e diz QUAL efeito', () => {
+    const ramo = ramoDe(sql(), 'SEM CANARIA NO AR — HTTP');
+    expect(ramo).toContain('RODOU O FLUXO REAL');
+    expect(ramo).toContain("|| l.efeito ||");
+    expect(ramo).toContain('NAO e canaria vermelha');
+  });
+
+  it('bundle velho e canária vermelha DIZEM que não são a mesma coisa', () => {
+    expect(ramoDe(sql(), 'SEM CANARIA NO AR — 401')).toContain('NAO e canaria vermelha');
+    expect(ramoDe(sql(), 'CANARIA VERMELHA')).toContain('NAO e deploy pendente');
+    expect(ramoDe(sql(), 'CANARIA DE OUTRA FATIA')).toContain('PRECISA DEPLOY');
+  });
+
+  it('o eco é julgado ANTES do status — a 500 da generate-tactical-plan é vermelha, não recusa', () => {
+    const s = sql();
+    const eco = s.indexOf("WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code >= 400");
+    const statusCru = s.indexOf('WHEN l.status_code >= 400');
+    expect(eco).toBeGreaterThan(-1);
+    // Não existe ramo que julgue o status sem antes exigir a ausência do eco.
+    expect(statusCru).toBe(-1);
+  });
+
+  it('o campo do marcador é POR CANÁRIA — a generate-tactical-plan serve em `versao`', () => {
+    const s = sql();
+    expect(s).toContain("('generate-tactical-plan', 'versao', ");
+    expect(s).toContain("('copilot-analyze', 'contrato', ");
+    expect(s).toContain('l.corpo ->> l.campo_marcador');
+  });
+});
+
+describe('CLI do modo canária — as flags sem sentido são RECUSADAS, não ignoradas', () => {
+  it('--canaria muda o significado dos posicionais', () => {
+    const a = parsearArgs(['--canaria', 'omie-analytics-sync:doc_ambiguo_probe']);
+    expect(a.canaria).toBe(true);
+    expect(a.edges).toEqual(['omie-analytics-sync:doc_ambiguo_probe']);
+  });
+
+  it('sem --canaria o campo fica indefinido (o modo sonda segue o padrão)', () => {
+    expect(parsearArgs(['copilot-analyze']).canaria).toBeUndefined();
+  });
+
+  it('--so-leitura é recusado: sem o mapa toda linha sairia INDETERMINADA', () => {
+    const msg = msgDoErro(() => parsearArgs(['--canaria', '--so-leitura']));
+    expect(msg).toMatch(/NÃO ecoa o slug/);
+  });
+
+  it('--caro é recusado: quem é caro está no registro, não na memória de quem chama', () => {
+    const msg = msgDoErro(() => parsearArgs(['--canaria', '--caro=carteira-rebuild']));
+    expect(msg).toMatch(/fluxoRealSeVelho/);
+  });
+
+  it('--so-disparo é recusado: em modo canária tudo o que se emite já é disparo', () => {
+    expect(msgDoErro(() => parsearArgs(['--canaria', '--so-disparo']))).toMatch(/--so-disparo/);
+  });
+
+  it('canária repetida na leva é recusada — linha duplicada dispara duas vezes', () => {
+    const msg = msgDoErro(() => parsearArgs(['--canaria', 'copilot-analyze', 'copilot-analyze']));
+    expect(msg).toMatch(/canária repetida/);
+  });
+
+  it('nome com `:` passa (é canária), e nome fora do registro sai com a LISTA das opções', () => {
+    expect(parsearArgs(['--canaria', 'omie-analytics-sync:transferencia_probe']).edges).toHaveLength(1);
+    const msg = msgDoErro(() =>
+      gerarSqlDasCanarias({ raiz: RAIZ_REPO, nomes: ['copilot-analise'], ler: lerCanariasReal }),
+    );
+    expect(msg).toMatch(/canária desconhecida: copilot-analise/);
+    expect(msg).toMatch(/copilot-analyze/);
+  });
+
+  it('--canaria sem leitor injetado RECUSA — marcador digitado é a via do veredito falso', () => {
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+      git: gitEspelho(RAIZ_REPO),
+    });
+    expect(rc).toBe(1);
+    expect(saida).toHaveLength(0);
+    expect(erros.join('\n')).toMatch(/sem leitor de canárias/);
+  });
+
+  it('main --canaria escreve o SQL e devolve 0', () => {
+    const saida: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: () => {},
+      git: gitEspelho(RAIZ_REPO),
+      lerCanarias: lerCanariasReal,
+    });
+    expect(rc).toBe(0);
+    expect(saida.join('')).toContain('AS veredito');
+  });
+
+  it('o guard de sincronia vale IGUAL aqui — disco fora da main NÃO emite SQL', () => {
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+      git: gitEspelho(RAIZ_REPO, 'copilot-analyze'),
+      lerCanarias: lerCanariasReal,
+    });
+    expect(rc).toBe(1);
+    expect(saida).toHaveLength(0);
+    expect(erros.join('\n')).toMatch(/DESSINCRONIZADO/);
   });
 });

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -34,7 +34,7 @@
  * `--so-disparo` e `--so-leitura` recortam exatamente nessa fronteira.
  */
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { ARQ_MAPA, lerMapaCommitado } from './sonda-fingerprint';
@@ -876,6 +876,649 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
   return partes.join('\n');
 }
 
+// ==========================================================================================
+// MODO CANÁRIA — a irmã COMPORTAMENTAL da sonda
+// ==========================================================================================
+//
+// A sonda responde "qual bundle está no ar?". A canária responde "o COMPORTAMENTO que esta fatia
+// atesta continua no ar?" — ela roda o helper REAL sobre fixtures e devolve o veredito. Até aqui
+// o disparo dela era `net.http_post` escrito à mão a cada verificação, com o CASE do veredito
+// reescrito junto (fecho do #2367: o SQL saiu do bloco da sonda trocando `'probe'` por `'canary'`).
+// Duas coisas viajavam na mão nesse caminho, e as duas produzem VEREDITO FALSO:
+//
+//   1. O CORPO. Ele NÃO é uniforme — `docs/agent/deploy.md` §"Canárias de deploy" lista quatro
+//      formas: `{"canary":true}`, `?canary=1` na URL, e rotas nomeadas por `action`
+//      (`identidade_probe`, `doc_ambiguo_probe`, `transferencia_probe`, `paginacao_probe`). Corpo
+//      errado não é "canária que não respondeu": a edge cai no FLUXO REAL, e em várias delas isso
+//      é caro e ESCREVE (a `carteira-rebuild` faz o rebuild inteiro, lease + upserts).
+//   2. O MARCADOR esperado. Digitado errado, o veredito sai "bundle velho" numa canária que está
+//      no ar — o mesmo falso do cabeçalho deste arquivo, uma camada acima. Aqui ele é DERIVADO do
+//      repo (o `contrato` emitido no `index.ts`, lido pelo mesmo extrator que o gate `canaria:bump`
+//      usa), nunca digitado no registro.
+//
+// POR QUE A LEITURA NÃO ACHA A LINHA PELO ECO DO SLUG, como a da sonda: a resposta da canária NÃO
+// ecoa o nome da edge. Medido nas 7 emissões: `{canary, contrato, ok, ...}` — `executarCanaria` da
+// `copilot-analyze`, o `result` das três `omie-*`, o `Response` da `carteira-rebuild`. Sem eco não
+// há como casar resposta com edge sem o `request_id`, e por isso o modo canária SÓ existe na forma
+// de mapa EMBUTIDO: o passo 1 escreve o passo 2 com o mapa dentro, e `--so-leitura` é RECUSADO —
+// um bloco de leitura sem mapa aqui não seria "menos preciso", seria INDETERMINADO em toda linha.
+
+/** Como a canária é acordada. Não é uniforme entre as 8 — ver a tabela do `deploy.md`. */
+export type DisparoCanaria =
+  /** corpo JSON no POST (`{"canary":true}` ou `{"action":"<rota>"}`) */
+  | { readonly tipo: 'corpo'; readonly corpo: string }
+  /** query string na URL (`?canary=1`) — o corpo vai `{}` */
+  | { readonly tipo: 'query'; readonly query: string };
+
+export interface CanariaRegistrada {
+  /** identificador na CLI. Edge com DUAS canárias precisa de sufixo: `<edge>:<rota>`. */
+  readonly nome: string;
+  readonly edge: string;
+  /** Chave de `localizarCanarias` que hospeda esta canária: `case:<rota>` ou `if:<ordinal>`. */
+  readonly chave: string;
+  readonly disparo: DisparoCanaria;
+  /** Campo da resposta que carrega o marcador. A `generate-tactical-plan` serve em `versao`. */
+  readonly campoMarcador: 'contrato' | 'versao';
+  /**
+   * `null` = alcançável pelo SQL Editor. Texto = por que NÃO é, e o que fazer no lugar. Canária
+   * atrás de gate de JWT de usuário é inalcançável por `x-cron-secret`: pedir o disparo dela aqui
+   * devolveria 401, e 401 se lê como "bundle velho" — veredito falso sobre uma canária que talvez
+   * esteja perfeita. Recusar é o honesto.
+   */
+  readonly inalcancavel: string | null;
+  /**
+   * O que um bundle SEM esta canária faz com o disparo. `true` = cai no fluxo real e ele é
+   * caro/escreve, então ela sai no bloco COM trava. Derivado do código, não da memória de quem
+   * chama: o `--caro` da sonda depende de o operador lembrar, e aqui esquecer significa rebuild
+   * real da carteira ou token de LLM queimado.
+   */
+  readonly fluxoRealSeVelho: boolean;
+  /** O efeito do fluxo real, nomeado. Entra no veredito de "rodou o fluxo real". */
+  readonly efeitoSeVelho: string;
+}
+
+/**
+ * As 8 canárias de `docs/agent/deploy.md` §"Canárias de deploy".
+ *
+ * O que está aqui é o que NÃO dá para derivar: como acordar a canária, e onde ela responde. O
+ * MARCADOR não está — ele é lido do repo por `resolverCanarias`, que também recusa canária do repo
+ * fora deste registro (a armadilha "canária fora da tabela" do próprio `deploy.md`).
+ */
+export const CANARIAS: readonly CanariaRegistrada[] = [
+  {
+    nome: 'copilot-analyze',
+    edge: 'copilot-analyze',
+    chave: 'if:1',
+    disparo: { tipo: 'corpo', corpo: '{"canary": true}' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    // A canária responde ANTES do gate de `Bearer`: um bundle sem ela cai no gate e devolve 401.
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'analise por LLM (token) — mas o gate de Bearer recusa antes',
+  },
+  {
+    nome: 'carteira-rebuild',
+    edge: 'carteira-rebuild',
+    chave: 'if:1',
+    disparo: { tipo: 'query', query: '?canary=1' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    // Sem o ramo `?canary=1` a requisição segue para o rebuild REAL: lease + upserts na carteira.
+    fluxoRealSeVelho: true,
+    efeitoSeVelho: 'rebuild REAL da carteira (lease + upserts) — idempotente, mas e ESCRITA',
+  },
+  {
+    nome: 'generate-tactical-plan',
+    edge: 'generate-tactical-plan',
+    // Serve o marcador no campo `versao`, por REFERÊNCIA ao `VERSAO` do `versao.ts` — a única das
+    // 8 nessa forma. O `canaria:bump` passou a enxergá-la no #2374 (`contrato: null` + `simbolo`),
+    // e é dele que sai o sinal: `resolverCanarias` cobra que `campoMarcador` case com a forma que
+    // o REPO usa, nos dois sentidos.
+    chave: 'if:1',
+    disparo: { tipo: 'corpo', corpo: '{"canary": true}' },
+    campoMarcador: 'versao',
+    inalcancavel: null,
+    // `body.canary === true` é comparação CRUA (não passa pelo classificador), e a edge não tem
+    // gate de auth antes: bundle velho vai direto para o plano com LLM.
+    fluxoRealSeVelho: true,
+    efeitoSeVelho: 'plano tatico com LLM (token) — nao ha gate de auth antes para segurar',
+  },
+  {
+    nome: 'omie-vendas-sync',
+    edge: 'omie-vendas-sync',
+    chave: 'case:identidade_probe',
+    disparo: { tipo: 'corpo', corpo: '{"action": "identidade_probe"}' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'action desconhecida LANCA antes de qualquer escrita',
+  },
+  {
+    nome: 'omie-analytics-sync:doc_ambiguo_probe',
+    edge: 'omie-analytics-sync',
+    chave: 'case:doc_ambiguo_probe',
+    disparo: { tipo: 'corpo', corpo: '{"action": "doc_ambiguo_probe"}' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'action desconhecida devolve 400 antes de qualquer escrita',
+  },
+  {
+    nome: 'omie-analytics-sync:transferencia_probe',
+    edge: 'omie-analytics-sync',
+    chave: 'case:transferencia_probe',
+    disparo: { tipo: 'corpo', corpo: '{"action": "transferencia_probe"}' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'action desconhecida devolve 400 antes de qualquer escrita',
+  },
+  {
+    nome: 'omie-financeiro',
+    edge: 'omie-financeiro',
+    chave: 'case:paginacao_probe',
+    disparo: { tipo: 'corpo', corpo: '{"action": "paginacao_probe"}' },
+    campoMarcador: 'contrato',
+    inalcancavel: null,
+    // O `default` fecha o log como ERRO (não `complete`), então não carimba frescor falso.
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'action desconhecida fecha o fin_sync_log como erro — nao carimba frescor',
+  },
+  {
+    nome: 'analyze-unified-order',
+    edge: 'analyze-unified-order',
+    chave: 'if:1',
+    disparo: { tipo: 'corpo', corpo: '{"canary": true}' },
+    campoMarcador: 'contrato',
+    inalcancavel:
+      'a canária de preço vive DEPOIS do gate de staff (JWT de usuário), e o gate não conhece ' +
+      '`x-cron-secret` — pelo SQL Editor ela responde 401, que é indistinguível de bundle velho. ' +
+      'Chame-a pelo APP LOGADO: Governança → Auditoria, card "Canária de preço". (A SONDA desta ' +
+      'edge é alcançável e responde antes do gate: `bun run sonda:sql analyze-unified-order`.)',
+    fluxoRealSeVelho: false,
+    efeitoSeVelho: 'inalcancavel pelo SQL Editor',
+  },
+];
+
+/**
+ * O único símbolo de marcador resolvível — o mesmo que o `canaria:bump` sabe seguir. Canária que
+ * sirva `versao: <outro>` fica FORA do alcance, e dizer isso é melhor do que adivinhar.
+ */
+const SIMBOLO_VERSAO = 'VERSAO';
+
+/** Uma canária do registro com o marcador que o REPO diz que ela emite hoje. */
+export interface CanariaResolvida extends CanariaRegistrada {
+  readonly marcador: string;
+}
+
+/**
+ * Lê do repo as canárias de UMA edge: a chave do arm e o marcador emitido.
+ *
+ * Injetado, e não importado no topo, pelo MESMO motivo documentado em `guardEfeitoLegado`: o eval
+ * da skill `lovable-deploy-verify` copia SÓ `sonda-versao-sql.ts` e `sonda-fingerprint.ts` para um
+ * diretório temporário e importa daqui. Um import de topo de `canaria-contrato-bump-gate` (que por
+ * sua vez importa `@/lib/gates/limpeza-fonte`) não resolveria lá, o módulo inteiro deixaria de
+ * carregar, e os cenários do eval voltariam a devolver `SQL_VAZIO`. Quem executa como CLI resolve
+ * o leitor real no fim deste arquivo.
+ */
+export type LeitorCanariasDoRepo = (
+  raiz: string,
+  edge: string,
+) => ReadonlyArray<{ chave: string; contrato: string | null; simbolo: string | null }>;
+
+/** Pastas de `supabase/functions/` que podem hospedar canária (toda pasta com `index.ts`). */
+function edgesDoRepo(raiz: string): string[] {
+  const dir = join(raiz, 'supabase', 'functions');
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(dir, d.name, 'index.ts')))
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * Toda canária do REPO tem de estar no registro — senão a leva silenciosamente pula uma.
+ *
+ * É a armadilha "canária fora da tabela" do `deploy.md` aplicada à ferramenta: o `canaria:bump`
+ * mediu "6 canária(s) conferida(s)" ANTES e DEPOIS de a 7ª existir, e nada ficou vermelho. Um
+ * registro que só cresce quando alguém lembra tem o mesmo modo de falha, e aqui ele é pior: a
+ * canária ausente do registro nunca é DISPARADA, então a verificação sai verde sobre 7 de 8.
+ *
+ * O pré-filtro por texto CRU é `canary:true`, o mesmo SINAL que o gate usa, e não `contrato`: a
+ * `generate-tactical-plan` serve o marcador em `versao` e não tem a palavra `contrato` em lugar
+ * nenhum do código — filtrar por ela deixaria a 8ª canária fora da varredura, que é exatamente a
+ * cegueira que o #2374 fechou no gate. É superset seguro porque `removerComentarios` só REMOVE:
+ * uma fonte sem o sinal no bruto não pode ganhá-lo depois da limpeza.
+ */
+function conferirRegistroCompleto(raiz: string, ler: LeitorCanariasDoRepo): void {
+  const registradas = new Set(CANARIAS.map((c) => `${c.edge} ${c.chave}`));
+  const forasteiras: string[] = [];
+  for (const edge of edgesDoRepo(raiz)) {
+    const bruto = readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8');
+    if (!/canary\s*:\s*true/.test(bruto)) continue;
+    for (const c of ler(raiz, edge)) {
+      if (!registradas.has(`${edge} ${c.chave}`)) {
+        forasteiras.push(`${edge} (${c.chave} -> ${c.contrato ?? `versao: ${c.simbolo ?? '?'}`})`);
+      }
+    }
+  }
+  if (forasteiras.length > 0) {
+    throw new Error(
+      `canária no REPO e FORA do registro CANARIAS: ${forasteiras.join(', ')}. ` +
+        'Uma canária que não está no registro nunca é disparada, e a leva sai verde sem tê-la ' +
+        'verificado — é a armadilha "canária fora da tabela" do deploy.md dentro da ferramenta. ' +
+        'Acrescente a entrada (nome, disparo, campoMarcador, fluxoRealSeVelho) e a linha na ' +
+        'tabela de docs/agent/deploy.md §Canárias. Nenhum SQL foi emitido.',
+    );
+  }
+}
+
+/**
+ * Resolve os nomes pedidos em canárias com MARCADOR VINDO DO REPO — ou LANÇA.
+ *
+ * Acusa tudo de uma vez, como `resolverLeva`: quem pediu 5 canárias quer saber quais 2 estão
+ * tortas. Nada é emitido enquanto houver uma pendente.
+ */
+export function resolverCanarias(
+  raiz: string,
+  nomes: string[],
+  ler: LeitorCanariasDoRepo,
+): CanariaResolvida[] {
+  conferirRegistroCompleto(raiz, ler);
+  const porNome = new Map(CANARIAS.map((c) => [c.nome, c]));
+  const desconhecidas = nomes.filter((n) => !porNome.has(n));
+  if (desconhecidas.length > 0) {
+    throw new Error(
+      `canária desconhecida: ${desconhecidas.join(', ')}. As registradas são: ` +
+        `${CANARIAS.map((c) => c.nome).join(', ')}. Nenhum SQL foi emitido.`,
+    );
+  }
+  const barradas = nomes.filter((n) => porNome.get(n)!.inalcancavel !== null);
+  if (barradas.length > 0) {
+    throw new Error(
+      barradas.map((n) => `${n}: ${porNome.get(n)!.inalcancavel}`).join(' | ') +
+        ' Nenhum SQL foi emitido.',
+    );
+  }
+
+  const semMarcador: string[] = [];
+  const campoDesalinhado: string[] = [];
+  const resolvidas: CanariaResolvida[] = [];
+  for (const nome of nomes) {
+    const reg = porNome.get(nome)!;
+    const achada = ler(raiz, reg.edge).find((c) => c.chave === reg.chave);
+    if (achada === undefined) {
+      semMarcador.push(`${nome} (o index.ts de ${reg.edge} não hospeda canária em ${reg.chave})`);
+      continue;
+    }
+
+    // O campo que o registro LÊ tem de ser o campo que o repo SERVE, nos dois sentidos. Sem esta
+    // conferência, uma canária que trocasse de forma continuaria "funcionando" lendo o campo
+    // errado: no sentido `versao`→`contrato` o veredito só saberia dizer SEM MARCADOR; no sentido
+    // inverso ele leria o marcador da SONDA achando que é o da canária — dois papéis num campo só,
+    // o defeito de `canaria-papel-duplo.md`. Fail-CLOSED: o registro acompanha, ou nada é emitido.
+    if (achada.contrato !== null) {
+      if (reg.campoMarcador !== 'contrato') {
+        campoDesalinhado.push(
+          `${nome} (o repo emite o LITERAL \`contrato: "${achada.contrato}"\`, o registro lê ` +
+            `\`${reg.campoMarcador}\`)`,
+        );
+        continue;
+      }
+      resolvidas.push({ ...reg, marcador: achada.contrato });
+      continue;
+    }
+
+    if (achada.simbolo === null) {
+      semMarcador.push(`${nome} (a canária em ${reg.chave} não serve marcador nenhum)`);
+      continue;
+    }
+    if (reg.campoMarcador !== 'versao') {
+      campoDesalinhado.push(
+        `${nome} (o repo serve por REFERÊNCIA em \`versao: ${achada.simbolo}\`, o registro lê ` +
+          `\`${reg.campoMarcador}\`)`,
+      );
+      continue;
+    }
+    if (achada.simbolo !== SIMBOLO_VERSAO) {
+      semMarcador.push(
+        `${nome} (serve \`versao: ${achada.simbolo}\`, e só \`${SIMBOLO_VERSAO}\` é resolvível — ` +
+          'o literal desse símbolo é o que o `versao.ts` declara)',
+      );
+      continue;
+    }
+    const texto = (() => {
+      try {
+        return readFileSync(caminhoVersao(raiz, reg.edge), 'utf8');
+      } catch {
+        return null;
+      }
+    })();
+    const versao = texto === null ? null : extrairVersao(texto);
+    if (versao === null) {
+      semMarcador.push(`${nome} (versao.ts sem \`export const VERSAO = "..."\` legível)`);
+      continue;
+    }
+    resolvidas.push({ ...reg, marcador: versao });
+  }
+
+  const problemas: string[] = [];
+  if (semMarcador.length > 0) {
+    problemas.push(`marcador ILEGÍVEL no repo: ${semMarcador.join(', ')}`);
+  }
+  if (campoDesalinhado.length > 0) {
+    problemas.push(
+      'a canária trocou de FORMA e o registro não acompanhou: ' +
+        `${campoDesalinhado.join(', ')} — ajuste \`campoMarcador\` no registro e a tabela de ` +
+        'docs/agent/deploy.md §Canárias',
+    );
+  }
+  if (problemas.length > 0) {
+    throw new Error(
+      `${problemas.join(' | ')}. O marcador esperado é DERIVADO do repo de propósito: digitá-lo ` +
+        'no registro é a via do veredito falso que esta ferramenta existe para fechar. ' +
+        'Nenhum SQL foi emitido.',
+    );
+  }
+  return resolvidas;
+}
+
+/** Lista `('nome', 'edge', '<corpo>'::jsonb, '<sufixo>'),` para o `VALUES` do disparo. */
+function valuesAlvosCanaria(leva: CanariaResolvida[]): string {
+  return leva
+    .map((c) => {
+      const corpo = c.disparo.tipo === 'corpo' ? c.disparo.corpo : '{}';
+      const sufixo = c.disparo.tipo === 'query' ? c.disparo.query : '';
+      return `  (${lit(c.nome)}, ${lit(c.edge)}, ${lit(corpo)}::jsonb, ${lit(sufixo)})`;
+    })
+    .join(',\n');
+}
+
+/** Lista `('nome', 'campo', 'marcador', 'efeito'),` para a lista canônica da leitura. */
+function valuesEsperadoCanaria(leva: CanariaResolvida[]): string {
+  return leva
+    .map(
+      (c) =>
+        `  (${lit(c.nome)}, ${lit(c.campoMarcador)}, ${lit(c.marcador)}, ${lit(c.efeitoSeVelho)})`,
+    )
+    .join(',\n');
+}
+
+/**
+ * A chamada `net.http_post` da canária. Difere da da sonda em DOIS pontos, e os dois importam: o
+ * corpo vem da LINHA (não é `jsonb_build_object('probe', true)` fixo, porque as 8 não têm corpo
+ * uniforme) e a URL leva sufixo de query, porque a `carteira-rebuild` se acorda por `?canary=1`.
+ */
+function httpPostCanaria(ref: string, indent: string): string {
+  const i = indent;
+  return (
+    'net.http_post(\n' +
+    `${i}  url := 'https://${ref}.supabase.co/functions/v1/' || a.edge || a.sufixo,\n` +
+    `${i}  headers := jsonb_build_object(\n` +
+    `${i}    'Content-Type', 'application/json',\n` +
+    `${i}    'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets\n` +
+    `${i}                      WHERE name = 'CRON_SECRET' LIMIT 1)),\n` +
+    `${i}  body := a.corpo,\n` +
+    `${i}  timeout_milliseconds := 20000)`
+  );
+}
+
+/**
+ * Bloco de DISPARO da canária — o único que precisa do founder, pela mesma razão da sonda: lê
+ * `vault.decrypted_secrets` e faz INSERT via `net.http_post`, e o wrapper read-only recusa os dois.
+ *
+ * Ele DEVOLVE o passo de leitura já escrito, com o mapa `nome → request_id` interpolado por
+ * `format()`. Aqui isso não é conveniência, é REQUISITO: a resposta da canária não ecoa o slug, e
+ * sem o mapa nenhuma linha seria atribuível. Continuam sendo DOIS blocos pela imposição do pg_net
+ * (o `http_post` só ENFILEIRA; o worker de fundo só enxerga linha COMMITADA).
+ */
+function blocoDisparoCanaria(
+  ref: string,
+  leva: CanariaResolvida[],
+  passoDisparo: number,
+  janelaMin: number,
+  comTrava = false,
+): string {
+  const passoLeitura = passoDisparo + 1;
+  const cabeca = comTrava
+    ? "WITH guard(confirmei_o_deploy) AS (VALUES ('nao')),  -- ⬅️ 'nao' → 'sim' só DEPOIS do verde\n" +
+      `alvos(nome, edge, corpo, sufixo) AS (VALUES\n${valuesAlvosCanaria(leva)}\n),\n`
+    : `WITH alvos(nome, edge, corpo, sufixo) AS (VALUES\n${valuesAlvosCanaria(leva)}\n),\n`;
+  const projecao = comTrava
+    ? "         CASE WHEN g.confirmei_o_deploy = 'sim'\n" +
+      `              THEN ${httpPostCanaria(ref, '                   ')}\n` +
+      '         END AS request_id\n' +
+      '  FROM alvos a CROSS JOIN guard g\n'
+    : `         ${httpPostCanaria(ref, '         ')} AS request_id\n` + '  FROM alvos a\n';
+  return (
+    cabeca +
+    'disparos AS (\n' +
+    '  SELECT a.nome,\n' +
+    projecao +
+    '),\n' +
+    'mapa AS (\n' +
+    '  -- O par (nome, id) é agregado na MESMA execução que disparou: o request_id nunca existe\n' +
+    '  -- solto, e por isso não há como colá-lo na linha da canária errada.\n' +
+    '  SELECT jsonb_object_agg(nome, request_id)::text AS ids FROM disparos\n' +
+    ')\n' +
+    `-- O PASSO ${passoLeitura} sai ESCRITO na célula abaixo, com o mapa já dentro. Copie a célula\n` +
+    '-- INTEIRA e rode/entregue como está: não há número a anotar nem campo a preencher.\n' +
+    `SELECT format(${TAG_SONDA}\n` +
+    corpoDoPassoDeLeituraCanaria(leva, janelaMin, passoDisparo) +
+    `${TAG_SONDA}, m.ids) AS passo_${passoLeitura}_copie_esta_celula\n` +
+    'FROM mapa m;\n'
+  );
+}
+
+/** O texto do passo de leitura da canária, pronto para virar o 1º argumento de `format()`. */
+function corpoDoPassoDeLeituraCanaria(
+  leva: CanariaResolvida[],
+  janelaMin: number,
+  passoDisparo: number,
+): string {
+  const passoLeitura = passoDisparo + 1;
+  const texto =
+    `-- PASSO ${passoLeitura} — lê e julga a CANÁRIA. O mapa nome→id já está EMBUTIDO aqui, escrito\n` +
+    `--          pelo passo ${passoDisparo}: nada a colar. Espere ~10s pela resposta HTTP. É SELECT\n` +
+    '--          puro — roda no read-only: cole no chat, ou em ~/.config/afiacao/psql-ro\n' +
+    blocoLeituraCanaria(leva, janelaMin, passoDisparo);
+  return escaparParaFormat(texto);
+}
+
+/**
+ * O JULGAMENTO da canária. Exige os TRÊS campos que o `deploy.md` §Canárias manda —
+ * `canary === true` E `<campoMarcador> === '<marcador>'` E `ok === true` — e, antes deles, separa
+ * a classe que a receita à mão confundia:
+ *
+ *   BUNDLE VELHO  ≠  CANÁRIA VERMELHA
+ *
+ * Um bundle anterior à canária IGNORA a flag e cai no fluxo real: responde 401 (gate), outro 4xx,
+ * ou 200 sem eco nenhum de `canary`. Nada disso é "a fixture reprovou" — é "não há canária no ar",
+ * e o desfecho é DEPLOY, não investigar regressão de comportamento. A ausência do eco é veredito
+ * PRÓPRIO, e vem ANTES de qualquer leitura de marcador ou de `ok`, senão a linha cai no ELSE e sai
+ * com um texto que se lê como reprovação.
+ *
+ * A ordem dos ramos é o desenho:
+ *   1. sem id / sem resposta / fora da janela ....... ausência de dado, nunca veredito
+ *   2. sem eco `canary` ............................. SEM CANARIA NO AR (3 sabores: 401 com
+ *      controle de credencial, outro 4xx/5xx, e o 200 que RODOU O FLUXO REAL — o caro)
+ *   3. eco `canary` sem o campo do marcador ......... CANARIA SEM MARCADOR (pré-versionamento)
+ *   4. marcador DIVERGENTE .......................... CANARIA DE OUTRA FATIA — é a armadilha 2 do
+ *      deploy.md: o bundle velho carrega o `expected` VELHO e compara velho×velho, então o `ok:true`
+ *      dele MENTE VERDE. Por isso o marcador é julgado ANTES do `ok`, e não junto.
+ *   5. `ok` ausente ................................. CANARIA SEM VEREDITO (fail-closed)
+ *   6. `ok:false` COM marcador batendo .............. CANARIA VERMELHA — esta, sim, é regressão
+ *   7. os três campos ............................... CANARIA VERDE
+ *
+ * ⚠️ O ramo 2 vem antes de qualquer teste de status: a `generate-tactical-plan` responde HTTP **500**
+ * quando a canária dela reprova. Julgar pelo status antes do eco leria uma canária vermelha legítima
+ * como recusa de bundle velho — e mandaria redeployar em vez de investigar a regressão.
+ */
+function blocoLeituraCanaria(
+  leva: CanariaResolvida[],
+  janelaMin: number,
+  passoDisparo: number,
+): string {
+  return (
+    'WITH esperado(nome, campo_marcador, marcador_esperado, efeito) AS (VALUES\n' +
+    `${valuesEsperadoCanaria(leva)}\n),\n` +
+    'ids AS (\n' +
+    `  -- EMBUTIDO pelo passo ${passoDisparo} — o mapa \`nome → request_id\` foi escrito pelo próprio\n` +
+    '  -- banco no disparo (format()). A canária NÃO ecoa o slug, então este mapa não é atalho: é a\n' +
+    '  -- ÚNICA via de atribuir a resposta à canária certa. Trava fechada ⇒ id nulo ⇒ INDETERMINADO.\n' +
+    `  SELECT chave AS nome, valor::bigint AS request_id\n` +
+    `  FROM jsonb_each_text(${SENTINELA_MAPA}::jsonb) AS t(chave, valor)\n` +
+    '),\n' +
+    'controle_credencial AS (\n' +
+    '  -- Mesma mecânica da sonda: o 401 é ambíguo (bundle sem a canária × CRON_SECRET inválido) e\n' +
+    '  -- só vira veredito determinado se este bloco provar que o secret do vault está sendo ACEITO\n' +
+    '  -- agora. NOT EXISTS (não NOT IN): a trava fechada devolve request_id NULL, e `NOT IN` com\n' +
+    '  -- NULL é NULL-blind — zeraria o controle inteiro em silêncio.\n' +
+    '  SELECT count(*) FILTER (WHERE r.status_code BETWEEN 200 AND 299) AS ok_recentes,\n' +
+    '         count(*) FILTER (WHERE r.status_code = 401)               AS recusas_recentes\n' +
+    '  FROM net._http_response r\n' +
+    "  WHERE r.created > now() - interval '6 hours'\n" +
+    '    AND NOT EXISTS (SELECT 1 FROM ids i2 WHERE i2.request_id = r.id)\n' +
+    '),\n' +
+    'lidas AS (\n' +
+    '  -- Parte de `esperado`: zero linhas não pode virar "nada a reportar". O envelope `data` é\n' +
+    '  -- descido aqui porque a omie-analytics-sync responde `{success, data:{...}}` e as outras no\n' +
+    '  -- topo — sem o COALESCE as DUAS canárias dela sairiam como "sem eco".\n' +
+    '  SELECT e.nome, e.campo_marcador, e.marcador_esperado, e.efeito,\n' +
+    '         i.request_id, x.status_code, x.created,\n' +
+    '         CASE WHEN x.content IS NOT NULL AND left(ltrim(x.content), 1) = \'{\'\n' +
+    "              THEN COALESCE(x.content::jsonb -> 'data', x.content::jsonb)\n" +
+    '         END AS corpo\n' +
+    '  FROM esperado e\n' +
+    '  LEFT JOIN ids i ON i.nome = e.nome\n' +
+    '  LEFT JOIN net._http_response x ON x.id = i.request_id\n' +
+    ')\n' +
+    'SELECT l.nome,\n' +
+    '       l.request_id,\n' +
+    '       l.status_code,\n' +
+    "       l.corpo ->> 'canary' AS canary_respondido,\n" +
+    '       l.corpo ->> l.campo_marcador AS marcador_respondido,\n' +
+    '       l.marcador_esperado,\n' +
+    "       l.corpo ->> 'ok' AS ok_respondido,\n" +
+    '       CASE\n' +
+    '         WHEN l.request_id IS NULL\n' +
+    `           THEN 'INDETERMINADO — esta canaria nao tem request_id no mapa embutido pelo passo ` +
+    `${passoDisparo}. Isto e ausencia de dado, nao veredito: ou a trava ficou FECHADA e nada foi ` +
+    `disparado, ou a celula veio de OUTRA leva'\n` +
+    '         WHEN l.status_code IS NULL\n' +
+    `           THEN 'AGUARDE — o request_id embutido pelo passo ${passoDisparo} ainda nao tem ` +
+    `resposta HTTP (leva ~10s); rode este passo de novo'\n` +
+    `         WHEN l.created <= now() - interval '${janelaMin} minutes'\n` +
+    `           THEN 'INDETERMINADO — a resposta e de ' || l.created || ', FORA da janela de ` +
+    `${janelaMin} min: esta celula e de outra sessao e o veredito seria de um deploy anterior. ` +
+    `Redispare o passo ${passoDisparo}'\n` +
+    // ------------------------------------------------------------------ SEM CANARIA NO AR ---
+    // O eco vem ANTES do status de propósito: a generate-tactical-plan devolve 500 quando a
+    // canária dela REPROVA, e julgar pelo status primeiro leria regressão como bundle velho.
+    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code = 401\n` +
+    `              AND c.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL} AND c.recusas_recentes = 0\n` +
+    `           THEN 'SEM CANARIA NO AR — 401, e o CRON_SECRET esta PROVADO bom agora (' ||\n` +
+    `                c.ok_recentes || ' resposta(s) 2xx e ZERO 401 fora desta leva em 6h), logo a ` +
+    `recusa e da EDGE: o bundle no ar e anterior a canaria, ela NAO rodou e NADA executou. Isto ` +
+    `NAO e canaria vermelha — o desfecho e DEPLOY'\n` +
+    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code = 401\n` +
+    `           THEN 'INDETERMINADO — 401 nao separa bundle sem canaria de CRON_SECRET invalido, e ` +
+    `o controle de credencial NAO foi observado (2xx fora da leva em 6h: ' || c.ok_recentes ||\n` +
+    `                ', recusas 401: ' || c.recusas_recentes || '). Confira o CRON_SECRET no vault ` +
+    `ANTES de redeployar'\n` +
+    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code >= 400\n` +
+    `           THEN 'SEM CANARIA NO AR — o bundle recusou o request (HTTP ' || l.status_code ||\n` +
+    `                '), NADA executou. Isto NAO e canaria vermelha: nao ha canaria no ar para ` +
+    `ficar vermelha'\n` +
+    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true'\n` +
+    `           THEN 'SEM CANARIA NO AR — HTTP ' || l.status_code || ' SEM eco canary: o bundle ` +
+    `ignorou a flag e RODOU O FLUXO REAL (' || l.efeito || '). Isto NAO e canaria vermelha, e ` +
+    `canaria AUSENTE — e o efeito ja aconteceu'\n` +
+    // ------------------------------------------------------------ marcador antes do `ok` ---
+    '         WHEN l.corpo ->> l.campo_marcador IS NULL\n' +
+    `           THEN 'CANARIA SEM MARCADOR — respondeu canary:true e o corpo NAO TEM o campo ' ||\n` +
+    `                l.campo_marcador || ': o bundle e anterior ao versionamento da canaria. O ok ` +
+    `sozinho NAO discrimina reversao de fatia (armadilha 2 do deploy.md). PRECISA DEPLOY'\n` +
+    '         WHEN l.corpo ->> l.campo_marcador IS DISTINCT FROM l.marcador_esperado\n' +
+    `           THEN 'CANARIA DE OUTRA FATIA — respondeu ' || l.campo_marcador || '=' ||\n` +
+    `                COALESCE(l.corpo ->> l.campo_marcador, '?') || ' (esperado ' ||\n` +
+    `                l.marcador_esperado || '). O bundle velho carrega o expected VELHO e compara ` +
+    `velho x velho, entao o ok dele nao vale — e assim que uma reversao MENTE VERDE. PRECISA DEPLOY'\n` +
+    `         WHEN l.corpo ->> 'ok' IS NULL\n` +
+    `           THEN 'CANARIA SEM VEREDITO — canary:true e marcador batendo, mas o corpo nao traz ` +
+    `ok. Fail-closed: sem os TRES campos nao ha confirmacao'\n` +
+    `         WHEN l.corpo ->> 'ok' = 'false'\n` +
+    `           THEN 'CANARIA VERMELHA — o bundle no ar E o esperado (' || l.marcador_esperado ||\n` +
+    `                ') e a fixture REPROVOU: o comportamento regrediu. NAO e deploy pendente — ` +
+    `leia os casos do corpo para saber QUAL lado caiu'\n` +
+    `         WHEN l.corpo ->> 'canary' = 'true'\n` +
+    '              AND l.corpo ->> l.campo_marcador = l.marcador_esperado\n' +
+    `              AND l.corpo ->> 'ok' = 'true'\n` +
+    "           THEN 'CANARIA VERDE'\n" +
+    `         ELSE 'INDETERMINADO — combinacao nao prevista: canary=' ||\n` +
+    `              COALESCE(l.corpo ->> 'canary', '?') || ', ' || l.campo_marcador || '=' ||\n` +
+    `              COALESCE(l.corpo ->> l.campo_marcador, '?') || ', ok=' ||\n` +
+    `              COALESCE(l.corpo ->> 'ok', '?')\n` +
+    '       END AS veredito\n' +
+    'FROM lidas l CROSS JOIN controle_credencial c\n' +
+    'ORDER BY l.nome;\n'
+  );
+}
+
+/** A leva de canárias pedida, e o recorte. */
+export interface OpcoesCanaria {
+  raiz: string;
+  /** Nomes do registro `CANARIAS`. Vazio = todas as alcançáveis. */
+  nomes: string[];
+  janelaMin?: number;
+  ler: LeitorCanariasDoRepo;
+}
+
+/**
+ * Gera o SQL de verificação das canárias.
+ *
+ * A divisão em blocos é a MESMA da sonda, e pela mesma fronteira de permissão: o disparo precisa de
+ * ESCRITA (vault + INSERT do `net.http_post`) e passa pelo founder no SQL Editor; a leitura é SELECT
+ * em `net._http_response` e roda no `psql-ro`. O que muda é que aqui a leitura NÃO tem versão
+ * standalone — ela nasce dentro da célula que o disparo devolve.
+ */
+export function gerarSqlDasCanarias(opts: OpcoesCanaria): string {
+  const janelaMin = validarJanela(opts.janelaMin);
+  const pedidas =
+    opts.nomes.length > 0
+      ? opts.nomes
+      : CANARIAS.filter((c) => c.inalcancavel === null).map((c) => c.nome);
+  const leva = resolverCanarias(opts.raiz, pedidas, opts.ler);
+  const ref = lerProjectRef(opts.raiz);
+  const baratas = leva.filter((c) => !c.fluxoRealSeVelho);
+  const caras = leva.filter((c) => c.fluxoRealSeVelho);
+  const partes: string[] = [];
+
+  if (baratas.length > 0) {
+    partes.push(
+      `-- PASSO 1 — dispara as ${baratas.length} canária(s) cujo bundle velho NÃO cai em efeito caro.\n` +
+        '--          É o bloco do FOUNDER: lê o vault e faz INSERT, e o read-only recusa os dois.\n' +
+        '-- Ele DEVOLVE o passo 2 já escrito, com o mapa nome→id dentro: copie a célula inteira.\n' +
+        blocoDisparoCanaria(ref, baratas, 1, janelaMin),
+    );
+  }
+
+  if (caras.length > 0) {
+    partes.push(
+      `-- PASSO 3 — dispara as ${caras.length} canária(s) CARAS, com trava.\n` +
+        '-- ⚠️ Bundle sem a canária IGNORA a flag e RODA O FLUXO REAL destas:\n' +
+        caras.map((c) => `--    · ${c.nome}: ${c.efeitoSeVelho}\n`).join('') +
+        '--    Só abra a trava depois de o deploy estar confirmado por outro caminho (a SONDA da\n' +
+        '--    edge, `bun run sonda:sql <edge>`, responde antes de qualquer I/O e não tem efeito).\n' +
+        '-- ⚠️ A trava é CASE e NÃO um filtro: o Postgres avalia a projeção mesmo descartando todas\n' +
+        '--    as linhas, então travar por filtro deixa o http_post sair igual.\n' +
+        '-- Ele também DEVOLVE o passo 4 já escrito, com o mapa dentro: copie a célula inteira.\n' +
+        blocoDisparoCanaria(ref, caras, 3, janelaMin, true),
+    );
+  }
+
+  return partes.join('\n');
+}
+
 /** A leva pedida na linha de comando. */
 export interface ArgsCli {
   edges: string[];
@@ -886,12 +1529,19 @@ export interface ArgsCli {
   semRede?: boolean;
   /** Libera o bloco LEGADO (POST direto na edge) para uma edge que já tem o caminho seguro. */
   permitirEfeitoLegado?: boolean;
+  /** Modo CANÁRIA: os posicionais deixam de ser edges e viram nomes do registro `CANARIAS`. */
+  canaria?: boolean;
 }
 
 const USO =
   'uso: bun run sonda:sql <edge> [<edge> ...] [--caro=<edge>[,<edge>]] [--permitir-efeito-legado]\n' +
   '                        [--janela=<min>] [--so-disparo | --so-leitura]\n' +
+  '     bun run sonda:sql --canaria [<canaria> ...] [--janela=<min>]\n' +
   '  <edge>        nome do diretório em supabase/functions/ (precisa ter versao.ts)\n' +
+  '  --canaria     verifica a CANÁRIA (comportamento) em vez da sonda (bundle). Sem nomes, faz\n' +
+  '                todas as alcançáveis pelo SQL Editor. O corpo de disparo e o marcador esperado\n' +
+  '                saem do registro/repo — nunca digitados. Nomes registrados:\n' +
+  CANARIAS.map((c) => `                  ${c.nome}${c.inalcancavel === null ? '' : '  (inalcançável pelo SQL Editor)'}\n`).join('') +
   '  --caro        marca um SUBCONJUNTO da leva cujo bundle pré-sensor dispara o fluxo real;\n' +
   '                essas saem em bloco separado, com trava por CASE.\n' +
   `  --janela      janela do guard temporal da leitura, em minutos (padrão ${JANELA_PADRAO_MIN}, ` +
@@ -917,9 +1567,14 @@ export function parsearArgs(argv: string[]): ArgsCli {
   let soLeitura: boolean | undefined;
   let semRede: boolean | undefined;
   let permitirEfeitoLegado: boolean | undefined;
+  let canaria: boolean | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
+    if (arg === '--canaria') {
+      canaria = true;
+      continue;
+    }
     if (arg === '--caro' || arg.startsWith('--caro=')) {
       const bruto = arg === '--caro' ? argv[++i] : arg.slice('--caro='.length);
       if (!bruto) throw new Error(`--caro sem valor.\n${USO}`);
@@ -956,6 +1611,50 @@ export function parsearArgs(argv: string[]): ArgsCli {
     edges.push(arg);
   }
 
+  if (canaria === true) {
+    // As flags da sonda que NÃO têm sentido aqui são RECUSADAS, não ignoradas. Flag aceita em
+    // silêncio é a via de "pedi --so-leitura e o SQL veio sem ela" — e `--caro` ignorado seria
+    // pior: quem o passou acredita ter armado a trava, e a trava aqui vem do registro.
+    const proibidas: string[] = [];
+    if (soLeitura === true) {
+      proibidas.push(
+        '--so-leitura: a resposta da canária NÃO ecoa o slug da edge, então um bloco de leitura ' +
+          'sem o mapa `nome → request_id` sairia INDETERMINADO em toda linha. Aqui a leitura já ' +
+          'vem escrita DENTRO da célula que o passo de disparo devolve — é ela que roda no psql-ro',
+      );
+    }
+    if (soDisparo === true) {
+      proibidas.push(
+        '--so-disparo: em modo canária TUDO o que se emite já é disparo (a leitura sai embutida ' +
+          'na célula de resposta dele), então o recorte não recorta nada',
+      );
+    }
+    if (caras.length > 0) {
+      proibidas.push(
+        '--caro: quais canárias caem em efeito caro num bundle velho é propriedade do CÓDIGO, e ' +
+          'está no registro CANARIAS (`fluxoRealSeVelho`). Depender de o operador lembrar é como ' +
+          'a trava deixa de ser armada justamente na noite em que ela importa',
+      );
+    }
+    if (permitirEfeitoLegado === true) {
+      proibidas.push('--permitir-efeito-legado: é do bloco legado da SONDA, não existe aqui');
+    }
+    if (proibidas.length > 0) {
+      throw new Error(`flag sem sentido em modo canária —\n  ${proibidas.join('\n  ')}\n${USO}`);
+    }
+    const repetidasC = edges.filter((e, i) => edges.indexOf(e) !== i);
+    if (repetidasC.length > 0) {
+      throw new Error(
+        `canária repetida na leva: ${[...new Set(repetidasC)].join(', ')} — ` +
+          'linha duplicada no VALUES é canária disparada duas vezes.',
+      );
+    }
+    // A forma dos nomes NÃO é validada por `FORMA_EDGE` (eles levam `:` quando a edge tem duas
+    // canárias): quem valida é `resolverCanarias`, contra o registro, e um nome fora dele já sai
+    // com a lista das opções — mais útil que "fora da forma".
+    return { edges, caras, janelaMin, soDisparo, soLeitura, semRede, permitirEfeitoLegado, canaria };
+  }
+
   if (edges.length === 0) throw new Error(`nenhuma edge na leva.\n${USO}`);
 
   const tortas = [...edges, ...caras].filter((e) => !FORMA_EDGE.test(e));
@@ -973,7 +1672,7 @@ export function parsearArgs(argv: string[]): ArgsCli {
     );
   }
 
-  return { edges, caras, janelaMin, soDisparo, soLeitura, semRede, permitirEfeitoLegado };
+  return { edges, caras, janelaMin, soDisparo, soLeitura, semRede, permitirEfeitoLegado, canaria };
 }
 
 /** Saídas da CLI, injetáveis para o teste ver o que foi escrito. */
@@ -993,6 +1692,12 @@ export interface DependenciasCli {
    * compilador cobra — quem chama `main` decide entre o `git` de verdade e um fabricado no teste.
    */
   git: ExecutorGit;
+  /**
+   * O leitor de canárias do repo. Injetado pelo mesmo motivo do `edgesComRele` (o eval copia só
+   * dois arquivos), mas AUSENTE aqui é fail-CLOSED e não "nenhuma": sem ele o marcador esperado
+   * teria de ser digitado, que é a via do veredito falso. `--canaria` sem leitor RECUSA.
+   */
+  lerCanarias?: LeitorCanariasDoRepo;
 }
 
 /** Ponto de entrada. Devolve o código de saída; NADA é escrito na saída quando falha. */
@@ -1033,18 +1738,44 @@ export function main(argv: string[], deps: DependenciasCli): number {
   let sql: string;
   let aviso: string | null;
   try {
-    const { edges, caras, janelaMin, soDisparo, soLeitura, semRede, permitirEfeitoLegado } = parsearArgs(argv);
-    const recusa = guardEfeitoLegado(edges, permitirEfeitoLegado === true, deps.edgesComRele ?? []);
-    if (recusa !== null) {
-      deps.erro(`❌ ${recusa}`);
-      return 1;
+    const { edges, caras, janelaMin, soDisparo, soLeitura, semRede, permitirEfeitoLegado, canaria } =
+      parsearArgs(argv);
+    if (canaria === true) {
+      if (deps.lerCanarias === undefined) {
+        throw new Error(
+          'modo canária sem leitor de canárias do repo: o marcador esperado sairia digitado, e ' +
+            'marcador digitado é a via do veredito FALSO que esta ferramenta fecha. Quem chama ' +
+            '`main` com --canaria precisa injetar `lerCanarias`. Nenhum SQL foi emitido.',
+        );
+      }
+      const nomes =
+        edges.length > 0
+          ? edges
+          : CANARIAS.filter((c) => c.inalcancavel === null).map((c) => c.nome);
+      const leva = resolverCanarias(deps.raiz, nomes, deps.lerCanarias);
+      sql = gerarSqlDasCanarias({ raiz: deps.raiz, nomes, janelaMin, ler: deps.lerCanarias });
+      // O guard de sincronia vale IGUAL aqui, sobre as EDGES das canárias pedidas: o marcador
+      // esperado é lido do DISCO, e disco atrás de `origin/main` produz o mesmo falso da sonda —
+      // "canária de outra fatia" contra um repo local velho, não contra o bundle que está no ar.
+      ({ aviso } = conferirSincronia(
+        deps.raiz,
+        [...new Set(leva.map((c) => c.edge))],
+        semRede === true,
+        deps.git,
+      ));
+    } else {
+      const recusa = guardEfeitoLegado(edges, permitirEfeitoLegado === true, deps.edgesComRele ?? []);
+      if (recusa !== null) {
+        deps.erro(`❌ ${recusa}`);
+        return 1;
+      }
+      // A leva é resolvida ANTES do guard de sincronia porque as duas falhas competem pelo mesmo
+      // texto e a da leva é mais específica: uma edge sem `versao.ts` deve ouvir "sem sensor", não
+      // "não existe em origin/main". Nada é escrito até as DUAS passarem — `gerarSqlDaLeva` só
+      // monta a string, e é este `escrever` lá embaixo que emite.
+      sql = gerarSqlDaLeva({ raiz: deps.raiz, edges, caras, janelaMin, soDisparo, soLeitura });
+      ({ aviso } = conferirSincronia(deps.raiz, edges, semRede === true, deps.git));
     }
-    // A leva é resolvida ANTES do guard de sincronia porque as duas falhas competem pelo mesmo
-    // texto e a da leva é mais específica: uma edge sem `versao.ts` deve ouvir "sem sensor", não
-    // "não existe em origin/main". Nada é escrito até as DUAS passarem — `gerarSqlDaLeva` só monta
-    // a string, e é este `escrever` lá embaixo que emite.
-    sql = gerarSqlDaLeva({ raiz: deps.raiz, edges, caras, janelaMin, soDisparo, soLeitura });
-    ({ aviso } = conferirSincronia(deps.raiz, edges, semRede === true, deps.git));
   } catch (e) {
     deps.erro(`❌ ${(e as Error).message}`);
     return 1;
@@ -1062,6 +1793,12 @@ if (import.meta.main) {
   // Import DINÂMICO, e só aqui: quem apenas importa este módulo (o eval da skill, que o copia para
   // um diretório temporário) não pode depender de `supabase/functions/` resolver.
   const { SONDA_CRON_ALVOS } = await import('../supabase/functions/_shared/sonda-cron-alvos');
+  // O leitor de canárias sai daqui pela MESMA razão, e reusa o extrator do gate `canaria:bump`:
+  // duas cópias da regra "onde mora o marcador" divergiriam, e a que não tem gate é a que decide
+  // errado. O stripper é o COMPARTILHADO (`removerComentarios`) — regex local não sabe o que é
+  // string e apagaria o miolo do arquivo antes da medição.
+  const { localizarCanarias } = await import('./canaria-contrato-bump-gate');
+  const { removerComentarios } = await import('@/lib/gates/limpeza-fonte');
   process.exit(
     main(process.argv.slice(2), {
       raiz: join(import.meta.dirname, '..'),
@@ -1069,6 +1806,10 @@ if (import.meta.main) {
       erro: (t) => console.error(t),
       git: gitReal(join(import.meta.dirname, '..')),
       edgesComRele: SONDA_CRON_ALVOS.map((a) => a.edge),
+      lerCanarias: (raiz, edge) =>
+        localizarCanarias(
+          removerComentarios(readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8')),
+        ),
     }),
   );
 }


### PR DESCRIPTION
## O buraco

O `sonda:sql` gera o SQL de duas partes da **sonda** desde o #1998. A **canária** não tinha equivalente: toda medição pós-deploy era `net.http_post` escrito à mão, com o CASE do veredito reescrito junto — foi assim no fecho do #2367, derivando do bloco da sonda por troca de `'probe'` por `'canary'`. Duas coisas viajavam na mão nesse caminho, e as duas produzem **veredito falso**.

## 1. O corpo não é uniforme — e o errado cai no FLUXO REAL

A tabela do `deploy.md` tem quatro formas: `{"canary":true}`, `?canary=1` na URL, e rotas nomeadas por `action` (`identidade_probe`, `doc_ambiguo_probe`, `transferencia_probe`, `paginacao_probe`). Corpo errado não é "canária que não respondeu": a edge cai no fluxo real — na `carteira-rebuild` isso é o rebuild inteiro (lease + upserts), na `generate-tactical-plan` é token de LLM **sem gate de auth na frente**.

Essas duas saem em bloco **com trava**, e quem é caro vem do **registro** (`fluxoRealSeVelho`), não da memória de quem chama. `--caro` é recusado aqui pelo mesmo motivo que ele existe na sonda: depender de o operador lembrar é como a trava deixa de ser armada justamente na noite em que ela importa.

## 2. O marcador esperado é DERIVADO do repo

Pelo mesmo extrator do gate `canaria:bump` (`localizarCanarias` + o stripper compartilhado), nas **duas** formas que ele conhece desde o #2374:

| forma | quem usa | de onde sai o literal |
|---|---|---|
| `contrato: "<literal>"` | 7 canárias | o próprio `index.ts` |
| `versao: VERSAO` (referência) | `generate-tactical-plan` | o `versao.ts` da edge |

O `campoMarcador` do registro é conferido contra a forma que o repo usa **nos dois sentidos**: canária que troque de forma **recusa a geração** até o registro acompanhar. Sem isso, o sentido `versao`→`contrato` diria "sem marcador" (causa errada, e o desfecho seria redeployar edge que está no ar) e o inverso leria o marcador da **sonda** achando que é o da canária — o defeito do `canaria-papel-duplo.md`.

## 3. O veredito: BUNDLE VELHO ≠ CANÁRIA VERMELHA

Desfechos opostos — deploy × investigar regressão — e o CASE reescrito à mão erra a ordem com facilidade:

- **ausência do eco `canary`** → `SEM CANARIA NO AR`, em três sabores: 401 com controle de credencial, outro 4xx, e o **200 que RODOU O FLUXO REAL** (nomeando o efeito). Não é vermelha — é canária **ausente**, e o efeito já aconteceu.
- **marcador divergente** → `CANARIA DE OUTRA FATIA`: a armadilha 2 do `deploy.md`, em que o bundle velho carrega o `expected` velho, compara velho×velho e responde `ok:true` — **mentindo verde**.
- **só `ok:false` COM o marcador batendo** → `CANARIA VERMELHA`.
- ⚠️ **o eco é julgado ANTES do status**, porque a `generate-tactical-plan` responde **HTTP 500** quando a canária dela reprova. Julgar pelo status primeiro leria regressão como bundle velho e mandaria redeployar.

## A divisão de trabalho, e por que `--so-leitura` é recusado

PASSO 1 é do founder (vault + INSERT, que o read-only recusa) e devolve o **PASSO 2 já escrito, com o mapa `nome → request_id` dentro**. Aqui isso não é conveniência: a resposta da canária **não ecoa o slug** da edge (medido nas 8 emissões: `{canary, contrato, ok, …}`), então sem o mapa nenhuma linha é atribuível — um bloco de leitura sem mapa não seria "menos preciso", seria `INDETERMINADO` em toda linha.

A `analyze-unified-order` também é **recusada**: a canária dela vive depois do gate de staff (JWT), o SQL Editor recebe 401, e 401 se lê como bundle velho. Ela é do app logado (Governança → Auditoria) — a **sonda** dela continua alcançável.

Fail-closed extra: canária emitida no repo e **fora do registro** derruba a geração. É a armadilha "canária fora da tabela" do `deploy.md` dentro da ferramenta, onde ela é pior — a canária ausente do registro nunca é disparada, e a leva sai verde sobre 7 de 8.

## Prova

`db/test-canaria-veredito.sh` sobe um PG17, semeia fixtures em `net._http_response` e roda o SQL **gerado pelo script** (não uma cópia), com os marcadores **lidos de volta do SQL emitido** — bump legítimo de `contrato` não quebra o teste. 18 asserções cobrindo os três envelopes de resposta (topo, `data`, topo com `success`), as duas formas de marcador, os quatro sabores de bundle velho e a ausência de dado.

`--falsificar` roda o **controle verde na mesma invocação do laço, antes do primeiro `sed`** (cópia + os dois locales + `ALVO` sobrescrito, exatamente o caminho das sabotagens) e exige vermelho em 10 sabotagens. **Duas ficaram verdes na primeira tentativa** — as conjunções do ramo VERDE eram *inalcançáveis* pelos fixtures que existiam, não asserção frouxa. A correção foi honesta: um fixture de `ok` não-booleano tornou a primeira alcançável, e a segunda passou a atacar o ramo que decide. Está registrado no cabeçalho do bloco.

## Evidência

| gate | resultado |
|---|---|
| `bun run typecheck` | rc=0 |
| `bun lint` | 0 errors (75 warnings pré-existentes) |
| `bun run lint:shell` | 0 achados em 391 arquivos |
| `bun run test` | 810 arquivos · 8518 testes |
| `bun run canaria:bump` | ✓ 8 canária(s) conferida(s) |
| `bash db/test-canaria-veredito.sh` | VEREDITO DE CANARIA OK |
| `bash db/test-canaria-veredito.sh --falsificar` | FALSIFICACAO OK |

A prova PG17 **não** entra em `db/nucleo-ci.txt`: ela precisa de `bun` para gerar o SQL, e o job `provas-sql` é deliberadamente sem bun. Mesma situação da irmã `db/test-pendencias-deploy-eco-passivo.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
