### PR TITLE
fix(ci): tirar do CI o gate cuja falha ninguém explica — a hipótese do resíduo foi refutada por medição alheia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1126,21 +1126,29 @@ jobs:
       - name: mutcheck — selftest (mecânica da ferramenta, sem vitest)
         run: bun run mutcheck:selftest
 
-      - name: mutcheck — contratos de cobertura money-path (.mut)
-        env:
-          MUTCHECK_RESUMO: /tmp/mutcheck-resumo.json
-        run: bun run mutcheck
-
-      # O `mutcheck` acima roda a suíte INTEIRA e reporta o AGREGADO. Desde que a mecânica do
+      # O `mutcheck` abaixo roda a suíte INTEIRA e reporta o AGREGADO. Desde que a mecânica do
       # `controle_credencial` virou uma função só (sonda + canária), "PEGA" passou a significar
       # apenas "algum teste morreu" — uma metade bem coberta esconde a outra descoberta, e o `.mut`
       # ficaria afirmando cobertura que ninguém mediu. Este step roda a MESMA mutação contra cada
       # modo ISOLADO e exige vermelho nos dois. Vive aqui, e não à mão, porque falsificação que só
       # roda à mão é ausência de dado (docs/historico/falsificacao-fora-do-ci.md).
+      #
+      # ⚠️ ANTES do `mutcheck`, não depois — e a ordem é o conserto de um vermelho de main real
+      # (2026-09-09). O step nasceu depois dele e o CONTROLE saiu vermelho nos DOIS modos no
+      # runner, verde nas duas execuções locais (inclusive sob `LC_ALL=C`). O `mutcheck` muta o
+      # fonte e restaura por cópia; este script MEDE o fonte. Rodando depois, ele herda o que a
+      # restauração alheia deixou — e o que ele mede deixa de ser o código do repo. Aqui ele roda
+      # sobre a árvore recém-checada, que é a condição em que foi validado. O guard de árvore suja
+      # dentro do próprio script é o cinto: ele NOMEIA a sujeira em vez de medir outro código.
       # Custo MEDIDO 2026-09-08 na M2 do founder, sem `heavy`: 20s (4 rodadas de vitest filtradas
-      # por `-t`). O job tem teto de 15min e o step acima consome ~10min — cabe com folga.
+      # por `-t`). O job tem teto de 15min e o `mutcheck` consome ~10min — cabe com folga.
       - name: prova por consumidor — o mutante compartilhado morre nos DOIS modos
         run: bash scripts/prova-consumidores-controle.sh
+
+      - name: mutcheck — contratos de cobertura money-path (.mut)
+        env:
+          MUTCHECK_RESUMO: /tmp/mutcheck-resumo.json
+        run: bun run mutcheck
 
       # ─── Sensor (2026-09-07) ────────────────────────────────────────────────
       # Este job JÁ rodava na main a cada push — ele só não FALAVA. O vermelho do #2279 durou

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1126,24 +1126,22 @@ jobs:
       - name: mutcheck — selftest (mecânica da ferramenta, sem vitest)
         run: bun run mutcheck:selftest
 
-      # O `mutcheck` abaixo roda a suíte INTEIRA e reporta o AGREGADO. Desde que a mecânica do
-      # `controle_credencial` virou uma função só (sonda + canária), "PEGA" passou a significar
-      # apenas "algum teste morreu" — uma metade bem coberta esconde a outra descoberta, e o `.mut`
-      # ficaria afirmando cobertura que ninguém mediu. Este step roda a MESMA mutação contra cada
-      # modo ISOLADO e exige vermelho nos dois. Vive aqui, e não à mão, porque falsificação que só
-      # roda à mão é ausência de dado (docs/historico/falsificacao-fora-do-ci.md).
+      # ⏸️ O step `prova por consumidor` (scripts/prova-consumidores-controle.sh) SAIU daqui em
+      # 2026-09-09, no mesmo dia em que entrou pelo #2424 — ele derrubou a main e a causa ainda
+      # NÃO é conhecida. O que se sabe, medido: no runner o passo reprova em ~1,45 s por execução
+      # (#2413) — tempo de falha de INICIALIZAÇÃO do vitest, não de rodar 164 testes —, o CONTROLE
+      # sai vermelho nos DOIS modos, e local é verde em todas as combinações tentadas: com e sem
+      # `LC_ALL=C`, e reproduzindo a sequência exata `mutcheck → prova`.
       #
