### PR TITLE
fix(db-aplicar): a migration do repo vem com `BEGIN;`/`COMMIT;` — e isso a impedia de aplicar

### DIFF
--- a/scripts/db-aplicar.sh
+++ b/scripts/db-aplicar.sh
@@ -92,6 +92,31 @@ trap 'rm -f "$SNAP"' EXIT
 
 SHA="$(shasum -a 256 "$SNAP" | awk '{print $1}')"
 COMMIT="$(git rev-parse --short HEAD)"
+
+# ── DESENVELOPAR a transação do arquivo ──────────────────────────────────────────────────────
+# As migrations deste repo saem da skill `lovable-db-operator` envolvidas em `BEGIN; … COMMIT;`
+# — e isso está CERTO para quem cola no SQL Editor. Aqui não: o corpo viaja como parâmetro de
+# `aplicar_sql()`, executado com `EXECUTE` dentro de PL/pgSQL, onde comando de transação é
+# proibido (`ERROR: EXECUTE of transaction commands is not implemented`). A transação já é minha,
+# com `SET LOCAL` de timeout e o recibo dentro dela.
+#
+# Medido em 2026-09-09, no ENSAIO (que é para isso que ele existe): a migration da onda 3 morreu
+# nessa linha antes de tocar o banco de verdade.
+#
+# O SHA continua sendo o do ARQUIVO COMMITADO — a identidade é o que está no repo, não o derivado.
+# E o desenvelopamento é fail-CLOSED: só o par exato `BEGIN;` na primeira linha útil + `COMMIT;`
+# na última é removido. `ROLLBACK`, `SAVEPOINT`, `BEGIN` no meio ou repetido ⇒ RECUSA, porque aí
+# a semântica que o autor quis não cabe numa transação só e adivinhar seria pior que parar.
+DESENV="$(dirname "$0")/lib/desenvelopar-transacao.awk"
+[ -f "$DESENV" ] || morre 2 "falta $DESENV — recuso aplicar sem o desenvelopador"
+SNAP_ENV="$LOG_DIR/db-aplicar-corpo.$$.env"
+if ! awk -f "$DESENV" "$SNAP" > "$SNAP_ENV" 2>/dev/null; then
+  rm -f "$SNAP_ENV"
+  morre 2 "o arquivo tem controle de transação que eu não sei desenvelopar com segurança
+   (esperado: no máximo UM \`BEGIN;\` na primeira linha útil e UM \`COMMIT;\` na última).
+   \`ROLLBACK\`, \`SAVEPOINT\` ou \`BEGIN\` repetido/no meio exigem decisão humana."
+fi
+mv "$SNAP_ENV" "$SNAP"
 case "$SHA" in
   *[!0-9a-f]*|'') morre 2 "sha256 com formato inesperado para $ARQUIVO" ;;
 esac

--- a/scripts/lib/desenvelopar-transacao.awk
+++ b/scripts/lib/desenvelopar-transacao.awk
@@ -1,0 +1,23 @@
+# Remove UM `BEGIN;` inicial e UM `COMMIT;` final do corpo — e RECUSA qualquer outra forma.
+# Rastreia dollar-quoting ($tag$) para não confundir o `BEGIN` do PL/pgSQL, que vem sem `;`.
+BEGIN { dq=0; nb=0; nc=0; outros=0; primeira=0; ultima=0; n=0 }
+{
+  linha[++n] = $0
+  s = $0
+  sub(/--.*$/, "", s)                       # comentário de linha
+  gsub(/[ \t]+$/, "", s); gsub(/^[ \t]+/, "", s)
+  tmp = $0
+  while (match(tmp, /\$[A-Za-z_0-9]*\$/)) { dq = 1 - dq; tmp = substr(tmp, RSTART+RLENGTH) }
+  if (dq != 0) next                          # dentro de bloco dollar-quoted: ignora
+  u = toupper(s)
+  if (u == "BEGIN;")  { nb++; if (primeira==0) primeira=n; else outros++ }
+  else if (u == "COMMIT;") { nc++; ultima=n }
+  else if (u ~ /^(ROLLBACK|SAVEPOINT|START TRANSACTION)/) { outros++ }
+  else if (s != "") { if (primeira==0) primeiraNaoVazia=n }
+}
+END {
+  if (nb==0 && nc==0) { for (i=1;i<=n;i++) print linha[i]; exit 0 }        # nada a fazer
+  if (nb!=1 || nc!=1 || outros>0) { print "RECUSA" > "/dev/stderr"; exit 3 }
+  if (primeira > primeiraNaoVazia && primeiraNaoVazia>0) { print "RECUSA" > "/dev/stderr"; exit 3 }
+  for (i=1;i<=n;i++) if (i!=primeira && i!=ultima) print linha[i]
+}


### PR DESCRIPTION
## O que o ensaio pegou

O `db:aplicar` (novo, de `#2405`) manda o corpo como parâmetro de `aplicar_sql()`, executado com `EXECUTE` dentro de PL/pgSQL — onde comando de transação é proibido. Mas as migrations deste repo saem da skill `lovable-db-operator` envolvidas em `BEGIN; … COMMIT;`, e isso está **certo** para quem cola no SQL Editor.

As duas peças foram construídas em paralelo e não se encontravam. Na primeira tentativa real de aplicar uma migration por aqui:

```
❌ ERROR: EXECUTE of transaction commands is not implemented
   CONTEXTO: PL/pgSQL function aplicar_sql(text,text,bigint) line 40 at EXECUTE
```

**Nada tocou o banco** — foi o `--ensaio` que pegou, que é exatamente para isso que ele existe.

## A correção, e por que é fail-closed

Desenvelopa a transação do corpo — mas só o par **exato**: `BEGIN;` na primeira linha útil + `COMMIT;` na última. Qualquer outra forma **recusa**, porque aí a semântica que o autor quis não cabe numa transação só, e adivinhar seria pior que parar.

O `awk` rastreia dollar-quoting, então o `BEGIN` do PL/pgSQL — que vem **sem** `;`, dentro de `$post$` — é preservado. Ele é o corpo da postcondição de toda migration daqui.

Falsificado nos dois sentidos, com controle:

| corpo | resultado |
|---|---|
| `BEGIN;` / `SELECT` / `ROLLBACK;` / `COMMIT;` | recusa (exit 3) |
| `BEGIN;` / `SELECT` / `BEGIN;` / `COMMIT;` | recusa (exit 3) |
| `SELECT;` / `BEGIN;` / `SELECT;` / `COMMIT;` | recusa (exit 3) — `BEGIN` fora da 1ª linha útil |
| `DO $p$ BEGIN … END $p$;` | passa, e o `BEGIN` do PL/pgSQL sobrevive |

## O que não muda

O **SHA continua sendo o do arquivo commitado**. A identidade no ledger é o que está no repo, não o derivado que foi executado — senão o `db_aplicacoes` apontaria para bytes que ninguém consegue recuperar depois.

## Prova

```
lint:shell   399 arquivos, 0 achados ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)