### PR TITLE
docs(fecho): número da allowlist do cron envelheceu em 6 horas — troca por "conte no arquivo"

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -267,8 +267,10 @@ AMPLIAR a enumeração, nunca absolver: cada alvo segue classificado um a um por
 
 🕳️ **`SEM_PROVA` por "nenhuma sonda na janela" NÃO se resolve esperando — DISPARE.** O cron de
 sondagem existe desde 2026-09-06 (`deploy-sonda-cron`, `37 */2 * * *`, pelo relé OPTIONS
-fail-closed), mas cobre só a allowlist provada de `_shared/sonda-cron-alvos.ts` — **7 edges de
-59**. Para as outras 52, esperar é esperar para sempre, e tudo abaixo vale palavra por palavra. Quem dá prova passiva é só a edge
+fail-closed), mas cobre só a allowlist provada de `_shared/sonda-cron-alvos.ts` — **contada NO
+ARQUIVO, nunca de cabeça**: 7 alvos em 2026-09-06, 11 na onda 2 de 2026-09-08, e o número sobe a
+cada onda aprovada. Para toda edge FORA dela, esperar é esperar para sempre, e tudo abaixo vale
+palavra por palavra. Quem dá prova passiva é só a edge
 cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) **e** tem cron frequente —
 `analytics-outbox-drain` (5 em 5 min) é o caso típico. Medido 2026-09-05: **24 das 54 edges do
 mapa não têm cron NENHUM** (webhook como `omie-nfe-webhook`, ou invocada sob demanda pelo app como

--- a/.claude/skills/fecho/scripts/edges-pendentes.sh
+++ b/.claude/skills/fecho/scripts/edges-pendentes.sh
@@ -698,8 +698,9 @@ echo "      e foi por isso que a MESMA edge virava chip em toda sessão que fech
 # ⚠️ "nenhuma sonda na janela" NÃO se resolve esperando, e dizer só "INDETERMINADO" convida o
 # leitor a esperar. O cron de sondagem existe desde 2026-09-06 (`deploy-sonda-cron`, 37 */2 * * *,
 # pelo relé OPTIONS fail-closed), mas cobre só a ALLOWLIST provada de
-# `_shared/sonda-cron-alvos.ts` — 7 edges de 59. Para as outras 52 esperar continua sendo
-# esperar para sempre, e o argumento abaixo vale palavra por palavra. Quem dá
+# `_shared/sonda-cron-alvos.ts` — conte NO ARQUIVO (7 em 2026-09-06, 11 na onda 2 de 2026-09-08;
+# sobe a cada onda). Para a edge FORA dela, esperar continua sendo esperar para sempre, e o
+# argumento abaixo vale palavra por palavra. Quem dá
 # prova passiva é só a edge cujo fluxo NORMAL já ecoa o envelope (`edge`+`fonte`) E tem cron
 # frequente — `analytics-outbox-drain` (5/5min) é o caso típico. Medido 2026-09-05: 24 das 54
 # edges do mapa não têm cron NENHUM (webhook, ou invocada sob demanda pelo app), e para essas a


### PR DESCRIPTION
O [#2387](https://github.com/LucasSardenbergL/afiacao/pull/2387), hoje de manhã, escreveu
**"7 edges de 59"** ao corrigir a afirmação de que não havia cron de sondagem. O número foi
MEDIDO na hora e estava certo.

Ao rodar o `/fecho` da mesma sessão, seis horas depois, a onda 2 da allowlist (`89887025b`) já
havia subido para **11** — e o texto passou a mentir com a autoridade de uma medição.

## A lição não é "esqueceram de atualizar"

É que **o número absoluto de uma lista em crescimento ativo não pertence à prosa.**
`_shared/sonda-cron-alvos.ts` ganha alvos a cada onda aprovada pelo `sonda:cron-prova`, então
qualquer valor cravado ali tem validade de dias. O que a skill precisa ensinar é a DIREÇÃO —
"cobre só a allowlist, e para a edge fora dela esperar não termina" — e **onde ler** o número.

Troca o valor cravado por "conte NO ARQUIVO", mantendo as duas medições com data como histórico:
elas mostram que a lista cresce, que é justamente o motivo de não cravar. Mesma correção nos dois
lugares que a repetiam (`.claude/skills/fecho/SKILL.md` e `edges-pendentes.sh`).

## Evidência

`bash scripts/test-fecho-edges-pendentes.sh` exit 0 · `bun run lint:shell` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)