-      # ⚠️ ANTES do `mutcheck`, não depois — e a ordem é o conserto de um vermelho de main real
-      # (2026-09-09). O step nasceu depois dele e o CONTROLE saiu vermelho nos DOIS modos no
-      # runner, verde nas duas execuções locais (inclusive sob `LC_ALL=C`). O `mutcheck` muta o
-      # fonte e restaura por cópia; este script MEDE o fonte. Rodando depois, ele herda o que a
-      # restauração alheia deixou — e o que ele mede deixa de ser o código do repo. Aqui ele roda
-      # sobre a árvore recém-checada, que é a condição em que foi validado. O guard de árvore suja
-      # dentro do próprio script é o cinto: ele NOMEIA a sujeira em vez de medir outro código.
-      # Custo MEDIDO 2026-09-08 na M2 do founder, sem `heavy`: 20s (4 rodadas de vitest filtradas
-      # por `-t`). O job tem teto de 15min e o `mutcheck` consome ~10min — cabe com folga.
-      - name: prova por consumidor — o mutante compartilhado morre nos DOIS modos
-        run: bash scripts/prova-consumidores-controle.sh
+      # Sai porque main vermelha é custo de TODAS as worktrees, e um gate cuja falha ninguém
+      # explica não é cobertura: é ruído com poder de veto. Não vira "verde condicional" nem
+      # `continue-on-error` — gate que não pode reprovar mente pior do que gate ausente.
+      #
+      # VOLTA quando a causa estiver medida. O script segue no repo, roda à mão, e agora despeja a
+      # saída do vitest na falha (era só isso que faltava para o diagnóstico não parar por falta de
+      # evidência). Enquanto ele não volta, a consolidação que o `.mut` declara — duas mutações
+      # gêmeas viraram uma — segue afirmada e NÃO medida no CI:
+      #   bash scripts/prova-consumidores-controle.sh
 
       - name: mutcheck — contratos de cobertura money-path (.mut)
         env:

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -61,6 +61,10 @@ PEGA      | fallback do 401 deixa de ser INDETERMINADO (fail-open)    | s/THEN '
 # suite AGREGADA, entao 'PEGA' aqui diz que ALGUM teste morreu, nao que os DOIS modos estao
 # cobertos (ressalva do parecer Codex 2026-09-08). Quem prova isso e
 # `scripts/prova-consumidores-controle.sh`, que roda a mutacao contra cada modo ISOLADO.
+# ⏸️ ELE NAO RODA NO CI desde 2026-09-09 (derrubou a main; causa em apuracao — ver o comentario
+#    no job `mutation-check` do ci.yml). Ate voltar, a consolidacao acima esta AFIRMADA e nao
+#    medida automaticamente: rode `bash scripts/prova-consumidores-controle.sh` a mao antes de
+#    confiar nela, e trate 'PEGA' na linha consolidada como 'algum modo morreu', nao 'os dois'.
 PEGA      | controle nao exclui a propria leva (nenhum modo se avaliza) | s/AND NOT EXISTS \(SELECT 1 FROM ids id_leva WHERE id_leva\.request_id = r\.id\)/AND true/
 PEGA      | piso do controle zerado (1 resposta 2xx ja 'prova')       | s/PISO_CONTROLE_CREDENCIAL = 10/PISO_CONTROLE_CREDENCIAL = 0/
 PEGA      | 401 alheio deixa de desqualificar o controle              | s/AND c\.recusas_recentes = 0/AND true/

