### PR TITLE
fix(mutcheck): o `.mut` da sonda ficou stale no #2380 — 18 mutações ambíguas deixaram a main VERMELHA

### DIFF
--- a/db/test-canaria-veredito.sh
+++ b/db/test-canaria-veredito.sh
@@ -348,38 +348,38 @@ sabota() { # <descricao> <expressao-sed>
 
 # (a1) O ramo que dá sentido ao arquivo: sem ele, "está no ar" vira "está correto".
 sabota "sem o ramo de ok:false (a vermelha perde o nome)" \
-  "s/WHEN l\.corpo ->> 'ok' = 'false'/WHEN false/"
+  "s/WHEN ca\.corpo ->> 'ok' = 'false'/WHEN false/"
 # (a2) A conjunção do ramo verde, agora ALCANÇÁVEL pelo fixture de \`ok\` não-booleano.
 sabota "verde deixa de exigir ok:true (ok nao-booleano vira verde)" \
-  "s/AND l\.corpo ->> 'ok' = 'true'//"
+  "s/AND ca\.corpo ->> 'ok' = 'true'//"
 # (b1) O ramo que nomeia a divergência de marcador.
 sabota "sem o ramo de marcador divergente (a outra fatia perde o nome)" \
-  "s/WHEN l\.corpo ->> l\.campo_marcador IS DISTINCT FROM l\.marcador_esperado/WHEN false/"
+  "s/WHEN ca\.corpo ->> ca\.campo_marcador IS DISTINCT FROM ca\.marcador_esperado/WHEN false/"
 # (b2) A armadilha 2 do deploy.md RECONSTRUÍDA: nada no CASE julga o marcador. O bundle velho
 #      compara velho x velho, responde ok:true, e o veredito sai CANARIA VERDE — mentindo verde.
 sabota "o CASE inteiro deixa de julgar o marcador (bundle velho MENTE VERDE)" \
-  "s/WHEN l\.corpo ->> l\.campo_marcador IS DISTINCT FROM l\.marcador_esperado/WHEN false/; s/AND l\.corpo ->> l\.campo_marcador = l\.marcador_esperado//"
+  "s/WHEN ca\.corpo ->> ca\.campo_marcador IS DISTINCT FROM ca\.marcador_esperado/WHEN false/; s/AND ca\.corpo ->> ca\.campo_marcador = ca\.marcador_esperado//"
 # (b3) O marcador esperado que sai do REPO vira um digitado qualquer: a canária no ar deixa de bater.
 sabota "marcador esperado fabricado no VALUES (repo deixa de mandar)" \
   "s/(\('copilot-analyze', 'contrato', ')[^']*/\1marcador-fabricado-v0/"
 # (b4) O campo do marcador deixa de ser POR CANÁRIA: quem serve em \`versao\` some.
 sabota "marcador lido sempre de 'contrato' (a generate-tactical-plan some)" \
-  "s/l\.corpo ->> l\.campo_marcador/l.corpo ->> 'contrato'/g"
+  "s/ca\.corpo ->> ca\.campo_marcador/ca.corpo ->> 'contrato'/g"
 # (c) A ORDEM dos ramos: julgar o status ANTES do eco faz a vermelha de HTTP 500 da
 #     generate-tactical-plan sair como 'recusou o request'.
 sabota "status julgado antes do eco (500 vermelha vira bundle velho)" \
-  "s/WHEN l\.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l\.status_code >= 400/WHEN l.status_code >= 400/"
+  "s/WHEN ca\.corpo ->> 'canary' IS DISTINCT FROM 'true' AND ca\.status_code >= 400/WHEN ca.status_code >= 400/"
 # (d) O envelope \`data\`: sem descer nele, as canárias da omie-analytics-sync somem para
 #     'sem eco' — um bundle correto classificado como velho.
 sabota "sem o COALESCE do envelope data (analytics vira 'sem eco')" \
-  "s/COALESCE\(x\.content::jsonb -> 'data', x\.content::jsonb\)/x.content::jsonb/"
+  "s/COALESCE\(resp\.content::jsonb -> 'data', resp\.content::jsonb\)/resp.content::jsonb/"
 # (e) NULL-blind: trocar IS DISTINCT FROM por <> faz a chave AUSENTE devolver NULL, o ramo do
 #     eco não casa, e a resposta sem `canary` cai adiante no CASE.
 sabota "eco testado por <> (NULL-blind: chave ausente devolve NULL)" \
-  "s/l\.corpo ->> 'canary' IS DISTINCT FROM 'true'/l.corpo ->> 'canary' <> 'true'/g"
+  "s/ca\.corpo ->> 'canary' IS DISTINCT FROM 'true'/l.corpo ->> 'canary' <> 'true'/g"
 # (f) A janela: sem ela, uma resposta de outra sessão vira veredito de agora.
 sabota "sem o guard de janela (resposta velha vira veredito de agora)" \
-  "/WHEN l\.created <= now\(\) - interval/,+3d"
+  "/WHEN ca\.created <= now\(\) - interval/,+3d"
 
 if [ "$falhou" -eq 0 ]; then printf '\nFALSIFICACAO OK — todo verde tem vermelho alcancavel\n'; exit 0; fi
 printf '\nVERMELHO\n'; exit 1

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -8,12 +8,12 @@
 # Rode: scripts/mutcheck.sh scripts/sonda-versao-sql.ts scripts/sonda-versao-sql.test.ts scripts/mutcheck.d/sonda-versao-sql.mut
 PEGA      | trava do bloco caro CASE -> WHERE (teatro) | s/CASE WHEN g\.confirmei/WHERE g.confirmei/
 PEGA      | leitura sai da lista canonica (LEFT->JOIN) | s/LEFT JOIN ids i/JOIN ids i/
-PEGA      | resposta ausente vira veredito (LEFT->JOIN)| s/LEFT JOIN net\._http_response/JOIN net._http_response/
-PEGA      | ramo AGUARDE some do passo EMBUTIDO        | s/'AGUARDE — o request_id embutido/'AGUARDOU — o request_id embutido/
+PEGA      | resposta ausente vira veredito (LEFT->JOIN)| s/LEFT JOIN net\._http_response x ON/JOIN net._http_response x ON/
+PEGA      | ramo AGUARDE some do passo EMBUTIDO        | s/'AGUARDE — o request_id embutido pelo passo \$\{passoDisparo\} ainda não/'AGUARDOU — o request_id embutido pelo passo \$\{passoDisparo\} ainda não/
 PEGA      | ramo AGUARDE some do passo do ECO          | s/'AGUARDE — o request_id colado/'AGUARDOU — o request_id colado/
 PEGA      | placeholder do bloco que le fica invalido  | s/: `'\{\}'::jsonb`;/: `'<COLE_AQUI>'::jsonb`;/
 PEGA      | marcador hardcoded em vez de lido do arquivo | s/lit\(e\.versao\)/lit('v1.0-sensor-inicial')/
-PEGA      | timeout_milliseconds implicito (default 5s) | s/timeout_milliseconds := 20000/-- sem timeout/
+PEGA      | timeout_milliseconds implicito (default 5s) | s/^const TIMEOUT_HTTP_MS = 20000;/const TIMEOUT_HTTP_MS = 0;/
 PEGA      | --caro forasteira aceita em silencio       | s/!edges\.includes\(c\)/false/
 PEGA      | edge sem sensor degrada em vez de lancar   | s/if \(problemas\.length > 0\)/if (false)/
 PEGA      | eco probe:true dispensado no CONFIRMADO    | s/AND l\.corpo ->> 'probe' = 'true'/AND true/
@@ -42,17 +42,17 @@ PEGA      | edge fora do mapa degrada em vez de lancar     | s/if \(!\(edge in m
 # aos dois muta as DUAS e cai no guard de substituição única do mutcheck como INVÁLIDA — que
 # é ausência de medição, não medição. Ramo novo com esse prefixo: ancore no texto dele.
 PEGA      | 4xx generico perde a cobertura (404 cai no ELSE)       | s/l\.status_code >= 400/l.status_code = 401/
-PEGA      | fallback do 401 deixa de ser INDETERMINADO (fail-open)    | s/THEN 'INDETERMINADO — 401 nao separa/THEN 'BUNDLE VELHO (pre-sonda) — 401 nao separa/
+PEGA      | fallback do 401 deixa de ser INDETERMINADO (fail-open)    | s/THEN 'INDETERMINADO — 401 nao separa bundle velho/THEN 'BUNDLE VELHO (pre-sonda) — 401 nao separa bundle velho/
 PEGA      | controle nao exclui a propria leva (a sonda se avaliza)   | s/AND NOT EXISTS \(SELECT 1 FROM ids i2 WHERE i2\.request_id = r\.id\)/AND true/
 PEGA      | piso do controle zerado (1 resposta 2xx ja 'prova')       | s/PISO_CONTROLE_CREDENCIAL = 10/PISO_CONTROLE_CREDENCIAL = 0/
 PEGA      | 401 alheio deixa de desqualificar o controle              | s/AND c\.recusas_recentes = 0/AND true/
-PEGA      | controle nao chega na projecao (CROSS JOIN removido)      | s/ CROSS JOIN controle_credencial c//
+PEGA      | controle nao chega na projecao (CROSS JOIN removido)      | s/FROM lidas l CROSS JOIN controle_credencial c/FROM lidas l/
 # Os 7 abaixo guardam a LEITURA SEM COLAGEM (#2127). Ela troca o `request_id` colado a mao pelo ECO
 # do slug que a propria resposta carrega — e cada guard aqui e a diferenca entre achar a linha CERTA
 # e achar UMA linha. Sem eles a suite aceitava um SQL que le a resposta de OUTRA execucao.
 PEGA      | casamento por slug neutralizado (pega qualquer linha) | s/WHERE rr\.corpo ->> 'edge' = e\.edge/WHERE true/
 PEGA      | casamento dispensa probe:true (pega linha de CRON)    | s/AND rr\.corpo ->> 'probe' = 'true'/AND true/
-PEGA      | janela larga: sondagem de ontem vira veredito de hoje | s/interval '\$\{janelaMin\} minutes'/interval '30 days'/
+PEGA      | janela larga: sondagem de ontem vira veredito de hoje | s/r\.created > now\(\) - interval '\$\{janelaMin\} minutes'/r.created > now() - interval '30 days'/
 PEGA      | teto da janela removido (guard do #2079 desligado)    | s/ \|\| janelaMin > JANELA_MAX_MIN//
 PEGA      | LIMIT 1 sem desempate (created EMPATA em prod)        | s/ORDER BY rr\.created DESC, rr\.id DESC/ORDER BY rr.created DESC/
 PEGA      | LATERAL vira INNER: edge sem eco SOME da saida        | s/LEFT JOIN LATERAL \(/JOIN LATERAL (/
@@ -71,13 +71,13 @@ PEGA      | --so-leitura passa a emitir o disparo junto           | s/const quer
 # que o default. MEDIDO 2026-09-07 com controle+ verde na MESMA invocacao: 20000 -> 3000, -> 1 e
 # -> 0 SOBREVIVIAM as 54 mutacoes deste contrato. As duas abaixo sao o dente novo; a de 5000 e a
 # mutacao de FRONTEIRA (pina que a comparacao e `>` estrito, nao `>=`: com `>=` ela sobrevive).
-PEGA      | timeout IGUAL ao default de 5s (fronteira > vs >=) | s/timeout_milliseconds := 20000/timeout_milliseconds := 5000/
-PEGA      | timeout ABAIXO do default (3s: pior que implicito) | s/timeout_milliseconds := 20000/timeout_milliseconds := 3000/
+PEGA      | timeout IGUAL ao default de 5s (fronteira > vs >=) | s/^const TIMEOUT_HTTP_MS = 20000;/const TIMEOUT_HTTP_MS = 5000;/
+PEGA      | timeout ABAIXO do default (3s: pior que implicito) | s/^const TIMEOUT_HTTP_MS = 20000;/const TIMEOUT_HTTP_MS = 3000;/
 # ACEITO, com justificativa: 20s e TUNING, nao fronteira. Nenhuma decisao do gerador depende de o
 # numero ser 20000 em vez de 30000 — o que decide e estar ACIMA do piso de 5s, e ISSO agora tem
 # asercao (as duas PEGA acima). Pinar 20000 seria fachada: travaria o valor sem invariante atras,
 # e a proxima pessoa que ajustasse o tuning ficaria vermelha sem ter quebrado nada.
-SOBREVIVE | timeout 20s -> 30s (tuning acima do piso)  | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
+SOBREVIVE | timeout 20s -> 30s (tuning acima do piso)  | s/^const TIMEOUT_HTTP_MS = 20000;/const TIMEOUT_HTTP_MS = 30000;/
 # ACEITO, com justificativa: INERTE, nao apenas cosmetico. `SELECT l.edge,` e a PRIMEIRA coluna da
 # projecao final (conferido em 2026-09-07), entao `ORDER BY 1` e EXATAMENTE o mesmo plano e a mesma
 # ordem — o mutante nao muda nem a saida. E mesmo que a 1a coluna mudasse, ordem de LINHAS de um
@@ -103,7 +103,7 @@ PEGA      | bump nao-mergeado deixa de contar como divergencia     | s/ausentes\
 PEGA      | fatia perde o mapa (so o versao.ts e conferido)        | s/, ARQ_MAPA\]/]/
 PEGA      | fetch some: compara contra retrato velho por padrao    | s/const f = git\(\['fetch', REMOTO, RAMO_DEPLOYADO\]\);/const f = { status: 0, stdout: '', stderr: '' };/
 PEGA      | fetch que falha degrada em vez de abortar              | s/if \(f\.status !== 0\) \{/if (false) {/
-PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/semRede === true/true/
+PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/conferirSincronia\(deps\.raiz, edges, semRede === true/conferirSincronia(deps.raiz, edges, true/
 # O `cwd` do `gitReal`. O #2227 tirou a ref `origin/main` herdada do checkout (a causa do
 # `mutation-check` vermelho em todo PR — docs/historico/teste-que-afirma-o-checkout.md) e pôs um
 # repo fixture no lugar. Esta linha é o que transforma esse conserto em COBERTURA: com a asserção
@@ -141,4 +141,4 @@ PEGA      | ramo do id que NAO e sonda neutralizado               | s/l\.corpo -
 # CONDIÇÃO e RAMO (`WHEN … IS DISTINCT FROM 'true'` seguido do `THEN 'NAO E RESPOSTA DE SONDA`); o
 # veredito EXECUTADO continua provado no cenário `cron_sem_probe` do
 # .claude/skills/lovable-deploy-verify/evals/sonda-veredito-401-eval.sh.
-PEGA      | negacao NULL-blind no ramo do nao-sonda               | s/IS DISTINCT FROM 'true'/<> 'true'/
+PEGA      | negacao NULL-blind no ramo do nao-sonda               | s/'probe' IS DISTINCT FROM 'true'/'probe' <> 'true'/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -1524,8 +1524,14 @@ describe('o CORPO do disparo é POR CANÁRIA — corpo errado cai no FLUXO REAL'
     expect(sql).not.toContain("body := jsonb_build_object('canary'");
   });
 
+  // Mede o PISO, não o número: 20s é TUNING e o `.mut` declara 20000→30000 como SOBREVIVE.
+  // Pinar o literal aqui reprovaria um ajuste legítimo — a fronteira é o default de 5s do pg_net,
+  // que mata silencioso (é a mesma lição da asserção irmã da sonda, algumas centenas de linhas
+  // acima; ela foi aprendida por mutcheck e esta cópia nasceu ignorando-a).
   it('timeout_milliseconds é EXPLÍCITO e acima do default de 5s, que mata silencioso', () => {
-    expect(sqlReal()).toContain('timeout_milliseconds := 20000');
+    const m = sqlReal().match(/timeout_milliseconds\s*:=\s*(\d+)\)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThan(5000);
   });
 
   it('o segredo sai do vault, nunca do texto colado', () => {
@@ -1597,20 +1603,20 @@ describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
   it('CANARIA VERDE exige canary + marcador + ok, os três', () => {
     const ramo = ramoDe(sql(), 'CANARIA VERDE');
     const antes = sql().slice(0, sql().indexOf("THEN 'CANARIA VERDE"));
-    const cond = antes.slice(antes.lastIndexOf("WHEN l.corpo ->> 'canary' = 'true'"));
-    expect(cond).toContain("l.corpo ->> 'canary' = 'true'");
-    expect(cond).toContain('l.corpo ->> l.campo_marcador = l.marcador_esperado');
-    expect(cond).toContain("l.corpo ->> 'ok' = 'true'");
+    const cond = antes.slice(antes.lastIndexOf("WHEN ca.corpo ->> 'canary' = 'true'"));
+    expect(cond).toContain("ca.corpo ->> 'canary' = 'true'");
+    expect(cond).toContain('ca.corpo ->> ca.campo_marcador = ca.marcador_esperado');
+    expect(cond).toContain("ca.corpo ->> 'ok' = 'true'");
     expect(ramo).toContain('CANARIA VERDE');
   });
 
   it('a leitura parte da lista CANÔNICA — zero linhas não pode virar "nada a reportar"', () => {
     expect(sql()).toContain('WITH esperado(nome, campo_marcador, marcador_esperado, efeito) AS (VALUES');
-    expect(sql()).toContain('FROM esperado e');
+    expect(sql()).toContain('FROM esperado esp');
   });
 
   it('desce no envelope `data` — a omie-analytics-sync responde aninhado', () => {
-    expect(sql()).toContain("COALESCE(x.content::jsonb -> 'data', x.content::jsonb)");
+    expect(sql()).toContain("COALESCE(resp.content::jsonb -> 'data', resp.content::jsonb)");
   });
 
   it('os ramos que separam BUNDLE VELHO de CANARIA VERMELHA estão todos nomeados', () => {
@@ -1632,7 +1638,7 @@ describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
   it('o 200 sem eco DIZ que rodou o fluxo real, e diz QUAL efeito', () => {
     const ramo = ramoDe(sql(), 'SEM CANARIA NO AR — HTTP');
     expect(ramo).toContain('RODOU O FLUXO REAL');
-    expect(ramo).toContain("|| l.efeito ||");
+    expect(ramo).toContain("|| ca.efeito ||");
     expect(ramo).toContain('NAO e canaria vermelha');
   });
 
@@ -1644,8 +1650,8 @@ describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
 
   it('o eco é julgado ANTES do status — a 500 da generate-tactical-plan é vermelha, não recusa', () => {
     const s = sql();
-    const eco = s.indexOf("WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code >= 400");
-    const statusCru = s.indexOf('WHEN l.status_code >= 400');
+    const eco = s.indexOf("WHEN ca.corpo ->> 'canary' IS DISTINCT FROM 'true' AND ca.status_code >= 400");
+    const statusCru = s.indexOf('WHEN ca.status_code >= 400');
     expect(eco).toBeGreaterThan(-1);
     // Não existe ramo que julgue o status sem antes exigir a ausência do eco.
     expect(statusCru).toBe(-1);
@@ -1655,7 +1661,7 @@ describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
     const s = sql();
     expect(s).toContain("('generate-tactical-plan', 'versao', ");
     expect(s).toContain("('copilot-analyze', 'contrato', ");
-    expect(s).toContain('l.corpo ->> l.campo_marcador');
+    expect(s).toContain('ca.corpo ->> ca.campo_marcador');
   });
 });
 

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -376,6 +376,20 @@ function valuesEsperado(leva: EdgeSondada[]): string {
   return leva.map((e) => `  (${lit(e.edge)}, ${lit(e.versao)}, ${lit(e.fonte)})`).join(',\n');
 }
 
+/**
+ * Teto de tempo do `net.http_post`, em ms. É CONSTANTE, e não literal repetido, porque a regra é
+ * uma só e vale para toda chamada: o default do pg_net é 5s e mata em SILÊNCIO (`sync.md`). Duas
+ * cópias do número são duas verdades, e a que ninguém atualiza é a que decide errado.
+ */
+const TIMEOUT_HTTP_MS = 20000;
+
+/**
+ * A trava do bloco caro, como CASE — nunca como filtro. O Postgres avalia a projeção mesmo
+ * descartando todas as linhas, então travar por `WHERE` deixa o `http_post` sair igual. Também
+ * mora aqui por ser uma verdade só: os blocos de disparo da sonda e da canária a compartilham.
+ */
+const TRAVA_CASE = "CASE WHEN g.confirmei_o_deploy = 'sim'";
+
 /** A chamada `net.http_post`, idêntica nos dois blocos de disparo. */
 function httpPost(ref: string, indent: string): string {
   const i = indent;
@@ -387,7 +401,7 @@ function httpPost(ref: string, indent: string): string {
     `${i}    'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets\n` +
     `${i}                      WHERE name = 'CRON_SECRET' LIMIT 1)),\n` +
     `${i}  body := jsonb_build_object('probe', true),\n` +
-    `${i}  timeout_milliseconds := 20000)`
+    `${i}  timeout_milliseconds := ${TIMEOUT_HTTP_MS})`
   );
 }
 
@@ -418,6 +432,16 @@ export const SENTINELA_MAPA = '\u0001mapa\u0001';
 const TAG_SONDA = '$sonda$';
 
 /**
+ * Fecha o `format()` e batiza a célula que o operador copia. Verdade ÚNICA para os dois blocos de
+ * disparo (sonda e canária): o nome da coluna é o que diz ao operador que ali mora um SQL pronto,
+ * e não um blob de ids para transportar à mão — duas cópias divergiriam, e a que diverge é a que
+ * devolve o operador ao round-trip que `docs/historico/sonda-request-id-a-mao.md` fechou.
+ */
+function rodapeDoFormat(passoLeitura: number): string {
+  return `${TAG_SONDA}, m.ids) AS passo_${passoLeitura}_copie_esta_celula\nFROM mapa m;\n`;
+}
+
+/**
  * Bloco de DISPARO — o único que precisa do founder: lê `vault.decrypted_secrets` e faz INSERT via
  * `net.http_post`, e o wrapper read-only recusa os dois (`permission denied for schema vault` e
  * `cannot execute INSERT in a read-only transaction`, provado 2026-08-30).
@@ -446,7 +470,7 @@ function blocoDisparo(
       `alvos(edge) AS (VALUES\n${valuesAlvos(leva)}\n),\n`
     : `WITH alvos(edge) AS (VALUES\n${valuesAlvos(leva)}\n),\n`;
   const projecao = comTrava
-    ? `         CASE WHEN g.confirmei_o_deploy = 'sim'\n` +
+    ? `         ${TRAVA_CASE}\n` +
       `              THEN ${httpPost(ref, '                   ')}\n` +
       `         END AS request_id\n` +
       `  FROM alvos a CROSS JOIN guard g\n`
@@ -466,8 +490,7 @@ function blocoDisparo(
     `-- INTEIRA e rode/entregue como está: não há número a anotar nem campo a preencher.\n` +
     `SELECT format(${TAG_SONDA}\n` +
     corpoDoPassoDeLeitura(leva, janelaMin, passoDisparo) +
-    `${TAG_SONDA}, m.ids) AS passo_${passoLeitura}_copie_esta_celula\n` +
-    `FROM mapa m;\n`
+rodapeDoFormat(passoLeitura)
   );
 }
 
@@ -1201,20 +1224,20 @@ export function resolverCanarias(
     resolvidas.push({ ...reg, marcador: versao });
   }
 
-  const problemas: string[] = [];
+  const pendencias: string[] = [];
   if (semMarcador.length > 0) {
-    problemas.push(`marcador ILEGÍVEL no repo: ${semMarcador.join(', ')}`);
+    pendencias.push(`marcador ILEGÍVEL no repo: ${semMarcador.join(', ')}`);
   }
   if (campoDesalinhado.length > 0) {
-    problemas.push(
+    pendencias.push(
       'a canária trocou de FORMA e o registro não acompanhou: ' +
         `${campoDesalinhado.join(', ')} — ajuste \`campoMarcador\` no registro e a tabela de ` +
         'docs/agent/deploy.md §Canárias',
     );
   }
-  if (problemas.length > 0) {
+  if (pendencias.length > 0) {
     throw new Error(
-      `${problemas.join(' | ')}. O marcador esperado é DERIVADO do repo de propósito: digitá-lo ` +
+      `${pendencias.join(' | ')}. O marcador esperado é DERIVADO do repo de propósito: digitá-lo ` +
         'no registro é a via do veredito falso que esta ferramenta existe para fechar. ' +
         'Nenhum SQL foi emitido.',
     );
@@ -1258,7 +1281,7 @@ function httpPostCanaria(ref: string, indent: string): string {
     `${i}    'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets\n` +
     `${i}                      WHERE name = 'CRON_SECRET' LIMIT 1)),\n` +
     `${i}  body := a.corpo,\n` +
-    `${i}  timeout_milliseconds := 20000)`
+    `${i}  timeout_milliseconds := ${TIMEOUT_HTTP_MS})`
   );
 }
 
@@ -1284,7 +1307,7 @@ function blocoDisparoCanaria(
       `alvos(nome, edge, corpo, sufixo) AS (VALUES\n${valuesAlvosCanaria(leva)}\n),\n`
     : `WITH alvos(nome, edge, corpo, sufixo) AS (VALUES\n${valuesAlvosCanaria(leva)}\n),\n`;
   const projecao = comTrava
-    ? "         CASE WHEN g.confirmei_o_deploy = 'sim'\n" +
+    ? `         ${TRAVA_CASE}\n` +
       `              THEN ${httpPostCanaria(ref, '                   ')}\n` +
       '         END AS request_id\n' +
       '  FROM alvos a CROSS JOIN guard g\n'
@@ -1304,8 +1327,7 @@ function blocoDisparoCanaria(
     '-- INTEIRA e rode/entregue como está: não há número a anotar nem campo a preencher.\n' +
     `SELECT format(${TAG_SONDA}\n` +
     corpoDoPassoDeLeituraCanaria(leva, janelaMin, passoDisparo) +
-    `${TAG_SONDA}, m.ids) AS passo_${passoLeitura}_copie_esta_celula\n` +
-    'FROM mapa m;\n'
+rodapeDoFormat(passoLeitura)
   );
 }
 
@@ -1377,90 +1399,90 @@ function blocoLeituraCanaria(
     '         count(*) FILTER (WHERE r.status_code = 401)               AS recusas_recentes\n' +
     '  FROM net._http_response r\n' +
     "  WHERE r.created > now() - interval '6 hours'\n" +
-    '    AND NOT EXISTS (SELECT 1 FROM ids i2 WHERE i2.request_id = r.id)\n' +
+    '    AND NOT EXISTS (SELECT 1 FROM ids mp2 WHERE mp2.request_id = r.id)\n' +
     '),\n' +
     'lidas AS (\n' +
     '  -- Parte de `esperado`: zero linhas não pode virar "nada a reportar". O envelope `data` é\n' +
     '  -- descido aqui porque a omie-analytics-sync responde `{success, data:{...}}` e as outras no\n' +
     '  -- topo — sem o COALESCE as DUAS canárias dela sairiam como "sem eco".\n' +
-    '  SELECT e.nome, e.campo_marcador, e.marcador_esperado, e.efeito,\n' +
-    '         i.request_id, x.status_code, x.created,\n' +
-    '         CASE WHEN x.content IS NOT NULL AND left(ltrim(x.content), 1) = \'{\'\n' +
-    "              THEN COALESCE(x.content::jsonb -> 'data', x.content::jsonb)\n" +
+    '  SELECT esp.nome, esp.campo_marcador, esp.marcador_esperado, esp.efeito,\n' +
+    '         mp.request_id, resp.status_code, resp.created,\n' +
+    '         CASE WHEN resp.content IS NOT NULL AND left(ltrim(resp.content), 1) = \'{\'\n' +
+    "              THEN COALESCE(resp.content::jsonb -> 'data', resp.content::jsonb)\n" +
     '         END AS corpo\n' +
-    '  FROM esperado e\n' +
-    '  LEFT JOIN ids i ON i.nome = e.nome\n' +
-    '  LEFT JOIN net._http_response x ON x.id = i.request_id\n' +
+    '  FROM esperado esp\n' +
+    '  LEFT JOIN ids mp ON mp.nome = esp.nome\n' +
+    '  LEFT JOIN net._http_response resp ON resp.id = mp.request_id\n' +
     ')\n' +
-    'SELECT l.nome,\n' +
-    '       l.request_id,\n' +
-    '       l.status_code,\n' +
-    "       l.corpo ->> 'canary' AS canary_respondido,\n" +
-    '       l.corpo ->> l.campo_marcador AS marcador_respondido,\n' +
-    '       l.marcador_esperado,\n' +
-    "       l.corpo ->> 'ok' AS ok_respondido,\n" +
+    'SELECT ca.nome,\n' +
+    '       ca.request_id,\n' +
+    '       ca.status_code,\n' +
+    "       ca.corpo ->> 'canary' AS canary_respondido,\n" +
+    '       ca.corpo ->> ca.campo_marcador AS marcador_respondido,\n' +
+    '       ca.marcador_esperado,\n' +
+    "       ca.corpo ->> 'ok' AS ok_respondido,\n" +
     '       CASE\n' +
-    '         WHEN l.request_id IS NULL\n' +
+    '         WHEN ca.request_id IS NULL\n' +
     `           THEN 'INDETERMINADO — esta canaria nao tem request_id no mapa embutido pelo passo ` +
     `${passoDisparo}. Isto e ausencia de dado, nao veredito: ou a trava ficou FECHADA e nada foi ` +
     `disparado, ou a celula veio de OUTRA leva'\n` +
-    '         WHEN l.status_code IS NULL\n' +
+    '         WHEN ca.status_code IS NULL\n' +
     `           THEN 'AGUARDE — o request_id embutido pelo passo ${passoDisparo} ainda nao tem ` +
     `resposta HTTP (leva ~10s); rode este passo de novo'\n` +
-    `         WHEN l.created <= now() - interval '${janelaMin} minutes'\n` +
-    `           THEN 'INDETERMINADO — a resposta e de ' || l.created || ', FORA da janela de ` +
+    `         WHEN ca.created <= now() - interval '${janelaMin} minutes'\n` +
+    `           THEN 'INDETERMINADO — a resposta e de ' || ca.created || ', FORA da janela de ` +
     `${janelaMin} min: esta celula e de outra sessao e o veredito seria de um deploy anterior. ` +
     `Redispare o passo ${passoDisparo}'\n` +
     // ------------------------------------------------------------------ SEM CANARIA NO AR ---
     // O eco vem ANTES do status de propósito: a generate-tactical-plan devolve 500 quando a
     // canária dela REPROVA, e julgar pelo status primeiro leria regressão como bundle velho.
-    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code = 401\n` +
-    `              AND c.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL} AND c.recusas_recentes = 0\n` +
+    `         WHEN ca.corpo ->> 'canary' IS DISTINCT FROM 'true' AND ca.status_code = 401\n` +
+    `              AND cred.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL} AND cred.recusas_recentes = 0\n` +
     `           THEN 'SEM CANARIA NO AR — 401, e o CRON_SECRET esta PROVADO bom agora (' ||\n` +
-    `                c.ok_recentes || ' resposta(s) 2xx e ZERO 401 fora desta leva em 6h), logo a ` +
+    `                cred.ok_recentes || ' resposta(s) 2xx e ZERO 401 fora desta leva em 6h), logo a ` +
     `recusa e da EDGE: o bundle no ar e anterior a canaria, ela NAO rodou e NADA executou. Isto ` +
     `NAO e canaria vermelha — o desfecho e DEPLOY'\n` +
-    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code = 401\n` +
+    `         WHEN ca.corpo ->> 'canary' IS DISTINCT FROM 'true' AND ca.status_code = 401\n` +
     `           THEN 'INDETERMINADO — 401 nao separa bundle sem canaria de CRON_SECRET invalido, e ` +
-    `o controle de credencial NAO foi observado (2xx fora da leva em 6h: ' || c.ok_recentes ||\n` +
-    `                ', recusas 401: ' || c.recusas_recentes || '). Confira o CRON_SECRET no vault ` +
+    `o controle de credencial NAO foi observado (2xx fora da leva em 6h: ' || cred.ok_recentes ||\n` +
+    `                ', recusas 401: ' || cred.recusas_recentes || '). Confira o CRON_SECRET no vault ` +
     `ANTES de redeployar'\n` +
-    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true' AND l.status_code >= 400\n` +
-    `           THEN 'SEM CANARIA NO AR — o bundle recusou o request (HTTP ' || l.status_code ||\n` +
+    `         WHEN ca.corpo ->> 'canary' IS DISTINCT FROM 'true' AND ca.status_code >= 400\n` +
+    `           THEN 'SEM CANARIA NO AR — o bundle recusou o request (HTTP ' || ca.status_code ||\n` +
     `                '), NADA executou. Isto NAO e canaria vermelha: nao ha canaria no ar para ` +
     `ficar vermelha'\n` +
-    `         WHEN l.corpo ->> 'canary' IS DISTINCT FROM 'true'\n` +
-    `           THEN 'SEM CANARIA NO AR — HTTP ' || l.status_code || ' SEM eco canary: o bundle ` +
-    `ignorou a flag e RODOU O FLUXO REAL (' || l.efeito || '). Isto NAO e canaria vermelha, e ` +
+    `         WHEN ca.corpo ->> 'canary' IS DISTINCT FROM 'true'\n` +
+    `           THEN 'SEM CANARIA NO AR — HTTP ' || ca.status_code || ' SEM eco canary: o bundle ` +
+    `ignorou a flag e RODOU O FLUXO REAL (' || ca.efeito || '). Isto NAO e canaria vermelha, e ` +
     `canaria AUSENTE — e o efeito ja aconteceu'\n` +
     // ------------------------------------------------------------ marcador antes do `ok` ---
-    '         WHEN l.corpo ->> l.campo_marcador IS NULL\n' +
+    '         WHEN ca.corpo ->> ca.campo_marcador IS NULL\n' +
     `           THEN 'CANARIA SEM MARCADOR — respondeu canary:true e o corpo NAO TEM o campo ' ||\n` +
-    `                l.campo_marcador || ': o bundle e anterior ao versionamento da canaria. O ok ` +
+    `                ca.campo_marcador || ': o bundle e anterior ao versionamento da canaria. O ok ` +
     `sozinho NAO discrimina reversao de fatia (armadilha 2 do deploy.md). PRECISA DEPLOY'\n` +
-    '         WHEN l.corpo ->> l.campo_marcador IS DISTINCT FROM l.marcador_esperado\n' +
-    `           THEN 'CANARIA DE OUTRA FATIA — respondeu ' || l.campo_marcador || '=' ||\n` +
-    `                COALESCE(l.corpo ->> l.campo_marcador, '?') || ' (esperado ' ||\n` +
-    `                l.marcador_esperado || '). O bundle velho carrega o expected VELHO e compara ` +
+    '         WHEN ca.corpo ->> ca.campo_marcador IS DISTINCT FROM ca.marcador_esperado\n' +
+    `           THEN 'CANARIA DE OUTRA FATIA — respondeu ' || ca.campo_marcador || '=' ||\n` +
+    `                COALESCE(ca.corpo ->> ca.campo_marcador, '?') || ' (esperado ' ||\n` +
+    `                ca.marcador_esperado || '). O bundle velho carrega o expected VELHO e compara ` +
     `velho x velho, entao o ok dele nao vale — e assim que uma reversao MENTE VERDE. PRECISA DEPLOY'\n` +
-    `         WHEN l.corpo ->> 'ok' IS NULL\n` +
+    `         WHEN ca.corpo ->> 'ok' IS NULL\n` +
     `           THEN 'CANARIA SEM VEREDITO — canary:true e marcador batendo, mas o corpo nao traz ` +
     `ok. Fail-closed: sem os TRES campos nao ha confirmacao'\n` +
-    `         WHEN l.corpo ->> 'ok' = 'false'\n` +
-    `           THEN 'CANARIA VERMELHA — o bundle no ar E o esperado (' || l.marcador_esperado ||\n` +
+    `         WHEN ca.corpo ->> 'ok' = 'false'\n` +
+    `           THEN 'CANARIA VERMELHA — o bundle no ar E o esperado (' || ca.marcador_esperado ||\n` +
     `                ') e a fixture REPROVOU: o comportamento regrediu. NAO e deploy pendente — ` +
     `leia os casos do corpo para saber QUAL lado caiu'\n` +
-    `         WHEN l.corpo ->> 'canary' = 'true'\n` +
-    '              AND l.corpo ->> l.campo_marcador = l.marcador_esperado\n' +
-    `              AND l.corpo ->> 'ok' = 'true'\n` +
+    `         WHEN ca.corpo ->> 'canary' = 'true'\n` +
+    '              AND ca.corpo ->> ca.campo_marcador = ca.marcador_esperado\n' +
+    `              AND ca.corpo ->> 'ok' = 'true'\n` +
     "           THEN 'CANARIA VERDE'\n" +
     `         ELSE 'INDETERMINADO — combinacao nao prevista: canary=' ||\n` +
-    `              COALESCE(l.corpo ->> 'canary', '?') || ', ' || l.campo_marcador || '=' ||\n` +
-    `              COALESCE(l.corpo ->> l.campo_marcador, '?') || ', ok=' ||\n` +
-    `              COALESCE(l.corpo ->> 'ok', '?')\n` +
+    `              COALESCE(ca.corpo ->> 'canary', '?') || ', ' || ca.campo_marcador || '=' ||\n` +
+    `              COALESCE(ca.corpo ->> ca.campo_marcador, '?') || ', ok=' ||\n` +
+    `              COALESCE(ca.corpo ->> 'ok', '?')\n` +
     '       END AS veredito\n' +
-    'FROM lidas l CROSS JOIN controle_credencial c\n' +
-    'ORDER BY l.nome;\n'
+    'FROM lidas ca CROSS JOIN controle_credencial cred\n' +
+    'ORDER BY ca.nome;\n'
   );
 }
 


### PR DESCRIPTION
## A main está vermelha, e a culpa é do #2380

O #2380 acrescentou o modo canária ao `sonda-versao-sql.ts` e, com ele, um **segundo bloco de SQL que fala o mesmo vocabulário do primeiro**. As mutações de `scripts/mutcheck.d/sonda-versao-sql.mut` são `perl -pe` de **uma linha**, e o guard `linhas_mudadas == 1` passou a reprovar **18 delas** por "regex largo": o mesmo padrão casava a sonda **e** a canária.

`mutcheck-all: ✗ 1/23 contrato(s) com problema: scripts/mutcheck.d/sonda-versao-sql.mut (exit 18)` → job `mutation-check` vermelho na main.

⚠️ **`mutation-check` não faz parte do `validate`**, então o auto-merge do #2380 não o viu. Detectado agora pelo Passo 5 da `/fecho` (disparar `gh workflow run CI --ref main`), que existe exatamente para isso.

## Consertado na CAUSA, não no sintoma

A ambiguidade era **duplicação real** que o #2380 introduziu. Não apertei só os regex — tirei as cópias:

| duplicação | virou |
|---|---|
| `timeout_milliseconds := 20000` (2×) | `const TIMEOUT_HTTP_MS` |
| `CASE WHEN g.confirmei_o_deploy = 'sim'` (2×) | `const TRAVA_CASE` |
| rodapé `$sonda$, m.ids) AS passo_N_copie_esta_celula` (2×) | `rodapeDoFormat(passoLeitura)` |
| aliases `l`/`e`/`i`/`x`/`c` copiados da sonda para o SQL da canária | `ca`/`esp`/`mp`/`resp`/`cred` |
| `problemas` em `resolverCanarias` | `pendencias` |

Duas cópias de um número são duas verdades, e a que ninguém atualiza é a que decide errado. Os aliases próprios não são cosmética: o SQL da canária fala de `nome` e de mapa, não de `edge`.

Os padrões que sobraram ambíguos foram **apertados para nomear a sonda** — `x ON`, `r.created >`, `'probe' IS DISTINCT`, `bundle velho`, `FROM lidas l CROSS JOIN`, `conferirSincronia(deps.raiz, edges,`. Cada um volta a medir o que o rótulo dele promete.

## Uma asserção MINHA estava errada — e o mutcheck tinha razão

Depois de desfeita a ambiguidade, sobrou um `DIVERGE`: o `.mut` declara `20000 → 30000` como **SOBREVIVE** ("20s é tuning, não fronteira"), mas veio `PEGA`. O culpado era o teste **novo** do timeout da canária, que pinava o literal `20000` — enquanto a asserção irmã da sonda já mede o **piso** desde 2026-09-07, com o comentário explicando por quê (`:= 1` e `:= 0` também são "explícitos" e são piores que o default).

A cópia nasceu ignorando a lição registrada 20 linhas acima dela. Agora mede o piso: `> 5000`, o default do pg_net que mata silencioso.

## Evidência

| gate | antes | agora |
|---|---|---|
| `mutcheck` do contrato | **exit 18** · 37 pegas · 18 inválidas | **exit 0** · 56 mutações · 54 pegas · 2 sobreviventes (as declaradas) · **0 inválidas** · controle+ ✓ (54/54) |
| `bun run typecheck` | — | rc=0 |
| `bun lint` | — | 0 errors |
| `bun run lint:shell` | — | 0 achados / 393 arquivos |
| `bun run test` | — | 813 arquivos · 8584 testes |
| `db/test-canaria-veredito.sh` | — | VEREDITO DE CANARIA OK |
| `… --falsificar` | — | FALSIFICACAO OK |

Nota sobre a falsificação: as 9 sabotagens do teste PG usavam os aliases antigos e, ao renomeá-los, todas passaram a não casar. O guard `"padrao nao casou, SQL intacto — falsificacao vazia"` as pegou **antes** de eu ver qualquer resultado — falsificação vazia não passou por verde nem por um ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
