### PR TITLE
fix(canaria): o gate novo reprovava TODO PR que tocasse qualquer edge — 5 travados de uma vez

### DIFF
--- a/db/test-canaria-veredito.sh
+++ b/db/test-canaria-veredito.sh
@@ -43,11 +43,27 @@ BARATAS="copilot-analyze omie-analytics-sync:doc_ambiguo_probe omie-financeiro"
 CARA="generate-tactical-plan"
 GERADO="$TMP/gerado.sql"
 # shellcheck disable=SC2086  # a lista de nomes é intencionalmente dividida em argumentos
-if ! (cd "$RAIZ" && bun scripts/sonda-versao-sql.ts --canaria $BARATAS "$CARA" --sem-rede) > "$GERADO" 2>"$TMP/gen.err"; then
+# `SONDA_REF_DEPLOYADA=HEAD`: este teste usa o gerador como produtor de TEXTO — ele compara o
+# SQL com um esperado e NÃO sonda prod nenhuma, então sincronia com o que está no ar é
+# irrelevante aqui. Sem isto o guard reprova todo PR que toque QUALQUER edge: ele compara o
+# working tree com `origin/main`, e no CI de um PR o working tree é o merge commit, que por
+# definição ainda não mergeou. Medido em 2026-09-09 — `provas-sql` verde na main e VERMELHO
+# em 5 PRs abertos simultâneos. Apontando para HEAD o guard compara o disco consigo mesmo:
+# as 5 portas continuam sendo exercitadas, muda só o alvo. E o SQL sai CARIMBADO como
+# ref não-padrão, então este artefato nunca passa por prova de deploy.
+if ! (cd "$RAIZ" && SONDA_REF_DEPLOYADA=HEAD bun scripts/sonda-versao-sql.ts --canaria $BARATAS "$CARA" --sem-rede) > "$GERADO" 2>"$TMP/gen.err"; then
   echo "VERMELHO — o gerador falhou:"; cut -c1-400 "$TMP/gen.err"; exit 1
 fi
 # Sonda POSITIVA: geração vazia/silenciosa viraria suíte verde sobre SQL nenhum.
 grep -q 'AS veredito' "$GERADO" || { echo "VERMELHO — SQL gerado não tem CASE de veredito"; exit 1; }
+# O SQL gerado com ref NÃO-PADRÃO tem de se DENUNCIAR no próprio texto. É o que impede a env
+# `SONDA_REF_DEPLOYADA` de virar porta dos fundos: sem o carimbo, um artefato gerado fora do
+# padrão seria indistinguível de um conferido contra a main, e o "BUNDLE VELHO" dele passaria por
+# veredito de deploy. Some o carimbo, esta linha fica VERMELHA.
+grep -q 'ref NÃO-PADRÃO' "$GERADO" || {
+  echo "VERMELHO — SQL gerado com SONDA_REF_DEPLOYADA=HEAD não veio CARIMBADO como ref não-padrão"
+  exit 1
+}
 grep -q 'net.http_post' "$GERADO" || { echo "VERMELHO — SQL gerado não dispara nada"; exit 1; }
 
 # extrai_leitura <ordinal> <arquivo_sql> — o corpo do n-ésimo `format($sonda$…$sonda$`, que é o

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -171,7 +171,29 @@ export function lerProjectRef(raiz: string): string {
 /** O que o Lovable deploya. Não é o `<sha>` do PR nomeado: é a MAIN (#2123). */
 const REMOTO = 'origin';
 const RAMO_DEPLOYADO = 'main';
-const REF_DEPLOYADA = `${REMOTO}/${RAMO_DEPLOYADO}`;
+/**
+ * Contra o que o guard de sincronia compara o disco. `origin/main` é a resposta em TODO uso real,
+ * porque é o que o Lovable deploya — e é o default quando a env não existe.
+ *
+ * A env existe por um defeito MEDIDO (2026-09-09): o guard compara o working tree com
+ * `origin/main`, e no CI de um PR o working tree é o merge commit — que por definição ainda NÃO
+ * está na main. Como `sonda-fingerprints.ts` entra sempre em `fatiaDaVerdade()`, e esse arquivo
+ * muda em QUALQUER PR que toque QUALQUER edge, o gate reprovava a fila inteira: medido com
+ * `provas-sql` **success na main** e **fail nos 5 PRs abertos** (#2405, #2407, #2412, #2413,
+ * #2415) no mesmo dia em que `db/test-canaria-veredito.sh` entrou no núcleo (#a1d25a38a).
+ *
+ * Quem precisa disso é o TESTE, não o operador: ele usa o gerador como produtor de TEXTO para
+ * comparar com um esperado, e não vai sondar prod nenhuma — a sincronia com o que está no ar é
+ * irrelevante ali. Apontando a ref para `HEAD`, o guard compara o disco consigo mesmo e continua
+ * EXERCITADO (as 5 portas rodam; o que muda é só o alvo da comparação).
+ *
+ * Por que isto não é uma porta dos fundos: o SQL emitido CARIMBA a ref usada no cabeçalho, então
+ * um artefato gerado fora do padrão se denuncia no próprio texto que alguém colaria. E o default
+ * segue fail-closed — não setar a env é o caminho normal.
+ */
+const REF_DEPLOYADA = process.env.SONDA_REF_DEPLOYADA?.trim() || `${REMOTO}/${RAMO_DEPLOYADO}`;
+/** `true` quando o guard NÃO está comparando com o que o Lovable deploya — vai para o SQL. */
+const REF_NAO_PADRAO = REF_DEPLOYADA !== `${REMOTO}/${RAMO_DEPLOYADO}`;
 
 /** O comando que conserta o worktree defasado — o mesmo que a mensagem de aborto entrega. */
 const CORRECAO = `git fetch ${REMOTO} && git merge --ff-only ${REF_DEPLOYADA}`;
@@ -302,6 +324,19 @@ export function conferirSincronia(
     );
   }
 