--- a/scripts/prova-consumidores-controle.sh
+++ b/scripts/prova-consumidores-controle.sh
@@ -41,17 +41,38 @@ rodar() {  # $1 = filtro -t; ecoa nada, devolve o rc do vitest
 # exatamente a falha que este script existe para nao cometer. Exigimos "N passed" com N>=1.
 casou_algum() { grep -qE 'Tests +[1-9][0-9]* passed' /tmp/prova-consumidores.$$.log; }
 
+# A arvore tem de estar LIMPA nos dois arquivos que este script mede. Nao e' preciosismo: em
+# 2026-09-09 este step rodava logo depois do `bun run mutcheck` (que muta e restaura o fonte) e o
+# CONTROLE saiu vermelho nos DOIS modos, com a mensagem dizendo apenas "nao ficou verde OU o filtro
+# nao casou" -- duas causas opostas no mesmo ramo, e nenhuma saida do vitest para separa-las.
+# Aqui a sujeira e' NOMEADA antes de qualquer medicao; restaurar em silencio apagaria trabalho
+# local de quem roda isto na maquina.
+sujos=$(git status --porcelain -- "$SRC" "$TESTE" 2>/dev/null)
+if [ -n "$sujos" ]; then
+  echo "PROVA_CONSUMIDORES_FIM abortada: arvore SUJA — o controle mediria outro codigo, nao o do repo"
+  printf '%s\n' "$sujos" | sed 's/^/  /'
+  exit 1
+fi
+
 falhas=0
 
 # ── CONTROLE: sem mutacao, os dois filtros tem de ficar VERDES e casar >=1 teste ──
 for par in "SONDA:$FILTRO_SONDA" "CANARIA:$FILTRO_CANARIA"; do
   modo="${par%%:*}"; filtro="${par#*:}"
-  if rodar "$filtro" && casou_algum; then
-    printf 'CONTROLE  %-8s verde e casou teste ✓\n' "$modo"
-  else
-    printf 'CONTROLE  %-8s NAO ficou verde ou o filtro nao casou teste algum ✗\n' "$modo"
-    printf '          (filtro: %s)\n' "$filtro"
+  # As duas causas de reprovacao sao SEPARADAS: suite vermelha e filtro que nao casa exigem
+  # consertos opostos, e junta-las num ramo so foi o que cegou o diagnostico no CI.
+  if ! rodar "$filtro"; then
+    printf 'CONTROLE  %-8s a suite ficou VERMELHA com este filtro ✗\n' "$modo"
+    printf '          (filtro: %s) — ultimas linhas do vitest:\n' "$filtro"
+    tail -25 /tmp/prova-consumidores.$$.log | sed 's/^/          /'
     falhas=$((falhas+1))
+  elif ! casou_algum; then
+    printf 'CONTROLE  %-8s o filtro NAO CASOU teste algum (vitest saiu 0 por VAZIO) ✗\n' "$modo"
+    printf '          (filtro: %s) — ultimas linhas do vitest:\n' "$filtro"
+    tail -25 /tmp/prova-consumidores.$$.log | sed 's/^/          /'
+    falhas=$((falhas+1))
+  else
+    printf 'CONTROLE  %-8s verde e casou teste ✓\n' "$modo"
   fi
 done
 if [ "$falhas" -ne 0 ]; then


### PR DESCRIPTION
## O vermelho

O step `prova por consumidor`, que entrei pelo #2424, derrubou o `mutation-check` da **main** no mesmo dia ([run 34371192695](https://github.com/LucasSardenbergL/afiacao/actions/runs/34371192695)):

```
CONTROLE  SONDA    NAO ficou verde ou o filtro nao casou teste algum ✗
CONTROLE  CANARIA  NAO ficou verde ou o filtro nao casou teste algum ✗
```

## A causa NÃO é conhecida — e minha primeira hipótese foi refutada

Supus resíduo do `mutcheck`: ele muta o fonte e restaura por cópia, este script **mede** o fonte, e rodava logo depois. Cheguei a mover o step para antes.

A sessão do #2413 já tinha medido o que refuta isso: no runner o passo reprova em **~1,45 s por execução** — tempo de falha de **inicialização** do vitest, não de rodar 164 testes — e **reproduzir a sequência exata `mutcheck → prova` localmente dá VERDE**. Local também é verde com e sem `LC_ALL=C` (o acento no filtro `-t` da canária era a outra suspeita óbvia).

Então mover o step conserta nada. Ele sai.

## Por que remover, e não afrouxar

Main vermelha é custo de **todas** as ~30 worktrees, e um gate cuja falha ninguém explica não é cobertura: é ruído com poder de veto. Não vira `continue-on-error` nem "verde condicional" — **gate que não pode reprovar mente pior do que gate ausente**.

O comentário no `ci.yml` carrega o que se sabe, o que não se sabe e o gatilho de volta. E o `.mut` passa a dizer, no ponto de uso, que a consolidação das duas mutações gêmeas está **afirmada e não medida no CI** até o step voltar — em vez de seguir apontando para uma prova que não roda.

## O que fica, porque é correto de qualquer jeito

- **Os dois ramos de falha separados.** "não ficou verde **OU** o filtro não casou" juntava desfechos com conserto oposto; agora cada um diz o que houve.
- **A saída do vitest despejada na falha.** Ela ia para `/tmp`, que o runner descarta — era exatamente o que faltava para o diagnóstico não parar por falta de evidência. O #2413 chegou à mesma conclusão de forma independente; quando ele mergear, isto aqui é redundante e o diferencial deste PR é a remoção do step.
- **Guard de árvore suja:** se `$SRC`/`$TESTE` estiverem modificados, ele **nomeia** os arquivos e aborta em vez de medir outro código. Restaurar em silêncio apagaria trabalho local.

## Verificação

```
prova por consumidor (árvore limpa) ...... rc=0 · CONTROLE verde nos 2 · MUTANTE morto nos 2
falsificação do guard (árvore suja) ...... vermelho (rc=1) e NOMEIA o arquivo sujo
mutcheck --seco .......................... 25 contratos cirúrgicos · 94 padrões · 0 problemas
lint:shell ............................... 0 achados em 406 arquivos
YAML do ci.yml ........................... válido · mutation-check com 8 steps (era 9)
```

Controle verde e sabotagem na mesma invocação — sempre-vermelha aprovaria tudo.

## Colisões conferidas

- **#2413** toca `scripts/prova-consumidores-controle.sh` (+9/-0: o mesmo despejo de log). Se ele mergear antes, resolvo por rebase mantendo só a remoção do step.
- **#2420** toca `.github/workflows/ci.yml` (+13/-0), em outro job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)