### PR TITLE
fix(fecho): o chip de deploy renascia porque a SKILL não sabia que o braço já era da sessão

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -151,7 +151,7 @@ git diff --name-only origin/main...HEAD -- supabase/functions/
 # se auto-deploya (chat do Lovable, manual) e a falha é igualmente SILENCIOSA.
 #
 # Este script enumera a janela INTEIRA (a desta sessão e a das outras) e já classifica quem
-# precisa de chip. Use-o em vez do `git log` cru — o cru é o gatilho velho, ver abaixo.
+# precisa de deploy. Use-o em vez do `git log` cru — o cru é o gatilho velho, ver abaixo.
 bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início da sessão> UTC"
 # aceita REVISÃO (SHA), DATA RELATIVA ("3 hours ago") ou DATA ABSOLUTA **com fuso explícito**.
 # ⚠️ Data absoluta SEM fuso é RECUSADA (exit 3, marca `DESDE_SEM_FUSO`). Aqui o `--desde` cai no
@@ -161,7 +161,7 @@ bash .claude/skills/fecho/scripts/edges-pendentes.sh --desde "<hora de início d
 #    silêncio: medido 2026-09-05, `--desde "2026-09-05 17:34"` em GMT-3 pulou o merge das 19:40Z e
 #    devolveu `✅ nenhuma edge na janela` sobre uma janela de DUAS. Escreva "… 17:34 UTC".
 # Se você anotou o SHA de origin/main ao abrir a sessão, prefira o SHA: não tem fuso para errar.
-# exit 0 = nada pendente · 1 = abra chip para a lista · 2 = MECÂNICA não confiável (o script já
+# exit 0 = nada pendente · 1 = DEPLOYE a lista nesta sessão · 2 = MECÂNICA não confiável (o script já
 # imprime tudo como pendente; trate assim) · 3 = uso inválido
 #
 # Ele consulta o LEDGER durável por dentro (`bun run pendencias:deploy --json`) para a edge que não
@@ -182,7 +182,7 @@ enterra o chip que importava. O script troca isso pela evidência que já existe
 `fonte` que a sonda serve (SHA-256 do fecho transitivo dos imports) comparado com
 `sonda-fingerprints.ts` da main:
 
-| veredito | o que significa | chip? |
+| veredito | o que significa | pendência? |
 |---|---|---|
 | `NO_AR` | `fonte` servido == main, **na janela viva** — o bundle no ar é este | **não** |
 | `LEDGER_CONFERE` | sem sonda na janela, mas o **ledger** `deploy_atestacoes` atesta `CONFERE` **e** o `fonte` atestado bate com o mapa da REF | **não** — prova DURÁVEL, além das 6 h |
@@ -241,13 +241,13 @@ saíram `PRE_SONDA_FONTE` e as 3 restantes saíram "nenhuma sonda em 6 hours" �
 `PRE_SONDA_FONTE` uma geração de campo atrás, e desta vez com a resposta gravada no banco. Não dá
 para presumir de qual edge é a linha (`net.http_request_queue`, a única tabela do pg_net com a URL,
 é apagada quando a resposta chega — conferido no mesmo dia), então **a identidade ausente continua
