### PR TITLE
fix(canaria): o guard comparava o mapa INTEIRO — e travava todo PR que tocasse uma edge

### DIFF
--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -10,8 +10,10 @@ import { removerComentarios } from '@/lib/gates/limpeza-fonte';
 
 import {
   CANARIAS,
+  entradaDoMapa,
   escaparParaFormat,
   fatiaDaVerdade,
+  mapaDivergeNaEdge,
   gerarSqlDaLeva,
   gerarSqlDasCanarias,
   gitReal,
@@ -1888,3 +1890,113 @@ describe('CLI do modo canária — as flags sem sentido são RECUSADAS, não ign
     expect(erros.join('\n')).toMatch(/DESSINCRONIZADO/);
   });
 });
+
+// ── A fatia do MAPA: por ENTRADA, não pelo arquivo inteiro ────────────────────────────────────
+// O guard comparava `sonda-fingerprints.ts` byte a byte com a origin/main. O mapa é GERADO, cobre
+// as ~60 edges, e o fingerprint é TRANSITIVO dos imports locais — então mexer em UM `_shared/`
+// muda a entrada de toda edge que o alcança. Combinado com o gate `sonda:fingerprint`, que EXIGE
+// regravar o mapa quando uma edge muda, os dois se tornavam mutuamente exclusivos: nenhum PR que
+// tocasse uma edge instrumentada passava nos dois. Medido em 2026-09-09 nos PRs #2412 e #2405,
+// que falharam com a MESMA mensagem; o último PR de edge a mergear (#2404) passou numa janela de
+// corrida, antes de a canária entrar no núcleo do CI pelo #2403.
+//
+// A fatia certa nunca foi o arquivo: o `esperado(...)` de uma canária consome a entrada DAQUELA
+// edge. A entrada de uma edge que ninguém está sondando não produz veredito falso para nenhuma.
+describe('fatia do mapa — entrada da edge sondada, não o arquivo inteiro', () => {
+  // Hex de verdade: o mapa real guarda sha256, e o extrator exige `[0-9a-f]+` para que uma
+  // entrada malformada devolva `null` (⇒ divergência) em vez de casar qualquer coisa. Fixture
+  // com "ZZZ" faria asserts passarem por acidente — `null !== 'bbb'` também é "diverge".
+  const MAPA_A = [
+    'export const FONTE_SHA256: Record<string, string> = {',
+    '  "copilot-analyze": "aa11",',
+    '  "omie-vendas-sync": "bb22",',
+    '};',
+  ].join('\n');
+  // Só `omie-vendas-sync` mudou — exatamente o que acontece quando um PR toca UMA edge.
+  const MAPA_B = MAPA_A.replace('"bb22"', '"cc33"');
+
+  it('entrada de OUTRA edge divergindo não é divergência para a sondada', () => {
+    expect(entradaDoMapa(MAPA_A, 'copilot-analyze')).toBe(entradaDoMapa(MAPA_B, 'copilot-analyze'));
+  });
+
+  it('entrada da PRÓPRIA edge divergindo continua sendo divergência', () => {
+    // O contraste que prova que o guard não foi apenas afrouxado: se a entrada da edge sondada
+    // mudar, o `esperado(...)` sai errado e o veredito vira "BUNDLE VELHO" numa edge no ar.
+    expect(entradaDoMapa(MAPA_A, 'omie-vendas-sync')).not.toBe(entradaDoMapa(MAPA_B, 'omie-vendas-sync'));
+  });
+
+  it('entrada AUSENTE devolve null, e null nunca casa com null', () => {
+    // Fail-closed: se as duas pontas devolvessem `null` e `null === null` fosse aceito, uma edge
+    // fora do mapa (o caso que o `sonda:fingerprint` existe para barrar) passaria como sincronizada.
+    expect(entradaDoMapa(MAPA_A, 'nao-existe')).toBeNull();
+    expect(mapaDivergeNaEdge(MAPA_A, MAPA_A, 'nao-existe')).toBe(true);
+  });
+
+  it('mapaDivergeNaEdge decide pelas entradas: mesma edge igual, outra edge irrelevante', () => {
+    expect(mapaDivergeNaEdge(MAPA_A, MAPA_B, 'copilot-analyze')).toBe(false);
+    expect(mapaDivergeNaEdge(MAPA_A, MAPA_B, 'omie-vendas-sync')).toBe(true);
+  });
+
+  it('a entrada é casada pelo NOME exato — prefixo não passa por ela', () => {
+    // `omie-vendas` é prefixo de `omie-vendas-sync`. Casar por prefixo leria o hash da edge errada
+    // e compararia duas coisas diferentes achando que são a mesma.
+    const mapa = MAPA_A.replace('"omie-vendas-sync": "bb22",', '"omie-vendas": "dd44",\n  "omie-vendas-sync": "bb22",');
+    expect(entradaDoMapa(mapa, 'omie-vendas')).toBe('dd44');
+    expect(entradaDoMapa(mapa, 'omie-vendas-sync')).toBe('bb22');
+  });
+
+  it('o guard REAL deixa passar um mapa que mudou só fora da fatia sondada', () => {
+    // O caso de produção: um PR mexe numa edge que a canária não sonda. Antes, isto abortava.
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+      git: gitEspelhoMapaAlterado(RAIZ_REPO, 'omie-vendas-sync'),
+      lerCanarias: lerCanariasReal,
+    });
+    expect(erros.join('\n')).not.toMatch(/DESSINCRONIZADO/);
+    expect(rc).toBe(0);
+    expect(saida.join('')).toContain('AS veredito');
+  });
+
+  it('o guard REAL continua abortando quando a entrada da edge SONDADA muda', () => {
+    // O par do anterior. Sem ele, o teste acima aprovaria um guard que nunca aborta.
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+      git: gitEspelhoMapaAlterado(RAIZ_REPO, 'copilot-analyze'),
+      lerCanarias: lerCanariasReal,
+    });
+    expect(rc).toBe(1);
+    expect(saida).toHaveLength(0);
+    expect(erros.join('\n')).toMatch(/DESSINCRONIZADO/);
+  });
+});
+
+/** Espelho que devolve o repo real, mas com a entrada de UMA edge trocada no mapa — o retrato
+ *  fiel do que um PR produz ao mexer numa edge (o fingerprint dela muda, o resto fica). */
+function gitEspelhoMapaAlterado(raiz: string, edgeAlterada: string): ExecutorGit {
+  return (args) => {
+    if (args[0] === 'fetch') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'rev-parse') return { status: 0, stdout: 'abc123456789\n', stderr: '' };
+    if (args[0] === 'show') {
+      const caminho = args[1].slice(args[1].indexOf(':') + 1);
+      try {
+        const conteudo = readFileSync(join(raiz, caminho), 'utf8');
+        if (!caminho.endsWith('sonda-fingerprints.ts')) return { status: 0, stdout: conteudo, stderr: '' };
+        const re = new RegExp(`("${edgeAlterada}":\\s*")([0-9a-f]+)(")`);
+        if (!re.test(conteudo)) throw new Error(`espelho inútil: ${edgeAlterada} não está no mapa real`);
+        return { status: 0, stdout: conteudo.replace(re, '$1deadbeef$3'), stderr: '' };
+      } catch (e) {
+        if (e instanceof Error && e.message.startsWith('espelho inútil')) throw e;
+        return { status: 1, stdout: '', stderr: 'no such path' };
+      }
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -212,6 +212,33 @@ export function fatiaDaVerdade(edges: string[]): string[] {
   return [...edges.map((e) => `supabase/functions/${e}/versao.ts`), ARQ_MAPA];
 }
 
+/**
+ * O fingerprint de UMA edge dentro do mapa, ou `null` se ela não estiver lá.
+ *
+ * O mapa é gerado e cobre as ~60 edges; comparar o ARQUIVO seria comparar 60 fatos para usar um.
+ * O `\b` no fim do nome importa: `omie-vendas` é prefixo de `omie-vendas-sync`, e casar por
+ * prefixo leria o hash da edge errada achando que são a mesma.
+ */
+export function entradaDoMapa(fonteDoMapa: string, edge: string): string | null {
+  const m = new RegExp(`"${edge.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"\\s*:\\s*"([0-9a-f]+)"`).exec(fonteDoMapa);
+  return m ? m[1] : null;
+}
+
+/**
+ * O mapa diverge NA edge sondada?
+ *
+ * Fail-CLOSED em duas direções, e a segunda é a que não é óbvia: entrada AUSENTE de qualquer lado
+ * conta como divergência. Se `null === null` fosse aceito, uma edge fora do mapa — exatamente o
+ * caso que o `sonda:fingerprint` existe para barrar — passaria por aqui como "sincronizada", e o
+ * `esperado(...)` sairia sem fingerprint nenhum.
+ */
+export function mapaDivergeNaEdge(mapaLocal: string, mapaDeployado: string, edge: string): boolean {
+  const local = entradaDoMapa(mapaLocal, edge);
+  const deployado = entradaDoMapa(mapaDeployado, edge);
+  if (local === null || deployado === null) return true;
+  return local !== deployado;
+}
+
 /** O que o guard concluiu. `aviso` só existe no caminho `--sem-rede`, que degradou de propósito. */
 export interface ResultadoSincronia {
   aviso: string | null;
@@ -280,7 +307,27 @@ export function conferirSincronia(
       ausentes.push(caminho);
       continue;
     }
-    if (r.stdout !== readFileSync(join(raiz, caminho), 'utf8')) divergentes.push(caminho);
+    const local = readFileSync(join(raiz, caminho), 'utf8');
+    if (caminho === ARQ_MAPA) {
+      // O MAPA compara-se por ENTRADA, não byte a byte — e a diferença não é folga, é precisão.
+      //
+      // Ele é gerado, cobre as ~60 edges, e o fingerprint é TRANSITIVO dos imports locais: mexer
+      // em UM `_shared/` muda a entrada de toda edge que o alcança. Como o gate `sonda:fingerprint`
+      // EXIGE regravar o mapa quando uma edge muda, a comparação byte a byte tornava os dois gates
+      // mutuamente exclusivos — nenhum PR que tocasse uma edge instrumentada passava nos dois.
+      // Medido em 2026-09-09: os PRs #2412 e #2405, de sessões diferentes, reprovaram com a MESMA
+      // mensagem; o último PR de edge a mergear (#2404) passou numa janela de corrida, antes de a
+      // canária entrar no núcleo do CI pelo #2403.
+      //
+      // A fatia certa nunca foi o arquivo. O `esperado(...)` de uma canária consome a entrada
+      // DAQUELA edge; a entrada de uma edge que ninguém está sondando não produz veredito falso
+      // para nenhuma. O que o guard fecha — retrato velho virando "BUNDLE VELHO SERVINDO" — segue
+      // fechado, porque a entrada da edge sondada continua sendo comparada, e ausência em qualquer
+      // ponta conta como divergência.
+      if (edges.some((e) => mapaDivergeNaEdge(local, r.stdout, e))) divergentes.push(caminho);
+      continue;
+    }
+    if (r.stdout !== local) divergentes.push(caminho);
   }
 
   if (ausentes.length > 0 || divergentes.length > 0) {


### PR DESCRIPTION
fix(canaria): o guard comparava o mapa INTEIRO — e travava todo PR que tocasse uma edge

## O deadlock

Dois gates do CI eram mutuamente exclusivos:

- `sonda:fingerprint` EXIGE regravar `_shared/sonda-fingerprints.ts` quando uma edge muda;
- `test-canaria-veredito` exigia que esse arquivo fosse IDÊNTICO a `origin/main`.

Nenhum PR que alterasse uma edge instrumentada satisfazia os dois. E não é só "uma edge": o
fingerprint é TRANSITIVO dos imports locais, então mexer em UM `_shared/` muda a entrada de toda
edge que o alcança — foi assim que uma mudança em `itens-com-pedido.ts` alterou o hash de
`omie-analytics-sync`, que é uma das quatro canárias.

Medido em 2026-09-09: os PRs #2412 e #2405, de sessões diferentes, reprovaram com a MESMA
mensagem. O último PR de edge a mergear (#2404) passou numa janela de corrida — o CI dele rodou
antes de a canária entrar no núcleo pelo #2403.

## A correção

A fatia certa nunca foi o arquivo. O `esperado(edge, versao, fonte)` de uma canária consome a
entrada DAQUELA edge; a entrada de uma edge que ninguém está sondando não produz veredito falso
para nenhuma. O mapa passa a ser comparado por ENTRADA das edges sondadas.

Não é afrouxamento: o que o guard fecha — retrato velho virando "BUNDLE VELHO SERVINDO" numa edge
que está no ar — segue fechado, porque a entrada da edge sondada continua sendo comparada. E
`mapaDivergeNaEdge` é fail-closed nas duas direções: entrada AUSENTE de qualquer ponta conta como
divergência, senão uma edge fora do mapa (o caso que o `sonda:fingerprint` existe para barrar)
passaria como "sincronizada" e o `esperado(...)` sairia sem fingerprint nenhum.

`entradaDoMapa` casa o nome EXATO: `omie-vendas` é prefixo de `omie-vendas-sync`, e casar por
prefixo leria o hash da edge errada.

## Evidência

7 testes novos, 164/164 na suíte do arquivo. Duas sabotagens, ambas VERMELHAS, com controle verde
e NÃO-VAZIO na mesma invocação (7 selecionados, 157 skipped):

- `null === null` aceito como igual → PEGA (o fail-closed da ausência);
- o guard nunca marcando divergência → PEGO (o guard virando decorativo).

Os fixtures usam hex de verdade: a primeira versão usava "ZZZ", que não casa `[0-9a-f]+` — o
extrator devolvia `null` e alguns asserts passavam por acidente, já que `null !== 'bbb'` também é
"diverge".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

