### PR TITLE
fix(desconto-omie): o fail-closed morria um andar acima — `?? 0` na SAÍDA devolvia receita CHEIA

### DIFF
--- a/scripts/mutcheck.d/desconto-omie.mut
+++ b/scripts/mutcheck.d/desconto-omie.mut
@@ -42,6 +42,19 @@ PEGA | desconto acima da base deixa de ser anomalia       | s/if \(bruto !== nul
 PEGA | valor negativo vira desconto em vez de lixo        | s/return Number.isFinite\(n\) && n >= 0 \? n : null;/return Number.isFinite(n) ? n : null;/
 PEGA | ausente vira zero na raiz (Number(null)===0)      | s~if \(raw === null \|\| raw === undefined\) return null;~if (raw === null || raw === undefined) return 0;~
 
+# ── A SAÍDA também é porta: o fail-closed morria um passo depois de nascer ────────────────────
+# O contrato acima vigiava `Number(null)===0` na ENTRADA (`finitoNaoNegativo`) e deixava a saída
+# aberta: `receitaLiquidaItem`/`precoUnitarioLiquido` faziam `finitoNaoNegativo(discount) ?? 0`,
+# convertendo o `null` de `descontoItemOmie` — "não sei o desconto" — em receita CHEIA. Era o
+# `prod.desconto || 0` original renascido um andar acima, com o mesmo efeito: superestimar a
+# receita. Achado pela 2ª opinião (Codex, 2026-09-08) e provado executando ANTES de corrigir.
+# As duas mutações abaixo são a restauração literal do defeito; ambas TÊM de morrer.
+# Elas casam por NOME DE FUNÇÃO (flag `$f` no `perl -pe`, que guarda estado entre linhas) porque
+# a linha-alvo é textualmente IDÊNTICA nas duas funções. Número de linha seria mais simples e
+# ficaria stale no primeiro refactor — foi assim que o `.mut` da sonda quebrou a main no #2380.
+PEGA | receita: desconto desconhecido volta a virar zero  | $f=1 if /export function receitaLiquidaItem/; $f=0 if /export function precoUnitarioLiquido/; s/  const desc = finitoNaoNegativo\(discount\);/  const desc = finitoNaoNegativo(discount) ?? 0;/ if $f
+PEGA | preço unitário: desconto desconhecido vira zero    | $f=1 if /export function precoUnitarioLiquido/; s/  const desc = finitoNaoNegativo\(discount\);/  const desc = finitoNaoNegativo(discount) ?? 0;/ if $f
+
 # ── Preço unitário líquido: o desconto é da LINHA, dilui-se pela quantidade ───────────────────
 # Quem migrar por analogia com a fórmula percentual antiga (`preço × (1 − d/100)`, que já era
 # por unidade) tende a escrever `preço − desconto` e multiplicar o desconto pela quantidade.

--- a/supabase/functions/_shared/desconto-omie.ts
+++ b/supabase/functions/_shared/desconto-omie.ts
@@ -33,6 +33,30 @@
 //   3. O próprio Omie distribui o desconto de capa aos itens COMO VALOR (citação acima), e o
 //      exemplo canônico da doc traz `"tipo_desconto": "V"`.
 
+// ── O que o chamador faz com o null ───────────────────────────────────────────────────────────
+// `receitaLiquidaItem`/`precoUnitarioLiquido` devolvem `null` quando NÃO SABEM — e quem consome
+// não pode trocá-lo por 0. Com desconto, `null → 0` devolve o número CHEIO, numericamente
+// IDÊNTICO ao caso legítimo "o Omie informou que não há desconto": a fabricação fica invisível
+// na tela, sem nada para conferir. É o mesmo defeito que já renasceu duas vezes — `prod.desconto
+// || 0` na ingestão, depois `finitoNaoNegativo(discount) ?? 0` aqui dentro — e cujo próximo
+// endereço natural é exatamente o primeiro consumidor desta régua.
+//
+// A régua para quem consome, alinhada ao repo (ausente ≠ zero):
+//   1. Some só o que conhece — uma linha que degradou NÃO entra no total como 0.
+//   2. Conte as recusadas num contador SEPARADO e torne-o legível na superfície: "R$ X em 128
+//      de 130 itens" é verdade; "R$ X" com 2 itens comidos em silêncio não é.
+//   3. Nunca apresente um agregado incompleto com a mesma cara de um completo.
+//
+// ⚠️ O contra-exemplo está VIVO e é o consumidor previsto: `fin-valor-cockpit` compõe receita
+// com `l.discount ?? 0` em todos os pontos onde a monta à mão — endereço estável:
+//     git grep -n "discount ?? 0" supabase/functions/fin-valor-cockpit
+// Hoje isso é INALCANÇÁVEL, não ativo, e a diferença importa: medido em 2026-09-08,
+// `order_items.discount` tem default 0 e ZERO NULLs em 71.006 linhas, então o `?? 0` nunca
+// dispara. Ele acorda no dia em que a ingestão passar a gravar o `null` desta régua, ou quando
+// o cockpit passar a ler `order_items.desconto_valor` — nullable, sem default e 100% NULL
+// (71.006/71.006) na mesma medição. Ligar a leitura ANTES de trocar o `?? 0` converteria 71 mil
+// linhas de "não apurado" em receita cheia de uma vez só, e o total continuaria parecendo são.
+
 /** O que a API do Omie realmente devolve em `det.produto` para desconto. */
 export interface DescontoOmieBruto {
   tipo_desconto?: string | null;
@@ -124,6 +148,17 @@ export function descontoItemOmie(prod: DescontoOmieBruto | null | undefined, bru
  *
  * Devolve `null` quando o preço é desconhecido: `Number(null) === 0` transformaria "não sei o
  * preço" em "receita zero", que com custo cheio vira margem negativa fabricada.
+ *
+ * ⚠️ E devolve `null` quando o DESCONTO é desconhecido — o eixo que este módulo existe para
+ * proteger. `discount` nulo tem duas origens, e nenhuma delas é "não há desconto": ou
+ * `descontoItemOmie` recusou-se a ler (discriminador ambíguo, percentual fora de faixa,
+ * desconto maior que a base), ou a linha é anterior à apuração e `order_items.desconto_valor`
+ * ainda é NULL. `0` é a ÚNICA forma de dizer "o Omie informou que não há desconto".
+ *
+ * Tratar esse `null` como 0 devolveria a receita CHEIA — numericamente idêntica ao caso sem
+ * desconto — e seria o bug original (`prod.desconto || 0`) renascido um andar acima, com a
+ * mesma assinatura: superestimar a receita silenciosamente. Quem chama deve somar só o que
+ * conhece e tornar a incompletude legível (ver §"O que o chamador faz com o null" no cabeçalho).
  */
 export function receitaLiquidaItem(
   unitPrice: number | null | undefined,
@@ -134,7 +169,8 @@ export function receitaLiquidaItem(
   if (preco === null) return null;
   const qtd = finitoNaoNegativo(quantity);
   if (qtd === null) return null;
-  const desc = finitoNaoNegativo(discount) ?? 0;
+  const desc = finitoNaoNegativo(discount);
+  if (desc === null) return null;
   return Math.round((preco * qtd - desc) * 100) / 100;
 }
 
@@ -147,7 +183,9 @@ export function receitaLiquidaItem(
  * fabricada. É a armadilha específica da troca de unidade: a fórmula percentual antiga
  * `preço × (1 − d/100)` já era por unidade, então quem migrar por analogia direta erra aqui.
  *
- * `null` quando o preço é desconhecido ou a quantidade não serve de divisor.
+ * `null` quando o preço é desconhecido, quando a quantidade não serve de divisor, ou quando o
+ * DESCONTO é desconhecido — pela mesma razão de `receitaLiquidaItem`: desconto nulo tratado como
+ * zero devolve o preço CHEIO, que é o número superestimado que este módulo existe para impedir.
  */
 export function precoUnitarioLiquido(
   unitPrice: number | null | undefined,
@@ -158,6 +196,7 @@ export function precoUnitarioLiquido(
   if (preco === null) return null;
   const qtd = finitoNaoNegativo(quantity);
   if (qtd === null || qtd === 0) return null;
-  const desc = finitoNaoNegativo(discount) ?? 0;
+  const desc = finitoNaoNegativo(discount);
+  if (desc === null) return null;
   return Math.round((preco - desc / qtd) * 100) / 100;
 }

--- a/supabase/functions/_shared/desconto-omie_test.ts
+++ b/supabase/functions/_shared/desconto-omie_test.ts
@@ -113,7 +113,32 @@ Deno.test("DISCRIMINANTE: receitaLiquidaItem SUBTRAI o desconto, não multiplica
   eq(receitaLiquidaItem(100, 2, 10), 190, "absoluto: 190");
   eq(receitaLiquidaItem(100, 2, 10) === 180, false, "NÃO é a fórmula percentual");
   eq(receitaLiquidaItem(100, 2, 0), 200, "sem desconto");
-  eq(receitaLiquidaItem(100, 2, null), 200, "desconto ausente conta como zero desconto");
+});
+
+// DISCRIMINANTE do fail-closed na SAÍDA. O teste anterior fixava `receitaLiquidaItem(100,2,null)
+// === 200` — "desconto ausente conta como zero desconto" — e isso era o bug original renascido:
+// `descontoItemOmie` recusa-se a ler o desconto (null), o consumidor troca por 0, e a receita
+// volta CHEIA. 200 é exatamente o número superestimado que este módulo existe para impedir; o
+// contrato de mutação vigiava `Number(null)===0` na ENTRADA (`finitoNaoNegativo`) e deixava a
+// SAÍDA aberta. Achado pela 2ª opinião (Codex, 2026-09-08) e provado executando.
+Deno.test("DISCRIMINANTE: desconto DESCONHECIDO não vira zero — receita degrada para null", () => {
+  // O caminho real: o Omie mandou um discriminador que não sabemos ler, COM desconto > 0.
+  const desconhecido = descontoItemOmie({ tipo_desconto: "X", valor_desconto: 10 }, 200);
+  eq(desconhecido, null, "pré-condição: a leitura degradou");
+
+  eq(receitaLiquidaItem(100, 2, desconhecido), null, "não sei o desconto ⇒ não sei a receita");
+  eq(receitaLiquidaItem(100, 2, desconhecido) === 200, false, "NÃO é a receita cheia (fabricação)");
+  eq(precoUnitarioLiquido(100, 2, desconhecido), null, "não sei o desconto ⇒ não sei o preço");
+  eq(precoUnitarioLiquido(100, 2, desconhecido) === 100, false, "NÃO é o preço cheio (fabricação)");
+
+  // A linha ainda não apurada (`order_items.desconto_valor` NULL, o acervo inteiro hoje) entra
+  // pelo mesmo portão: NULL é "não apurado", nunca "não há desconto".
+  eq(receitaLiquidaItem(100, 2, null), null, "coluna não apurada ⇒ null");
+  eq(receitaLiquidaItem(100, 2, undefined), null, "desconto não informado ⇒ null");
+
+  // E o contraste que prova que o portão não fechou DEMAIS: 0 é dado, e passa.
+  eq(receitaLiquidaItem(100, 2, 0), 200, "0 é 'o Omie informou que não há desconto' — é dado");
+  eq(precoUnitarioLiquido(100, 2, 0), 100, "idem no preço unitário");
 });
 
 Deno.test("receitaLiquidaItem degrada para null quando o preço é desconhecido", () => {


### PR DESCRIPTION
## O defeito

`receitaLiquidaItem`/`precoUnitarioLiquido` faziam `finitoNaoNegativo(discount) ?? 0`.

O contrato de mutação vigiava `Number(null)===0` na **entrada** (`finitoNaoNegativo`) e deixava a **saída** aberta: o `null` de `descontoItemOmie` — *"não sei o desconto"* — virava `0`, e a receita voltava **cheia**, numericamente idêntica ao caso legítimo *"não há desconto"*. Era o `prod.desconto || 0` original renascido um andar acima, com a mesma assinatura: superestimar a receita em silêncio, sem nada na tela para conferir.

Achado pela 2ª opinião (Codex) e provado **executando** antes de corrigir.

O teste antigo **fixava** o defeito:

```ts
eq(receitaLiquidaItem(100, 2, null), 200, "desconto ausente conta como zero desconto");
```

## O que muda

- As duas funções degradam para `null` quando o desconto é desconhecido.
- Discriminante novo cobre as **duas** origens do desconhecido (leitura recusada · coluna não apurada) e mantém o contraste que prova que o portão **não fechou demais**: `0` é dado e passa.
- Duas mutações novas no contrato, casando por **nome de função** (flag `$f` no perl) porque a linha-alvo é textualmente idêntica nas duas — número de linha ficaria stale no primeiro refactor, que foi como o `.mut` da sonda quebrou a main no #2380.

## O que a revisão desta entrega encontrou

O comentário remetia a `§"O que o chamador faz com o null"` — **seção que não existia**. Fui atrás do porquê e achei o contexto que faltava:

**O módulo não tem um único chamador no repo.** A régua foi escrita, testada e vigiada, e nunca plugada. Medido via psql-ro em 2026-09-08:

| Camada | Estado |
|---|---|
| régua (`desconto-omie.ts`) | existe, 1056 testes, contrato de mutação |
| escrita (`omie-vendas-sync` → `desconto_valor`) | **não ligada** — 0 de 71.006 linhas preenchidas |
| leitura (`fin-valor-cockpit`) | **não ligada** — ainda faz `l.discount ?? 0` |

Então a seção que faltava é o artefato que mais importa aqui: é o que impede o **primeiro** consumidor de reescrever o `?? 0` um andar acima pela terceira vez. Ela agora existe, e documenta o contra-exemplo **vivo** — com endereço por `git grep`, não por número de linha — e por que ele hoje é **inalcançável e não ativo**: `order_items.discount` tem default 0 e **zero NULLs** em 71.006 linhas; `desconto_valor` é nullable, sem default e **100% NULL** (71.006/71.006). O `?? 0` acorda no dia em que a ingestão gravar o `null` desta régua, ou quando o cockpit ler a coluna nova.

**Este PR não liga as fases 2 e 3** — é money-path em edge de produção e merece entrega própria.

## Evidência

| Gate | Resultado |
|---|---|
| `test:edges` | **1056 passed, 0 failed** — exit 0 (revalidado pós-rebase) |
| `edges:typecheck` | **0 erros de classe-crash** — exit 0 |
| `mutcheck` | 17 mutações · **16 pegas · 1 sobrevivente esperado · 0 inválidas** · controle+ 16/16 · **0 problemas** |

As duas mutações novas, nominalmente:

```
PEGA      receita: desconto desconhecido volta a virar zero ✓ PEGA
PEGA      preço unitário: desconto desconhecido vira zero ✓ PEGA
```

Risco específico da edição de comentário (as strings `?? 0` inseridas no cabeçalho poderiam capturar regexes do `.mut` e tornar mutações inválidas) foi descartado por duas medições diretas — aridade de 1 linha por mutação, e alvo sempre em linha de código, nunca comentário — e depois pelo mutcheck completo, verde e idêntico ao de antes da edição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
