### PR TITLE
test(canaria): a prova aprovava dois vereditos OPOSTOS pelo prefixo — e o controle de credencial tinha um conjunto nunca exercitado

### DIFF
--- a/db/test-canaria-veredito.sh
+++ b/db/test-canaria-veredito.sh
@@ -242,13 +242,36 @@ SQL
   espera "401 SEM controle de credencial é INDETERMINADO, nunca veredito" \
     'copilot-analyze' "$LB" 'INDETERMINADO'
 
+  # O ramo determinado exige DUAS coisas: 2xx acima do piso E zero recusa 401 fora da leva.
+  # Os casos acima so exercitam a PRIMEIRA (no de cima o 401 esta DENTRO da leva, excluido
+  # pelo NOT EXISTS; no de baixo o ok_recentes fica em 0 e ja reprova por outro conjunto),
+  # entao `cred.recusas_recentes = 0` podia virar `true` sem nenhum teste reclamar — e virar
+  # `true` e fail-OPEN: manda deployar num CRON_SECRET quebrado AGORA. Este caso satisfaz o
+  # piso e ainda assim tem recusa alheia, isolando o segundo conjunto.
+  P -q -c "TRUNCATE net._http_response;" >/dev/null
+  P -q >/dev/null <<'SQL'
+INSERT INTO net._http_response (id, status_code, content, created) VALUES
+  (1001, 401, '{"code":401}', now()),
+  -- id FORA do mapa embutido {1001,1002,1003}: recusa de OUTRA chamada, nao desta leva
+  (1500, 401, '{"code":401}', now());
+INSERT INTO net._http_response (id, status_code, content, created)
+  SELECT 9000 + g, 200, '{"ok":true}', now() - (g || ' minutes')::interval FROM generate_series(1, 40) g;
+SQL
+  espera "401 com 2xx acima do piso mas recusa 401 ALHEIA = INDETERMINADO (fail-closed)" \
+    'copilot-analyze' "$LB" 'INDETERMINADO'
+
   P -q -c "TRUNCATE net._http_response;" >/dev/null
   P -q >/dev/null <<'SQL'
 INSERT INTO net._http_response (id, status_code, content, created) VALUES
   (1001, 404, '{"code":404}', now());
 SQL
+  # O prefixo TEM de nomear o RAMO. O `>= 400` e o ELSE comecam os dois com
+  # 'SEM CANARIA NO AR — ' e dizem coisas OPOSTAS: aqui NADA executou (o bundle recusou
+  # o request), la o fluxo real RODOU e o efeito JA ACONTECEU. Casar so o prefixo comum
+  # aprova os dois — era assim que a mutacao `>= 400` -> `= 401` sobrevivia: o 404 caia
+  # no ELSE e o teste continuava verde julgando o oposto.
   espera "4xx sem eco = recusou o request, NADA executou" \
-    'copilot-analyze' "$LB" 'SEM CANARIA NO AR'
+    'copilot-analyze' "$LB" 'SEM CANARIA NO AR — o bundle recusou o request (HTTP 404)'
 
   # ------------------------------------------------- (E) ausência de dado ---
   P -q -c "TRUNCATE net._http_response;" >/dev/null


### PR DESCRIPTION
O #2403 acabou de pôr `db/test-canaria-veredito.sh` no núcleo do CI (`provas-sql`, **required** via
`validate`). Ele passa a ser bloqueante — e entrou com **duas asserções que não discriminam**.

Medido com um contrato de mutação rodado contra ESTE teste (12 mutações sobre o bloco canária):
**10 pegas, 2 sobreviventes**. As 2 são as de baixo. Remédio: reforçar o TESTE, nunca afrouxar a
mutação.

## 1. `espera()` casa por PREFIXO, e dois ramos começam igual dizendo o OPOSTO

```
ramo `>= 400`: 'SEM CANARIA NO AR — o bundle recusou o request (HTTP 404), NADA executou…'
ELSE:          'SEM CANARIA NO AR — HTTP 404 SEM eco canary: … RODOU O FLUXO REAL … o efeito ja aconteceu'
```

Um diz que **nada rodou**; o outro, que **o efeito já aconteceu**. Desfechos opostos para quem lê. A
asserção do 404 casava `'SEM CANARIA NO AR'` — o prefixo **comum** — e aprovava os dois. Com
`ca.status_code >= 400` → `= 401`, o 404 cai no ELSE e o teste seguia **verde julgando o oposto**.
Agora a asserção nomeia o ramo.

## 2. O controle de credencial tinha um conjunto que nenhum caso exercitava

O ramo determinado exige DUAS coisas: `cred.ok_recentes >= PISO` **e** `cred.recusas_recentes = 0`.
Dos dois casos existentes:

- num, o 401 está **dentro** da leva (excluído pelo `NOT EXISTS`, então `recusas_recentes` já é 0);
- no outro, `ok_recentes` fica em 0 e reprova pelo **primeiro** conjunto.

Nenhum tinha 2xx acima do piso **e** recusa 401 alheia ao mesmo tempo — então `recusas_recentes = 0`
podia virar `true` sem ninguém reclamar. Virar `true` é **fail-OPEN**: manda deployar com o
`CRON_SECRET` quebrado AGORA. O caso novo satisfaz o piso e ainda assim tem recusa alheia (id 1500,
fora do mapa embutido `{1001,1002,1003}`), isolando o segundo conjunto.

## Evidência

| passo | resultado |
|---|---|
| controle | rc=0 · `RESULTADO: 19 ok / 0 fail` · `VEREDITO DE CANARIA OK` (era 18) |
| `--falsificar` | rc=0 · `FALSIFICACAO OK — todo verde tem vermelho alcancavel` (2 locales) |
| sabotagem `>= 400` → `= 401` | 1 linha mutada · **rc=1** · 1 FALHA |
| sabotagem `recusas_recentes = 0` → `true` | 1 linha mutada · **rc=1** · 1 FALHA |
| worktree após cada sabotagem | limpo |

Controle verde na MESMA sessão das sabotagens.

## Escopo

Um arquivo. Eu tinha escrito também a wiring de CI e um contrato `.mut` medido contra este teste;
**descartei em favor da do #2403**, que é melhor (`fetch-depth: 0` + Setup Bun no `provas-sql`, mais
o gate seco barato no required). O contrato pode voltar como follow-up sobre a wiring deles — mas o
#2402 mediu o `mutation-check` em **10m03s de 15min**, então quem o reintroduzir mede a margem antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
