### PR TITLE
fix(money-path): o passivo do agregado pedido de venda fechou — 15 pedidos, R$ 10.676,56 devolvidos, 0 reprovados em 31.219

### DIFF
--- a/db/reparo-15o-pedido-11701.sql
+++ b/db/reparo-15o-pedido-11701.sql
@@ -1,0 +1,175 @@
+-- ╔══════════════════════════════════════════════════════════════════════════════╗
+-- ║ REPARO do 15º pedido — 11701 / omie 12121128593 (conta oben, faturado)        ║
+-- ║                                                                              ║
+-- ║ POR QUE ESTE VEIO SEPARADO: no reparo dos 14 eu o SUSPENDI de propósito. O    ║
+-- ║ jsonb dizia 1×221,80 onde o banco dizia 2×110,90, e 221,80 = exatamente       ║
+-- ║ 2 × 110,90 — parecia quantidade colapsada dentro do preço (o SKU nunca passou ║
+-- ║ de 180,95 em 171 referências; as linhas irmãs do MESMO SKU no MESMO pedido    ║
+-- ║ são 2×105,90 e 2×119,90). Precisão > recall: não reparei, perguntei.          ║
+-- ║                                                                              ║
+-- ║ O QUE DESEMPATOU: o founder consultou o OMIE (2026-09-08) e o Omie diz        ║
+-- ║ 1 unidade a R$ 221,80. O Omie é o árbitro; a heurística de preço era só isso. ║
+-- ║                                                                              ║
+-- ║ O QUE MUDA: uma linha. 2 × 110,90 vira 1 × 221,80. Mesmo dinheiro             ║
+-- ║ (R$ 221,80), uma unidade a menos no sinal de demanda — que é o ponto.         ║
+-- ║ NÃO toca `sales_orders`: total, subtotal e items ficam byte-a-byte iguais.    ║
+-- ║                                                                              ║
+-- ║ Mesmo mecanismo já provado no reparo dos 14 (DELETE+INSERT do jsonb, na       ║
+-- ║ MESMA transação — é o que a CONSTRAINT TRIGGER da 20260907220000 exige).      ║
+-- ║                                                                              ║
+-- ║ NÃO é idempotente, de propósito: rodar de novo ABORTA com "[PRE] JA           ║
+-- ║ APLICADO". A pré-condição ancora no estado exato que foi conferido no Omie,   ║
+-- ║ então re-colar não reescreve nada às cegas. Abortar aqui é o comportamento    ║
+-- ║ certo, não um erro. Rode no SQL Editor do Lovable.                            ║
+-- ╚══════════════════════════════════════════════════════════════════════════════╝
+
+BEGIN;
+
+CREATE TEMP TABLE _alvo_15 ON COMMIT DROP AS
+SELECT so.id, so.omie_pedido_id, so.account, so.customer_user_id, so.total
+FROM public.sales_orders so
+WHERE so.omie_pedido_id = 12121128593
+  AND so.hash_payload IS NOT NULL          -- só a linha canônica do pedido
+FOR UPDATE;                                -- serializa contra o sync de 2 em 2 h
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- PRÉ-CONDIÇÃO: fail-closed. Ancorada no estado EXATO que o founder consultou
+-- no Omie. Se qualquer lado se mexeu desde então, aborta inteiro em vez de
+-- aplicar sobre uma realidade diferente da que foi verificada.
+-- ────────────────────────────────────────────────────────────────────────────
+DO $pre$
+DECLARE v_n int; v_linha_velha int; v_ja int; v_json_novo int; v_prod_nulo int; v_sem_produto int;
+BEGIN
+  SELECT count(*) INTO v_n FROM _alvo_15;
+  IF v_n <> 1 THEN
+    RAISE EXCEPTION '[PRE] esperava 1 pedido canonico (omie 12121128593), achei %', v_n;
+  END IF;
+
+  SELECT count(*) INTO v_linha_velha
+  FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id
+  WHERE oi.omie_codigo_produto = 8689743515
+    AND oi.quantity = 2 AND oi.unit_price = 110.90;
+
+  SELECT count(*) INTO v_ja
+  FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id
+  WHERE oi.omie_codigo_produto = 8689743515
+    AND oi.quantity = 1 AND oi.unit_price = 221.80;
+
+  -- Re-colada: o estado-alvo ja esta la. Aborta com mensagem que DIZ isso, em vez
+  -- de deixar o founder lendo um erro obscuro e achando que quebrou algo.
+  IF v_linha_velha = 0 AND v_ja = 1 THEN
+    RAISE EXCEPTION '[PRE] JA APLICADO: a linha ja e 1x221,80. Nada a fazer — isto NAO e um erro.';
+  END IF;
+
+  -- o lado que o Omie CONTRADIZ tem de estar exatamente como eu medi
+  IF v_linha_velha <> 1 THEN
+    RAISE EXCEPTION '[PRE] esperava 1 linha 2x110,90 do SKU 8689743515, achei % — o banco mudou desde a consulta ao Omie; NAO aplique as cegas', v_linha_velha;
+  END IF;
+
+  -- o lado que o Omie CONFIRMA tem de continuar dizendo o que dizia
+  SELECT count(*) INTO v_json_novo
+  FROM _alvo_15 a JOIN public.sales_orders so ON so.id = a.id
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+  WHERE (el->>'omie_codigo_produto')::bigint = 8689743515
+    AND (el->>'quantidade')::numeric = 1
+    AND (el->>'valor_unitario')::numeric = 221.80;
+  IF v_json_novo <> 1 THEN
+    RAISE EXCEPTION '[PRE] o jsonb nao diz mais 1x221,80 do SKU 8689743515 (achei % ocorrencia(s)) — o sync reescreveu; reveja antes de aplicar', v_json_novo;
+  END IF;
+
+  -- `ausente != zero`: linha de jsonb sem codigo de produto nao vira order_item
+  SELECT count(*) INTO v_prod_nulo
+  FROM _alvo_15 a JOIN public.sales_orders so ON so.id = a.id
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+  WHERE (el->>'omie_codigo_produto') IS NULL;
+  IF v_prod_nulo > 0 THEN
+    RAISE EXCEPTION '[PRE] % linha(s) de jsonb sem omie_codigo_produto — reparo nao igualaria os lados', v_prod_nulo;
+  END IF;
+
+  -- product_id e FK para omie_products
+  SELECT count(DISTINCT (el->>'omie_codigo_produto')::bigint) INTO v_sem_produto
+  FROM _alvo_15 a JOIN public.sales_orders so ON so.id = a.id
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+  WHERE NOT EXISTS (SELECT 1 FROM public.omie_products p
+                     WHERE p.omie_codigo_produto = (el->>'omie_codigo_produto')::bigint);
+  IF v_sem_produto > 0 THEN
+    RAISE EXCEPTION '[PRE] % SKU(s) do jsonb sem cadastro em omie_products', v_sem_produto;
+  END IF;
+END
+$pre$;
+
+DELETE FROM public.order_items oi
+USING _alvo_15 a
+WHERE oi.sales_order_id = a.id;
+
+INSERT INTO public.order_items (
+  sales_order_id, customer_user_id, product_id, omie_codigo_produto,
+  quantity, unit_price, discount, hash_payload, omie_codigo_item)
+SELECT
+  a.id,
+  a.customer_user_id,
+  (SELECT p.id FROM public.omie_products p
+    WHERE p.omie_codigo_produto = (el->>'omie_codigo_produto')::bigint),
+  (el->>'omie_codigo_produto')::bigint,
+  (el->>'quantidade')::numeric,
+  (el->>'valor_unitario')::numeric,
+  -- desconto EXPLICITO, nunca o DEFAULT 0 da coluna: chave ausente vira NULL
+  (el->>'desconto')::numeric,
+  'omie_' || a.account || '_' || a.omie_pedido_id || '_' || (el->>'omie_codigo_produto'),
+  NULL::bigint
+FROM _alvo_15 a
+JOIN public.sales_orders so ON so.id = a.id
+CROSS JOIN LATERAL jsonb_array_elements(so.items) el;
+-- created_at NAO e passado: `trg_order_items_created_at_omie` faz a linha herdar
+-- a DATA DO PEDIDO (30/06/2026), nao a do reparo.
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- POSTCONDIÇÃO — predicado idêntico ao de `pedido_venda_exigir_coerencia`,
+-- invertido, mais a conferência de dinheiro.
+-- ────────────────────────────────────────────────────────────────────────────
+DO $post$
+DECLARE v_div int; v_linhas int; v_visivel numeric; v_cab numeric; v_nova int;
+BEGIN
+  WITH rel AS (
+    SELECT oi.sales_order_id AS id, oi.omie_codigo_produto AS prod, oi.quantity AS qtd,
+           oi.unit_price AS preco, oi.discount AS desc_item
+    FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id),
+  js AS (
+    SELECT so.id, (el->>'omie_codigo_produto')::bigint, (el->>'quantidade')::numeric,
+           (el->>'valor_unitario')::numeric, (el->>'desconto')::numeric
+    FROM public.sales_orders so JOIN _alvo_15 a ON a.id = so.id
+    CROSS JOIN LATERAL jsonb_array_elements(so.items) el),
+  dif AS (
+    SELECT id FROM (TABLE rel EXCEPT ALL TABLE js) x
+    UNION ALL
+    SELECT id FROM (TABLE js EXCEPT ALL TABLE rel) y)
+  SELECT count(DISTINCT id) INTO v_div FROM dif;
+  IF v_div <> 0 THEN
+    RAISE EXCEPTION '[POST] o pedido AINDA diverge — a trigger de coerencia continuaria reprovando; nada foi commitado';
+  END IF;
+
+  SELECT count(*) INTO v_linhas
+  FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id;
+  IF v_linhas <> 6 THEN
+    RAISE EXCEPTION '[POST] esperava 6 linhas no pedido, achei % — o jsonb mudou desde a medicao', v_linhas;
+  END IF;
+
+  -- a linha nova existe e a velha sumiu
+  SELECT count(*) INTO v_nova
+  FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id
+  WHERE oi.omie_codigo_produto = 8689743515 AND oi.quantity = 1 AND oi.unit_price = 221.80;
+  IF v_nova <> 1 THEN
+    RAISE EXCEPTION '[POST] a linha 1x221,80 nao ficou de pe (achei %)', v_nova;
+  END IF;
+
+  -- DINHEIRO: a soma visivel tem de continuar batendo com o cabecalho ja emitido
+  SELECT sum(oi.quantity * oi.unit_price - coalesce(oi.discount, 0)) INTO v_visivel
+  FROM public.order_items oi JOIN _alvo_15 a ON a.id = oi.sales_order_id;
+  SELECT a.total INTO v_cab FROM _alvo_15 a;
+  IF round(v_visivel, 2) <> round(v_cab, 2) THEN
+    RAISE EXCEPTION '[POST] soma visivel % <> total do cabecalho % — o reparo mexeu no dinheiro; nada foi commitado', v_visivel, v_cab;
+  END IF;
+END
+$post$;
+
+COMMIT;

