### PR TITLE
docs(deploy): a metade do EVENTO fechou — `DIVERGE_P1` → `CONFERE` num prompt em LOTE, com o ANTES lido do ledger

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -129,9 +129,10 @@ Montar pro founder colar no chat do Lovable, para as edges que o `pendencias:dep
 — este passo decide o **conteúdo** do prompt, o closure ∪ {mapa}; ele NÃO decide *se* a edge precisa de
 deploy, e o mapa ter mudado depois do PR não é motivo (ver Passo 2).
 
-**UMA colagem por LEVA, não por edge (medido 2026-09-06).** Com 2+ edges pendentes, monte um prompt
-único numerando-as, cada uma com a SUA lista de arquivos — a forma exata está no fim deste passo, e a
-medição (8 edges, 70 arquivos, 54/54 depois) no §Estado. O prompt de 1 edge abaixo continua sendo a
+**UMA colagem por LEVA, não por edge (medido 2026-09-06, e a transição observada em 2026-09-08).**
+Com 2+ edges pendentes, monte um prompt único numerando-as, cada uma com a SUA lista de arquivos — a
+forma exata está no fim deste passo, e as duas medições (8 edges / 70 arquivos → 54/54; depois 2 edges
+com o ANTES **medido** no ledger, `DIVERGE_P1` → `CONFERE` → 59/59) no §Estado. O prompt de 1 edge abaixo continua sendo a
 unidade de construção, e é o que você usa quando a leva tem uma só:
 
 > Edit the existing edge function `<nome>` and replace its code with the current contents of
@@ -250,8 +251,10 @@ não só o `index.ts` (#2018).
 
 Mesmo conteúdo por edge, uma colagem só. O cabeçalho pede o total e proíbe pular; cada edge vira uma
 **seção numerada** com o closure ∪ {mapa} DELA; o fecho pede a confirmação item a item, que é o que
-dá ao founder o relato para comparar com a sonda. Medido em 2026-09-06 com **8 edges / 70 arquivos**:
-as 8 responderam `versao` + `fonte` da main e o `pendencias:deploy` fechou 54/54 (§Estado):
+dá ao founder o relato para comparar com a sonda. Medido em 2026-09-06 com **8 edges / 70 arquivos**
+(as 8 responderam `versao` + `fonte` da main, `pendencias:deploy` 54/54) e de novo em **2026-09-08**,
+desta vez com o ANTES conhecido — 2 edges, uma delas em `DIVERGE_P1` medido, que transitou para
+`CONFERE` depois do prompt único (§Estado):
 
 > Edit the following **eight** existing edge functions and update **each** of them from the `main`
 > branch using the current contents of the files listed under it. Deploy all of them **verbatim** —
@@ -1111,12 +1114,27 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   `NUNCA_ATESTADA` — estado ANTES **desconhecido** —, então "o Lovable deployou as 8" e "deployou
   algumas e as outras já estavam idênticas à main" produzem o MESMO eco. O que ficou provado é o par
   que importa para a decisão: o prompt em lote **não** deixa edge pela metade, e depois dele as 8
-  servem o bundle da main. Para fechar a outra metade, repita numa leva com ≥1 edge em `DIVERGE_P1`
-  MEDIDA antes (aí o antes é conhecido e a transição prova o deploy) — enquanto isso não acontecer,
-  a recomendação vale por conveniência com risco medido, não por prova de atomicidade.
+  servem o bundle da main. Para fechar a outra metade era preciso uma leva com ≥1 edge em `DIVERGE_P1`
+  MEDIDA antes — **e ela apareceu em 2026-09-08: item abaixo.** Até lá a recomendação valia por
+  conveniência com risco medido; agora a metade do EVENTO está medida.
   **Forma do prompt que funcionou** (Passo 3): cabeçalho pedindo as N funções + "Deploy every function
   listed; do not skip any", uma seção **numerada** por edge com o closure ∪ {mapa} dela, e o fecho
   "list the N function names and confirm that **each one** shows Active".
+- [x] **A metade do EVENTO, fechada — `DIVERGE_P1` → `CONFERE` num prompt em LOTE (2026-09-08):** a
+  leva prescrita acima apareceu, e não precisou ser fabricada. 2 edges, pacote `29258bf8ac3d` contra
+  `origin/main@5bc73bfac` (34 entradas, **24 arquivos únicos**), um prompt só, enviado por
+  `mcp__lovable__send_message` (canal do #2374) — 1,2 crédito. O ANTES saiu do ledger, não do relato:
+  `omie-vendas-sync` em **`DIVERGE_P1` medido** (prod `v1.2-preco-ausente-nao-e-zero` → main
+  `v1.3-edicao-write-back-atomico`, o fix money-path do #2370) e `sync-reprocess` em `DIVERGE_P2` com
+  **platô de 8 leituras do eco de cron em 13 h** no mesmo par. Depois do prompt: sonda de
+  `omie-vendas-sync` (`request_id` 72784, lido do mapa embutido pelo BANCO) com os quatro campos
+  batendo ⇒ `DEPLOY CONFIRMADO`; `sync-reprocess` atestada pelo relé; `pendencias:deploy` **exit 0,
+  59/59**. Um no-op teria deixado a `v1.2` no ar e o platô intacto — é isto que 2026-09-06 não podia
+  distinguir. **O que segue não provado:** N=2, não os 8 do lote grande; e o `sha256` que o agente
+  conferiu mede o REPO no sandbox, não os bytes servidos — a última ponte continua sendo o `fonte`
+  **declarado** pela sonda. Detalhe em
+  [`docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md`](../../../docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md) §7,
+  cruzado com o piloto do MCP (que mediu o CANAL com divergência FABRICADA e N=1).
 - [x] **O carimbo `__BUILD_SHA__` voltou a ser REAL (2026-09-08):** de junho a setembro a skill
   registrava `"dev"` e declarava o caminho determinístico *inviável*, obrigando sentinela em todo
   run. Medido no piloto da Camada 2: o ar carimbava `bb9d8d2e` (= #2357, ancestral da main), o

--- a/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
+++ b/docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md
@@ -285,3 +285,75 @@ atomicidade, e a skill diz isso em voz alta.
 nenhum — é ele que a `verificar-sonda-versao.md` chama de relato, e o repo inteiro é construído sobre
 "relato de veredito não é veredito". O que ele serve é para *estreitar a pergunta*: se o Lovable
 disser que pulou alguma, tire-a do bloco de sonda antes de rodar. A prova continua sendo o `fonte`.
+
+## 7. A outra metade — `DIVERGE_P1` → `CONFERE` observado num prompt em LOTE (2026-09-08)
+
+O §6 prescreveu o teste que faltava: *"repetir o prompt único numa leva com ≥1 edge em `DIVERGE_P1`
+MEDIDA antes"*. A leva apareceu dois dias depois — e, ao contrário do piloto do MCP, **não precisou
+ser fabricada**: era uma pendência real de money-path esperando deploy.
+
+**A leva.** 2 edges, pacote `29258bf8ac3d` (`bun run pendencias:pacote`), montado contra
+`origin/main@5bc73bfac`: **34 entradas de arquivo, 24 únicas** — os 10 duplicados são o `_shared/`
+que as duas compartilham, listado uma vez por edge porque o prompt numera por EDGE, não por arquivo
+(a redundância é do formato, e é ela que impede o furo do #2020). Um único prompt numerando as duas,
+enviado por `mcp__lovable__send_message` — o canal do #2374, não colagem humana. O agente conferiu os
+24 `sha256` contra `5bc73bfa`, reportou zero divergência e deployou na tool call seguinte. Custo:
+**1,2 crédito**.
+
+**O ANTES, lido do ledger — é ele que faz disto um EVENTO e não um estado.** As duas linhas abaixo
+saem de `public.deploy_atestacoes` por `request_id`, não do relato do chat:
+
+| edge | estado ANTES | evidência do ANTES | DEPOIS | `request_id` |
+|---|---|---|---|---|
+| `omie-vendas-sync` | **`DIVERGE_P1`** — prod `v1.2-preco-ausente-nao-e-zero` / `5e3a00e7dfdf` → main `v1.3-edicao-write-back-atomico` / `c9b3be428206` | req **72154**, 2026-09-07 19:14:14Z | `v1.3-edicao-write-back-atomico` + `c9b3be428206` ⇒ `CONFERE` | **72784**, 10:09:44Z |
+| `sync-reprocess` | **`DIVERGE_P2`** — `versao` igual (`v1.5-sonda-options`), fonte `67eab2b2a17b` → `a3f3b18975bf` | **8 observações consecutivas** do eco de cron, 2026-09-07 19:16:47Z → 2026-09-08 08:37:00Z, todas no MESMO par | fonte `a3f3b18975bf` ⇒ `CONFERE` | **72783**, 10:09:35Z |
+
+O P1 é o fix money-path do write-back atômico (#2370): os DOIS campos do par mudaram, que é a forma
+mais forte da transição. O P2 é o caso mais interessante como evidência — o ANTES não foi uma leitura
+única que pudesse ser ruído: foi um **platô de 8 leituras ao longo de 13 h**, e o único evento
+conhecido entre a última (08:37:00Z) e o novo par (10:09:35Z) foi o prompt em lote. O `request_id`
+72784 saiu do mapa `edge | request_id` embutido pelo BANCO no PASSO 2 do `sonda:sql` — nunca
+transportado à mão (Lei de Ferro #5); a sonda devolveu HTTP 200 com os quatro campos batendo
+(`edge`, `versao`, `fonte`, `probe`) ⇒ `DEPLOY CONFIRMADO`. `sync-reprocess` foi atestada pelo relé
+(`deploy_sonda_disparar`).
+
+**O que isto fecha.** A metade que o §6 declarou aberta: aqui o ANTES era conhecido e medido, então a
+transição prova o deploy **pelo evento**, não só pelo estado. O lado positivo deixou de ser
+indistinguível do no-op — um no-op teria deixado `omie-vendas-sync` em `v1.2` e o platô do
+`sync-reprocess` intacto. A recomendação de **um prompt por LEVA** deixa de valer só por conveniência
+com risco medido.
+
+**O que continua NÃO provado, e a ressalva não some, encolhe.**
+
+- **N = 2, não 8.** A atomicidade do lote foi observada num par; o teste de 2026-09-06 tinha os 8, mas
+  sem ANTES. Nenhuma das duas medições é a outra, e "zero deploy parcial em 2 de 2" não é a mesma
+  afirmação que "em 8 de 8".
+- **O `sha256` mede o REPO no sandbox, não os bytes que o runtime passou a servir.** O agente conferiu
+  os arquivos que leu contra `5bc73bfa`; a ponte entre "arquivo certo no sandbox" e "bundle certo em
+  produção" continua sendo o `fonte` **DECLARADO** da sonda — a constante `FONTE_SHA256[edge]` lida de
+  `_shared/sonda-versao.ts`, sem hashear nada em runtime. É o mesmo limite que o §Deploy de edge pela
+  SESSÃO de [`docs/agent/deploy.md`](../agent/deploy.md) já nomeia, e que a metade "verbatim" do
+  piloto do MCP deixou explicitamente em aberto.
+
+**O cruzamento com o piloto do MCP — as duas metades encostam pela primeira vez.**
+[`piloto-deploy-mcp-lovable.md`](piloto-deploy-mcp-lovable.md) mediu o **canal** em 2026-09-07 e foi
+honesto sobre o preço: para ter um ANTES conhecido teve de **fabricar** a divergência (bump do
+`VERSAO` da `copilot-analyze`, #2347), com **N = 1** e uma edge escolhida por ser inócua — e o
+§"O que o veredito não autoriza" registra isso. Esta leva não fabricou nada: a divergência era
+natural, a cobaia do P1 é money-path, e o prompt era em LOTE. Canal (MCP) e transição de veredito
+(`DIVERGE_P1` → `CONFERE`) aparecem juntos numa medição só, o que nenhuma das duas anteriores tinha.
+O que a soma **não** dá é a metade verbatim: ela segue exatamente onde o piloto a deixou.
+
+### Evidência
+
+- **Ledger, `psql-ro`** (leitura direta de `deploy_atestacoes`, ordenada por `observado_em`): as 5
+  linhas de `omie-vendas-sync` e as 11 de `sync-reprocess` acima — ANTES, platô e DEPOIS, com
+  `request_id` e `fonte` por linha. Re-confirmação em 72787 (10:14:56Z), mesmo par.
+- **`bun run pendencias:deploy` → exit 0, cobertura 59/59**, com as duas na lista de `✅ confere`.
+  Re-medido horas depois, de outra worktree: **exit 0, 59/59** de novo, `omie-vendas-sync` e
+  `sync-reprocess` presentes — e a seção de cron reportando `8/8 disparo(s) atestado(s)`. (O que esta
+  segunda rodada NÃO é: um teste contra main que andou. Os 5 commits desde `5bc73bfa` **não tocam**
+  `supabase/functions/` — `git log 5bc73bfac..origin/main -- supabase/functions/` sai vazio —, então o
+  lado esperado é idêntico. Ela mede persistência do veredito, não robustez a drift.)
+- **O artefato do prompt** (`pacote-deploy-29258bf8ac3d.md`): 34 entradas, 24 caminhos únicos, 10
+  `_shared/` repetidos exatamente 2× — contados no arquivo, não estimados.

--- a/docs/historico/piloto-deploy-mcp-lovable.md
+++ b/docs/historico/piloto-deploy-mcp-lovable.md
@@ -753,6 +753,13 @@ corrigir.
   de 2026-09-06 (8 edges, ANTES desconhecido, transição não observável), e é o que faltava para
   fechar aquela lacuna — mas só na metade CANAL. Não é "o MCP nunca edita": é "nenhuma edição
   REGISTRADA nesta", e a rede que pegaria uma edição NÃO registrada não existe hoje.
+  **Estendido em 2026-09-08, e vale registrar o que mudou:** uma leva de 2 edges saiu por
+  `send_message` num prompt em LOTE, com o ANTES lido do ledger e a divergência **natural** em vez de
+  fabricada (`omie-vendas-sync` em `DIVERGE_P1`, o fix money-path do #2370) — transição para `CONFERE`
+  observada nas duas, `pendencias:deploy` 59/59. É a primeira medição em que o CANAL (aqui) e a
+  transição de veredito num prompt de LEVA (lá) aparecem juntos; a metade **verbatim** continua
+  exatamente onde este piloto a deixou. Detalhe em
+  [`deploy-redundante-ledger-e-cron-de-sonda.md`](deploy-redundante-ledger-e-cron-de-sonda.md) §7.
 - **A cobaia foi escolhida por ser inócua.** `farmer_copilot_sessions` = 0, zero escrita, closure de
   7 arquivos. Uma edge grande ou money-path é mais superfície para o agente "melhorar", e este
   resultado não fala por ela.


### PR DESCRIPTION
## O que muda

O §6 de [`deploy-redundante-ledger-e-cron-de-sonda.md`](docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md) nomeou a própria lacuna e prescreveu o teste que a fecharia:

> repetir o prompt único numa leva com **≥1 edge em `DIVERGE_P1` MEDIDA antes** (…). Até lá a recomendação vale por **conveniência com risco medido** — não por prova de atomicidade.

A leva apareceu em 2026-09-08, e não precisou ser fabricada.

## A medição

2 edges, pacote `29258bf8ac3d` contra `origin/main@5bc73bfac` — **34 entradas, 24 arquivos únicos** (os 10 duplicados são o `_shared/` compartilhado, listado uma vez por edge). Um prompt só, enviado por `mcp__lovable__send_message` (canal do #2374). Custo 1,2 crédito.

| edge | ANTES (lido do ledger) | DEPOIS |
|---|---|---|
| `omie-vendas-sync` | **`DIVERGE_P1`** — req 72154, prod `v1.2-preco-ausente-nao-e-zero`/`5e3a00e7dfdf` → main `v1.3-edicao-write-back-atomico`/`c9b3be428206` (fix money-path do #2370) | req **72784**, par batendo ⇒ `CONFERE` |
| `sync-reprocess` | **`DIVERGE_P2`** — **platô de 8 leituras** do eco de cron em 13 h, todas em `67eab2b2a17b` | req **72783**, fonte `a3f3b18975bf` ⇒ `CONFERE` |

O ANTES era conhecido e medido ⇒ a transição prova o deploy **pelo evento**, não só pelo estado. Um no-op teria deixado a `v1.2` no ar e o platô intacto — que é exatamente o que 2026-09-06 não conseguia distinguir.

## O que continua NÃO provado (escrito no doc, não omitido)

- **N = 2**, não os 8 do lote grande. "Zero deploy parcial em 2 de 2" ≠ "em 8 de 8".
- O **`sha256` mede o repo no sandbox**, não os bytes que o runtime passou a servir. A última ponte segue sendo o `fonte` **DECLARADO** da sonda — o mesmo limite do §Deploy de edge pela SESSÃO de `docs/agent/deploy.md`, e a metade "verbatim" do piloto do MCP continua onde ela estava.

## Arquivos

- `docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md` — §7 novo, com ANTES/DEPOIS lidos de `deploy_atestacoes` por `request_id` (nunca do relato do chat).
- `.claude/skills/lovable-deploy-verify/SKILL.md` — a ressalva do §Estado deixa de dizer "conveniência com risco medido, não prova de atomicidade"; item novo com a medição; Passo 3 cita as duas medições.
- `docs/historico/piloto-deploy-mcp-lovable.md` — cruzamento: ele mediu o CANAL com divergência **fabricada** e N=1; aqui canal e transição de veredito aparecem juntos pela primeira vez.

## Evidência (exit 0 colado em cada uma)

- `bun run docs:links` → `✓ 729 docs — todo link relativo de .md resolve.`
- `bun run docs:citacoes` → `✓ 38 citação(ões) verificada(s) contra o conteúdo real`
- `bun run claude:size` → exit 0 (CLAUDE.md **não** foi tocado)
- `bun run gates:frescura` → `FRESCURA-OK`
- `bun run evals:deploy-verify` → `✅ evals lovable-deploy-verify: OK` (7 evals)
- `bun run pendencias:deploy` → **exit 0, 59/59**, com as duas edges em `✅ confere` — re-medido desta worktree. *(Honestidade: os 5 commits desde `5bc73bfa` não tocam `supabase/functions/`, então isto mede persistência do veredito, não robustez a drift.)*

Números conferidos na fonte primária, não herdados do relato: `fonte` das duas edges via `git show 5bc73bfac:supabase/functions/_shared/sonda-fingerprints.ts`, linhas do ledger via `psql-ro`, e as 34/24 entradas contadas no próprio `pacote-deploy-29258bf8ac3d.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ Achado do `/fecho` desta sessão — a `main` está VERMELHA, e não é por este PR