-ausente**: o veredito é INDETERMINADO e o chip continua. O que mudou é a saída dizer `SONDA_ANONIMA`
+ausente**: o veredito é INDETERMINADO e a pendência continua. O que mudou é a saída dizer `SONDA_ANONIMA`
 e contar quantas há, em vez de alegar que ninguém sondou — e apontar o `--request-ids`, que é o
 único vínculo determinístico. Com os 5 ids colados, as 5 edges daquele dia saíram `PRE_SONDA_FONTE`:
 pendência PROVADA que o diagnóstico anterior escondia.
 
 🔴 **A direção é uma só: presença PROVA, ausência NÃO reprova** (#2086/#2095). O script só sabe
-SUPRIMIR chip com evidência POSITIVA; ele é o lado que APAGA pendência, então na dúvida é chip.
+SUPRIMIR pendência com evidência POSITIVA; ele é o lado que APAGA pendência, então na dúvida é chip.
 O mapa cobre ~40 das ~95 edges — as outras seguem virando chip como sempre, nada regride.
 Medido em 2026-08-28 numa janela real de 24h: 7 edges na janela, 3 provadas no ar, **4 chips em
 vez de 7**. E não é só corte: o `DESATUALIZADA` é sinal que o gatilho velho nunca teve — ele
@@ -265,8 +265,10 @@ ESTREITA o diff, e sem ele nenhum par casa e a via (a) emite o mapa INTEIRO como
 devolve **16 `NO_AR` provadas + 25 `SEM_PROVA`** no lugar de 41 pendências cegas. Degradar aqui é
 AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por prova positiva.
 
-🕳️ **`SEM_PROVA` por "nenhuma sonda na janela" NÃO se resolve esperando — DISPARE.** Não existe
-cron de sondagem: `cron.job` tem 93 jobs e **zero** com `probe`. Quem dá prova passiva é só a edge
+🕳️ **`SEM_PROVA` por "nenhuma sonda na janela" NÃO se resolve esperando — DISPARE.** O cron de
+sondagem existe desde 2026-09-06 (`deploy-sonda-cron`, `37 */2 * * *`, pelo relé OPTIONS
+fail-closed), mas cobre só a allowlist provada de `_shared/sonda-cron-alvos.ts` — **7 edges de
+59**. Para as outras 52, esperar é esperar para sempre, e tudo abaixo vale palavra por palavra. Quem dá prova passiva é só a edge
 cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) **e** tem cron frequente —
 `analytics-outbox-drain` (5 em 5 min) é o caso típico. Medido 2026-09-05: **24 das 54 edges do
 mapa não têm cron NENHUM** (webhook como `omie-nfe-webhook`, ou invocada sob demanda pelo app como
@@ -280,9 +282,21 @@ espera nunca terminaria, e o `SEM_PROVA` persistente passaria por pendência rea
 edge que já está no ar). O script hoje imprime o remédio no rodapé, preso pelo caso 3b e pela
 sabotagem (a6).
 
-Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
-na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
-de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.
+Se a sessão tocou edge: ela está NO AR? (Evidência: o veredito do script acima — não a memória
+da conversa, e não "o Lovable disse Active".) **Pendente → DEPLOYE AQUI, nesta sessão**, não
+escreva um recado sobre isso:
+
+```bash
+bun scripts/pendencias-deploy.ts --json > /tmp/pend.json   # quem julga é o LEDGER
+bun scripts/pendencias-pacote.ts - < /tmp/pend.json        # gate de ordem: RPC em prod ANTES da edge
+```
+
+O **Passo 2** do pacote vai **verbatim** para `mcp__lovable__send_message` (projeto `steu`,
+`8f005805-000a-42b7-88a1-9683f785fab6`) — o canal é o mesmo do chat, e o prompt já carrega o
+`sha256` de cada arquivo do closure mandando o agente conferir ANTES de deployar. Detalhe,
+limites e o que continua sendo do founder: `docs/agent/deploy.md` §"Deploy de edge pela SESSÃO".
+Depois **meça o ledger de novo** — `pendencias:deploy` em exit 0 é a prova; o relato do agente
+não é.
 
 ⚠️ **"Se a sessão tocou edge" NÃO é o gatilho deste passo — é só o gatilho da metade dele.**
 Edge de TERCEIRO na janela é pendência desta `/fecho` do mesmo jeito que migration de terceiro é,
@@ -292,11 +306,27 @@ e pela mesma razão. Medido em 2026-08-26, na sessão do #2023/#2027: o `7e076f1
 alargou a consulta por conta própria — pela letra deste passo, ele teria olhado a saída do
 `git log`, visto commit que não era dele, e seguido em frente.
 