--- a/db/reparo-passivo-coerencia-pedido-venda.sql
+++ b/db/reparo-passivo-coerencia-pedido-venda.sql
@@ -1,0 +1,140 @@
+-- ╔══════════════════════════════════════════════════════════════════════════════╗
+-- ║ REPARO do passivo de coerência do agregado PEDIDO DE VENDA (PR #2363)         ║
+-- ║                                                                              ║
+-- ║ O QUE FAZ: reconstrói `order_items` a partir de `sales_orders.items` (jsonb)  ║
+-- ║ nos pedidos em que os dois lados descrevem conjuntos diferentes.              ║
+-- ║                                                                              ║
+-- ║ O QUE NÃO FAZ: NÃO toca `sales_orders`. `total`, `subtotal` e `items` ficam   ║
+-- ║ byte-a-byte como estão. Nenhum valor de nota fiscal é alterado por este SQL.  ║
+-- ║ O que muda é a TABELA DERIVADA que o money-path lê, que hoje discorda do      ║
+-- ║ cabeçalho que a própria empresa já emitiu.                                    ║
+-- ║                                                                              ║
+-- ║ Medido em prod 2026-09-07 via psql-ro. Rode no SQL Editor do Lovable.         ║
+-- ║ Idempotente: rodar de novo converge para o mesmo estado.                      ║
+-- ╚══════════════════════════════════════════════════════════════════════════════╝
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- BLOCO 1 — os 14 pedidos com direção de reparo defensável.
+-- Fora daqui de propósito: 12121128593 (o jsonb parece ter colapsado a
+-- quantidade dentro do preço: 1×221,80 onde o banco diz 2×110,90; as linhas
+-- irmãs do mesmo SKU no MESMO pedido são 2×105,90 e 2×119,90, o catálogo é
+-- 144,20 e o preço nunca passou de 180,95 em nenhum outro pedido). Reparar
+-- aquele pela regra geral APAGARIA 1 unidade de demanda sem base para isso.
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE TEMP TABLE _alvo_reparo ON COMMIT DROP AS
+SELECT so.id, so.omie_pedido_id, so.account, so.customer_user_id
+FROM public.sales_orders so
+WHERE so.omie_pedido_id IN (
+        12098848089, 12098907348, 12099420341, 12101768638, 12101775770,
+        12104022506, 12127942977, 12128013807, 12129511432, 12137805363,
+        12153747325, 12155972321, 12156120068, 12163560448)
+  AND so.hash_payload IS NOT NULL          -- só a linha canônica do pedido
+ORDER BY so.id
+FOR UPDATE;                                -- serializa contra o sync de 2 em 2 h
+
+-- PRÉ-CONDIÇÃO: fail-closed. Se o sync mexeu em algo entre a medição e o Run,
+-- a contagem não fecha e o reparo aborta INTEIRO em vez de aplicar meio certo.
+DO $pre$
+DECLARE v_n int; v_prod_nulo int; v_sem_produto int;
+BEGIN
+  SELECT count(*) INTO v_n FROM _alvo_reparo;
+  IF v_n <> 14 THEN
+    RAISE EXCEPTION '[PRE] esperava 14 pedidos canonicos, achei % — o alvo mudou desde a medicao de 2026-09-07; nao aplique as cegas', v_n;
+  END IF;
+
+  -- `ausente != zero`: linha de jsonb sem codigo de produto nao vira order_item
+  -- (o escritor canonico filtra por IS NOT NULL). Se aparecer uma, o reparo NAO
+  -- consegue igualar os dois lados e a trigger continuaria reprovando o pedido.
+  SELECT count(*) INTO v_prod_nulo
+  FROM _alvo_reparo a JOIN public.sales_orders so ON so.id = a.id
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+  WHERE (el->>'omie_codigo_produto') IS NULL;
+  IF v_prod_nulo > 0 THEN
+    RAISE EXCEPTION '[PRE] % linha(s) de jsonb sem omie_codigo_produto — reparo nao igualaria os lados', v_prod_nulo;
+  END IF;
+
+  -- product_id e FK para omie_products: sem cadastro, o INSERT quebraria
+  SELECT count(DISTINCT (el->>'omie_codigo_produto')::bigint) INTO v_sem_produto
+  FROM _alvo_reparo a JOIN public.sales_orders so ON so.id = a.id
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+  WHERE NOT EXISTS (SELECT 1 FROM public.omie_products p
+                     WHERE p.omie_codigo_produto = (el->>'omie_codigo_produto')::bigint);
+  IF v_sem_produto > 0 THEN
+    RAISE EXCEPTION '[PRE] % SKU(s) do jsonb sem cadastro em omie_products', v_sem_produto;
+  END IF;
+END
+$pre$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- O reparo: apaga as linhas do pedido e reescreve a partir do jsonb.
+-- DELETE e INSERT na MESMA transação — é o que a CONSTRAINT TRIGGER
+-- (DEFERRABLE INITIALLY DEFERRED) da migration 20260907220000 exige. Este SQL
+-- funciona igual ANTES ou DEPOIS de ela ser aplicada.
+-- ────────────────────────────────────────────────────────────────────────────
+DELETE FROM public.order_items oi
+USING _alvo_reparo a
+WHERE oi.sales_order_id = a.id;
+
+INSERT INTO public.order_items (
+  sales_order_id, customer_user_id, product_id, omie_codigo_produto,
+  quantity, unit_price, discount, hash_payload, omie_codigo_item)
+SELECT
+  a.id,
+  a.customer_user_id,                                    -- 54/54 iguais ao cabeçalho hoje
+  (SELECT p.id FROM public.omie_products p
+    WHERE p.omie_codigo_produto = (el->>'omie_codigo_produto')::bigint),
+  (el->>'omie_codigo_produto')::bigint,
+  (el->>'quantidade')::numeric,
+  (el->>'valor_unitario')::numeric,
+  -- desconto EXPLÍCITO, nunca o DEFAULT 0 da coluna: chave ausente tem de virar
+  -- NULL, senão `ausente` viraria `zero` e a trigger reprovaria (NULL casa com
+  -- NULL no EXCEPT ALL; NULL nunca casa com 0).
+  (el->>'desconto')::numeric,
+  'omie_' || a.account || '_' || a.omie_pedido_id || '_' || (el->>'omie_codigo_produto'),
+  NULL::bigint                                           -- o jsonb não carrega identidade de linha
+FROM _alvo_reparo a
+JOIN public.sales_orders so ON so.id = a.id
+CROSS JOIN LATERAL jsonb_array_elements(so.items) el;
+-- created_at NÃO é passado de propósito: a trigger BEFORE INSERT
+-- `trg_order_items_created_at_omie` faz a linha herdar a DATA DO PEDIDO do pai,
+-- não a data do reparo. É o que mantém a receita atribuída ao mês certo.
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- POSTCONDIÇÃO — o predicado é o MESMO de `pedido_venda_exigir_coerencia`,
+-- invertido. Se o reparo não igualou os dois lados, aborta com o motivo escrito
+-- em vez de commitar meio-feito.
+-- ────────────────────────────────────────────────────────────────────────────
+DO $post$
+DECLARE v_div int; v_linhas int;
+BEGIN
+  WITH rel AS (
+    SELECT oi.sales_order_id AS id, oi.omie_codigo_produto AS prod, oi.quantity AS qtd,
+           oi.unit_price AS preco, oi.discount AS desc_item
+    FROM public.order_items oi JOIN _alvo_reparo a ON a.id = oi.sales_order_id),
+  js AS (
+    SELECT so.id, (el->>'omie_codigo_produto')::bigint AS prod,
+           (el->>'quantidade')::numeric AS qtd, (el->>'valor_unitario')::numeric AS preco,
+           (el->>'desconto')::numeric AS desc_item
+    FROM public.sales_orders so JOIN _alvo_reparo a ON a.id = so.id
+    CROSS JOIN LATERAL jsonb_array_elements(so.items) el),
+  dif AS (
+    SELECT id FROM (TABLE rel EXCEPT ALL TABLE js) x
+    UNION ALL
+    SELECT id FROM (TABLE js EXCEPT ALL TABLE rel) y)
+  SELECT count(DISTINCT id) INTO v_div FROM dif;
+
+  IF v_div <> 0 THEN
+    RAISE EXCEPTION '[POST] % pedido(s) do alvo AINDA divergem — a trigger de coerencia continuaria reprovando; nada foi commitado', v_div;
+  END IF;
+
+  SELECT count(*) INTO v_linhas
+  FROM public.order_items oi JOIN _alvo_reparo a ON a.id = oi.sales_order_id;
+  IF v_linhas <> 77 THEN
+    RAISE EXCEPTION '[POST] esperava 77 linhas nos 14 pedidos, achei % — o jsonb mudou desde a medicao', v_linhas;
+  END IF;
+END
+$post$;
+
+COMMIT;

--- a/db/test-reparo-passivo-coerencia.sh
+++ b/db/test-reparo-passivo-coerencia.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Prova do reparo do passivo de coerência (PR #2363) — PG17 descartável, dados
+# REAIS de produção como fixture. Roda o reparo DE VERDADE (PL/pgSQL é
+# late-bound: só falha em runtime) e falsifica os asserts no fim.
+set -euo pipefail
+export LC_ALL="${LC_ALL:-C}"
+
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="${FIXTURE:-}"
+[ -n "$FIXTURE" ] && [ -f "$FIXTURE" ] || { echo "FIXTURE=<caminho.sql> obrigatorio"; exit 1; }
+REPARO="${REPARO:-$RAIZ/db/reparo-passivo-coerencia-pedido-venda.sql}"
+MIGRACAO="${MIGRACAO:-}"
+
+PGVER=17; PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"; PORT="${PGPORT_TEST:-5479}"
+SLUG="reparo-coerencia"; DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+Q() { "$PGBIN/psql" -h /tmp -p "$PORT" -U postgres -d postgres -v ON_ERROR_STOP=1 "$@"; }
+V() { Q -A -t -c "$1"; }
+
+FALHAS=0
+ok()  { echo "  ok   — $1"; }
+bad() { echo "  FALHA— $1 (esperado='$2' obtido='$3')"; FALHAS=$((FALHAS+1)); }
+eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi; }
+
+echo "== esquema =="
+Q -q <<'SQL'
+CREATE TABLE omie_products (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  omie_codigo_produto bigint UNIQUE, descricao text);
+CREATE TABLE sales_orders (id uuid PRIMARY KEY, omie_pedido_id bigint, account text NOT NULL,
+  customer_user_id uuid NOT NULL, items jsonb, total numeric, subtotal numeric, status text,
+  hash_payload text, created_at timestamptz, updated_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE order_items (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sales_order_id uuid NOT NULL REFERENCES sales_orders(id) ON DELETE CASCADE,
+  customer_user_id uuid NOT NULL, product_id uuid REFERENCES omie_products(id),
+  omie_codigo_produto bigint, quantity numeric NOT NULL DEFAULT 1, unit_price numeric,
+  discount numeric DEFAULT 0, created_at timestamptz DEFAULT now(),
+  hash_payload text, omie_codigo_item bigint);
+
+-- trigger real de prod: a linha herda a DATA DO PEDIDO, nunca now() da carga
+CREATE FUNCTION order_items_herdar_created_at_omie() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $f$
+DECLARE v_pai_created_at timestamptz; v_pai_hash text;
+BEGIN
+  SELECT created_at, hash_payload INTO v_pai_created_at, v_pai_hash
+    FROM public.sales_orders WHERE id = NEW.sales_order_id;
+  IF v_pai_hash LIKE 'omie\_%' AND v_pai_created_at IS NOT NULL THEN
+    NEW.created_at := v_pai_created_at;
+  END IF;
+  RETURN NEW;
+END $f$;
+CREATE TRIGGER trg_order_items_created_at_omie BEFORE INSERT ON order_items
+  FOR EACH ROW EXECUTE FUNCTION order_items_herdar_created_at_omie();
+SQL
+
+echo "== fixture (dados reais de prod) =="
+Q -q -f "$FIXTURE"
+eq "fixture: 15 pedidos"        15 "$(V "SELECT count(*) FROM sales_orders;")"
+eq "fixture: 54 linhas"         54 "$(V "SELECT count(*) FROM order_items;")"
+
+# predicado do EXCEPT ALL — o MESMO de pedido_venda_exigir_coerencia
+DIVERGENTES="WITH rel AS (SELECT oi.sales_order_id id, oi.omie_codigo_produto prod, oi.quantity qtd,
+   oi.unit_price preco, oi.discount d FROM order_items oi),
+ js AS (SELECT so.id, (el->>'omie_codigo_produto')::bigint, (el->>'quantidade')::numeric,
+   (el->>'valor_unitario')::numeric, (el->>'desconto')::numeric
+   FROM sales_orders so CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+   WHERE EXISTS (SELECT 1 FROM order_items o2 WHERE o2.sales_order_id=so.id)),
+ dif AS (SELECT id FROM (TABLE rel EXCEPT ALL TABLE js) a UNION ALL SELECT id FROM (TABLE js EXCEPT ALL TABLE rel) b)
+ SELECT count(DISTINCT id) FROM dif"
+
+echo "== A · ANTES: o passivo existe =="
+eq "A1 15 pedidos divergem"     15 "$(V "$DIVERGENTES;")"
+
+# retrato do cabecalho ANTES — o reparo NAO pode mudar nenhum byte disto
+ANTES_CAB="$(V "SELECT md5(string_agg(so.id::text||so.total||so.subtotal||so.items::text||so.status, '|' ORDER BY so.id)) FROM sales_orders so;")"
+ANTES_OUTROS="$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12121128593;")"
+
+if [ -n "$MIGRACAO" ]; then
+  echo "== instalando a CONSTRAINT TRIGGER do PR #2363 (reparo tem de passar COM ela) =="
+  Q -q -f "$MIGRACAO"
+  eq "trigger instalada" 2 "$(V "SELECT count(*) FROM pg_trigger WHERE NOT tgisinternal AND tgname LIKE 'trg_pedido_venda_coerencia%';")"
+fi
+
+echo "== B · o REPARO (executado de verdade) =="
+if Q -q -f "$REPARO" 2>/tmp/reparo-erro.log; then ok "B1 reparo commitou"
+else bad "B1 reparo commitou" "exit 0" "$(head -c 300 /tmp/reparo-erro.log)"; fi
+
+echo "== C · DEPOIS =="
+eq "C1 so 12121128593 diverge (14 reparados)" 1 "$(V "$DIVERGENTES;")"
+eq "C2 o que sobra é o 12121128593" 12121128593 \
+   "$(V "WITH rel AS (SELECT oi.sales_order_id id, oi.omie_codigo_produto prod, oi.quantity qtd, oi.unit_price preco, oi.discount d FROM order_items oi),
+        js AS (SELECT so.id, (el->>'omie_codigo_produto')::bigint, (el->>'quantidade')::numeric, (el->>'valor_unitario')::numeric, (el->>'desconto')::numeric
+               FROM sales_orders so CROSS JOIN LATERAL jsonb_array_elements(so.items) el
+               WHERE EXISTS (SELECT 1 FROM order_items o2 WHERE o2.sales_order_id=so.id)),
+        dif AS (SELECT id FROM (TABLE rel EXCEPT ALL TABLE js) a UNION ALL SELECT id FROM (TABLE js EXCEPT ALL TABLE rel) b)
+        SELECT DISTINCT so.omie_pedido_id FROM dif JOIN sales_orders so ON so.id=dif.id;")"
+eq "C3 77 linhas nos 14 alvos" 77 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id <> 12121128593;")"
+eq "C4 CABECALHO intacto (md5)" "$ANTES_CAB" \
+   "$(V "SELECT md5(string_agg(so.id::text||so.total||so.subtotal||so.items::text||so.status, '|' ORDER BY so.id)) FROM sales_orders so;")"
+eq "C5 12121128593 NAO foi tocado" "$ANTES_OUTROS" \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12121128593;")"
+eq "C6 created_at herdou a DATA DO PEDIDO (0 linhas com data de hoje)" 0 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE oi.created_at <> so.created_at;")"
+eq "C7 nenhum product_id ficou nulo" 0 \
+   "$(V "SELECT count(*) FROM order_items WHERE product_id IS NULL;")"
+eq "C8 hash_payload no formato do escritor canonico" 0 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE oi.hash_payload <> 'omie_'||so.account||'_'||so.omie_pedido_id||'_'||oi.omie_codigo_produto;")"
+eq "C9 valor visivel passou a bater com o cabecalho nos 14" 14 \
+   "$(V "SELECT count(*) FROM sales_orders so WHERE so.omie_pedido_id <> 12121128593
+         AND round((SELECT sum(oi.quantity*oi.unit_price-coalesce(oi.discount,0)) FROM order_items oi WHERE oi.sales_order_id=so.id),2) = round(so.total,2);")"
+
+echo "== D · idempotencia: rodar de novo converge =="
+if Q -q -f "$REPARO" >/dev/null 2>&1; then ok "D1 2a execucao commitou"; else bad "D1 2a execucao" "exit 0" "erro"; fi
+eq "D2 continua 77 linhas" 77 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id <> 12121128593;")"
+
+echo "== E · ausente != zero: chave 'desconto' faltando vira NULL, nao 0 =="
+# UMA transacao: com a CONSTRAINT TRIGGER instalada, cabecalho e linhas TEM de
+# mudar juntos. (A 1a versao deste teste usava statements soltos e a trigger a
+# recusou — comportamento correto dela, defeito do teste.)
+Q -q <<'SQL'
+BEGIN;
+UPDATE sales_orders SET items = jsonb_build_array(jsonb_build_object(
+  'omie_codigo_produto',(items->0->>'omie_codigo_produto')::bigint,'quantidade',1,'valor_unitario',10))
+WHERE omie_pedido_id=12137805363;
+DELETE FROM order_items WHERE sales_order_id=(SELECT id FROM sales_orders WHERE omie_pedido_id=12137805363);
+INSERT INTO order_items (sales_order_id,customer_user_id,product_id,omie_codigo_produto,quantity,unit_price,discount,hash_payload)
+SELECT so.id, so.customer_user_id, (SELECT id FROM omie_products p WHERE p.omie_codigo_produto=(el->>'omie_codigo_produto')::bigint),
+       (el->>'omie_codigo_produto')::bigint,(el->>'quantidade')::numeric,(el->>'valor_unitario')::numeric,(el->>'desconto')::numeric,
+       'omie_'||so.account||'_'||so.omie_pedido_id||'_'||(el->>'omie_codigo_produto')
+FROM sales_orders so CROSS JOIN LATERAL jsonb_array_elements(so.items) el WHERE so.omie_pedido_id=12137805363;
+COMMIT;
+SQL
+eq "E1 discount ficou NULL (nao virou 0 pelo DEFAULT)" "" \
+   "$(V "SELECT discount FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12137805363;")"
+
+echo
+if [ "$FALHAS" -eq 0 ]; then echo "PROVA-REPARO-OK (0 falhas)"; else echo "PROVA-REPARO-FALHOU ($FALHAS)"; exit 1; fi

