### PR TITLE
refactor(ci): a guarda anti-vácuo cobra VOLUME de entradas — a igualdade de conjunto ERA o eixo do órfão, e `docs:indice` sai de `[redund] 0/8` para `[SO ELE] 1/8`

### DIFF
--- a/docs/historico/custo-de-gate-medido-beneficio-nao.md
+++ b/docs/historico/custo-de-gate-medido-beneficio-nao.md
@@ -80,8 +80,8 @@ para prever o CI (`medir-ganho-de-ci-sob-ruido.md`: o runner varia 45%).
 | `docs:links` | **1**/7 | 2 | 903ms | só ele pega link quebrado FORA de índice |
 | `exclusividade` | **1**/7 | 1 | 245ms | só ele lê a matriz — nenhum outro gate a enxerga |
 | `gates:frescura` | **1**/7 | 1 | 419ms | só ele pega gate que sumiu do censo |
-| `docs:indice` | **0**/7 | 2 | 58ms | zero **por CÓPIA**, e a cópia só saiu pela metade — ver abaixo |
-| `test` (vitest) | 0/7 | 2 | 128s | `[s/ mira]`: nenhum defeito foi escrito para ele |
+| `docs:indice` | **0**/7 | 2 | 58ms | zero **por CÓPIA**; a cópia saiu em DUAS etapas e hoje ele tem **1** exclusivo — ver abaixo |
+| `test` (vitest) | 0/7 | 2 | 128s | `[s/ mira]`: nenhum defeito foi escrito para ele — e os 2 que ele pegava eram a CÓPIA, hoje remedidos em 0 |
 | `docs:citacoes` | 0/7 | 0 | 3,8s | `[s/ mira]`: idem — e é o mais caro dos "baratos" |
 
 ### O achado central, e ele inverte a recomendação
@@ -136,8 +136,9 @@ conjunto *é* a invariante do órfão. A implementação excede o contrato decla
 exatamente a parte que duplica o step. Uma guarda fiel ao que ela diz proteger cobraria *volume* de
 entradas ("o parse não morreu"), não *identidade* com a lista de arquivos.
 
-Estreitá-la é decisão em aberto, e deliberadamente não tomada aqui: enfraquecer uma rede anti-vácuo
-para ganhar 0 exclusivo é caro pelo lado errado. Fica medido para quem decidir.
+Estreitá-la ficou como decisão em aberto neste ponto — enfraquecer uma rede anti-vácuo para ganhar 0
+exclusivo é caro pelo lado errado, e sem falsificação não dava para saber se sobraria rede. A seção
+seguinte é o desfecho: ela foi estreitada, falsificada e remedida.
 
 #### Cuidado ao ler a coluna `mediana` desta remedição
 
@@ -152,6 +153,68 @@ máquinas e cargas diferentes, e não são comparáveis entre si.
 A sobreposição parcial com `docs:links` que o Codex também anotou está medida na segunda linha:
 os dois pegam o alvo-fantasma, mas só `docs:links` pega o link quebrado fora de um índice. As
 obrigações são **distintas** e as duas ficam.
