### PR TITLE
fix(deploy): o gate de ordem lia o `index.ts` do DISCO e liberava a colagem da REF — procedência vira argumento obrigatório

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -98,8 +98,12 @@ Mordido 2026-08-14 (#1520 `9f7e8962`, FU4-F fase 3): o `/fecho` pegou `…130000
   mesmo SHA), na ordem **DDL → edges → Publish**. Cada RPC ausente vem com a contagem da **família**
   (irmãs de mesmo prefixo), que separa duas ações opostas: família povoada ⇒ falta ESTA migration,
   aplique-a; família **vazia** ⇒ o domínio não está em prod ou o nome mudou ⇒ **diagnostique, não
-  reaplique**. Cobre só RPC **literal** e só **função** (coluna/tabela/policy seguem manuais) — e
-  não decide deploy: quem decide é o ledger. Narrativa e falsificação:
+  reaplique**. Cobre só RPC **literal**, só **função** e só **existência** — assinatura incompatível
+  de RPC de mesmo nome passa (coluna/tabela/policy seguem manuais) — e não decide deploy: quem
+  decide é o ledger. **As duas metades leem a `origin/main`**: a fatia da colagem E a descoberta das
+  RPCs que a liberam. Ler as RPCs do disco enquanto a colagem saía da ref foi um bug real (2026-09-08,
+  §6 do doc abaixo) — numa worktree atrasada o gate media o `index.ts` que ninguém vai deployar e
+  liberava. Por isso `coletarDaEdge` exige a árvore como ARGUMENTO, sem default. Narrativa e falsificação:
   [`precondicao-de-banco-como-gate.md`](../historico/precondicao-de-banco-como-gate.md).
 - **Proibir "melhorias"** — instrua o chat a deployar **verbatim** o arquivo do repo (o Lovable tende a reescrever a função).
 - **Verificar por comportamento/bytes, não pela palavra do Lovable** — `503 LOAD_FUNCTION_ERROR` + zero `running` no log = a edge não BOOTA → fix é **redeploy**, não código (ver `docs/agent/sync.md`).

--- a/docs/historico/precondicao-de-banco-como-gate.md
+++ b/docs/historico/precondicao-de-banco-como-gate.md
@@ -142,3 +142,44 @@ a própria entrada é o que transforma esta classe de erro em um vermelho barato
 - **Não cobre secrets nem o frontend.** A ordem canônica é secrets → DDL → edges → frontend; o
   pacote mede o elo **DDL→edge** e ordena o resto sem medi-lo. Dizer que ordena não é dizer que mede.
 - **Não decide deploy.** Quem decide é o ledger; este script só responde "PODE AGORA?".
+- **Só existência, não ASSINATURA.** A sonda casa `pg_proc.proname`: ela responde *"foi criada?"* e
+  é cega para *"foi alterada?"*. Uma RPC antiga de mesmo nome com contrato incompatível conta como
+  presente e o gate libera — o erro sai em runtime, com a cara do #2285, só que depois do deploy.
+  Declarado e **não** corrigido por precisão > recall: conferir assinatura exige extrair a
+  ESPERADA do call-site (`db.rpc(nome, { a, b })`), um segundo extrator cujo modo de falha é o
+  **bloqueio falso** — e um gate de deploy que bloqueia sem razão ensina o operador a contorná-lo.
+  Gatilho de reentrada: o primeiro incidente em que a RPC **existia** e a edge quebrou por
+  contrato (assinatura, tipo de retorno, overload ambíguo).
+
+## 6. O buraco que o gate tinha na PRÓPRIA procedência (2026-09-08, achado pelo Codex)
+
+O gate nasceu com as duas metades lendo **fontes diferentes**, e o furo é o defeito que ele existe
+para impedir, reencenado pela ferramenta:
+
+| Metade | Lia de | Por quê |
+|---|---|---|
+| a **fatia** da colagem (`fatiaDeDeploy`) | `origin/main`, via `git show` | deliberado, medido no #2123: **o Lovable deploya a MAIN**, não este checkout |
+| a **descoberta das RPCs** (`coletarDaEdge`) | o **working tree**, via `existsSync`/`readFileSync` | herdado do `preflight:rpcs`, onde ler o disco é a resposta certa |
+
+Numa worktree atrasada — o normal aqui, com ~30 em paralelo — a edge da main chama uma RPC que este
+checkout desconhece. O gate então lia o `index.ts` **velho**, media em prod só as RPCs **velhas**
+(que existem), respondia `✅ pré-condição de banco satisfeita` e **emitia a colagem**. Nenhum eixo
+fail-closed disparava: os quatro vigiam a MEDIÇÃO, e aqui o defeito estava na **pergunta**.
+
+Na sessão que achou isto o worktree estava **4 commits atrás** da `origin/main` e o pacote foi
+emitido assim mesmo — não houve dano só porque nenhuma das 4 mudanças tocava as RPCs da leva.
+Sorte, como no #2285; não desenho.
+
+> **REGRA. Num gate, a fonte que RESPONDE e a fonte que a pergunta MEDE têm de ser a mesma — e a
+> procedência é ARGUMENTO, nunca default.** `coletarDaEdge(edge, arvore, raiz)` passou a exigir a
+> árvore: sem default de disco, todo chamador declara de onde sua resposta vale e o **typecheck**
+> cobra quem não declarar. A classe é mais larga que este gate: quando um verificador aceita
+> `raiz = process.cwd()` para ler o que outra metade lê de uma ref, o desacordo é silencioso e só
+> aparece na worktree atrasada de outra pessoa.
+
+**Falsificação** (controle verde na mesma invocação, uma camada por vez): montado o caso em que o
+disco tem o `index.ts` **sem** a RPC e `origin/main` tem **com**, e a RPC não está em prod. Contra o
+código anterior: **`0` — liberado**, que é o bug. Com a correção: **`3` — bloqueado**, a RPC nova
+nomeada no pacote e a colagem ausente. Os controles (disco e ref concordam ⇒ `0`; a RPC nova **já**
+em prod ⇒ `0`; edge fora da ref ⇒ `2`) ficaram verdes nas duas rodadas — sem eles, um gate que
+bloqueasse SEMPRE passaria pelo teste principal.