--- a/db/test-reparo-passivo-coerencia.sh
+++ b/db/test-reparo-passivo-coerencia.sh
@@ -120,24 +120,26 @@ eq "D2 continua 77 linhas" 77 \
    "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id <> 12121128593;")"
 
 echo "== E · ausente != zero: chave 'desconto' faltando vira NULL, nao 0 =="
-# UMA transacao: com a CONSTRAINT TRIGGER instalada, cabecalho e linhas TEM de
-# mudar juntos. (A 1a versao deste teste usava statements soltos e a trigger a
-# recusou — comportamento correto dela, defeito do teste.)
+# Tira a chave `desconto` do jsonb de um dos alvos E zera as linhas dele na MESMA
+# transacao (0 linhas = push do app, que a trigger aceita). Depois roda O REPARO:
+# quem tem de produzir NULL e a expressao (el->>'desconto')::numeric do reparo —
+# se ela cair para o DEFAULT 0 da coluna, este assert fica VERMELHO.
 Q -q <<'SQL'
 BEGIN;
-UPDATE sales_orders SET items = jsonb_build_array(jsonb_build_object(
-  'omie_codigo_produto',(items->0->>'omie_codigo_produto')::bigint,'quantidade',1,'valor_unitario',10))
-WHERE omie_pedido_id=12137805363;
-DELETE FROM order_items WHERE sales_order_id=(SELECT id FROM sales_orders WHERE omie_pedido_id=12137805363);
-INSERT INTO order_items (sales_order_id,customer_user_id,product_id,omie_codigo_produto,quantity,unit_price,discount,hash_payload)
-SELECT so.id, so.customer_user_id, (SELECT id FROM omie_products p WHERE p.omie_codigo_produto=(el->>'omie_codigo_produto')::bigint),
-       (el->>'omie_codigo_produto')::bigint,(el->>'quantidade')::numeric,(el->>'valor_unitario')::numeric,(el->>'desconto')::numeric,
-       'omie_'||so.account||'_'||so.omie_pedido_id||'_'||(el->>'omie_codigo_produto')
-FROM sales_orders so CROSS JOIN LATERAL jsonb_array_elements(so.items) el WHERE so.omie_pedido_id=12137805363;
+UPDATE sales_orders so
+   SET items = (SELECT jsonb_agg(el - 'desconto') FROM jsonb_array_elements(so.items) el)
+ WHERE so.omie_pedido_id = 12137805363;
+DELETE FROM order_items WHERE sales_order_id = (SELECT id FROM sales_orders WHERE omie_pedido_id = 12137805363);
 COMMIT;
 SQL
