### PR TITLE
test(canaria): a prova executada entra no núcleo do CI, e um gate de 9s barra o `.mut` stale que o #2380 introduziu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,6 +788,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # O núcleo inclui db/test-canaria-veredito.sh, que NÃO confere um SQL commitado:
+      # gera o SQL pelo PRÓPRIO gerador (`bun scripts/sonda-versao-sql.ts --canaria`) e
+      # sabota o resultado. É isso que faz a prova envelhecer junto com o gerador em vez
+      # de virar retrato velho. Só o RUNTIME é preciso — os imports do gerador são
+      # builtins `node:*` mais um relativo, então nada de `bun install` aqui.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       # A versão é conferida POSITIVAMENTE, e o número exato vai para o log. Precedente
       # do próprio repo: o runner trazia shellcheck 0.9.0 contra 0.11.0 do laptop e o
       # gate reprovava PR sadio — "gate cuja VERDADE depende da versão do runner não é

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,6 +731,18 @@ jobs:
       - name: Dead code gate (knip — export/dep sem consumidor)
         run: bunx knip
 
+      # A metade DETERMINÍSTICA do mutation-check, aqui porque é barata (~1s medido sobre 92
+      # padrões) e este job já é required via `validate`. Ela reprova quando ESTE diff INTRODUZ
+      # um `.mut` ambíguo — o modo de falha do #2380, que duplicou o bloco SQL, deixou 18
+      # padrões casando duas linhas e mergeou 42s depois do `mutation-check` concluir FAILURE,
+      # porque aquele job não é required. Comparar contra a base é o que devolve a falha a quem
+      # tocou o fonte, em vez de travar PR alheio — que é o motivo do job cheio seguir fora do
+      # caminho obrigatório (leia o comentário dele, mais abaixo).
+      # NÃO substitui o `mutation-check`: aqui a suíte não roda, então isto não afirma NADA
+      # sobre cobertura. Só afirma que os padrões ainda são cirúrgicos.
+      - name: Contratos de mutação ainda cirúrgicos (mutcheck --seco, introduzidos por ESTE diff)
+        run: bash scripts/mutcheck-seco-gate.sh origin/${{ github.base_ref || 'main' }}
+
   # ─── Agregador — É ESTE o required status check ─────────────────────────────
   # `validate` não roda trabalho nenhum: ele só AFIRMA que os 4 jobs acima terminaram em
   # success. Existe porque é o único context exigido pela branch protection da main e o que
@@ -776,9 +788,11 @@ jobs:
   # ## Custo
   #
   # Job próprio e PARALELO, entrando no `needs:` do `validate` — de propósito fora do
-  # `gates-e-falsificacao`, que é o gargalo atual (mediana 357s). Não precisa de bun
-  # nem de deno, e não precisa de `fetch-depth: 0` (nenhum gate aqui usa merge-base),
-  # então o preâmbulo é bem mais barato que o dos outros quatro.
+  # `gates-e-falsificacao`, que é o gargalo atual (mediana 357s). Carrega o RUNTIME bun
+  # (só o runtime, sem `bun install`) desde que `db/test-canaria-veredito.sh` entrou no
+  # núcleo: essa prova gera o SQL pelo próprio gerador em vez de conferir um retrato
+  # commitado. Não precisa de deno nem de `fetch-depth: 0` (nenhum gate aqui usa
+  # merge-base), então o preâmbulo segue mais barato que o dos outros quatro.
   provas-sql:
     runs-on: ubuntu-latest
     timeout-minutes: 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,10 +789,11 @@ jobs:
   #
   # Job próprio e PARALELO, entrando no `needs:` do `validate` — de propósito fora do
   # `gates-e-falsificacao`, que é o gargalo atual (mediana 357s). Carrega o RUNTIME bun
-  # (só o runtime, sem `bun install`) desde que `db/test-canaria-veredito.sh` entrou no
-  # núcleo: essa prova gera o SQL pelo próprio gerador em vez de conferir um retrato
-  # commitado. Não precisa de deno nem de `fetch-depth: 0` (nenhum gate aqui usa
-  # merge-base), então o preâmbulo segue mais barato que o dos outros quatro.
+  # (só o runtime, sem `bun install`) e `fetch-depth: 0` desde que
+  # `db/test-canaria-veredito.sh` entrou no núcleo: essa prova gera o SQL pelo próprio
+  # gerador em vez de conferir um retrato commitado, e o gerador RECUSA emitir sem uma
+  # `origin/main` contra a qual conferir que a árvore não está defasada. Não precisa de
+  # deno, então o preâmbulo segue mais barato que o dos outros quatro.
   provas-sql:
     runs-on: ubuntu-latest
     timeout-minutes: 12
