### PR TITLE
test(deploy): a 8ª canária entra na CALIBRAÇÃO do `canaria:bump` — o fecho dela não estava falsificado

### DIFF
--- a/scripts/canaria-contrato-bump-gate.test.ts
+++ b/scripts/canaria-contrato-bump-gate.test.ts
@@ -291,6 +291,12 @@ const SOB_TESTE: Array<{ edge: string; chave: string; simbolo: string }> = [
   { edge: 'omie-analytics-sync', chave: 'case:transferencia_probe', simbolo: 'classificarLoteProof' },
   { edge: 'omie-financeiro', chave: 'case:paginacao_probe', simbolo: 'desfechoVarreduraReversa' },
   { edge: 'omie-vendas-sync', chave: 'case:identidade_probe', simbolo: 'decideAccountIdentity' },
+  // A 8ª canária — a que serve o marcador em `versao`. Entra aqui com DOIS símbolos de propósito:
+  // `avaliarCanariaMargem` é o que o bloco chama DIRETO, e `margemConhecida` está um salto adiante,
+  // em `_shared/`. É esse segundo que prova o eixo pelo qual ela estava descoberta — se o fecho
+  // transitivo parar de alcançá-lo, isto fica vermelho ANTES de o gate ficar cego.
+  { edge: 'generate-tactical-plan', chave: 'if:1', simbolo: 'avaliarCanariaMargem' },
+  { edge: 'generate-tactical-plan', chave: 'if:1', simbolo: 'margemConhecida' },
 ];
 
 // A fronteira de I/O é onde o gate irmão embarcou DOIS falsos-verdes com 23 testes de núcleo


### PR DESCRIPTION
## O que faltou no #2377

O #2377 ensinou o `canaria:bump` a **descobrir** a canária da `generate-tactical-plan` (a que serve o marcador no campo `versao`). Mas a lista `SOB_TESTE` da CALIBRAÇÃO ficou com 6 entradas, nenhuma dessa edge — então o fecho de símbolos dela não é falsificado por ninguém.

Isso importa porque o cabeçalho do próprio gate diz que é a calibração que "converte suposição em medida" para o índice de definições: **se o fecho parar de alcançar os símbolos, é ela que fica vermelha ANTES de o gate ficar cego.** Descoberta sem calibração é meia entrega.

## O que entra

Dois símbolos, de propósito:

- `avaliarCanariaMargem` — o que o bloco da canária chama **direto**;
- `margemConhecida` — um salto adiante, em `_shared/`. É **o eixo pelo qual essa canária estava descoberta** (o `sonda:bump` exclui `_shared/`), então é exatamente o que precisa de vigia.

## Falsificação

Trocar `margemConhecida` por um símbolo que a canária **não** exercita (`clampRecencyCapDays`, local do `index.ts`) faz o teste reprovar com *"o fecho não alcançou `clampRecencyCapDays` — o gate ficaria cego para ele"*. A calibração discrimina; não é sempre-verde.

Verde: `bunx vitest run scripts/canaria-contrato-bump-gate.test.ts` rc=0 — 49 testes, **6 asserções nomeando a 8ª canária** (confirmado com `--reporter=verbose`, não por ausência de erro).

## Por que é um PR separado

A edição existia durante o #2377 e **se perdeu**: estava no working tree quando o laço de falsificação da própria calibração rodou, e o `trap restaurar EXIT` (`git checkout --`) a descartou. O `git add` + `--amend` seguinte encontrou o arquivo idêntico ao HEAD e passou sem erro, então o #2377 mergeou sem ela.

É a armadilha que o CLAUDE.md nomeia — *"COMMITE antes de falsificar — `restaurar()` costuma ser `git checkout --`"*. O furo foi de **escopo**: commitei o gate antes de falsificar o *gate*, mas não a calibração antes de falsificar a *calibração*. E o sinal que li como sucesso (`restaurado: 0 sujo(s)`) significava o arquivo de volta ao HEAD — sem a mudança.

Detectado pela `/fecho`, ao conferir o artefato na main **por símbolo** em vez de confiar na memória da sessão. Aqui o commit veio **antes** da validação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