-eq "E1 discount ficou NULL (nao virou 0 pelo DEFAULT)" "" \
-   "$(V "SELECT discount FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12137805363;")"
+# `|| true`: se o reparo RECUSAR (postcondicao), E1 mede o estado e reprova —
+# sem isso o set -e mataria o teste antes do assert falar.
+Q -q -f "$REPARO" >/dev/null 2>&1 || true
+eq "E1 discount NULL nas linhas sem a chave (nao virou 0 pelo DEFAULT)" 2 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12137805363 AND oi.discount IS NULL;")"
+eq "E2 o total de linhas nao mudou" 77 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id <> 12121128593;")"
 
 echo
 if [ "$FALHAS" -eq 0 ]; then echo "PROVA-REPARO-OK (0 falhas)"; else echo "PROVA-REPARO-FALHOU ($FALHAS)"; exit 1; fi

--- a/db/test-reparo-passivo-coerencia.sh
+++ b/db/test-reparo-passivo-coerencia.sh
@@ -9,6 +9,7 @@ RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURE="${FIXTURE:-}"
 [ -n "$FIXTURE" ] && [ -f "$FIXTURE" ] || { echo "FIXTURE=<caminho.sql> obrigatorio"; exit 1; }
 REPARO="${REPARO:-$RAIZ/db/reparo-passivo-coerencia-pedido-venda.sql}"