@@ -800,7 +801,13 @@ jobs:
       contents: read
 
     steps:
+      # fetch-depth: 0 porque `db/test-canaria-veredito.sh` gera o SQL pelo gerador real, e o
+      # gerador tem guard fail-CLOSED: sem `origin/main` para comparar ele RECUSA emitir, em vez
+      # de emitir a partir de uma árvore possivelmente defasada (o achado do #2143). Checkout
+      # raso não traz a main, e o job reprovava com "origin/main não existe neste repo".
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       # O núcleo inclui db/test-canaria-veredito.sh, que NÃO confere um SQL commitado:
       # gera o SQL pelo PRÓPRIO gerador (`bun scripts/sonda-versao-sql.ts --canaria`) e

--- a/db/nucleo-ci.txt
+++ b/db/nucleo-ci.txt
@@ -63,3 +63,15 @@ db/test-claim-disparo-cenario-b.sh         76
 db/test-disparado-simulado-pos-disparo.sh  59
 db/test-fin-sync-lease.sh                  22
 db/test-pedido-venda-coerencia.sh          31
+
+# ── Eixo 5 — VEREDITO DE DEPLOY ──────────────────────────
+# O SQL que responde "a edge está REALMENTE no ar?". O dano aqui é acreditar num
+# veredito: `CANARIA VERMELHA` que nunca dispara, 401 que vira fail-open, resposta
+# de ontem valendo como veredito de hoje. Esta prova é a única do núcleo que GERA o
+# SQL pelo próprio gerador (`bun scripts/sonda-versao-sql.ts --canaria --sem-rede`)
+# em vez de conferir um retrato commitado — por isso o job carrega o runtime bun, e
+# por isso ela envelhece junto com o gerador em vez de virar retrato velho.
+# Entrou no núcleo em 2026-09-08: o gate de mutação NÃO cobre o bloco canária (medido:
+# 10 de 12 mutações sobrevivem lá), e as 10 sabotagens daqui eram a única rede real —
+# rodando fora do CI, que pelo critério do repo é ausência de dado.
+db/test-canaria-veredito.sh                18

--- a/db/test-canaria-veredito.sh
+++ b/db/test-canaria-veredito.sh
@@ -99,8 +99,11 @@ SQL
 
 # ------------------------------------------------------------------- asserções ---
 fail=0
-ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
-bad() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+# Contadores para o recibo do nucleo-ci (db/roda-nucleo-ci.sh exige a linha
+# RESULTADO: <pass> ok / <fail> fail — sem ela, exit 0 nao prova que asseriu algo).
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
 
 # veredito <id-da-canaria> <arquivo-de-leitura> -> imprime o veredito daquela linha
 veredito() {
@@ -283,6 +286,7 @@ SQL
 if [ "${1:-}" != "--falsificar" ]; then
   printf '== canaria: BUNDLE VELHO x CANARIA VERMELHA ==\n'
   ALVO="$GERADO"; suite
+  echo "RESULTADO: $PASS ok / $FAIL fail"
   if [ "$fail" -eq 0 ]; then printf '\nVEREDITO DE CANARIA OK\n'; exit 0; fi
   printf '\nVERMELHO\n'; exit 1
 fi

--- a/scripts/mutcheck-all.sh
+++ b/scripts/mutcheck-all.sh
@@ -36,6 +36,12 @@ set -uo pipefail
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || { echo "mutcheck-all: não consegui ir pra raiz do repo" >&2; exit 2; }
 MUTCHECK="scripts/mutcheck.sh"
 
+# --seco: repassado a cada contrato. Roda só perl+diff (sem suíte, sem compilar) para medir
+# se os padrões ainda são CIRÚRGICOS no fonte de hoje — é o que o gate barato do CI usa
+# (scripts/mutcheck-seco-gate.sh). Não mede cobertura; o sumário de cada contrato diz isso.
+SECO_ARGS=()
+if [[ "${1:-}" == "--seco" ]]; then SECO_ARGS=(--seco); shift; fi
+
 # MUTCHECK_DIR existe para o teste do SENSOR (scripts/test-mutcheck-sensor.sh) poder medir os
 # quatro estados — honrado, DIVERGE, INVÁLIDA e baseline vermelho — contra contratos de fixture,
 # em segundos. Sem isso a única forma de exercitar o alarme seria sabotar um contrato real e
@@ -93,7 +99,7 @@ for mut in "${muts[@]}"; do
   # capturado PELADO (um `| tee` aqui devolveria o status do tee — a classe de
   # docs/historico/evidencia-positiva-shell.md).
   saida=$(mktemp)
-  env ${envs[@]+"${envs[@]}"} bash "$MUTCHECK" "$src" "$tst" "$mut" > "$saida" 2>&1
+  env ${envs[@]+"${envs[@]}"} bash "$MUTCHECK" ${SECO_ARGS[@]+"${SECO_ARGS[@]}"} "$src" "$tst" "$mut" > "$saida" 2>&1
   rc=$?
   cat "$saida"
   registrar "$mut" "$rc" "$saida"
@@ -112,7 +118,13 @@ fi
 
 echo "══════════════════════════════════════════════════════════"
 if [[ ${#failed[@]} -eq 0 ]]; then
-  echo "mutcheck-all: ✓ ${#muts[@]} contrato(s) honrado(s) — nenhuma regressão de cobertura."
+  # No SECO a suíte não roda: afirmar "nenhuma regressão de cobertura" aqui seria vender
+  # como medição o que foi só conferência de padrão — a classe de evidencia-positiva-shell.md.
+  if [[ ${#SECO_ARGS[@]} -gt 0 ]]; then
+    echo "mutcheck-all: ✓ ${#muts[@]} contrato(s) com padrões CIRÚRGICOS — cobertura NÃO medida (modo seco)."
+  else
+    echo "mutcheck-all: ✓ ${#muts[@]} contrato(s) honrado(s) — nenhuma regressão de cobertura."
+  fi
   exit 0
 fi
 echo "mutcheck-all: ✗ ${#failed[@]}/${#muts[@]} contrato(s) com problema:"

--- a/scripts/mutcheck-seco-gate.sh
+++ b/scripts/mutcheck-seco-gate.sh
@@ -62,8 +62,16 @@ git worktree add --detach "$BASE_WT" "$BASE_SHA" >/dev/null 2>&1 || {
   echo "::error::não consegui materializar a base em worktree — não dá para atribuir a falha."
   exit 2
 }
-# O gate roda o mutcheck DA BASE contra o fonte DA BASE: medir a base com o sensor de hoje
-# responderia outra pergunta.
+# O sensor é o de HOJE, aplicado ao fonte+contratos DA BASE. Duas razões: (1) a pergunta
+# aqui é mecânica — "este padrão casa UMA linha?" — e medi-la com dois critérios diferentes
+# nos dois lados não daria comparação nenhuma; (2) a base pode ser anterior ao próprio
+# `--seco`, e aí o script de lá ignoraria a flag e rodaria a suíte inteira por mutação —
+# minutos de gate, não segundos. Medido na falsificação: sem esta cópia o gate estourou
+# 240s sem terminar.
+cp scripts/mutcheck.sh scripts/mutcheck-all.sh "$BASE_WT/scripts/" || {
+  echo "::error::não consegui levar o sensor de hoje para a base — sem isso a comparação não é comparável."
+  exit 2
+}
 if (cd "$BASE_WT" && bash scripts/mutcheck-all.sh --seco > "$TMP/base.log" 2>&1); then
   : > "$TMP/base.txt"   # base limpa: tudo que o HEAD acusa é novo
 else

--- a/scripts/mutcheck-seco-gate.sh
+++ b/scripts/mutcheck-seco-gate.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# mutcheck-seco-gate.sh — o gate barato que teria barrado o #2380.
+#
+# Roda `mutcheck-all.sh --seco` (perl+diff, ~1s) e reprova quando ESTE diff INTRODUZ um
+# contrato ambíguo — padrão do `.mut` que deixou de casar o fonte, ou passou a casar mais
+# de uma linha. Foi assim que o #2380 envenenou a main: 754 linhas duplicaram o bloco SQL,
+# 18 padrões viraram ambíguos, e o PR mergeou 42s depois do job concluir FAILURE porque
+# `mutation-check` não é required.
+#
+# Por que "INTRODUZ" e não "existe": o job cheio segue não-required de propósito
+# (ci.yml, job mutation-check) — ele leva minutos e um refactor alheio pode dessincronizar
+# um `.mut` que não é seu, travando PR de terceiro. Comparar contra a base devolve a falha
+# a quem tocou o fonte. O caminho feliz nem paga a comparação: só quando o HEAD acusa é
+# que a base é consultada.
+#
+# NÃO mede cobertura — a suíte não roda aqui. Verde significa "os padrões ainda são
+# cirúrgicos", não "os testes têm dente". Quem mede dente é o `mutation-check`.
+#
+# Uso: scripts/mutcheck-seco-gate.sh [base-ref]     (default: origin/main)
+# Exit: 0 = nada introduzido · 1 = este diff introduziu · 2 = não consegui decidir
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+TMP=$(mktemp -d)
+BASE_WT="$TMP/base"
+# shellcheck disable=SC2329  # invocada indiretamente pelo trap logo abaixo
+cleanup() {
+  [ -d "$BASE_WT" ] && git worktree remove --force "$BASE_WT" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Lista os contratos com problema, um caminho por linha (basename, para comparar entre
+# árvores). Sem `|| true`: a saída vazia é o sinal de sucesso, e queremos o exit code.
+contratos_com_problema() {
+  sed -n 's/^  - \(.*\) (exit [0-9]*)$/\1/p' "$1" | xargs -n1 basename 2>/dev/null | sort -u
+}
+
+echo "== mutcheck --seco no HEAD =="
+if bash scripts/mutcheck-all.sh --seco > "$TMP/head.log" 2>&1; then
+  tail -1 "$TMP/head.log"
+  echo "✅ nenhum contrato ambíguo — nada a comparar com a base."
+  exit 0
+fi
+tail -2 "$TMP/head.log"
+contratos_com_problema "$TMP/head.log" > "$TMP/head.txt"
+if [ ! -s "$TMP/head.txt" ]; then
+  echo "::error::mutcheck-all --seco falhou mas não nomeou contrato — não dá para decidir de quem é a falha."
+  cat "$TMP/head.log"
+  exit 2
+fi
+
+# O HEAD está sujo. A base decide se a sujeira é DESTE diff.
+echo "== o HEAD acusou; conferindo a base ($BASE_REF) =="
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "::error::base '$BASE_REF' não existe nesta árvore (fetch raso?). Fail-closed: tratando tudo como introduzido."
+  cat "$TMP/head.txt"
+  exit 1
+fi
+BASE_SHA=$(git merge-base HEAD "$BASE_REF")
+git worktree add --detach "$BASE_WT" "$BASE_SHA" >/dev/null 2>&1 || {
+  echo "::error::não consegui materializar a base em worktree — não dá para atribuir a falha."
+  exit 2
+}
+# O gate roda o mutcheck DA BASE contra o fonte DA BASE: medir a base com o sensor de hoje
+# responderia outra pergunta.
+if (cd "$BASE_WT" && bash scripts/mutcheck-all.sh --seco > "$TMP/base.log" 2>&1); then
+  : > "$TMP/base.txt"   # base limpa: tudo que o HEAD acusa é novo
+else
+  contratos_com_problema "$TMP/base.log" > "$TMP/base.txt"
+fi
+
+INTRODUZIDOS=$(comm -23 "$TMP/head.txt" "$TMP/base.txt" || true)
+if [ -z "$INTRODUZIDOS" ]; then
+  echo "⚠️  contrato(s) ambíguo(s) no HEAD, mas JÁ ambíguos na base — não é deste diff:"
+  sed 's/^/     /' "$TMP/head.txt"
+  echo "✅ gate passa (a dívida é anterior; o job mutation-check segue reportando-a)."
+  exit 0
+fi
+echo "::error::este diff INTRODUZIU contrato(s) de mutação ambíguo(s):"
+printf '%s\n' "$INTRODUZIDOS" | sed 's/^/     - /'
+echo ""
+echo "O padrão do .mut deixou de casar UMA linha do fonte — normalmente porque o fonte"
+echo "ganhou um bloco parecido. Ancore o padrão no texto PRÓPRIO do bloco que ele mede"
+echo "(alias, nome de coluna, o THEN do ramo) e rode:"
+echo "  bash scripts/mutcheck-all.sh --seco"
+exit 1

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -203,3 +203,9 @@ PEGA      | guard de sincronia cego no modo canaria          | s/\[\.\.\.new Set
 PEGA      | --caro aceito em silencio no modo canaria        | s/^    if \(caras\.length > 0\)/    if (false)/
 PEGA      | --so-leitura aceito em silencio (leitura sem mapa)| s/if \(soLeitura === true\)/if (false)/
 PEGA      | canaria repetida na leva (dispara duas vezes)    | s/if \(repetidasC\.length > 0\)/if (false)/
+
+# As duas invariantes do controle de credencial que as asserções `>= \d+` NAO prendiam: o
+# regex aceita `>= 0`, e com piso zero UMA resposta 2xx ja "prova" a credencial. A segunda
+# guarda o fail-CLOSED do 401 ambiguo — trocar o THEN por veredito confiante e fail-open.
+PEGA      | canaria: piso do controle zerado (1 resposta 2xx ja 'prova')  | s/cred\.ok_recentes >= \$\{PISO_CONTROLE_CREDENCIAL\}/cred.ok_recentes >= 0/
+PEGA      | canaria: fallback do 401 deixa de ser INDETERMINADO (fail-open) | s/THEN 'INDETERMINADO — 401 nao separa bundle sem canaria/THEN 'SEM CANARIA NO AR — 401 nao separa bundle sem canaria/

--- a/scripts/mutcheck.sh
+++ b/scripts/mutcheck.sh
@@ -83,8 +83,13 @@ EOF
 fi
 
 # ───────────────────────── args ─────────────────────────
+# --seco: só perl+diff. NÃO mede cobertura (a suíte não roda) — mede se cada padrão do
+# .mut ainda é CIRÚRGICO no fonte de hoje: casa, e casa UMA linha. É o guard barato que
+# pega o .mut stale (o modo de falha do #2380) em ~1s em vez dos minutos da rodada cheia.
+SECO=0
+if [[ "${1:-}" == "--seco" ]]; then SECO=1; shift; fi
 if [[ $# -ne 3 ]]; then
-  echo "uso: $0 <src.ts> <test.ts> <mutations.mut>   (ou --selftest)" >&2
+  echo "uso: $0 [--seco] <src.ts> <test.ts> <mutations.mut>   (ou --selftest)" >&2
   exit 2
 fi
 SRC="$1"; TEST="$2"; MUT="$3"
@@ -122,11 +127,12 @@ echo "mutcheck: $SRC × $TEST"
 # falso-INVÁLIDO ("não compila"), mascarando a causa como se fosse cobertura. É controle do
 # AMBIENTE, não da cobertura. (Achado do Codex: sem isso o gate de CI fica vermelho mudo se
 # o bun sumir.)
-if ! compila; then
+if [[ $SECO -eq 1 ]]; then
+  echo "  baseline: — modo SECO (perl+diff; a suíte NÃO roda, logo isto não é veredito de cobertura)"
+elif ! compila; then
   echo "  baseline: ✗ o SRC ORIGINAL não compila com '${COMPILE_CMD[*]:-}' — harness/ambiente quebrado (bun no PATH?). Abortando." >&2
   exit 1
-fi
-if run_tests; then
+elif run_tests; then
   echo "  baseline: ✓ verde (compila + suíte passa)"
 else
   echo "  baseline: ✗ VERMELHO — a suíte já falha sem mutação. Resultados seriam lixo. Abortando." >&2
@@ -161,6 +167,12 @@ while IFS='|' read -r c_expect c_label c_expr || [[ -n "${c_expect:-}" ]]; do
     printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (tocou $nl linhas — regex largo)"
     invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
   fi
+  # No SECO o veredito termina aqui: o padrão casou e tocou UMA linha, que é tudo que
+  # este modo se propõe a afirmar. Segue sem compilar nem testar.
+  if [[ $SECO -eq 1 ]]; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "✓ cirúrgica"
+    restore; continue
+  fi
   # guard 3: o mutante COMPILA? senão "morto pelo compilador" seria falso-PEGA (poder inflado)
   if ! compila; then
     printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (não compila — seria falso-PEGA)"
@@ -186,11 +198,17 @@ done < "$MUT"
 
 # ───────────────────────── controle+ ─────────────────────────
 ctrl_msg="n/d"
-if [[ $ctrl_total -gt 0 ]]; then
+if [[ $SECO -eq 1 ]]; then
+  ctrl_msg="n/d (seco)"
+elif [[ $ctrl_total -gt 0 ]]; then
   if [[ $ctrl_ok -eq $ctrl_total ]]; then ctrl_msg="✓ ($ctrl_ok/$ctrl_total)"; else ctrl_msg="✗ ($ctrl_ok/$ctrl_total)"; fi
 else
   ctrl_msg="⚠ NENHUM controle+ (suspeite do harness)"; problems=$((problems+1))
 fi
 
-echo "sumário: $n mutações · $pegas pegas · $sobrev sobreviventes · $invalid inválidas · controle+ $ctrl_msg · $problems problema(s)"
+if [[ $SECO -eq 1 ]]; then
+  echo "sumário SECO: $n padrões · $((n-invalid)) cirúrgicos · $invalid ambíguo(s)/não-casado(s) · $problems problema(s) — cobertura NÃO medida"
+else
+  echo "sumário: $n mutações · $pegas pegas · $sobrev sobreviventes · $invalid inválidas · controle+ $ctrl_msg · $problems problema(s)"
+fi
 exit "$problems"

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -18,6 +18,7 @@ import {
   guardEfeitoLegado,
   main,
   parsearArgs,
+  PISO_CONTROLE_CREDENCIAL,
   resolverCanarias,
   resolverLeva,
   SENTINELA_MAPA,
@@ -1786,6 +1787,23 @@ describe('PASSO 2 da canária — o julgamento exige os TRÊS campos', () => {
     expect(s).toMatch(
       /AND cred\.ok_recentes >= \d+ AND cred\.recusas_recentes = 0\n\s*THEN 'SEM CANARIA NO AR — 401/,
     );
+  });
+
+  it('o piso do controle é a CONSTANTE — zerá-lo deixaria UMA resposta 2xx provar a credencial', () => {
+    // As asserções acima casam `>= \d+`, que aceita `>= 0`. Com piso zero UMA resposta 2xx já
+    // "prova" a credencial — o oposto do que o controle existe para fazer, e o gate de mutação
+    // não via a diferença. Referenciar a constante importada mantém a asserção viva quando o
+    // piso for ajustado, em vez de pedir edição de teste a cada tuning.
+    const s = sql();
+    expect(s).toContain(`cred.ok_recentes >= ${PISO_CONTROLE_CREDENCIAL}`);
+    expect(s).not.toMatch(/cred\.ok_recentes >= 0\b/);
+  });
+
+  it('401 sem controle observado permanece INDETERMINADO — nunca veredito confiante', () => {
+    // O fail-CLOSED do 401 ambíguo: sem controle de credencial provado, 401 não separa
+    // bundle-sem-canária de CRON_SECRET inválido. Trocar este THEN por um veredito confiante
+    // é fail-open — e nenhuma asserção da suíte pegava a troca.
+    expect(sql()).toMatch(/THEN 'INDETERMINADO — 401 nao separa bundle sem canaria/);
   });
 });
 

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -552,7 +552,7 @@ export function escaparParaFormat(texto: string): string {
  * por janela de 6h (medido em 2026-08-30: 208 linhas, todas 200); abaixo de 10 o fundo está
  * anormalmente quieto e a resposta honesta é INDETERMINADO.
  */
-const PISO_CONTROLE_CREDENCIAL = 10;
+export const PISO_CONTROLE_CREDENCIAL = 10;
 
 /**
  * Bloco de LEITURA e veredito. NÃO exige colar `request_id` nenhum.


### PR DESCRIPTION
## O que aconteceu

O `#2380` acrescentou 754 linhas com um bloco SQL paralelo (o `--canaria`) e não atualizou o contrato de mutação. 18 padrões passaram a casar duas linhas e viraram `INVÁLIDO`. O PR mergeou **42 segundos depois** de o `mutation-check` concluir `FAILURE` — o auto-merge só exige `validate`, e `validate` não depende daquele job. A main ficou vermelha por 77 minutos e 11 PRs mergearam nesse estado, cada um gerando email de CI falhando.

O `.mut` em si já foi consertado na main (`#2392`) e a canária ganhou 33 mutações no `#2397`. Este PR fecha o que sobrou: a **cobertura que ninguém rodava** e o **gate que teria barrado o problema na origem**.

## 1 — A prova executada da canária entra no núcleo do CI

`db/test-canaria-veredito.sh` tem 10 sabotagens que cobrem os vereditos (`ok:false`, marcador, janela, NULL-blind) e **rodava fora do CI** — que, pelo critério do próprio repo, é ausência de dado.

Não bastava uma linha no manifesto:

- o script passa a emitir `RESULTADO: <pass> ok / <fail> fail`, sem o que `roda-nucleo-ci.sh` reprova de propósito (exit 0 não prova que asseriu algo);
- `provas-sql` ganha o **runtime** bun — a prova gera o SQL pelo próprio gerador em vez de conferir um retrato commitado; sem `bun install`, porque os imports são builtins `node:*` mais um relativo;
- eixo 5 no `db/nucleo-ci.txt`, mínimo de 18 asserts.

Como `provas-sql` é required via `validate`, as sabotagens passam a bloquear merge.

**Medido:** `SQL_PROOF_OK provas=16/16`, com `test-canaria-veredito asserts=18 (≥18) 2s`.

## 2 — `>= \d+` aceita `>= 0`

Duas invariantes do controle de credencial ficaram fora do `#2397`, e as asserções existentes não as prendiam:

- **piso zerado** — as asserções casam `cred.ok_recentes >= \d+`, e `\d+` aceita `0`. Com piso zero, **uma** resposta 2xx "prova" a credencial, o oposto do que o controle existe para fazer. A asserção nova referencia `PISO_CONTROLE_CREDENCIAL` (agora exportada): ajustar o piso não pede edição de teste, zerá-lo reprova.
- **fallback do 401** — o ramo `INDETERMINADO` é o fail-CLOSED do 401 ambíguo. Trocá-lo por veredito confiante é fail-open, e nada pegava a troca.

Ambas sobreviviam antes, pegam agora.

## 3 — O gate de 9s

O `mutation-check` segue não-required pelo motivo documentado (346-533s; refactor alheio o deixa `INVÁLIDO` e travaria PR de terceiro). Mas a metade determinística dele cabe no caminho obrigatório.

`mutcheck --seco` roda só perl+diff: confere que cada padrão ainda casa o fonte e casa **uma** linha. **24 contratos em 8,8s.** O `mutcheck-seco-gate.sh` reprova só o que **este** diff introduz — quando o HEAD acusa, materializa a merge-base num worktree e compara; dívida anterior não trava PR alheio. O caminho feliz nem consulta a base.

Entra no `gates-e-falsificacao`, que já é required e já tem `fetch-depth: 0`.

O modo recusa vender o que não mediu: sumário sai `cobertura NÃO medida`, controle+ sai `n/d (seco)`, e o fecho do `mutcheck-all` deixa de dizer "nenhuma regressão de cobertura" no seco.

## Falsificação (com controle na mesma rodada)

```
árvore limpa     → rc=0  "nenhum contrato ambíguo"
bloco duplicado  → rc=1  "este diff INTRODUZIU: sonda-versao-sql.mut"  (90s)
```

A falsificação achou um bug real: o gate media a base com o sensor **dela**, e a base é anterior ao `--seco` — o script de lá ignorava a flag e rodava o modo cheio (estourou 240s). Corrigido em `fed8c3a`: o sensor de hoje é copiado para a base antes de medir.

## Evidência

| gate | resultado |
|---|---|
| `mutcheck-all` (contrato completo) | 92 mutações · 90 pegas · 2 sobreviventes (declaradas) · **0 inválidas** · controle+ ✓ (90/90) |
| `mutcheck --selftest` | ✓ mecânica intacta |
| `db/roda-nucleo-ci.sh` | `SQL_PROOF_OK provas=16/16` |
| `vitest` (sonda-versao-sql) | 157 testes |
| `typecheck` · `lint:shell` | rc=0 · rc=0 |

## Fora de escopo, de propósito

O DRY do que sobrou duplicado (CTE `controle_credencial`, ramo do 401) fica para PR separada: o arquivo está quente (`#2380`, `#2386`, `#2392`, `#2397` no mesmo dia) e é money-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)