### PR TITLE
perf(contexto): o teto de saída do Bash cai 30.000 → 4.000 — a chave era env var atrás de um allowlist, e o corte é fail-LOUD

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "disableClaudeAiConnectors": true,
   "skillListingMaxDescChars": 220,
   "skillListingBudgetFraction": 0.004,
+  "env": {
+    "BASH_MAX_OUTPUT_LENGTH": "4000"
+  },
   "enabledPlugins": {
     "adobe-for-creativity@claude-plugins-official": false,
     "mercadopago@claude-plugins-official": false,

--- a/docs/historico/ocupacao-bash-por-comando.md
+++ b/docs/historico/ocupacao-bash-por-comando.md
@@ -120,16 +120,52 @@ quartos de todo o `docs/agent`**. Média de 5,0 disparos por sessão; só o 1º 
 |---|---:|---|
 | **1º disparo ensina, repetições só lembram** (886 → 95 chars) | **65,4M tok×req = 72,9% do custo do hook ≈ 3,0% da ocupação de Bash** | ✅ aplicado |
 | deduplicar comando idêntico repetido na mesma sessão | 20,9M = **1,0%** | ❌ refutado — não paga |
-| baixar o teto de saída para 8.000 chars | 171,3M = 7,9% da ocupação de Bash | 🧭 decisão do founder |
-| … para 4.000 | 404,1M = 18,5% | 🧭 |
-| … para 3.000 | 537,1M = 24,6% | 🧭 |
-| … para 2.000 | 757,8M = **34,8%** (≈26,8% da ocupação TOTAL) | 🧭 |
+| baixar o teto de saída para 8.000 chars | 171,3M = 7,9% da ocupação de Bash | ❌ preterido — ganho modesto |
+| **… para 4.000** | **404,1M = 18,5% (≈14,3% da ocupação TOTAL)** | ✅ **aplicado** (2026-09-08) |
+| … para 3.000 | 537,1M = 24,6% | ❌ preterido |
+| … para 2.000 | 757,8M = **34,8%** (≈26,8% da ocupação TOTAL) | ❌ preterido — encosta no preview |
 
-**O teto já existe**, e a evidência é a forma da distribuição: entre 20k e 29k a frequência é um
+**O teto já existia**, e a evidência era a forma da distribuição: entre 20k e 29k a frequência é um
 platô achatado (11·26·18·12·9·12·10·10·13 por faixa de 1k) e acima de 29.000 há **zero** em
 69.737 chamadas. Saídas que seriam de 50k ou 1 MB foram todas grampeadas para dentro da faixa.
 Baixar esse teto é uma chave, não um refactor — a lição "procure a chave" do `piso-de-contexto.md`.
-É mudança de raio grande (trunca toda sessão do repo), por isso fica como proposta com número.
+
+A inferência estava certa **no número exato**. A chave é a env var `BASH_MAX_OUTPUT_LENGTH`, lida
+do bloco `env` do `.claude/settings.json`; no binário do harness (2.1.202):
+
+```js
+function Pft(){return bpe("BASH_MAX_OUTPUT_LENGTH",process.env.BASH_MAX_OUTPUT_LENGTH,jfo,qfo).effective}
+var qfo=150000, jfo=30000;   // default 30.000 · upperLimit 150.000 (acima disso é "capped")
+```
+
+Três coisas que só apareceram ao aplicar, e que valem mais que o número:
+
+1. **O bloco `env` não vai inteiro para `process.env`.** Há um allowlist (`jot`) e só o que está
+   nele passa: `if(jot.has(r.toUpperCase())) process.env[r]=n`. `BASH_MAX_OUTPUT_LENGTH` está lá,
+   ao lado de `BASH_DEFAULT_TIMEOUT_MS` e `BASH_MAX_TIMEOUT_MS` — mas uma chave **fora** dessa
+   lista seria escrita no arquivo, versionada, revisada em PR e **ignorada em silêncio**. Escrever
+   no settings não é evidência de que o harness leu: a sonda positiva é `echo $BASH_MAX_OUTPUT_LENGTH`
+   dentro de um comando Bash, que devolve o `process.env` do próprio harness. Ela acusou `4000` na
+   sessão corrente, **sem restart**.
+2. **Acima do teto o corte é fail-LOUD, não perda.** O harness não trunca em silêncio: salva a
+   saída inteira em arquivo, anuncia `Output too large (109.4KB). Full output saved to: <path>` e
+   mostra os primeiros 2.000 chars (`Emt=2000`, constante fixa — não é fração do teto). O fim, onde
+   moram o erro e o exit code, sai do contexto mas fica **recuperável num `Read`**. Foi essa
+   descoberta que permitiu escolher 4.000 em vez do 8.000 conservador: o risco que justificaria
+   começar alto é o de perda silenciosa, e ela não existe aqui.
+3. **A tabela SUBESTIMA os tetos altos.** Ela assumiu que a chamada passa a custar o teto; na
+   prática toda saída acima do teto colapsa para os mesmos ~2.000 chars. Logo a economia real de
+   4.000 é *maior* que 18,5% — quanto, não dá para dizer sem re-rodar o levantamento, e número
+   inventado aqui seria fabricação. A linha de 2.000 é a única em que teto ≈ preview e o cálculo
+   original já valia; ela foi preterida justamente por isso: ganharia pouco além de 4.000 e
+   afetaria 11% das chamadas em vez de ~4% (p95=3.347, p99=8.531).
+
+Provado nos dois lados antes de aplicar: 29.213 chars vieram **inteiros, com a última linha**;
+109,4KB viraram ponteiro para arquivo com a última linha ausente. O gate
+`scripts/teto-saida-bash.test.ts` lê o **arquivo**, não `process.env` — eixo por fora, já que
+`process.env` é a máquina que o gate vigiaria — e trava o invariante (presente · dígitos · abaixo
+do default de 30.000 · dentro do upperLimit), não o literal `4000`. Falsificado com 9 sabotagens
+× 2 locales, todas vermelhas, com controle verde na mesma invocação.
 
 Baixar o **gatilho** do nudge não é alternativa: ele já vê 38,7% da ocupação e é cego aos outros
 61,3%, que estão em chamadas pequenas — **77,9% das chamadas ficam abaixo de 1.000 chars e ainda

--- a/scripts/teto-saida-bash.test.ts
+++ b/scripts/teto-saida-bash.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * O teto de saída do Bash (`BASH_MAX_OUTPUT_LENGTH`) é a chave que corta a maior fatia de
+ * ocupação de contexto do repo — 77,1% da ocupação é Bash, e o corte em 4.000 rende ~14,3% do
+ * total (`docs/historico/ocupacao-bash-por-comando.md` §5).
+ *
+ * Ela é uma env var, não uma chave de primeira classe do schema do settings: quem apagar o bloco
+ * `env` não quebra nada visível — o harness volta ao default de 30.000 em SILÊNCIO, e a regressão
+ * só aparece meses depois numa conta de tokens. Este teste é o alarme.
+ *
+ * Os três números vêm do binário do harness (2.1.202), não de suposição:
+ *   `function Pft(){return bpe("BASH_MAX_OUTPUT_LENGTH",process.env.BASH_MAX_OUTPUT_LENGTH,jfo,qfo).effective}`
+ *   `var qfo=150000, jfo=30000;`  → default 30.000, upperLimit 150.000 (acima disso é "capped").
+ *
+ * Eixo POR FORA: o teste NÃO consulta `process.env` — que é justamente o que o harness já
+ * aplicou nesta sessão e, portanto, herdaria o defeito da máquina que vigia. Ele lê o ARQUIVO,
+ * que é o artefato versionado e a única coisa que sobrevive à sessão.
+ */
+
+const DEFAULT_DO_HARNESS = 30000;
+const UPPER_LIMIT_DO_HARNESS = 150000;
+
+function lerTeto(): { bruto: unknown; settings: Record<string, unknown> } {
+  const caminho = join(process.cwd(), '.claude/settings.json');
+  const settings = JSON.parse(readFileSync(caminho, 'utf8')) as Record<string, unknown>;
+  const env = (settings.env ?? {}) as Record<string, unknown>;
+  return { bruto: env.BASH_MAX_OUTPUT_LENGTH, settings };
+}
+
+describe('teto de saída do Bash em .claude/settings.json', () => {
+  it('declara BASH_MAX_OUTPUT_LENGTH no bloco env', () => {
+    const { bruto } = lerTeto();
+    expect(bruto, 'bloco env.BASH_MAX_OUTPUT_LENGTH ausente do .claude/settings.json').toBeDefined();
+  });
+
+  it('usa string de dígitos — o harness lê de process.env, que só carrega string', () => {
+    const { bruto } = lerTeto();
+    expect(typeof bruto).toBe('string');
+    expect(String(bruto)).toMatch(/^[0-9]+$/);
+  });
+
+  it('aperta ABAIXO do default do harness — senão a chave não tem efeito nenhum', () => {
+    const { bruto } = lerTeto();
+    const valor = Number(bruto);
+    expect(valor).toBeGreaterThan(0);
+    expect(
+      valor,
+      `teto ${valor} >= default ${DEFAULT_DO_HARNESS} do harness: a chave existe mas não corta nada`,
+    ).toBeLessThan(DEFAULT_DO_HARNESS);
+  });
+
+  it('fica dentro do upperLimit, senão o harness capa o valor em silêncio', () => {
+    const { bruto } = lerTeto();
+    expect(Number(bruto)).toBeLessThanOrEqual(UPPER_LIMIT_DO_HARNESS);
+  });
+
+  it('sobrevive ao merge: o bloco env não engoliu as outras chaves de contexto', () => {
+    const { settings } = lerTeto();
+    expect(settings.skillListingMaxDescChars).toBeDefined();
+    expect(settings.skillListingBudgetFraction).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fecha a decisão 🧭 que a §5 de [`ocupacao-bash-por-comando.md`](docs/historico/ocupacao-bash-por-comando.md) deixou em aberto no #2375. Bash é **77,1% da ocupação de contexto** (760 sessões / 69.737 chamadas); o teto em 4.000 rende **18,5% da ocupação de Bash ≈ 14,3% do total** — ~3,4x o que renderia apagar toda a `docs/agent/`.

## A chave, confirmada e não presumida

O schema do settings **não tem** chave dedicada para isto — o caminho é a env var, no binário do harness (2.1.202):

```js
function Pft(){return bpe("BASH_MAX_OUTPUT_LENGTH",process.env.BASH_MAX_OUTPUT_LENGTH,jfo,qfo).effective}
var qfo=150000, jfo=30000;   // default 30.000 · upperLimit 150.000
```

O default de **30.000** bate exatamente com o que o levantamento inferiu pela *forma* da distribuição (zero saídas acima de 29.000 em 69.737 chamadas).

## Três coisas que só apareceram ao aplicar

1. **O bloco `env` não vai inteiro para `process.env`.** Há um allowlist — `if(jot.has(r.toUpperCase())) process.env[r]=n`. `BASH_MAX_OUTPUT_LENGTH` está nele (ao lado de `BASH_DEFAULT_TIMEOUT_MS` e `BASH_MAX_TIMEOUT_MS`), mas uma chave **fora** da lista seria escrita no arquivo, versionada, revisada em PR e **ignorada em silêncio**. Escrever no settings não é evidência de que o harness leu — a sonda positiva é `echo $BASH_MAX_OUTPUT_LENGTH` dentro de um comando Bash, que devolve o `process.env` do próprio harness. Acusou `4000` na sessão corrente, sem restart.

2. **Acima do teto o corte é fail-LOUD.** Não trunca em silêncio: salva a saída inteira em arquivo, anuncia `Output too large (109.4KB). Full output saved to: <path>` e mostra os primeiros 2.000 chars (`Emt=2000`, constante fixa, não fração do teto). O fim — erro e exit code — sai do contexto mas fica **recuperável num `Read`**. Foi essa descoberta que autorizou 4.000 em vez do 8.000 conservador: o risco que justificaria começar alto é o de perda silenciosa, e ele não existe.

3. **A tabela da §5 subestima os tetos altos.** Assumiu que a chamada passa a custar o teto; na prática toda saída acima dele colapsa para os mesmos ~2.000. A economia real de 4.000 é *maior* que 18,5% — **o quanto fica explicitamente não quantificado**: sem re-rodar o levantamento, número aqui seria fabricação.

## Prova

| o quê | evidência |
|---|---|
| limiar | 29.213 chars vieram **inteiros, com a última linha**; 109,4KB viraram ponteiro com a última linha ausente |
| chave chegou ao harness | `echo $BASH_MAX_OUTPUT_LENGTH` → `4000`, na sessão corrente |
| gate | `scripts/teto-saida-bash.test.ts` — lê o **arquivo**, não `process.env` (eixo por fora: `process.env` é a máquina que o gate vigiaria) |
| falsificação | **9 sabotagens × 2 locales** (`LC_ALL=C` e `pt_BR.UTF-8`), todas vermelhas, com **controle verde na mesma invocação** antes da primeira sabotagem, e guarda anti-vácuo exigindo o arquivo limpo ao fim |

O gate trava o **invariante** (presente · dígitos · abaixo do default de 30.000 · dentro do upperLimit), não o literal `4000` — mudar o número não quebra o teste; remover a chave, ou pôr um valor sem efeito, quebra.

## Escopo

Vale para toda sessão do repo. Reversível em uma linha. Fora de escopo: destilar `money-path.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)