+REPARO15="${REPARO15:-$RAIZ/db/reparo-15o-pedido-11701.sql}"
 MIGRACAO="${MIGRACAO:-}"
 
 PGVER=17; PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"; PORT="${PGPORT_TEST:-5479}"
@@ -28,6 +29,16 @@ eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi; }
 
 echo "== esquema =="
 Q -q <<'SQL'
+-- roles do Supabase: a migration mergeada fecha as SECDEF por REVOKE NOMINAL
+-- (PUBLIC + anon + authenticated) e a postcondicao dela MEDE has_function_privilege.
+-- Sem as roles aqui, o apply morre em "role anon does not exist" e o teste nunca
+-- chega a rodar o reparo COM a trigger no ar.
+DO $r$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon') THEN CREATE ROLE anon NOLOGIN; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='service_role') THEN CREATE ROLE service_role NOLOGIN BYPASSRLS; END IF;
+END $r$;
+
 CREATE TABLE omie_products (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   omie_codigo_produto bigint UNIQUE, descricao text);
 CREATE TABLE sales_orders (id uuid PRIMARY KEY, omie_pedido_id bigint, account text NOT NULL,
@@ -140,6 +151,107 @@ eq "E1 discount NULL nas linhas sem a chave (nao virou 0 pelo DEFAULT)" 2 \
          WHERE so.omie_pedido_id=12137805363 AND oi.discount IS NULL;")"
 eq "E2 o total de linhas nao mudou" 77 \
    "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id <> 12121128593;")"