Registrado aqui porque chip morre com a sessão (destino durável, `/fecho` passo 6).

O job `mutation-check` do CI reprova em `scripts/mutcheck.d/sonda-versao-sql.mut` (**exit 18** — a classe "`.mut` stale após refactor" que a própria mensagem do gate nomeia).

**Bisect pelos runs de CI na `main`:**

| commit | run | veredito |
|---|---|---|
| `bc50183ac` (10:15:15Z) | [34214454640](https://github.com/LucasSardenbergL/afiacao/actions/runs/34214454640) | ✅ success — último verde |
| `ddccb6164` (10:26:13Z) | [34215435046](https://github.com/LucasSardenbergL/afiacao/actions/runs/34215435046) | ❌ failure — **primeiro vermelho** |
| `703ccdddb` (este PR, 10:38:10Z) | [34216492232](https://github.com/LucasSardenbergL/afiacao/actions/runs/34216492232) | ❌ failure (herdado) |

Entre o último verde e o primeiro vermelho há **exatamente um commit**: `ddccb6164` = #2380 (`feat(deploy): a canária ganha modo no sonda:sql`). Ele tocou `scripts/sonda-versao-sql.ts` e `.test.ts` e **não** tocou o `.mut` que os vigia.

Este PR é docs-only (3 arquivos `.md`, zero `.ts`) — não pode ter causado, e herdou o vermelho.

**Ao consertar, a decisão não é automática:** exit 18 sugere `.mut` stale (atualizar o contrato), mas se o refactor fez o TESTE perder poder, atualizar o `.mut` apagaria o sinal — aí o conserto é no teste. Leia o código antes, e falsifique depois.

**De brinde, e talvez mereça entrega própria:** este PR mergeou às 10:37:46Z com o `mutation-check` ainda rodando (7m39s) e que veio a reprovar — ou seja, `mutation-check` não segura o auto-merge. Se for desenho, tudo bem; se não for, é gate que reprova sem barrar nada.