-Destino de edge de terceiro **não é** "deployar por ela" nem "assumir que a outra sessão já
-pediu": é **chip** (a sessão dona pode ter fechado sem pedir o deploy) — para as que o script
-marcar como pendentes, e só para elas —, com o prompt mandando CONFIRMAR antes de pedir deploy
-redundante. E o prompt tem de nomear **todos** os arquivos,
-`_shared` novo incluído — prompt que nomeia um só deixa a edge sem bootar (#2020).
+Destino de edge de terceiro **não é** "assumir que a outra sessão já pediu" — a dona pode ter
+fechado sem pedir o deploy. Mas também **não é mais um chip**: é o MESMO deploy pela sessão do
+bloco acima, para as que o script marcar como pendentes e só para elas.
+
+⚠️ **Por que o chip saiu daqui (pedido do founder, 2026-09-08).** O chip é um convite que só vira
+trabalho quando ele CLICA, e a sessão que ele abria clicando não fazia nada que esta não faça:
+re-rodava `pendencias:deploy` — o MESMO veredito que o script deste passo já consultou por dentro
+— e montava à mão uma colagem que `pendencias:prompt` emite pronta. Como o gatilho é "uma sessão
+fechou" e há ~30 worktrees, a mesma edge virava chip em toda sessão que fechasse antes do deploy
+acontecer: *"repetidamente esses chips abrem com a mesma necessidade"*. Enquanto o braço era
+humano isso era o melhor possível; desde o #2374 não é.
+
+**A pendência não sumiu com o chip — mudou de dono, e o dono é durável.** Ela mora no ledger
+`deploy_atestacoes`, não na sessão: nenhuma sessão precisa lembrar dela, e nenhuma pode
+declará-la resolvida sem `pendencias:deploy` em exit 0. Gerar o pacote NÃO resolve; enviar ao
+Lovable NÃO resolve; só a reconciliação com prod resolve.
+
+Chip aqui volta a ser o certo em UM caso: o braço indisponível (MCP fora, `send_message` falhando,
+`pendencias:pacote` em exit 3 por DDL que só o founder aplica). Aí o chip diz o que falta e por
+quê — e o prompt tem de nomear **todos** os arquivos, `_shared` novo incluído: prompt que nomeia
+um só deixa a edge sem bootar (#2020).
 
 ### Passo 4 — Publish do frontend
 

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -102,7 +102,8 @@
 # única via que enxerga mudança em `_shared/`, que muda o bundle de N edges sem tocar na pasta de
 # nenhuma; (b) o `git log --name-only` das pastas — única via que enxerga edge FORA do mapa.
 #
-# Exit: 0 = nada pendente (todas provadas no ar) · 1 = há pendência → abra chip para a lista
+# Exit: 0 = nada pendente (todas provadas no ar) · 1 = há pendência → RESOLVA na sessão (deploy
+#       pelo MCP para as provadas, sonda para as SEM_PROVA); chip só se o braço estiver indisponível
 #       2 = a MECÂNICA não é confiável (sem banco, mapa ilegível, janela inválida) → trate TUDO
 #           como pendente; o script já imprime todos os alvos como SEM_PROVA
 #       3 = uso inválido
@@ -676,14 +677,29 @@ if [ "$n_chips" -eq 0 ]; then
   echo "✅ nenhum chip de deploy por estas edges: todas provadas no ar (pelo fingerprint servido na janela viva, ou pela atestação durável do ledger) ou aposentadas."
   exit 0
 fi
-echo "🎫 abra chip para: $(tr '\n' ' ' < "$tmp/chips")"
+# ⚠️ A MARCA É ASCII, CAIXA FIXA, e só aparece NESTE ramo. A suíte casa `RESOLVER_NESTA_SESSAO`
+# sem `-i`: marca com acento ou emoji casa diferente sob `LC_ALL=C` × `pt_BR.UTF-8` (#1483), e
+# marca que vaze para o rodapé casa em TODA execução e esvazia a asserção (ver o bloco acima).
+echo "🚀 RESOLVER_NESTA_SESSAO: $(tr '\n' ' ' < "$tmp/chips")"
 # A legenda descreve SEM repetir os marcadores (ver o bloco acima: token no rodapé casa sempre e
 # esvazia a asserção da suíte que o procura).
 echo "   (linha a linha acima: bundle velho servindo, sonda sem o campo de fonte e divergência do"
-echo "    ledger são pendência PROVADA · sem prova = indeterminado, chip por fail-closed · edge"
-echo "    aposentada e edge atestada pelo ledger não entram no chip)"
+echo "    ledger são pendência PROVADA · sem prova = indeterminado, entra por fail-closed · edge"
+echo "    aposentada e edge atestada pelo ledger ficam de fora)"
+echo
+echo "   🔧 O DESTINO DESTA LISTA É A SESSÃO QUE ESTÁ LENDO, NÃO UM CHIP. O braço que deploya"
+echo "      deixou de ser humano em 2026-09-08 (docs/agent/deploy.md, §Deploy de edge pela SESSÃO):"
+echo "        bun scripts/pendencias-deploy.ts --json > /tmp/pend.json"
+echo "        bun scripts/pendencias-pacote.ts - < /tmp/pend.json"
+echo "      e o Passo 2 do pacote vai VERBATIM para mcp__lovable__send_message. Depois MEÇA o"
+echo "      ledger: 'o Lovable disse Active' não é prova do bundle servido — pendencias:deploy é."
+echo "      Abrir chip aqui é devolver ao founder um trabalho que esta sessão faz em 2 comandos,"
+echo "      e foi por isso que a MESMA edge virava chip em toda sessão que fechava."
 # ⚠️ "nenhuma sonda na janela" NÃO se resolve esperando, e dizer só "INDETERMINADO" convida o
-# leitor a esperar. NÃO HÁ cron de sondagem: `cron.job` tem 93 jobs e ZERO com `probe`. Quem dá
+# leitor a esperar. O cron de sondagem existe desde 2026-09-06 (`deploy-sonda-cron`, 37 */2 * * *,
+# pelo relé OPTIONS fail-closed), mas cobre só a ALLOWLIST provada de
+# `_shared/sonda-cron-alvos.ts` — 7 edges de 59. Para as outras 52 esperar continua sendo
+# esperar para sempre, e o argumento abaixo vale palavra por palavra. Quem dá
 # prova passiva é só a edge cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) E tem cron
 # frequente — `analytics-outbox-drain` (5/5min) é o caso típico. Medido 2026-09-05: 24 das 54
 # edges do mapa não têm cron NENHUM (webhook, ou invocada sob demanda pelo app), e para essas a

--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -109,7 +109,9 @@ esteja configurado. Errar para mais custa uma linha de checklist; errar para men
 > ⚠️ **Pra ir ao ar, falta (manual no Lovable) — nesta ordem, APÓS o merge do PR:**
 > - [ ] 🟣 **SQL Editor**: migration Z *(se tocou `supabase/migrations/` — bloco da `lovable-db-operator`; banco ANTES do código que o consome)*
 > - [ ] 🔑 **Secrets (Lovable → Edge Functions → Secrets)**: confirmar que `NOME_DO_SECRET` existe *(se o passo 1 deu `secrets=` com nome ou `?dinamico`)*
-> - [ ] 💬 **chat do Lovable**: deploy das edges X, Y — verbatim da main *(se tocou `supabase/functions/`)*
+> - [ ] 💬 ~~chat do Lovable~~ → **A SESSÃO deploya** as edges X, Y pelo MCP (`send_message`), verbatim da main
+>       *(se tocou `supabase/functions/`)* — desde 2026-09-08 esta linha **não é mais pendência do founder**:
+>       veja o Passo 3, faça o deploy AQUI e reporte o resultado do ledger em vez de pedir a colagem a ele
 >       — **QUAIS edges: as que `bun run pendencias:deploy` lista como `DIVERGE_P1`/`INCOERENTE`/`SEM_MAPA_NO_BUNDLE`**
 >       (2026-09-05). Não derive a lista do diff: "o mapa mudou"/"closure mudou" NÃO é motivo — só
 >       `(versao, fonte)` servido ≠ main. `DIVERGE_P2` (só `_shared/`) entra na leva agrupada, escala em 7 d.
@@ -125,9 +127,30 @@ persiste em disco): a linha pede ao founder para *conferir/criar* pelo nome, e o
 
 ### Passo 3 — Prompt de deploy de edge (se aplicável)
 
-Montar pro founder colar no chat do Lovable, para as edges que o `pendencias:deploy` deu como pendentes
-— este passo decide o **conteúdo** do prompt, o closure ∪ {mapa}; ele NÃO decide *se* a edge precisa de
-deploy, e o mapa ter mudado depois do PR não é motivo (ver Passo 2).
+⚡ **NÃO monte o prompt à mão, e não peça ao founder para colar.** Desde 2026-09-08 as duas metades
+têm ferramenta: quem MONTA é `pendencias:prompt`/`pendencias:pacote`, e quem COLA é esta sessão, pelo
+MCP do Lovable (`docs/agent/deploy.md` §"Deploy de edge pela SESSÃO"):
+
+```bash
+bun scripts/pendencias-deploy.ts --json > /tmp/pend.json   # quem julga é o LEDGER, não o diff do PR
+bun scripts/pendencias-pacote.ts - < /tmp/pend.json        # gate de ordem: RPC em prod ANTES da edge
+# o Passo 2 do pacote vai VERBATIM para mcp__lovable__send_message
+#   (projeto `steu`, 8f005805-000a-42b7-88a1-9683f785fab6)
+```
+
+O gerador já resolve o closure ∪ {mapa} lendo de `origin/main` (**nunca** do working tree — #2123), já
+emite UMA colagem para a leva inteira e já carrega o `sha256` de cada arquivo com a ordem de conferir
+ANTES de deployar (#2362). Medido em 2026-09-08 numa leva de 2 (`omie-vendas-sync` money-path +
+`sync-reprocess`): **24/24 hashes conferidos**, ambas `Active`, 1,2 crédito, e `pendencias:deploy`
+em exit 0 na medição seguinte.
+
+⚠️ **`pacote` em exit 3 = BLOQUEADO**: a DDL de que a edge depende não está em prod. Não contorne
+mandando a colagem assim mesmo — aplicar migration continua sendo do founder (SQL Editor), e é ESSE
+o caso em que a pendência vira chip.
+
+O resto deste passo é o que o gerador faz por dentro — leia quando precisar auditá-lo, ou quando a
+edge estiver fora do que ele cobre. Ele decide o **conteúdo** do prompt; ele NÃO decide *se* a edge
+precisa de deploy, e o mapa ter mudado depois do PR não é motivo (ver Passo 2).
 
 **UMA colagem por LEVA, não por edge (medido 2026-09-06, e a transição observada em 2026-09-08).**
 Com 2+ edges pendentes, monte um prompt único numerando-as, cada uma com a SUA lista de arquivos — a

--- a/scripts/test-fecho-edges-pendentes.sh
+++ b/scripts/test-fecho-edges-pendentes.sh
@@ -139,7 +139,7 @@ suite() {
 
   # 1. prova POSITIVA: fonte servida == main -> some o chip
   run ok "$tmp/psql-stub" edge-no-ar
-  if tem 'NO_AR' "$out" && [ "$rc" -eq 0 ] && ! tem 'abra chip' "$out"
+  if tem 'NO_AR' "$out" && [ "$rc" -eq 0 ] && ! tem 'RESOLVER_NESTA_SESSAO' "$out"
   then ok "fonte bate com a main -> NO_AR, exit 0, sem chip"
   else bad "fonte batendo devia dar NO_AR/exit 0 (rc=$rc): ${out:0:90}"; fi
 
@@ -553,7 +553,7 @@ MAPA3
   out="$(STUB_MODO=ok AFIACAO_PSQL="$tmp/psql-stub" CLAUDE_PROJECT_DIR="$repo3" FECHO_MAPA_FONTE="" \
          bash "$ALVO" edge-aposentada 2>&1)"; rc=$?
   if tem 'INERTE' "$out" && tem 'edge-aposentada' "$out" && tem 'founder' "$out" \
-     && [ "$rc" -eq 0 ] && ! tem 'abra chip' "$out"
+     && [ "$rc" -eq 0 ] && ! tem 'RESOLVER_NESTA_SESSAO' "$out"
   then ok "marcador EDGE-APOSENTADA na REF -> INERTE, exit 0, sem chip, e diz para nao pedir ao founder"
   else bad "edge aposentada devia dar INERTE/exit 0 sem chip (rc=$rc): ${out:0:120}"; fi
 
@@ -585,7 +585,7 @@ MAPA3
   #     `edge-muda` e a edge do fixture que NAO tem linha na janela viva — exatamente a que caia
   #     em "nenhuma sonda em 6 hours".
   LEDGER_MODO=confere run ok "$tmp/psql-stub" edge-muda
-  if tem 'LEDGER_CONFERE' "$out" && [ "$rc" -eq 0 ] && ! tem 'abra chip' "$out" \
+  if tem 'LEDGER_CONFERE' "$out" && [ "$rc" -eq 0 ] && ! tem 'RESOLVER_NESTA_SESSAO' "$out" \
      && ! tem 'SEM_PROVA' "$out"
   then ok "ledger CONFERE com fonte == REF -> LEDGER_CONFERE, exit 0, SEM chip (prova alem da janela)"
   else bad "ledger conferindo devia suprimir o chip (rc=$rc): ${out:0:160}"; fi
@@ -626,7 +626,7 @@ MAPA3
   #      deploy antes, sonda depois (a mesma assimetria do `--caro`).
   LEDGER_MODO=diverge run ok "$tmp/psql-stub" edge-muda
   linha_cmd="$(printf '%s' "$out" | command grep 'sonda:sql' || true)"
-  if tem 'LEDGER_DIVERGE' "$out" && [ "$rc" -eq 1 ] && tem 'abra chip' "$out" \
+  if tem 'LEDGER_DIVERGE' "$out" && [ "$rc" -eq 1 ] && tem 'RESOLVER_NESTA_SESSAO' "$out" \
      && ! tem 'edge-muda' "$linha_cmd"
   then ok "ledger DIVERGE -> pendencia PROVADA, chip, e FORA da lista do DISPARE"
   else bad "DIVERGE devia ser chip provado e nunca convidar a sondar (rc=$rc): ${out:0:200}"; fi


### PR DESCRIPTION
> Pedido do founder (2026-09-08): *"Eu cliquei mas não quero ficar fazendo isso toda vez;
> repetidamente esses chips abrem com a mesma necessidade — automatize isso você."*

## O diagnóstico

O #2374 mediu, ontem, que o deploy de edge **deixou de precisar do founder**: o MCP do Lovable
está autenticado como ele e `send_message` é o mesmo canal do chat. Isso foi escrito em
`docs/agent/deploy.md`. Mas quem a sessão LÊ ao fechar é a **skill** — e a skill não sabia:

```
grep -c 'send_message|mcp__lovable|pendencias:prompt|pendencias:pacote'
  .claude/skills/fecho/SKILL.md                 → 0
  .claude/skills/lovable-deploy-verify/SKILL.md → 0
```

**A doc aprendeu; o ritual não.** Então `/fecho` seguia imprimindo `🎫 abra chip para: <slugs>`, o
founder clicava, e a sessão nova não fazia nada que a sessão que fechou não pudesse fazer:
re-rodava `pendencias:deploy` — o MESMO veredito que `edges-pendentes.sh` já consulta por dentro —
e montava **à mão** uma colagem que `pendencias:prompt` emite pronta (a `lovable-deploy-verify`
ainda ensinava a derivação manual do closure). Com o gatilho sendo "uma sessão fechou" e ~30
worktrees, a mesma edge virava chip em toda sessão que fechasse antes do deploy acontecer.

## O que muda

**`edges-pendentes.sh`** — a lista deixa de ser destinada a um chip e passa a ser destinada à
sessão que está lendo, com os dois comandos impressos. Marca `RESOLVER_NESTA_SESSAO` no lugar de
`abra chip`: **ASCII, caixa fixa**, só neste ramo — marca com acento/emoji casa diferente sob
`LC_ALL=C` × `pt_BR.UTF-8` (#1483) e marca que vaze para o rodapé casa sempre e esvazia a
asserção, as duas armadilhas já documentadas no próprio arquivo. As 4 asserções da suíte migram
junto, preservando a força (ausência da marca em `NO_AR`/`LEDGER_CONFERE`, presença em
`LEDGER_DIVERGE`).

**`/fecho` (Passo 3)** — destino de edge pendente, própria ou de terceiro, passa de "chip" para
deploy aqui. E fica dito por que a pendência **não sumiu junto com o chip**: ela mora no ledger
`deploy_atestacoes`, não na sessão — nenhuma sessão precisa lembrar dela, e nenhuma pode
declará-la resolvida sem `pendencias:deploy` em exit 0. Gerar o pacote não resolve; enviar ao
Lovable não resolve; só a reconciliação com prod resolve. Chip continua sendo o destino certo em
UM caso, agora nomeado: **braço indisponível** (MCP fora, `pacote` em exit 3 por DDL que só o
founder aplica).

**`lovable-deploy-verify` (Passo 3)** — abre mandando NÃO montar o prompt à mão, com o gerador e o
envio pelo MCP; a derivação manual continua abaixo, para auditar o gerador ou cobrir o que ele não
alcança. No checklist do Passo 2, a linha do chat do Lovable deixa de ser pendência do founder.

**Correção factual nos dois arquivos:** "NÃO existe cron de sondagem: `cron.job` tem 93 jobs e zero
com `probe`". Existe desde 2026-09-06 (`deploy-sonda-cron`, relé OPTIONS fail-closed), cobrindo
**7 edges de 59** (allowlist `_shared/sonda-cron-alvos.ts`, contadas neste PR). Contradizia
`docs/agent/deploy.md` de frente. O argumento que o bloco sustenta — esperar sonda passiva nunca
termina — segue valendo para as outras 52, e por isso ficou.

## Exercitado de verdade, não só descrito

O ritual novo foi rodado nesta sessão sobre a leva real que o chip pedia — `omie-vendas-sync`
(`DIVERGE_P1`, money-path: o write-back atômico do #2370) e `sync-reprocess` (`DIVERGE_P2`):

- `pendencias:pacote` → pré-condição de banco satisfeita, 2 edges, 11 RPCs, `origin/main@5b5bcface`;
- Passo 2 verbatim → `send_message` → **24/24 hashes conferidos**, ambas `Active`, **1,2 crédito**;
- commit do bot: só `src/integrations/supabase/types.ts` (+10) — não reverteu edge;
- **a prova**: `pendencias:deploy` em **exit 0**, `pendentes=0`, as duas em `CONFERE` — 59/59.

A transição `DIVERGE_P1` → `CONFERE` com o ANTES medido é a mesma que o #2383 documenta.

## Evidência

`test-fecho-edges-pendentes.sh` exit 0 (verde nos 2 locales) · `--falsificar` **33/33 sabotagens
vermelhas nos 2 locales** · `lint:shell` 0 achados em 390 arquivos · `docs:links`,
`docs:citacoes`, `docs:indice`, `gates:frescura` exit 0 — todos re-rodados **depois** do rebase
sobre a main.

## O que este PR NÃO faz

O gatilho continua sendo "uma sessão fechou". Um monitor agendado foi avaliado e ficou de fora:
o Codex marcou [P1] que um monitor local não consegue denunciar a própria máquina desligada — o
silêncio dele é indistinguível de "tudo confere" —, e fechar isso exige heartbeat observado de
fora. Fica como decisão do founder, não como dívida silenciosa.

Achado separado, com chip aberto: o gate de ordem descobre as RPCs lendo o **working tree**
(`coletarDaEdge`, `raiz = process.cwd()`) enquanto a colagem sai de `origin/main` — numa worktree
atrasada ele pode liberar sem enxergar a RPC nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)