+
+#### A guarda foi estreitada — e `docs:indice` deixou de ser `[redund]`
+
+A decisão acima foi tomada. A igualdade de conjunto virou um **piso de volume**:
+
+```ts
+// antes — igualdade de conjunto, que É a invariante do órfão
+expect(hrefs, `entradas de ${d.dir}/README.md`).toEqual([...d.arquivos].sort());
+
+// depois — volume: "o parse não morreu", e só isso
+expect(entradas.length, `entradas de ${d.dir}/README.md`)
+  .toBeGreaterThanOrEqual(Math.floor(d.arquivos.length / 2));
+```
+
+O piso é **metade dos arquivos do diretório**, não um número fixo. `docs/historico` tem 166 entradas
+para 166 arquivos, então a guarda folga **83 linhas**: apagar uma entrada não a acorda — isso é
+trabalho do step. Um piso fixo apodreceria (o histórico saiu de ~40 para 166 docs desde que o gate
+nasceu), e `> 0` seria teatro. Diretório com ≤1 arquivo cai em piso 0 de propósito: nessa escala não
+existe volume a conferir, e um `Math.max(1, …)` seria a igualdade de conjunto voltando pela porta dos
+fundos.
+
+**Falsificada antes de medida**, com controle verde na MESMA invocação (veredito lido do JSON do
+vitest, não do glifo do reporter):
+
+| sabotagem | a guarda | controle na mesma invocação |
+|---|---|---|
+| repo íntegro | ✓ verde | 34/34 |
+| `parseEntradas` → `[]` (a ameaça que o comentário declara) | **× vermelha** | 10 verdes / 24 vermelhos |
+| `parseEntradas` → `.slice(0, 1)` | **× vermelha** | **25 verdes** / 9 vermelhos |
+| defeito `indice-orfao` | ✓ verde | 34/34 — **cega ao órfão, que era o alvo** |
+| árvore restaurada | ✓ verde | 34/34 |
+
+A linha do `.slice(0, 1)` é a que separa piso honesto de teatro: 25 testes verdes ao lado, e a guarda
+mesmo assim vermelha. Sem ela, "vermelha sob `[]`" não distinguiria um piso de volume de um `> 0`.
+
+E a medição, sobre baseline verde nomeado (`810 arquivos, 8478 testes, 0 vermelhos`):
+
+```
+defeito indice-orfao  (alvo docs/historico/README.md, suspeito: docs:indice)
+  VERMELHO docs:indice (38ms)          <- e MAIS NADA: o `test` ficou verde
+
+[SO ELE]  docs:indice   exclusivos  1/8 - pegou  2 - mediana     58ms
+[s/ mira] test          exclusivos  0/8 - pegou  0 - mediana 185063ms
+```
+
+`docs:indice` saiu de `[redund] 0/8` para `[SO ELE] 1/8`, e o `RELATA EXCLUSIVIDADE_ZERO` sumiu do
+`bun run exclusividade`. **O step de 58ms passou a ter obrigação própria**, que era o que a medição
+do #2366 não conseguia enxergar por causa da cópia.
+
+**A remedição obrigou uma segunda célula.** O `indice-alvo-fantasma` só troca o destino de um link,
+sem mexer na contagem de entradas — então a guarda estreitada ficou cega a ele também, e a célula
+`test: true` que a matriz guardava virou uma medição que não correspondia mais a nada. Foi remedida
+junto (`test` false; `docs:indice` e `docs:links` seguem vermelhos, obrigações distintas). **Estreitar
+uma asserção invalida toda célula da matriz que dependia dela** — e o fingerprint não avisa: o do
+`test` é o de `vitest run`, que não muda quando um `.test.ts` muda.
+
+**A primeira tentativa de medir abortou, e o aborto estava certo.** O motor achou `test` vermelho no
+repo LIMPO (513s sob a carga de ~30 sessões) e recusou medir; minutos depois o mesmo repo limpo deu
+verde em 266s, e o baseline nomeado do re-run fechou 8478/8478. O guard de linha de base pagou-se
+sozinho: sem ele, o resultado teria saído com aparência de medição. Mas note que "vermelho" sem o
+NOME do que caiu é ausência de dado — por isso o re-run rodou a suíte à parte, para ter o nome caso
+reincidisse.
 
 ### Sobre os dois `[s/ mira]`
 

--- a/scripts/docs-indice-gate-check.test.ts
+++ b/scripts/docs-indice-gate-check.test.ts
@@ -278,12 +278,30 @@ describe('o repo de verdade', () => {
     expect(total).toBeGreaterThanOrEqual(20);
   });
 