+  // Ref não-padrão CARIMBA o SQL, sempre — inclusive com rede. É o que impede a env de virar
+  // porta dos fundos silenciosa: quem colar o artefato lê, no próprio texto, contra o que ele foi
+  // conferido. Sem isto, um SQL gerado com `SONDA_REF_DEPLOYADA=HEAD` seria indistinguível de um
+  // gerado contra a main — e o veredito "BUNDLE VELHO" dele não valeria nada.
+  if (REF_NAO_PADRAO) {
+    return {
+      aviso:
+        `⚠️ ref NÃO-PADRÃO: o guard comparou o disco com \`${REF_DEPLOYADA}\`, não com ` +
+        `\`${REMOTO}/${RAMO_DEPLOYADO}\` (via SONDA_REF_DEPLOYADA). Isso existe para TESTE — o ` +
+        'veredito abaixo NÃO prova sincronia com o que o Lovable deploya. Não use este SQL para ' +
+        'decidir deploy.',
+    };
+  }
   if (!semRede) return { aviso: null };
   const data = git(['log', '-1', '--format=%ci', REF_DEPLOYADA]);
   const idade = data.status === 0 && data.stdout.trim() !== '' ? data.stdout.trim() : 'data desconhecida';


### PR DESCRIPTION
## O incidente

`db/test-canaria-veredito.sh` entrou no núcleo do CI ontem (`a1d25a38a`) e gera o SQL pelo `scripts/sonda-versao-sql.ts`. Esse gerador tem um guard fail-closed que exige o working tree **idêntico à `origin/main`** na fatia que vira o `esperado(...)`.

**O guard está certo no uso real:** o `esperado()` sai do disco e o veredito compara com o que prod serve — disco atrasado produziria "BUNDLE VELHO SERVINDO" numa edge que está no ar.

O problema é onde ele foi parar. No CI de um PR o working tree é o **merge commit**, que por definição ainda não está na main. E `fatiaDaVerdade()` inclui **sempre** o `_shared/sonda-fingerprints.ts` — arquivo que muda em qualquer PR que toque qualquer edge.

## Medido, com controle

| | `provas-sql` |
|---|---|
| `main` | **success** |
| #2405 · #2407 · #2412 · #2413 · #2415 | **fail** (todos) |

Cinco PRs de sessões diferentes, o mesmo job, no dia seguinte ao gate entrar.

## A correção

O teste usa o gerador como **produtor de texto** — compara o SQL com um esperado e não sonda prod nenhuma, então sincronia com o que está no ar é irrelevante ali. `REF_DEPLOYADA` passa a aceitar override por `SONDA_REF_DEPLOYADA`, e o teste aponta para `HEAD`: o guard compara o disco consigo mesmo e continua **exercitado** — as 5 portas rodam, muda só o alvo da comparação.

## Por que isto não é uma porta dos fundos

- o **default** segue `origin/main` — não setar a env é o caminho normal, e continua fail-closed;
- ref não-padrão **carimba o SQL emitido**: `⚠️ ref NÃO-PADRÃO … NÃO prova sincronia com o que o Lovable deploya. Não use este SQL para decidir deploy.` O artefato se denuncia no próprio texto que alguém colaria;
- o teste **asserta o carimbo**. Falsificado: com o bloco do carimbo desligado, ele fica vermelho (`SQL gerado … não veio CARIMBADO`), com controle verde na mesma invocação.

Verificado dos dois lados: **sem** a env e com disco divergente, o guard segue abortando com `DESSINCRONIZADO` (exit 1); **com** a env e working tree == HEAD (a situação do CI), exit 0 e SQL carimbado.

## Prova

```
db/test-canaria-veredito.sh    19 ok / 0 fail
sonda-versao-sql.test.ts       157 testes ✅
scripts:typecheck              ✅
lint:shell                     ✅
```

Este PR não toca `sonda-fingerprints.ts`, então ele mesmo não cai na armadilha que conserta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)