### PR TITLE
docs(mutcheck): o custo do `mutation-check` agora é MEDIDO — 10m03s de 15min, e não a projeção

### DIFF
--- a/docs/historico/mut-nao-acompanhou-o-modo-novo.md
+++ b/docs/historico/mut-nao-acompanhou-o-modo-novo.md
@@ -43,10 +43,15 @@ lugar nenhum.
 
 Os 6 testes que as matam nasceram desse run. O `.mut` foi de 56 para **90** mutações (88 pegas,
 as 2 sobreviventes declaradas de sempre, 0 inválidas, 0 problemas) e o contrato passou a custar
-158s locais no lugar de ~100s. O job `mutation-check` inteiro (`bun run mutcheck`,
-356 mutações) fecha em 602s locais e tem teto de 15min no CI, onde a medição de 2026-09-07 sobre
-28 runs deu 346-533s — a folga absorve as 34 novas, mas o próximo que engordar este contrato
-mede antes: o teto é o mesmo para todos os contratos somados.
+158s locais no lugar de ~100s.
+
+**O custo no CI, MEDIDO e não projetado** (run do #2399, 2026-09-08): o job `mutation-check`
+fechou em **10m03s** contra o teto de **15min** — 67% dele. A medição anterior, de 2026-09-07
+sobre 28 runs, dava 346-533s; as 34 mutações novas custaram ~70s de job. Sobra **~1/3 do teto**,
+e ele é o mesmo para os 24 contratos somados: quem for engordar o próximo `.mut` parte deste
+número, não da folga de antes. Estourar o `timeout-minutes` aqui não seria reprovação de
+cobertura — seria ausência de dado vestida de vermelho
+([timeout-de-job-e-ausencia-de-dado.md](timeout-de-job-e-ausencia-de-dado.md)).
 
 ## A régua
 


### PR DESCRIPTION
## Por quê

O [#2399](https://github.com/LucasSardenbergL/afiacao/pull/2399) dobrou o contrato `sonda-versao-sql.mut` (56 → 90 mutações) e o registro saiu com uma **projeção** do custo: *"a folga absorve as 34 novas"*. O run do próprio PR **mediu** — e projeção que já tem medição no lugar é dado velho ocupando a linha do novo.

| | antes (28 runs, 2026-09-07) | agora (run do #2399) |
|---|---|---|
| `mutation-check` | 346–533s | **603s (10m03s)** |
| teto (`timeout-minutes`) | 900s | 900s |
| folga | ~40% | **~33%** |

## O que muda

O número decide se cabe o **próximo** contrato: o teto é **um só** para os 24 `.mut` somados. Quem for engordar o seguinte parte de 603s, não da folga de antes — e as 34 mutações novas custaram ~70s de job, que é a régua de quanto uma dobra de contrato pesa.

O texto passa a ligar [`timeout-de-job-e-ausencia-de-dado.md`](docs/historico/timeout-de-job-e-ausencia-de-dado.md): estourar o teto aqui **não** seria reprovação de cobertura — seria ausência de dado vestida de vermelho.

## Validação

```
docs:links     rc=0  (734 docs — todo link relativo resolve)
docs:indice    rc=0
docs:citacoes  rc=0  (38 citações verificadas contra o conteúdo real)
```

Só documentação — nenhum arquivo de código ou `.mut` tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