+
+echo "== F · o 15o pedido (11701 / omie 12121128593) — Omie desempatou: 1x221,80 =="
+# Ficou de fora do reparo dos 14 de proposito (o preco parecia quantidade
+# colapsada). O founder consultou o Omie em 2026-09-08 e o Omie diz 1 unidade a
+# 221,80 — o jsonb estava certo. Aqui prova-se o reparo dedicado.
+CAB_ANTES_F="$(V "SELECT md5(string_agg(so.id::text||so.total||so.subtotal||so.items::text||so.status, '|' ORDER BY so.id)) FROM sales_orders so;")"
+eq "F0 ANTES: o banco diz 2x110,90" 1 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12121128593 AND oi.omie_codigo_produto=8689743515
+           AND oi.quantity=2 AND oi.unit_price=110.90;")"
+
+if Q -q -f "$REPARO15" 2>/tmp/reparo15-erro.log; then ok "F1 reparo do 15o commitou"
+else bad "F1 reparo do 15o commitou" "exit 0" "$(head -c 300 /tmp/reparo15-erro.log)"; fi
+
+eq "F2 ZERO pedidos divergem (os 15 coerentes)" 0 "$(V "$DIVERGENTES;")"
+eq "F3 6 linhas no 11701" 6 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12121128593;")"
+eq "F4 DEPOIS: a linha virou 1x221,80" 1 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12121128593 AND oi.omie_codigo_produto=8689743515
+           AND oi.quantity=1 AND oi.unit_price=221.80;")"
+eq "F5 a linha 2x110,90 sumiu" 0 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12121128593 AND oi.quantity=2 AND oi.unit_price=110.90;")"
+eq "F6 CABECALHO intacto (md5) — nao mexeu no dinheiro emitido" "$CAB_ANTES_F" \
+   "$(V "SELECT md5(string_agg(so.id::text||so.total||so.subtotal||so.items::text||so.status, '|' ORDER BY so.id)) FROM sales_orders so;")"
+eq "F7 soma visivel = total do cabecalho" 1 \
+   "$(V "SELECT count(*) FROM sales_orders so WHERE so.omie_pedido_id=12121128593
+         AND round((SELECT sum(oi.quantity*oi.unit_price-coalesce(oi.discount,0)) FROM order_items oi WHERE oi.sales_order_id=so.id),2) = round(so.total,2);")"
+# F8 documenta a garantia da TRIGGER de herança, nao do reparo: passar now() no
+# INSERT nao a derruba (o BEFORE INSERT sobrescreve). Nao e falsificavel pelo
+# script — esta aqui porque a regressao a vigiar e alguem REMOVER a trigger.
+eq "F8 created_at herdou a DATA DO PEDIDO" 0 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12121128593 AND oi.created_at <> so.created_at;")"
+eq "F13 hash_payload no formato do escritor canonico" 0 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id
+         WHERE so.omie_pedido_id=12121128593
+           AND oi.hash_payload <> 'omie_'||so.account||'_'||so.omie_pedido_id||'_'||oi.omie_codigo_produto;")"
+eq "F9 uma unidade a MENOS no sinal de demanda (12 -> 11)" 11 \
+   "$(V "SELECT sum(oi.quantity)::int FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12121128593;")"
+
+# NAO e idempotente de proposito: a pre-condicao ancora no estado conferido no
+# Omie, entao re-colar tem de ABORTAR — e dizendo que ja foi aplicado, nao com um
+# erro obscuro. Assert casa a MARCA do ramo, nao "lancou algo".
+if Q -q -f "$REPARO15" >/tmp/reparo15-2a.log 2>&1; then
+  bad "F10 2a execucao RECUSA (fail-closed)" "exit != 0" "commitou de novo"
+else
+  ok "F10 2a execucao RECUSA (fail-closed)"
+fi
+# rotulo IDENTICO nos dois ramos: assert cujo texto de falha nao casa com o de
+# sucesso e invisivel para quem faz grep (o falsificador quase deu verde por isso).
+if grep -q 'JA APLICADO' /tmp/reparo15-2a.log; then ok "F11 recusa pela marca certa (JA APLICADO)"
+else bad "F11 recusa pela marca certa (JA APLICADO)" "JA APLICADO" "$(head -c 200 /tmp/reparo15-2a.log)"; fi
+eq "F12 continua 6 linhas (a recusa nao mexeu em nada)" 6 \
+   "$(V "SELECT count(*) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id WHERE so.omie_pedido_id=12121128593;")"
+
+echo "== G · fail-closed sobre estado que MUDOU =="
+if [ -n "$MIGRACAO" ]; then
+  # Com a trigger no ar nao da para construir o cenario: tornar o 11701
+  # incoerente e exatamente o que ela recusa. Entao o que se prova aqui e a
+  # propriedade complementar — o pedido fica IMUNE a UPDATE que o desalinhe.
+  if Q -q -c "UPDATE order_items oi SET quantity = 9
+                FROM sales_orders so
+               WHERE so.id = oi.sales_order_id AND so.omie_pedido_id = 12121128593;" >/dev/null 2>&1; then
+    bad "G1 trigger recusa UPDATE que desalinha o agregado" "exit != 0" "aceitou"
+  else
+    ok "G1 trigger recusa UPDATE que desalinha o agregado"
+  fi
+else
+  # Sem a trigger: sabota o jsonb (1x221,80 vira 3x221,80) DEPOIS de restaurar o
+  # estado-antes das linhas, e exige que a PRE-CONDICAO aborte pela marca do jsonb.
+  Q -q >/dev/null 2>&1 <<'SQL'
+BEGIN;
+DELETE FROM order_items oi USING sales_orders so
+ WHERE so.id = oi.sales_order_id AND so.omie_pedido_id = 12121128593
+   AND oi.omie_codigo_produto = 8689743515 AND oi.quantity = 1 AND oi.unit_price = 221.80;
+INSERT INTO order_items (sales_order_id, customer_user_id, product_id, omie_codigo_produto,
+                         quantity, unit_price, discount, hash_payload, omie_codigo_item)
+SELECT so.id, so.customer_user_id,
+       (SELECT p.id FROM omie_products p WHERE p.omie_codigo_produto = 8689743515),
+       8689743515, 2, 110.90, 0, 'omie_'||so.account||'_'||so.omie_pedido_id||'_8689743515', NULL
+  FROM sales_orders so WHERE so.omie_pedido_id = 12121128593;
+UPDATE sales_orders so SET items = (
+   SELECT jsonb_agg(CASE WHEN (el->>'valor_unitario')::numeric = 221.80
+                         THEN jsonb_set(el, '{quantidade}', '3') ELSE el END)
+   FROM jsonb_array_elements(so.items) el)
+ WHERE so.omie_pedido_id = 12121128593;
+COMMIT;
+SQL
+  if Q -q -f "$REPARO15" >/tmp/reparo15-g.log 2>&1; then
+    bad "G1 recusa estado divergente do verificado" "exit != 0" "commitou assim mesmo"
+  else
+    ok "G1 recusa estado divergente do verificado"
+  fi
+  if grep -q 'jsonb nao diz mais 1x221,80' /tmp/reparo15-g.log; then
+    ok "G2 recusa pela marca certa (jsonb mudou)"
+  else
+    bad "G2 recusa pela marca certa" "jsonb nao diz mais 1x221,80" "$(head -c 200 /tmp/reparo15-g.log)"
+  fi
+fi
 
 echo
 if [ "$FALHAS" -eq 0 ]; then echo "PROVA-REPARO-OK (0 falhas)"; else echo "PROVA-REPARO-FALHOU ($FALHAS)"; exit 1; fi