-  // A mesma guarda no eixo das ENTRADAS: um parse quebrado que devolvesse [] zeraria as invariantes
-  // 3/4/5 em silêncio e ainda assim deixaria o gate verde no eixo do órfão.
-  it('cada índice real tem exatamente uma entrada por doc do diretório', () => {
+  // A mesma guarda no eixo das ENTRADAS — e ela cobra VOLUME, não IDENTIDADE.
+  //
+  // O que protege: TODAS as invariantes acima leem `parseEntradas`, e TODAS as unitárias deste
+  // arquivo o alimentam com markdown SINTÉTICO (`indice(...)`). Um parser que deixasse de
+  // reconhecer a forma do índice REAL passaria por elas inteiro e devolveria `[]` no repo — as
+  // invariantes 3/4/5 zeradas em silêncio, vácuo puro. Esta é a única asserção que aponta o parser
+  // para o corpus de verdade, e por isso ela não pode sair.
+  //
+  // O que ela deliberadamente NÃO faz: comparar as entradas com a LISTA DE ARQUIVOS. Igualdade de
+  // conjunto É a invariante do órfão, que é o eixo do step `docs:indice` do CI — e mantê-la aqui
+  // custava a mesma detecção dentro de um vitest de 128s por ZERO exclusivo, medido em
+  // `docs/historico/custo-de-gate-medido-beneficio-nao.md`.
+  //
+  // O piso é METADE dos arquivos do diretório: escala com o corpus (piso fixo apodrece — o
+  // histórico saiu de ~40 para 166 docs) e folga 83 linhas sobre o índice real, então apagar UMA
+  // entrada não acorda esta guarda; `[]` e "só casou a 1ª linha" acordam. Diretório com ≤1 arquivo
+  // cai em piso 0 de propósito: nessa escala não há volume a conferir, e um `Math.max(1, …)` seria
+  // a igualdade de conjunto voltando pela porta dos fundos.
+  it('o parse enxerga o índice REAL — volume de entradas, não identidade com os arquivos', () => {
     for (const d of lerDiretoriosIndexados()) {
-      const hrefs = parseEntradas(d.readme).map((e) => e.arquivo).sort();
-      expect(hrefs, `entradas de ${d.dir}/README.md`).toEqual([...d.arquivos].sort());
+      const entradas = parseEntradas(d.readme);
+      expect(entradas.length, `entradas de ${d.dir}/README.md`).toBeGreaterThanOrEqual(
+        Math.floor(d.arquivos.length / 2),
+      );
     }
   });
 

--- a/scripts/exclusividade-matriz.json
+++ b/scripts/exclusividade-matriz.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "medidoEm": "2026-09-08T09:32:20.005Z",
-  "sourceHead": "fe40aaa4dbbbca4bc09e4eea9a8b57c449f26257",
+  "medidoEm": "2026-09-08T11:11:03.138Z",
+  "sourceHead": "b199ba1599a108cd92c0d454150c6662839e078d",
   "dispensados": [
     {
       "gate": "authz:carimbo",
@@ -123,12 +123,12 @@
     {
       "gate": "docs:indice",
       "verde": true,
-      "ms": 99
+      "ms": 51
     },
     {
       "gate": "docs:links",
       "verde": true,
-      "ms": 522
+      "ms": 978
     },
     {
       "gate": "exclusividade",
@@ -153,7 +153,7 @@
     {
       "gate": "test",
       "verde": true,
-      "ms": 468349
+      "ms": 266623
     },
     {
       "gate": "tsc",
@@ -366,14 +366,14 @@
         {
           "gate": "docs:indice",
           "reprovou": true,
-          "ms": 39,
+          "ms": 163,
           "fingerprint": "a41d30136cdb032d",
           "fonteResolvida": true
         },
         {
           "gate": "docs:links",
           "reprovou": true,
-          "ms": 449,
+          "ms": 1296,
           "fingerprint": "f56e762e306f0671",
           "fonteResolvida": true
         },
@@ -393,8 +393,8 @@
         },
         {
           "gate": "test",
-          "reprovou": true,
-          "ms": 110792,
+          "reprovou": false,
+          "ms": 185063,
           "fingerprint": "ad6cd6b8acf39571",
           "fonteResolvida": false
         }

--- a/scripts/exclusividade-matriz.json
+++ b/scripts/exclusividade-matriz.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "medidoEm": "2026-09-08T11:11:03.138Z",
-  "sourceHead": "b199ba1599a108cd92c0d454150c6662839e078d",
+  "medidoEm": "2026-09-08T11:19:06.809Z",
+  "sourceHead": "3ffc105d0831a174e6f3e6cf6f63b948179c840f",
   "dispensados": [
     {
       "gate": "authz:carimbo",
@@ -123,7 +123,7 @@
     {
       "gate": "docs:indice",
       "verde": true,
-      "ms": 51
+      "ms": 33
     },
     {
       "gate": "docs:links",
@@ -153,7 +153,7 @@
     {
       "gate": "test",
       "verde": true,
-      "ms": 266623
+      "ms": 114328
     },
     {
       "gate": "tsc",
@@ -433,7 +433,7 @@
         {
           "gate": "docs:indice",
           "reprovou": true,
-          "ms": 363,
+          "ms": 38,
           "fingerprint": "a41d30136cdb032d",
           "fonteResolvida": true
         },
@@ -460,8 +460,8 @@
         },
         {
           "gate": "test",
-          "reprovou": true,
-          "ms": 687061,
+          "reprovou": false,
+          "ms": 124090,
           "fingerprint": "ad6cd6b8acf39571",
           "fonteResolvida": false
         }


### PR DESCRIPTION
## O que sobrou do corte do #2378

O #2378 tirou do vitest a auditoria de ponta a ponta do repo, mas a remedição mostrou `docs:indice`
ainda com **exclusivo ZERO**: a detecção do órfão sobrevivia noutro `expect` do mesmo arquivo — a
guarda anti-vácuo, escrita como **igualdade de conjunto** entre as entradas do índice e os arquivos
do diretório.

Igualdade de conjunto *é* a invariante do órfão. A guarda excedia o que o próprio comentário dela
declarava proteger ("um parse que devolvesse `[]`"), e o excedente era exatamente a parte duplicada.

```diff
- expect(hrefs, `entradas de ${d.dir}/README.md`).toEqual([...d.arquivos].sort());
+ expect(entradas.length, `entradas de ${d.dir}/README.md`)
+   .toBeGreaterThanOrEqual(Math.floor(d.arquivos.length / 2));
```

Piso é **metade dos arquivos do diretório**, não número fixo: `docs/historico` tem 166 entradas para
166 arquivos, então folga **83 linhas** — apagar uma entrada não acorda a guarda (isso é trabalho do
step de 58ms), e um piso fixo apodreceria (o histórico saiu de ~40 para 166 docs).

## Critério de aceitação — medido

```
$ bun run exclusividade:medir -- --defeitos indice-orfao --gates docs:indice,test --sem-poda
baseline (repo limpo): verde docs:indice 33ms | verde test 114328ms
defeito indice-orfao
  VERMELHO docs:indice (38ms)        <- e MAIS NADA: o `test` ficou verde

[SO ELE]  docs:indice   exclusivos  1/8 - pegou  2 - mediana     58ms
[s/ mira] test          exclusivos  0/8 - pegou  0 - mediana 185063ms
```

`docs:indice` saiu de `[redund] 0/8` para `[SO ELE] 1/8`; o `RELATA EXCLUSIVIDADE_ZERO` sumiu do
`bun run exclusividade`.

## Falsificação (controle verde na MESMA invocação, veredito lido do JSON do vitest)

| sabotagem | a guarda | controle |
|---|---|---|
| repo íntegro | ✓ verde | 34/34 |
| `parseEntradas` → `[]` | **× vermelha** | 10 verdes / 24 vermelhos |
| `parseEntradas` → `.slice(0, 1)` | **× vermelha** | **25 verdes** / 9 vermelhos |
| defeito `indice-orfao` | ✓ verde | 34/34 — cega ao órfão, que era o alvo |
| árvore restaurada | ✓ verde | 34/34 |

A linha do `.slice(0, 1)` é a que separa piso honesto de teatro: sem ela, "vermelha sob `[]`" não
distinguiria um piso de volume de um `> 0` disfarçado num repo de 166 docs.

## Uma segunda célula teve de ser remedida

`indice-alvo-fantasma` só troca o destino de um link, sem mexer na contagem — a guarda estreitada
ficou cega a ele também, e a célula `test: true` da matriz virou medição que não correspondia mais a
nada. Remedida junto (`test` false; `docs:indice` e `docs:links` seguem vermelhos, obrigações
distintas). **Estreitar uma asserção invalida toda célula da matriz que dependia dela — e o
fingerprint não avisa:** o do `test` é o de `vitest run`, que não muda quando um `.test.ts` muda.

## O que NÃO mudou

Step `docs:indice` no `ci.yml`, as outras duas guardas anti-vácuo, e as cinco invariantes do gate.

## Verificação

| comando | resultado |
|---|---|
| `bun run test` (baseline nomeado) | 810 arquivos, **8478 passed**, 0 vermelhos |
| `bun run typecheck` | exit 0 |
| `bunx eslint` no arquivo | exit 0 |
| `docs:indice` · `docs:links` · `docs:citacoes` | exit 0 nos três |
| `bun run exclusividade` | exit 0, sem `REPROVA` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
