### PR TITLE
fix(ci): a RAIZ do fecho entra no fecho — o job `validate` bloqueia o PR e sumia das DUAS contas ao mesmo tempo

### DIFF
--- a/docs/historico/custo-de-gate-medido-beneficio-nao.md
+++ b/docs/historico/custo-de-gate-medido-beneficio-nao.md
@@ -233,10 +233,46 @@ partição é asserida contra o `ci.yml` de verdade (nenhum step nas duas listas
 O `bloqueantesSemScript` usava uma aproximação diferente (`/\bbunx?\s+(?:run\s+)?[a-z]/`) que hoje
 concordava — passou a usar a mesma função, e a lista dele não mudou.
 
-Fica anotada uma fresta **latente**: o job `validate` não está no próprio `needs`, então nem
-`bloqueiaPR` nem o contador o alcançam. Hoje não esconde nada — seus únicos steps são o agregador e
-os de Issue. Remendar só o contador faria as duas contas falarem de universos diferentes, que é
-pior que a fresta.
+### A fresta latente, fechada logo depois: a raiz do fecho não estava no fecho
+
+O #2376 anotou uma fresta **latente**: o job `validate` não está no próprio `needs`, então nem
+`bloqueiaPR` nem o contador o alcançavam. A causa é estrutural, não esquecimento — **`needs` aponta
+para trás e ninguém aponta para a raiz**, então todo fecho transitivo calculado a partir de
+`X.needs` exclui `X` por construção. E a raiz é justamente o único job que o auto-merge exige por
+nome: se ela fica vermelha, o PR não mergeia.
+
+O ponto cego era **simétrico**, o pior formato: um step dentro do `validate` sumia das duas contas
+ao mesmo tempo — nem marcado `bloqueiaPR` (logo, nunca cobrado pela prova de exclusividade), nem
+listado como opaco. Uma fresta que nenhum dos dois números denuncia. Remendar só o contador faria
+as duas contas falarem de universos diferentes, que é pior que a fresta; por isso o conserto veio
+depois, mexendo nas duas ao mesmo tempo.
+
+O conserto é uma linha — `const fila = JOB_RAIZ in jobs ? [JOB_RAIZ] : []` —, e o efeito nas duas
+contas foi **medido**, não previsto:
+
+- bloqueantes: **28 → 28**. O `validate` não hospeda step que invoque script do `package.json`, e o
+  teste trava a *razão* disso (`gatesCandidatos(ci).filter(g => g.job === 'validate') == []`), nunca
+  o número 28 — travar o número apodreceria a cada gate novo;
+- opacos: **3 → 4**, com `validate: Todos os jobs passaram? (exige 'success' POSITIVO de cada um)`.
+
+**A raiz só entra se existir no arquivo.** Um `ci.yml` sem `validate` continua devolvendo conjunto
+vazio — a forma honesta de dizer "não achei o required check" em vez de somar um nome que ninguém
+escreveu. Ausência não vira presença; é a mesma regra de `ausente ≠ zero`, aplicada ao grafo.
+
+**O agregador não foi filtrado**, e a alternativa (um filtro nomeado e documentado) foi considerada.
+Três razões, em ordem de força:
+
+1. ele não é um no-op que soma resultados: tem lógica **própria**, que já falhou aberta — o guard de
+   denominador (`total -ne esperados`) e o guard **nominal** de `provas-sql`, este acrescentado pelo
+   parecer do Codex de 2026-09-07 sob *"cinco jobs quaisquer não provam que SQL entrou no
+   contrato"*. É a categoria exata que o contador existe para manter visível;
+2. o `gates:frescura` **já o listava** no contador dele (5 steps sem script, o `validate` entre
+   eles). Silenciá-lo aqui faria os dois contadores divergirem justamente onde concordam;
+3. filtrar por nome **quebraria a partição** asserida acima: o step ficaria fora das duas listas —
+   o silêncio de volta. Não é argumento de mesa: a sabotagem que insere o filtro derruba **dois**
+   testes, o do agregador e o da partição.
+
+Preço do fechamento: uma linha a mais no relatório do CI.
 
 ## O bootstrap tem um nó, e ele é honesto
 

--- a/scripts/exclusividade-gate.test.ts
+++ b/scripts/exclusividade-gate.test.ts
@@ -99,13 +99,29 @@ describe('parseDefeitos', () => {
 describe('jobsBloqueantes — o que de fato reprova um PR', () => {
   const ci = readFileSync('.github/workflows/ci.yml', 'utf8');
 
-  it('resolve o fecho transitivo de validate.needs', () => {
+  it('resolve o fecho transitivo de validate.needs — com a RAIZ dentro', () => {
     const y = ['jobs:', '  a: {}', '  b:', '    needs: [a]', '  validate:', '    needs: [b]'].join('\n');
-    expect([...jobsBloqueantes(y)].sort()).toEqual(['a', 'b']);
+    expect([...jobsBloqueantes(y)].sort()).toEqual(['a', 'b', 'validate']);
   });
 
   it('needs escrito como string (nao lista) tambem conta', () => {
-    expect([...jobsBloqueantes('jobs:\n  a: {}\n  validate:\n    needs: a')]).toEqual(['a']);
+    expect([...jobsBloqueantes('jobs:\n  a: {}\n  validate:\n    needs: a')].sort()).toEqual([
+      'a',
+      'validate',
+    ]);
+  });
+
+  // A fresta que o #2376 deixou aberta: `needs` aponta para tras, ninguem aponta para o
+  // `validate`, e um fecho que parte de `validate.needs` exclui a RAIZ por construcao — logo um
+  // step dentro dela sumia das DUAS contas ao mesmo tempo (nem `bloqueiaPR`, nem opaco).
+  it('o proprio validate BLOQUEIA o PR — e o required check do auto-merge', () => {
+    expect(jobsBloqueantes(ci).has('validate')).toBe(true);
+  });
+
+  // O outro lado da mesma linha: incluir a raiz nao pode virar presenca FABRICADA. Um ci.yml sem
+  // `validate` tem de continuar devolvendo vazio — que e como se diz "nao achei o required check".
+  it('sem job validate no arquivo, o conjunto e VAZIO (nao um nome inventado)', () => {
+    expect([...jobsBloqueantes('jobs:\n  a: {}\n  b:\n    needs: [a]')]).toEqual([]);
   });
 
   // A regressao concreta: `inventarioCI` filtra `continue-on-error` no STEP e nao ve a outra
@@ -165,6 +181,23 @@ describe('bloqueantesOpacos — exclusao silenciosa le como cobertura total', ()
     const nucleo = bloqueantesOpacos(ci).find((o) => o.comando.includes('roda-nucleo-ci.sh'));
     expect(nucleo, 'o contador tem de ve-lo').toBeDefined();
     expect(nucleo!.job).toBe('provas-sql');
+  });
+
+  // O agregador do `validate` e o caso que so aparece depois de a RAIZ entrar em
+  // `jobsBloqueantes`. Ele NAO e filtrado por nome de proposito: tem logica propria (guard de
+  // denominador + guard nominal de `provas-sql`) e e exatamente o que este contador existe para
+  // manter visivel. Se um dia alguem o silenciar por allowlist, este teste fica vermelho.
+  it('o agregador do validate esta DENTRO do contador — nao ha filtro por nome', () => {
+    const agregador = bloqueantesOpacos(ci).find((o) => o.job === 'validate');
+    expect(agregador, 'o step do required check tem de aparecer').toBeDefined();
+    expect(agregador!.step).toContain('Todos os jobs passaram');
+  });
+
+  // E o motivo de a conta de bloqueantes NAO ter mudado ao incluir a raiz: o `validate` nao
+  // hospeda nenhum step que invoque script do package.json. Trava a razao, nao o numero — travar
+  // o numero apodreceria a cada gate novo, que e o oposto do que esta maquina quer.
+  it('o validate nao acrescenta gate NOMEADO ao censo (por isso o total nao mudou)', () => {
+    expect(gatesCandidatos(ci).filter((g) => g.job === 'validate')).toEqual([]);
   });
 
   // A invariante que impede a FRESTA: censo e contador tem de PARTICIONAR os steps bloqueantes.

--- a/scripts/lib/exclusividade.ts
+++ b/scripts/lib/exclusividade.ts
@@ -99,18 +99,36 @@ export function parseDefeitos(texto: string, arquivo: string): Defeito[] {
 // ---------------------------------------------------------------------------------------------
 
 export interface GateAlvo extends GateCI {
-  /** True so se o job dele e alcancavel a partir de `validate.needs` (fecho transitivo). */
+  /** True so se o job dele e o `validate` ou alcancavel a partir dele (fecho de `needs`). */
   bloqueiaPR: boolean;
 }
 
+/** O unico job que o auto-merge exige por nome (`.github/workflows/auto-merge.yml`). */
+export const JOB_RAIZ = 'validate';
+
 /**
- * Fecho transitivo de `validate.needs`. Existe porque `inventarioCI` filtra `continue-on-error` no
- * **step** e isso nao ve a outra forma de ser informativo: um JOB inteiro fora de `validate.needs`.
+ * Fecho transitivo de `validate.needs`, **com o proprio `validate` dentro**. Existe porque
+ * `inventarioCI` filtra `continue-on-error` no **step** e isso nao ve a outra forma de ser
+ * informativo: um JOB inteiro fora de `validate.needs`.
  *
  * E exatamente o caso do job `mutation-check` do `ci.yml`, deliberadamente informativo e abrindo
  * Issue desde o #2344 — que `inventarioCI` hoje lista junto dos bloqueantes. Derivar do grafo, em
  * vez de manter uma lista de excecoes, e o que impede este censo de envelhecer como envelheceu o
  * censo datado de 15 nomes que originou o `gates:frescura`.
+ *
+ * ## Por que a RAIZ entra no fecho (o #2376 a deixou de fora)
+ *
+ * `needs` aponta para tras — ninguem aponta para o `validate` —, entao um fecho que parte de
+ * `validate.needs` exclui a raiz por CONSTRUCAO. E a raiz e justamente o unico job que o
+ * auto-merge exige por nome: se ele fica vermelho, o PR nao mergeia. O efeito era um ponto cego
+ * simetrico, o pior tipo: um step dentro do `validate` sumia das DUAS contas ao mesmo tempo — nem
+ * `gatesCandidatos` o marcava `bloqueiaPR` (logo, nunca cobrado pela prova de exclusividade), nem
+ * `bloqueantesOpacos` o listava. Hoje o `validate` so hospeda o agregador; "hoje nao esconde nada"
+ * e exatamente o que valia para o `provas-sql` ate o #2364 por la acrescentar um gate em shell.
+ *
+ * A raiz so entra se EXISTIR no arquivo. Somar um nome que o `ci.yml` nao tem seria fabricar
+ * presenca — e um `ci.yml` sem `validate` deve continuar devolvendo conjunto VAZIO, que e a forma
+ * honesta de dizer "nao encontrei o required check aqui".
  */
 export function jobsBloqueantes(fonteCI: string): Set<string> {
   const doc = parse(fonteCI) as { jobs?: Record<string, { needs?: unknown }> };
@@ -122,7 +140,7 @@ export function jobsBloqueantes(fonteCI: string): Set<string> {
     return [];
   };
   const vistos = new Set<string>();
-  const fila = [...needsDe('validate')];
+  const fila = JOB_RAIZ in jobs ? [JOB_RAIZ] : [];
   while (fila.length) {
     const j = fila.pop()!;
     if (vistos.has(j)) continue;
@@ -167,10 +185,15 @@ export interface StepOpaco {
  * "reprova alguma coisa", aqui e "reprova o PR". Este arquivo tem o grafo de `needs`; o frescura
  * nao.
  *
- * O job `validate` fica fora por consequencia: ele nao esta no proprio `needs`. Hoje nao esconde
- * nada (seus unicos steps sao o agregador e os de Issue), mas e uma fresta latente — vale um
- * arquivo proprio, nao um remendo local que faria o contador e `bloqueiaPR` falarem de universos
- * diferentes.
+ * ## O agregador do `validate` aparece aqui — e isso e o certo, nao ruido
+ *
+ * Desde que `jobsBloqueantes` passou a incluir a raiz, o step "Todos os jobs passaram?" cai neste
+ * contador. Ele nao e um no-op que soma resultados: tem logica PROPRIA, ja falha-aberta uma vez —
+ * o guard de DENOMINADOR (`total -ne esperados`, contra o jq que devolve nada) e o guard NOMINAL
+ * de `provas-sql`, acrescentado pelo parecer do Codex de 2026-09-07 sob a frase "cinco jobs
+ * quaisquer nao provam que SQL entrou no contrato". Um step assim e a categoria exata que este
+ * contador existe para manter visivel. Filtra-lo por nome reabriria o silencio na unica linha que
+ * o fecha, e devolveria a lista de excecoes que `jobsBloqueantes` se recusa a manter.
  */
 /**
  * A 1a linha do `run:` que de fato EXECUTA algo. Pula vazio, comentario e prologo (`set -euo

--- a/scripts/lib/exclusividade.ts
+++ b/scripts/lib/exclusividade.ts
@@ -103,8 +103,12 @@ export interface GateAlvo extends GateCI {
   bloqueiaPR: boolean;
 }
 
-/** O unico job que o auto-merge exige por nome (`.github/workflows/auto-merge.yml`). */
-export const JOB_RAIZ = 'validate';
+/**
+ * O unico job que o auto-merge exige por nome (`.github/workflows/auto-merge.yml`). Sem `export`
+ * de proposito: os testes casam o literal `'validate'`, nao este simbolo — asserir contra a
+ * constante faria a assercao se mover junto com o codigo, que e teste que nao pode falhar.
+ */
+const JOB_RAIZ = 'validate';
 
 /**
  * Fecho transitivo de `validate.needs`, **com o proprio `validate` dentro**. Existe porque


### PR DESCRIPTION
## O que estava aberto

`jobsBloqueantes()` calcula o fecho transitivo de `validate.needs`. Como **`needs` aponta para trás e ninguém aponta para o `validate`**, a raiz ficava fora do próprio fecho — por construção, não por esquecimento. E a raiz é justamente o único job que o auto-merge exige por nome.

O ponto cego era **simétrico**, o pior formato: um step dentro do `validate` sumia das **duas** contas ao mesmo tempo — nem `gatesCandidatos()` o marcava `bloqueiaPR` (logo, nunca cobrado pela prova de contribuição exclusiva), nem `bloqueantesOpacos()` (#2376) o listava. Uma fresta que nenhum dos dois números denuncia.

Hoje não escondia nada — o `validate` só hospeda o agregador e os steps de Issue. Era exatamente o que se podia dizer do `provas-sql` até o #2364 acrescentar lá `bash db/roda-nucleo-ci.sh`.

## O conserto (uma linha, e as duas contas mudam juntas)

```ts
const fila = JOB_RAIZ in jobs ? [JOB_RAIZ] : [];
```

**A raiz só entra se EXISTIR no arquivo.** Um `ci.yml` sem `validate` continua devolvendo conjunto vazio — a forma honesta de dizer "não achei o required check" em vez de somar um nome que ninguém escreveu.

## Medido, não previsto

| conta | antes | depois |
|---|---|---|
| gates bloqueantes | 28 | **28** |
| steps opacos | 3 | **4** |

O `validate` não hospeda step que invoque script do `package.json` — daí o 28 → 28. O teste trava a **razão** (`gatesCandidatos(ci).filter(g => g.job === 'validate') === []`), nunca o número 28: travar o número apodreceria a cada gate novo.

A linha nova no relatório:

```
     - validate: Todos os jobs passaram? (exige 'success' POSITIVO de cada um)
       $ esperados=5
```

## Por que o agregador NÃO foi filtrado

A alternativa (filtro nomeado e documentado) foi considerada. Três razões, em ordem de força:

1. **ele não é um no-op que soma resultados**: tem lógica própria que já falhou aberta — o guard de denominador (`total -ne esperados`) e o guard **nominal** de `provas-sql`, acrescentado pelo parecer do Codex de 2026-09-07 sob *"cinco jobs quaisquer não provam que SQL entrou no contrato"*. É a categoria exata que o contador existe para manter visível;
2. **o `gates:frescura` já o listava** no contador dele (5 steps sem script, `validate` entre eles). Silenciá-lo aqui faria os dois contadores divergirem justamente onde concordam;
3. **filtrar por nome quebra a partição** asserida desde o #2376 — o step ficaria fora das duas listas, o silêncio de volta. Não é argumento de mesa: a sabotagem que insere o filtro derruba **dois** testes.

## Verificação

| comando | resultado |
|---|---|
| `bunx vitest run scripts/exclusividade-gate.test.ts` | **50 passed** (46 + 4 novos) |
| `bun run exclusividade` | exit 0 — 28 bloqueantes, 4 opacos |
| `bun run gates:frescura` | exit 0 — `FRESCURA-OK`, lista inalterada (5) |
| `bun run docs:indice` / `docs:links` / `docs:citacoes` | exit 0 |

### Falsificação — controle verde na MESMA invocação do laço

```
== CONTROLE (limpo) ==   Tests  50 passed (50)   -> CONTROLE-VERDE
s1 raiz fora do fecho (volta ao #2376)  -> ✅ vermelho: "BLOQUEIA o PR" (4 testes caem)
s2 raiz INCONDICIONAL (presença fabric.) -> ✅ vermelho: "conjunto e VAZIO" (1 teste, só ele)
s3 allowlist do agregador                -> ✅ vermelho: "nao ha filtro por nome" + partição (2)
== restaurado (cmp OK) ==  FALSIFICACAO-OK: 3/3 no ramo certo
```

Cada sabotagem aborta se não aplicar (fail-closed), o vermelho é casado pela **marca ASCII do ramo** — nunca por "falhou algo" — e a restauração é conferida por `cmp`.

Resíduo em [`docs/historico/custo-de-gate-medido-beneficio-nao.md`](docs/historico/custo-de-gate-medido-beneficio-nao.md): o parágrafo "fica anotada uma fresta latente" virou a seção do fechamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