--- a/docs/historico/invariante-do-agregado-sem-dono.md
+++ b/docs/historico/invariante-do-agregado-sem-dono.md
@@ -103,3 +103,60 @@ e pede decisão caso a caso.
 Também não foi feito: corrigir o escritor alternativo (`omie-vendas-sync:3381`) para escrever as duas
 metades na mesma transação. Enquanto não for, a edição de pedido no Omie passa a **falhar em vez de
 corromper** — com o agravante de que o Omie já foi mutado quando a recusa acontece.
+
+## O passivo foi fechado (2026-09-08) — e o que ele ensinou
+
+Os 15 foram reparados e a trigger entrou em prod no mesmo dia. Medido por `psql-ro` depois do
+commit, de fora: **31.219 pedidos com linhas, 0 reprovados**; `order_items` 70.860 → 70.889;
+I2b (dano parcial) de 11 pedidos e **R$ 10.676,56 invisíveis** para **vazia**; I1/I3/I4 inalteradas;
+`sales_orders` sem um byte alterado. Scripts: `db/reparo-passivo-coerencia-pedido-venda.sql` (14) e
+`db/reparo-15o-pedido-11701.sql` (o suspenso), provados por `db/test-reparo-passivo-coerencia.sh`.
+
+**A direção do reparo foi `order_items ← jsonb`**, não o contrário. O jsonb somava exato ao cabeçalho
+em 15/15 contra 4/15 do relacional, nenhum dos 15 tinha chave de formato do app (`valor_total`/
+`unidade`/`codigo`), e o sync legado gravava linhas em blocos de 200 com erro só logado — o mecanismo
+exato de linha faltante. Não houve testemunha externa: `omie_payload`/`omie_response` são NULL nos 15
+e `omie_webhook_events` não referencia nenhum deles. Isso foi dito, não contornado.
+
+### O 15º: precisão > recall custa uma pergunta e paga
+
+Um pedido (11701 / omie 12121128593) ficou **de fora** do reparo dos 14. O jsonb dizia 1×221,80 onde
+o banco dizia 2×110,90 — e 221,80 = exatamente 2 × 110,90, o SKU nunca passou de 180,95 em 171
+referências, e as linhas irmãs do mesmo SKU no mesmo pedido eram 2×105,90 e 2×119,90. Parecia
+quantidade colapsada dentro do preço. **O Omie foi consultado e disse 1 unidade a R$ 221,80.** A
+heurística de preço perdeu para a fonte. O custo de ter perguntado foi uma pergunta; o custo de ter
+adivinhado seria uma unidade de demanda inventada num dos dois sentidos, sem ninguém saber qual.
+
+Uma pista intermediária **morreu na medição**: `tint_nome_cor` dizia "X097 CINZA BRILHO 20 = 2X
+900ML", o que parecia uma terceira testemunha da quantidade. Das 13 linhas da base com esse padrão,
+10 batem com a quantidade — mas as **3 que não batem são todas "texto diz 2, jsonb diz 1"**, e nas
+outras 2 o jsonb **e** o banco concordam em 1. O campo descreve a fórmula, não a quantidade vendida.
+Correlação de 77% num universo de 13 não é testemunha.
+
+### O que a disciplina pegou, e que teria passado sem ela
+
+- **FK antes de `DELETE`+`INSERT`**: zero tabelas referenciam `order_items` — o reparo dos 14 não
+  cascateou nada. Verificado **depois** do apply, o que é tarde. Num esquema com `ON DELETE CASCADE`
+  a jusante, o mesmo script apagaria filhos em silêncio. Sonda de script destrutivo é fail-closed.
+- **A migration MERGEADA não era a testada**: entre draft e merge ela ganhou `REVOKE` nominal das 3
+  SECDEF. Como `anon`/`authenticated` não existem em PG17 descartável, o apply morria em
+  `role "anon" does not exist` — o teste do próprio PR criava as roles, o meu não. **Diffar o que
+  foi mergeado contra o que foi provado** é passo, não zelo.
+- **Assert com rótulo diferente nos ramos ok/bad é invisível ao grep.** O F11 ficava vermelho de
+  verdade, mas o falsificador procurava `F11 … (JA APLICADO)` e o ramo de falha imprimia `F11 …` sem
+  o parêntese. A sabotagem quase foi contada como "assert sem dente" — quando o sem dente era o
+  falsificador. Rótulo idêntico nos dois ramos.
+- **Nem todo assert é falsificável pelo artefato que ele acompanha.** O de herança de `created_at`
+  prova a trigger `trg_order_items_created_at_omie` (BEFORE INSERT sobrescreve o valor), não o
+  reparo: passar `now()` não o derruba. Marcado no arquivo, para ninguém contar como prova do script.
+- **Fail-closed > idempotente, quando a decisão veio de fora do banco.** O reparo do 15º ancora na
+  linha exata que foi conferida no Omie e **recusa** a 2ª colada com `[PRE] JA APLICADO` — mensagem
+  que diz que não é erro. Re-rodar às cegas um script cuja premissa é uma consulta humana é pior que
+  abortar.
+
+### Continua em aberto
+
+Os 15 seguem com `omie_codigo_item` nulo e SKU repetido — a condição em que `reconciliar_pedidos_omie`
+os pula por ambiguidade (`omie_reconciliado_em` NULL em 15/15). Com a trigger no ar, se o Omie alterar
+um deles o cabeçalho é atualizado, as linhas não, e a transação é **recusada**. É a invariante
+funcionando, mas o modo de falha migrou de divergência silenciosa para falha de sync.