--- a/scripts/edge-rpcs.ts
+++ b/scripts/edge-rpcs.ts
@@ -19,16 +19,27 @@
  */
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 import { coletarDaEdge, montarRelatorio } from './lib/edge-rpcs';
+import { arvoreDeTrabalho } from './sonda-fingerprint';
 
 export function main(argv: string[]): number {
   if (argv.length === 0) {
     console.error('uso: bun run preflight:rpcs <edge> [<edge>...]');
     return 1;
   }
+  // Este CLI inspeciona o código DESTE checkout, e diz isso em voz alta. A procedência é escolha
+  // do chamador desde que ler o disco enquanto a colagem saía de `origin/main` deixou o
+  // `pendencias:pacote` liberar uma edge cuja RPC nova ele nunca viu. Aqui o working tree é a
+  // resposta certa — você quer saber o que o SEU código chama — mas quem decide deploy é o
+  // `pendencias:pacote`, e ele mede a ref.
+  const arvore = arvoreDeTrabalho();
+  console.error(
+    `ℹ️  fonte: ${arvore.rotulo} — vale para ESTE checkout. O deploy sobe a \`origin/main\`; ` +
+      'quem gateia contra ela é `bun run pendencias:pacote`.',
+  );
   let pior = 0;
   for (const edge of argv) {
     try {
-      const r = montarRelatorio(edge, coletarDaEdge(edge));
+      const r = montarRelatorio(edge, coletarDaEdge(edge, arvore));
       console.log(r.texto);
       console.log('');
       pior = Math.max(pior, r.codigo);

--- a/scripts/lib/edge-rpcs.test.ts
+++ b/scripts/lib/edge-rpcs.test.ts
@@ -121,20 +121,24 @@ describe('extrairRpcs — comentário não é dependência', () => {
 // Fixture prova a TRADUÇÃO; só o repo real prova que as cegueiras 2 (escopo) e 3 (indireção)
 // estão fechadas onde elas de fato acontecem. Se estes casos virarem fixture, o gate volta a
 // medir a si mesmo.
+import { type ArvoreDeFonte, arvoreDeTrabalho } from '../sonda-fingerprint';
 import { coletarDaEdge } from './edge-rpcs';
+
+// A procedência é ARGUMENTO, não default: estes casos afirmam sobre o working tree e dizem isso.
+const DISCO = arvoreDeTrabalho();
 
 describe('coletarDaEdge — contra o repo REAL', () => {
   it('segue o fecho de imports: acha RPC que mora em `_shared/`, não só no diretório da edge', () => {
     // `recommend` chama `recommend_cluster_agregado` de dentro de `_shared/recommend-leituras.ts`.
     // O grep do runbook, que só varria `supabase/functions/recommend/`, não via essa dependência —
     // e o deploy sobe o fecho inteiro, não o diretório.
-    const r = coletarDaEdge('recommend');
+    const r = coletarDaEdge('recommend', DISCO);
     expect(r.rpcs.map((a) => a.nome)).toContain('recommend_cluster_agregado');
     expect(r.rpcs.find((a) => a.nome === 'recommend_cluster_agregado')?.arquivo).toMatch(/_shared\//);
   });
 
   it('acha RPC escrita com aspas DUPLAS (36 das 53 do repo eram invisíveis)', () => {
-    const r = coletarDaEdge('omie-analytics-sync');
+    const r = coletarDaEdge('omie-analytics-sync', DISCO);
     expect(r.rpcs.map((a) => a.nome)).toContain('omie_sync_identity_snapshot');
   });
 
@@ -152,7 +156,7 @@ describe('coletarDaEdge — contra o repo REAL', () => {
     //
     // Este teste trava as duas metades: as RPCs aparecem NOMEADAS, e o arquivo não volta a
     // esconder dependência atrás de parâmetro. Se alguém reintroduzir o helper, ele fica vermelho.
-    const r = coletarDaEdge('fin-valor-cockpit');
+    const r = coletarDaEdge('fin-valor-cockpit', DISCO);
     expect(r.rpcs.map((a) => a.nome).sort()).toEqual(
       expect.arrayContaining(['apriori_universo_snapshot', 'cockpit_itens_snapshot']),
     );
@@ -162,7 +166,45 @@ describe('coletarDaEdge — contra o repo REAL', () => {
   });
 
   it('edge inexistente FALHA — nunca devolve lista vazia (que se lê como "sem dependências")', () => {
-    expect(() => coletarDaEdge('edge-que-nao-existe')).toThrow(/edge-que-nao-existe/);
+    expect(() => coletarDaEdge('edge-que-nao-existe', DISCO)).toThrow(/edge-que-nao-existe/);
+  });
+});
+
+// ── a ÁRVORE manda: a resposta é sobre a fonte que o chamador declarou ────────────────────────
+// O `pendencias:pacote` gateia a colagem que sai de `origin/main`, e lia as RPCs do disco. Numa
+// worktree atrasada isso mede o `index.ts` errado e libera o que devia bloquear (#2285 de novo).
+// Estes casos exercitam a extração DIRETO na unidade — o teste de nível `main` não os alcança,
+// porque lá o `fatiaDeDeploy` lança antes por outro motivo.
+describe('coletarDaEdge — lê a árvore que recebeu, não o disco', () => {
+  const ENTRADA = 'supabase/functions/edge-fake/index.ts';
+
+  function arvoreFalsa(arquivos: Record<string, string>, rotulo = 'ref-de-teste'): ArvoreDeFonte {
+    return {
+      rotulo,
+      ler: (rel) => (rel in arquivos ? Buffer.from(arquivos[rel] as string, 'utf8') : null),
+    };
+  }
+
+  it('acha a RPC que só existe NA ÁRVORE — o disco desta worktree não participa', () => {
+    // `edge-fake` não existe em `supabase/functions/`: se a leitura caísse para o disco, isto
+    // lançaria em vez de achar a RPC. É a asserção que a versão anterior não conseguia passar.
+    const r = coletarDaEdge('edge-fake', arvoreFalsa({
+      [ENTRADA]: `await db.rpc('rpc_so_da_ref', {});\n`,
+    }));
+    expect(r.rpcs.map((a) => a.nome)).toEqual(['rpc_so_da_ref']);
+  });
+
+  it('edge ausente NA ÁRVORE lança nomeando a árvore — ausência de dado não é "sem dependência"', () => {
+    const arvore = arvoreFalsa({ 'supabase/functions/outra/index.ts': '' }, 'origin/main');
+    expect(() => coletarDaEdge('edge-fake', arvore)).toThrow(/origin\/main/);
+  });
+
+  it('segue o fecho DENTRO da árvore — helper de `_shared/` que só existe nela conta', () => {
+    const r = coletarDaEdge('edge-fake', arvoreFalsa({
+      [ENTRADA]: `import { f } from '../_shared/ajuda.ts';\nawait db.rpc('da_entrada', {});\n`,
+      'supabase/functions/_shared/ajuda.ts': `await db.rpc('do_shared', {});\n`,
+    }));
+    expect(r.rpcs.map((a) => a.nome)).toEqual(['da_entrada', 'do_shared']);
   });
 });
 

--- a/scripts/lib/edge-rpcs.test.ts
+++ b/scripts/lib/edge-rpcs.test.ts
@@ -196,7 +196,29 @@ describe('coletarDaEdge — lê a árvore que recebeu, não o disco', () => {
 
   it('edge ausente NA ÁRVORE lança nomeando a árvore — ausência de dado não é "sem dependência"', () => {
     const arvore = arvoreFalsa({ 'supabase/functions/outra/index.ts': '' }, 'origin/main');
-    expect(() => coletarDaEdge('edge-fake', arvore)).toThrow(/origin\/main/);
+    // A mensagem do GUARD, não só o rótulo: o `fecharGrafo` também lança citando a árvore, então
+    // `toThrow(/origin\/main/)` ficava verde com o guard REMOVIDO. Pego na falsificação.
+    expect(() => coletarDaEdge('edge-fake', arvore)).toThrow(/edge não encontrada em origin\/main/);
+  });
+
+  it('árvore que muda sob os pés LANÇA — fonte vazia extrairia zero RPCs, e zero por cegueira libera', () => {
+    // O `fecharGrafo` lê cada arquivo do fecho ANTES desta função relê. Entre as duas leituras a
+    // ref pode se mover (dois `git show` distintos). Sem este ramo, `?? ''` transformaria o
+    // arquivo sumido em zero RPCs — a lista curta que o gate lê como "sem dependência".
+    const conteudo: Record<string, string> = {
+      [ENTRADA]: `await db.rpc('some_no_meio_do_caminho', {});\n`,
+    };
+    let leituras = 0;
+    const instavel: ArvoreDeFonte = {
+      rotulo: 'ref-instavel',
+      ler: (rel) => {
+        leituras += 1;
+        // As duas primeiras (guard + fecho) respondem; a terceira, a releitura, encontra o vazio.
+        if (leituras > 2) return null;
+        return rel in conteudo ? Buffer.from(conteudo[rel] as string, 'utf8') : null;
+      },
+    };
+    expect(() => coletarDaEdge('edge-fake', instavel)).toThrow(/sumiu de ref-instavel/);
   });
 
   it('segue o fecho DENTRO da árvore — helper de `_shared/` que só existe nela conta', () => {

--- a/scripts/lib/edge-rpcs.ts
+++ b/scripts/lib/edge-rpcs.ts
@@ -24,13 +24,11 @@
 //
 // O custo dessa cegueira já foi pago: 2026-07-17, `carteira-rebuild` foi deployada com
 // `claim_carteira_rebuild` inexistente em prod → 500 em produção por ~40 min, carteira congelada.
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { removerComentarios } from '@/lib/gates/limpeza-fonte';
 // Reusa o fecho de imports da SONDA em vez de reimplementá-lo. Não é economia de linhas: é o
 // mesmo grafo que decide o `fonte` do fingerprint de deploy, então pré-flight e sonda passam a
 // falar do MESMO conjunto de arquivos. Duas travessias independentes divergiriam em silêncio.
-import { fecharGrafo } from '../sonda-fingerprint';
+import { type ArvoreDeFonte, fecharGrafo } from '../sonda-fingerprint';
 
 interface AchadoRpc {
   nome: string;
@@ -108,22 +106,45 @@ export function extrairRpcs(fonte: string, arquivo: string): ExtracaoRpc {
  * Colhe as RPCs de uma edge INTEIRA — o fecho transitivo dos imports locais a partir do seu
  * `index.ts`, que é exatamente o que um deploy sobe.
  *
+ * ‼️ A PROCEDÊNCIA É OBRIGATÓRIA — não há default para `arvore`, de propósito.
+ *
+ * Esta função lia o WORKING TREE (`existsSync`/`readFileSync`) enquanto a colagem de deploy que ela
+ * gateia saía de `origin/main`. Numa worktree atrasada — o normal aqui — a edge da main chama uma
+ * RPC que este checkout desconhece: a lista saía curta, prod era medido só contra as RPCs velhas
+ * (que existem), e o gate respondia "pode subir". O #2285 reencenado pela ferramenta feita para
+ * evitá-lo. Um default de disco é o que torna esse erro FÁCIL de cometer e INVISÍVEL de ler; sem
+ * ele, todo chamador declara de qual árvore sua resposta vale, e o typecheck cobra os que não o
+ * fizerem. `raiz` continua opcional porque ela só RESOLVE caminhos relativos — não lê nada.
+ *
  * Fail-closed em edge inexistente: devolver `{rpcs: [], indirecoes: []}` para um nome errado
- * (typo, edge renomeada) se lê como "esta edge não tem dependência de banco" — a lista vazia que
- * parece uma resposta e é uma pergunta não feita.
+ * (typo, edge renomeada, ou uma edge que só existe no disco desta worktree) se lê como "esta edge
+ * não tem dependência de banco" — a lista vazia que parece uma resposta e é uma pergunta não feita.
  */
-export function coletarDaEdge(edge: string, raiz = process.cwd()): ExtracaoRpc {
+export function coletarDaEdge(
+  edge: string,
+  arvore: ArvoreDeFonte,
+  raiz = process.cwd(),
+): ExtracaoRpc {
   const entrada = `supabase/functions/${edge}/index.ts`;
-  if (!existsSync(resolve(raiz, entrada))) {
+  if (arvore.ler(entrada) === null) {
     throw new Error(
-      `edge não encontrada: ${edge} (esperava ${entrada}). Fail-closed: lista vazia para um nome ` +
-        `errado se leria como "sem dependências de banco".`,
+      `edge não encontrada em ${arvore.rotulo}: ${edge} (esperava ${entrada}). Fail-closed: lista ` +
+        `vazia para um nome errado se leria como "sem dependências de banco".`,
     );
   }
   const rpcs: AchadoRpc[] = [];
   const indirecoes: Indirecao[] = [];
-  for (const arquivo of fecharGrafo(entrada, raiz)) {
-    const r = extrairRpcs(readFileSync(resolve(raiz, arquivo), 'utf8'), arquivo);
+  for (const arquivo of fecharGrafo(entrada, raiz, arvore)) {
+    const bytes = arvore.ler(arquivo);
+    if (bytes === null) {
+      // `fecharGrafo` já leu cada um destes; chegar aqui é a árvore ter mudado sob os pés. Lançar,
+      // e nunca `?? ''`: fonte vazia extrai zero RPCs, e zero por cegueira é o falso verde.
+      throw new Error(
+        `arquivo do fecho sumiu de ${arvore.rotulo}: ${arquivo} — as RPCs dele não foram lidas, e ` +
+          `uma lista incompleta se leria como dependência a menos`,
+      );
+    }
+    const r = extrairRpcs(bytes.toString('utf8'), arquivo);
     rpcs.push(...r.rpcs);
     indirecoes.push(...r.indirecoes);
   }

--- a/scripts/lib/precondicao-banco.ts
+++ b/scripts/lib/precondicao-banco.ts
@@ -31,6 +31,25 @@
  * família vazia ⇒ o domínio inteiro não está em prod, ou o nome está errado (não cole nada, vá
  * diagnosticar). Um "ausente" sem essa distinção manda reaplicar migration sobre um diagnóstico
  * que ninguém fez.
+ *
+ * ## O que este gate NÃO mede: a ASSINATURA (declarado, não deduzido)
+ *
+ * A sonda casa `pg_proc.proname` — o NOME. Ela responde *"foi criada?"* e é CEGA para *"foi
+ * alterada?"*: uma RPC antiga, de mesmo nome e assinatura incompatível com a que a edge chama,
+ * conta como PRESENTE e o gate libera. O erro sai em runtime, com a mesma cara do #2285
+ * (`Could not find the function … in the schema cache`) — só que depois do deploy.
+ *
+ * Fica declarado, e não corrigido, por PRECISÃO > RECALL (money-path). Conferir assinatura exige
+ * saber a assinatura ESPERADA, que só existe no call-site (`db.rpc(nome, { a, b })`) — um segundo
+ * extrator, com cegueiras próprias (arg por variável, spread, objeto montado antes), cujo modo de
+ * falha é o BLOQUEIO FALSO. E gate de deploy que bloqueia sem razão não é conservador: ele ensina
+ * o operador a contorná-lo, e aí não gateia mais nada. O eixo 3 (`indirecoes`) já mostra o preço
+ * de extrair do call-site, e ali a resposta errada era só INCERTA.
+ *
+ * **Gatilho de reentrada** (o mesmo formato do limite "só função, não coluna"): o primeiro
+ * incidente em que a RPC EXISTIA e mesmo assim a edge quebrou por contrato — assinatura, tipo de
+ * retorno ou overload ambíguo. Até lá, o que cobre este buraco é a ordem canônica, não este gate:
+ * DDL primeiro, e a migration que ALTERA uma função em uso declara isso no cabeçalho.
  */
 
 /** Marca de formato que a sonda carimba no marcador de fim; o parser recusa outra. */

--- a/scripts/pendencias-pacote.test.ts
+++ b/scripts/pendencias-pacote.test.ts
@@ -1,6 +1,13 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { lerVeredito, separarSaida } from './pendencias-pacote';
+import { FORMATO_SONDA, TOKEN_NAO, TOKEN_SIM } from './lib/precondicao-banco';
+import { lerVeredito, main, separarSaida } from './pendencias-pacote';
+import { type ExecutorGitBytes, REF_DEPLOYADA } from './pendencias-prompt';
+import { ARQ_MAPA, RAIZ_EDGES } from './sonda-fingerprint';
 
 // ═══════════════════════════════════════════════════════════════════════════════════════════
 // Por que este arquivo existe
@@ -77,5 +84,132 @@ describe('lerVeredito — o contrato com o pendencias:deploy --json', () => {
 
   it('stdin que não é JSON LANÇA', () => {
     expect(() => lerVeredito('nada disso')).toThrow(/não é JSON/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// A PROCEDÊNCIA das duas metades do gate
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// Achado do Codex em 2026-09-08, confirmado por leitura: as duas metades do gate liam FONTES
+// DIFERENTES.
+//
+//   · a FATIA da colagem sai de `origin/main` (`fatiaDeDeploy(edge, raiz, arvore)`) — deliberado,
+//     medido no #2123: o Lovable deploya a MAIN, não este checkout;
+//   · a DESCOBERTA das RPCs saía do WORKING TREE (`coletarDaEdge` com `existsSync`/`readFileSync`).
+//
+// Numa worktree atrasada — o normal aqui, com ~30 em paralelo — a edge da main pode chamar uma RPC
+// que este checkout desconhece. O gate então lia o `index.ts` VELHO, media em prod só as RPCs
+// velhas (que existem), respondia `✅ pré-condição satisfeita` e EMITIA a colagem: o #2285
+// reencenado pela ferramenta criada para evitá-lo. Ausente ≠ zero — a RPC que o disco não vê não
+// é uma RPC que a edge não chama.
+//
+// O eixo destes testes é a DIVERGÊNCIA entre disco e ref, não "o gate bloqueia": por isso o
+// controle positivo mora no mesmo `describe` — um harness sempre-vermelho aprovaria qualquer
+// correção.
+describe('pendencias:pacote — a leitura da edge sai da REF, não do disco', () => {
+  const EDGE = 'edge-de-teste';
+  const ENTRADA = `${RAIZ_EDGES}/${EDGE}/index.ts`;
+  const SHA_REF = 'c0ffee1234567890c0ffee1234567890c0ffee12';
+  const MAPA = 'export const FINGERPRINTS = {};\n';
+
+  function escrever(raiz: string, rel: string, conteudo: string): void {
+    const abs = join(raiz, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, conteudo, 'utf8');
+  }
+
+  /** Working tree e ref com conteúdos INDEPENDENTES — é a divergência que estes testes medem. */
+  function montarRepo(noDisco: string | null, naRef: string | null) {
+    const raiz = mkdtempSync(join(tmpdir(), 'pacote-procedencia-'));
+    escrever(raiz, ARQ_MAPA, MAPA);
+    if (noDisco !== null) escrever(raiz, ENTRADA, noDisco);
+
+    const naArvore = new Map<string, string>([[ARQ_MAPA, MAPA]]);
+    if (naRef !== null) naArvore.set(ENTRADA, naRef);
+
+    const git: ExecutorGitBytes = (args) => {
+      const ok = (bytes: Buffer) => ({ ok: true, bytes, erro: '' });
+      if (args[0] === 'rev-parse') return ok(Buffer.from(`${SHA_REF}\n`));
+      if (args[0] === 'show') {
+        const rel = String(args[1]).slice(`${REF_DEPLOYADA}:`.length);
+        const c = naArvore.get(rel);
+        return c === undefined
+          ? { ok: false, bytes: Buffer.alloc(0), erro: `path '${rel}' does not exist` }
+          : ok(Buffer.from(c, 'utf8'));
+      }
+      return { ok: false, bytes: Buffer.alloc(0), erro: `git não esperado: ${args.join(' ')}` };
+    };
+    return { raiz, git, saida: join(raiz, 'pacote.md') };
+  }
+
+  /**
+   * Sonda falsa que responde ao que foi PEDIDO, com os tokens do PRÓPRIO módulo.
+   *
+   * O formato não sai da memória: `TOKEN_SIM`/`TOKEN_NAO`/`FORMATO_SONDA` são importados, que é a
+   * regra que o `precondicao-de-banco-como-gate.md` §3 fixou depois de um fixture inventado de
+   * cabeça custar um ciclo inteiro.
+   */
+  function sondaFalsa(existentesEmProd: readonly string[]) {
+    return (sql: string): string => {
+      const pedidas = [...sql.matchAll(/\('([a-z0-9_]+)'\)/g)].map((m) => m[1]);
+      return [
+        ...pedidas.map((r) =>
+          existentesEmProd.includes(r)
+            ? `rpc|${r}|${TOKEN_SIM}|7`
+            : `rpc|${r}|${TOKEN_NAO}|0`,
+        ),
+        'controle|funcoes_public|479|',
+        `autoteste|presente|${TOKEN_SIM}|`,
+        `autoteste|ausente|${TOKEN_NAO}|`,
+        `fim|${FORMATO_SONDA}||`,
+      ].join('\n');
+    };
+  }
+
+  const CHAMA_VELHA = `await db.rpc('rpc_velha', {});\n`;
+  const CHAMA_AS_DUAS = `await db.rpc('rpc_velha', {});\nawait db.rpc('rpc_nova_da_main', {});\n`;
+
+  it('BLOQUEIA (3) quando a REF chama uma RPC ausente em prod que o disco não conhece', () => {
+    // O caso que estava passando: disco atrasado (só a velha), main à frente (velha + nova).
+    const { raiz, git, saida } = montarRepo(CHAMA_VELHA, CHAMA_AS_DUAS);
+
+    const codigo = main([EDGE, '--saida', saida, '--sem-rede'], raiz, git, sondaFalsa(['rpc_velha']));
+
+    expect(codigo).toBe(3);
+    const pacote = readFileSync(saida, 'utf8');
+    expect(pacote).toContain('rpc_nova_da_main');
+    expect(pacote).toContain('BLOQUEADO no passo 1');
+  });
+
+  // ── controle positivo, na MESMA invocação ────────────────────────────────────────────────
+  // Sem estes dois, o teste acima seria satisfeito por um gate que bloqueia SEMPRE.
+  it('LIBERA (0) quando disco e ref concordam e a RPC existe em prod', () => {
+    const { raiz, git, saida } = montarRepo(CHAMA_VELHA, CHAMA_VELHA);
+
+    const codigo = main([EDGE, '--saida', saida, '--sem-rede'], raiz, git, sondaFalsa(['rpc_velha']));
+
+    expect(codigo).toBe(0);
+  });
+
+  it('LIBERA (0) quando a ref chama a RPC nova e ela JÁ está em prod — divergir do disco não é o crime', () => {
+    const { raiz, git, saida } = montarRepo(CHAMA_VELHA, CHAMA_AS_DUAS);
+
+    const codigo = main(
+      [EDGE, '--saida', saida, '--sem-rede'],
+      raiz,
+      git,
+      sondaFalsa(['rpc_velha', 'rpc_nova_da_main']),
+    );
+
+    expect(codigo).toBe(0);
+  });
+
+  // ── o fail-closed, do lado da REF ────────────────────────────────────────────────────────
+  it('MECÂNICA (2) quando a edge existe no disco mas NÃO na ref — lista vazia não é "sem dependência"', () => {
+    const { raiz, git, saida } = montarRepo(CHAMA_VELHA, null);
+
+    const codigo = main([EDGE, '--saida', saida, '--sem-rede'], raiz, git, sondaFalsa(['rpc_velha']));
+
+    expect(codigo).toBe(2);
   });
 });

--- a/scripts/pendencias-pacote.ts
+++ b/scripts/pendencias-pacote.ts
@@ -117,7 +117,12 @@ export function separarSaida(args: readonly string[]): { nomes: string[]; saida?
   return { nomes: args.filter((_, i) => i !== iSaida && i !== iSaida + 1), saida: args[iSaida + 1] };
 }
 
-export function main(argv: string[], raiz = process.cwd(), git = gitBytes(raiz)): number {
+export function main(
+  argv: string[],
+  raiz = process.cwd(),
+  git = gitBytes(raiz),
+  medir = medirEmProd,
+): number {
   const todos = argv.filter((a) => a !== '');
   const semRede = todos.includes('--sem-rede');
   const args = todos.filter((a) => a !== '--sem-rede');
@@ -170,7 +175,10 @@ export function main(argv: string[], raiz = process.cwd(), git = gitBytes(raiz))
     proc = { ref: REF_DEPLOYADA, sha: sincronizarRef(git, semRede) };
     const arvore = arvoreDaRef(REF_DEPLOYADA, git);
     fatias = nomes.map((edge) => {
-      const achado = coletarDaEdge(edge, raiz);
+      // A MESMA `arvore` das duas metades: a fatia da colagem e a descoberta das RPCs que a
+      // liberam têm de falar do MESMO arquivo. Ler as RPCs do disco enquanto a colagem sai da ref
+      // era o gate medindo um `index.ts` que ninguém vai deployar.
+      const achado = coletarDaEdge(edge, arvore, raiz);
       for (const r of achado.rpcs) pares.push({ edge, rpc: r.nome });
       indirecoes += achado.indirecoes.length;
       return { ...fatiaDeDeploy(edge, raiz, arvore), rpcs: achado.rpcs.map((r) => r.nome).sort() };
@@ -197,7 +205,7 @@ export function main(argv: string[], raiz = process.cwd(), git = gitBytes(raiz))
   } else {
     let saida: string;
     try {
-      saida = medirEmProd(montarSondaPrecondicao(alvos.map((a) => a.rpc)));
+      saida = medir(montarSondaPrecondicao(alvos.map((a) => a.rpc)));
     } catch (e) {
       process.stderr.write(
         `⛔ mecânica: a sonda de pré-condição não rodou (${mensagemDeErro(e) ?? 'psql falhou'})\n` +


### PR DESCRIPTION
## O defeito

O `pendencias:pacote` é o **gate de ordem entre camadas** (#2369): ele recusa emitir a colagem de deploy de uma edge enquanto a RPC de que ela depende não estiver em prod. As duas metades liam **fontes diferentes**:

| Metade | Lia de | Por quê |
|---|---|---|
| a **fatia** da colagem (`fatiaDeDeploy`) | `origin/main`, via `git show` | deliberado, medido no #2123: **o Lovable deploya a MAIN**, não este checkout |
| a **descoberta das RPCs** (`coletarDaEdge`) | o **working tree**, via `existsSync`/`readFileSync` | herdado do `preflight:rpcs`, onde ler o disco é a resposta certa |

Numa worktree atrasada — o normal aqui, com ~30 em paralelo — a edge da main chama uma RPC que este checkout desconhece. O gate então:

1. lia o `index.ts` **antigo** do disco,
2. não via a RPC nova,
3. media em prod só as RPCs velhas (que existem),
4. respondia `✅ pré-condição de banco satisfeita` e **emitia a colagem**.

É o **#2285 reencenado pela ferramenta criada para evitá-lo** — a edge sobe chamando RPC que não existe (lá: ≥2h25 servindo assim). Nenhum dos quatro eixos fail-closed disparava: os quatro vigiam a **medição**, e o defeito estava na **pergunta**.

Na sessão que achou isto o worktree estava **4 commits atrás** e o pacote foi emitido assim mesmo — não houve dano só porque nenhuma das 4 mudanças tocava as RPCs da leva. Sorte, como no #2285; não desenho.

Achado pelo **Codex** (gpt-6-astra, reasoning max) em revisão de arquitetura; confirmado por leitura e por teste.

## A correção

- **`coletarDaEdge(edge, arvore, raiz)` exige a `ArvoreDeFonte` como argumento — sem default.** Um default de disco é o que torna esse erro fácil de cometer e invisível de ler; sem ele, todo chamador declara de qual árvore sua resposta vale e o **typecheck** cobra quem não declarar. (`raiz` segue opcional: ela só *resolve* caminhos, não lê nada.)
- **O gate passa a MESMA `arvore` que já usava para a fatia** — um só dono da procedência, na mesma expressão.
- **Fail-closed preservado e estendido à ref:** edge ausente **na árvore** lança nomeando a árvore; arquivo do fecho que some vira erro — nunca `?? ''`, porque fonte vazia extrai zero RPCs e zero por cegueira é o falso verde.
- **`preflight:rpcs` continua lendo o working tree** — ali é a resposta certa — mas agora **declara a fonte em voz alta** e aponta quem gateia contra a ref.

## O 2º achado do Codex: DECLARADO, não corrigido

A sonda casa `pg_proc.proname` — o **nome**. Responde *"foi criada?"* e é cega para *"foi alterada?"*: RPC antiga de mesmo nome com contrato incompatível conta como presente.

Não corrigido, por **precisão > recall**: conferir assinatura exige extrair a **esperada** do call-site (`db.rpc(nome, { a, b })`), um segundo extrator com cegueiras próprias cujo modo de falha é o **bloqueio falso** — e gate de deploy que bloqueia sem razão ensina o operador a contorná-lo. Limite declarado no cabeçalho e na §5 do doc, com **gatilho de reentrada** nomeado: o primeiro incidente em que a RPC **existia** e a edge quebrou por contrato.

## Prova

O teste que falsifica: working tree **sem** a RPC, `origin/main` **com**, RPC ausente em prod.

- código anterior → **`0`, liberado** (o bug)
- com a correção → **`3`, bloqueado**, RPC nova nomeada no pacote, colagem ausente

**Controle positivo na MESMA invocação** (sem ele, um gate que bloqueasse sempre passaria): disco e ref concordam ⇒ `0` · RPC nova **já** em prod ⇒ `0` · edge fora da ref ⇒ `2`.

**Falsificação, uma camada por vez, com controle verde antes e depois: 5/5 vermelhas.** As duas primeiras rodadas deram 3/5 — e as duas verdes eram achados reais, não ruído:

- a asserção da edge ausente casava só o **rótulo** da árvore, que a mensagem do `fecharGrafo` também traz: passava com o guard **removido**. Agora casa a mensagem do próprio guard.
- o ramo do arquivo sumido era **inalcançado**. Alcançado com uma árvore que muda sob os pés — a corrida real entre dois `git show`.

## Validação

| comando | rc | evidência |
|---|---|---|
| `bun run test` | 0 | 814 arquivos · **8601 testes** passando |
| `bun run typecheck` | 0 | zero `error TS` (app + scripts) |
| `bun run lint:shell` | 0 | — |
| `bun run test:hooks` | 0 | `TODOS OS CASOS OK` |

Rebaseado sobre 25 commits novos. Um conflito com o #2400 (que corrigiu, no mesmo arquivo, a cegueira **diferente** do `NOME_LITERAL` — também achada pelo Codex na mesma revisão): resolvido preservando a intenção nova do teste da main e aplicando só a mudança mecânica da procedência. As duas correções coexistem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Adendo do `/fecho` (2026-09-09) — o gatilho de reentrada DISPAROU no mesmo dia

O limite declarado acima ("só existência, não assinatura") encontrou seu primeiro caso real
horas depois de ser escrito. Medido no banco via `psql-ro`, com controle positivo:

| migration (mergeada na main) | aplicada? | prova |
|---|---|---|
| `20260908215704_desconto_valor_atravessa_os_escritores` | **não** | `pg_get_functiondef(criar_pedidos_com_itens)` não contém `desconto_valor` (0) · controle: a função existe = 1 |
| `20260908220625_desconto_backfill_aplicar` | **não** | função ausente · família `desconto\_%` = 0 |
| `20260908163659_pedido_nasce_com_identidade_de_linha` | sim | marcador `omie_codigo_item` presente |
| `20260908204421` / `20260908223555` (ondas 3 e 4 da sonda) | sim | edges na allowlist (15 alvos) |
| `20260909074613_v_titulo_baixas_otica_canonica` | sim | view existe · controle: família `v_titulo%` = 1 |

**A edge `omie-vendas-sync` (`v1.6-desconto-valor-na-ingestao`) monta `desconto_valor: descontoItem`
no jsonb que passa a `criar_pedidos_com_itens`.** A função aplicada em prod é a da `163659`, que não
conhece o campo. Deployá-la antes da DDL não daria 500 — a RPC **ignoraria a chave em silêncio** e
`order_items.desconto_valor` ficaria NULL em todo pedido novo. Money-path descartado sem rastro.

E o `pendencias:pacote` **libera** essa leva: `criar_pedidos_com_itens` existe, e é só isso que ele
mede. Exatamente o buraco que este PR declarou em vez de fechar — a decisão segue certa (o extrator
de assinatura falharia para o lado do bloqueio falso), mas o custo do limite agora tem um caso.

**Ordem correta, e o deploy da edge foi SEGURADO por isto:** aplicar `215704` → `220625` (nessa
ordem; a `215704` já preserva o `omie_codigo_item` da `163659`, conferido) → provar no banco →
então deployar `omie-vendas-sync` e tratar `omie-desconto-backfill` (hoje `NUNCA_ATESTADA`, e que só
faz sentido depois da `220625`).

As outras 4 edges pendentes da janela (`omie-financeiro`, `omie-sync-nfes-recebidas`, `sonda-relay`,
`sync-reprocess`) não tocam esse eixo e **foram deployadas neste fecho** — 27 hashes conferidos
contra `745861f5`, publicadas verbatim.