### PR DESCRIPTION
O PR #2363 instalou a invariante de coerência do agregado pedido de venda e deixou explícito o que **não** ia junto: os 15 pedidos que a trigger reprovaria. Este PR fecha esse passivo e registra a lição.

**Os SQLs deste PR já foram rodados em produção** (SQL Editor do Lovable, 2026-09-08). Não há migration nova aqui — a `20260907220000` é a do #2363, também já aplicada. Os arquivos entram como registro auditável do que foi executado e como prova executável do mecanismo.

## Veredito, medido de fora por `psql-ro` depois do commit

| | ANTES (07/09) | DEPOIS (08/09) |
|---|---|---|
| Reprovados pelo critério da trigger (universo de 31.219) | **15** | **0** |
| `order_items` | 70.860 | 70.889 |
| I2 · parciais | 11 | **0** |
| I2b · dano real | 11 pedidos · **R$ 10.676,56 invisíveis** | **vazia** |
| I1 / I3 / I4 | 0 / 7 / 1 | 0 / 7 / 1 (inalteradas) |
| `sales_orders` | 31.248 | 31.248 — **nenhum byte alterado** |

A trigger está no ar e verificada por fora: 2 constraint triggers, `tgenabled = A` (ENABLE ALWAYS), `DEFERRABLE INITIALLY DEFERRED`, e ACL fechado (0 pares role/função com EXECUTE nas 3 SECDEF).

## Direção do reparo: `order_items ← jsonb`

Não havia testemunha externa — `omie_payload`/`omie_response` são NULL nos 15 e `omie_webhook_events` não referencia nenhum deles. Isso foi dito, não contornado. O que sustentou a direção: o jsonb soma exato ao cabeçalho em 15/15 contra 4/15 do relacional; nenhum dos 15 tem chave de formato do app; e o sync legado gravava linhas em blocos de 200 com erro só logado — o mecanismo exato de linha faltante.

## O 15º pedido: precisão > recall custa uma pergunta e paga

Um pedido (11701 / omie 12121128593) ficou **fora** do reparo dos 14. O jsonb dizia 1×221,80 onde o banco dizia 2×110,90 — e 221,80 = exatamente 2 × 110,90, o SKU nunca passou de 180,95 em 171 referências, e as linhas irmãs do mesmo SKU no mesmo pedido eram 2×105,90 e 2×119,90. Parecia quantidade colapsada dentro do preço.

**O Omie foi consultado e disse 1 unidade a R$ 221,80.** A heurística perdeu para a fonte. O custo de perguntar foi uma pergunta; o de adivinhar seria uma unidade de demanda inventada — sem ninguém saber em qual direção.

Uma pista intermediária morreu na medição: `tint_nome_cor` dizia "2X 900ML", o que parecia testemunha da quantidade. Das 13 linhas da base com esse padrão, 10 batem — mas as 3 que não batem são todas "texto diz 2, jsonb diz 1", e em 2 delas jsonb **e** banco concordam em 1. O campo descreve a fórmula. 77% em n=13 não é testemunha.

## Prova

`db/test-reparo-passivo-coerencia.sh` — PG17 descartável, fixture de dados REAIS de prod, roda os dois reparos DE VERDADE (PL/pgSQL é late-bound).

- **33 asserts**, verdes **com e sem** a trigger da `20260907220000` instalada, em `LC_ALL=C` **e** `pt_BR.UTF-8`.
- **Falsificação** com **controle verde exigido na mesma invocação, antes da 1ª sabotagem**: 5 sabotagens, 5 asserts **nomeados** vermelhos (`F1` postcondição · `F6` cabeçalho por md5 · `F13` hash_payload · `F11` marca da recusa · `F10` fail-closed).
- `shellcheck` 0 achados em 385 arquivos.
- Pré-voo contra a PROD antes de cada handoff: as pré-condições batem, soma visível = total.

## O que a disciplina pegou (está no doc de histórico)

- **FK antes de `DELETE`+`INSERT`**: zero tabelas referenciam `order_items`. Verificado **depois** do apply — tarde. Com `ON DELETE CASCADE` a jusante, o mesmo script apagaria filhos em silêncio.
- **A migration MERGEADA não era a testada**: ganhou `REVOKE` nominal das 3 SECDEF entre draft e merge, e morria em `role "anon" does not exist` no PG17 descartável. Diffar mergeado × provado é passo, não zelo.
- **Assert com rótulo diferente nos ramos ok/bad é invisível ao grep** — o `F11` ficava vermelho de verdade e o falsificador não via. Quase contei "assert sem dente" quando o sem dente era o falsificador.
- **Nem todo assert é falsificável pelo artefato que acompanha**: o de herança de `created_at` prova a trigger `BEFORE INSERT`, não o reparo. Marcado no arquivo.
- **Fail-closed > idempotente quando a premissa veio de fora do banco**: o reparo do 15º recusa a 2ª colada com `[PRE] JA APLICADO`.

## Continua em aberto

Os 15 seguem com `omie_codigo_item` nulo e SKU repetido — a condição em que `reconciliar_pedidos_omie` os pula por ambiguidade. Com a trigger no ar, se o Omie alterar um deles a transação é **recusada**: a invariante funcionando, mas o modo de falha migrou de divergência silenciosa para falha de sync. Rastreado em chip separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)