### PR TITLE
fix(canaria): a fatia da verdade não sabia de onde vem o marcador — sobrava o mapa e faltava o `index.ts`

### DIFF
--- a/docs/historico/sonda-le-worktree-defasado.md
+++ b/docs/historico/sonda-le-worktree-defasado.md
@@ -141,3 +141,60 @@ Limite **conhecido** da medição, registrado no próprio `.mut`: o `r.status ??
 (spawn morto por sinal/timeout ⇒ fail-CLOSED) não tem mutação — `git` fora de repo devolve 128 e não
 `null`, e forjar um spawn morto viraria teste do Node, não do guard. É limite nomeado, não
 cobertura silenciosa.
+
+---
+
+## Epílogo (2026-09-09): a fatia certa não é uma LISTA — é o que o resolvedor LEU
+
+O guard acima nasceu com a fatia escrita à mão: `fatiaDaVerdade(edges)` devolvia os `versao.ts` das
+edges pedidas mais o mapa de fingerprints. Uma lista mantida **à parte da lógica de leitura** que
+ela existe para vigiar. Enquanto os dois lados concordarem, funciona; e nada obriga os dois lados a
+concordar. No modo `--canaria` eles já discordavam nos **dois sentidos** — medido com a CLI real:
+
+- **sobrava** o mapa: o modo canária não o lê (`grep -c -i fingerprint` em ~20 KB de SQL emitido por
+  quatro canárias deu **0**). Conferir arquivo que não participa do resultado não fecha veredito
+  falso nenhum — só produz bloqueio, e um bloqueio de rotina, porque o `sonda:fingerprint` exige
+  regravar esse mapa a cada mudança em `_shared/`;
+- **faltava** o `index.ts`, de onde o `contrato: "..."` da canária de fato sai. Um `contrato:`
+  alterado e não mergeado saía no SQL como marcador esperado e o guard não notava: `exit 0`, 9 545
+  bytes, o marcador FABRICADO dentro. A canária no ar responde o contrato antigo, o veredito sai
+  `CANARIA DE OUTRA FATIA`, e isso **se lê como deploy pendente** — o falso de 2026-09-05 de volta,
+  pela porta que ninguém vigiava.
+
+O eixo dos dois erros é o mesmo, e é o que vale guardar:
+
+> **Fatia de guard tem de ser DERIVADA da leitura que ela vigia, nunca uma lista paralela.** Quem
+> resolve o marcador é quem sabe de que arquivos ele saiu — então é ele que declara a fatia
+> (`proveniencia`), no mesmo gesto em que resolve. Lista à parte erra nos dois sentidos ao mesmo
+> tempo, e os dois são invisíveis: a sobra se lê como CI chato, a falta se lê como deploy pendente.
+
+E o teste que "cobria" isso passava por **acidente**: o espelho de `origin/main` divergia por
+*substring* do nome da edge, então pegava o `versao.ts` — que, para uma canária de
+`campoMarcador: 'contrato'`, não alimenta o `esperado(...)`. Divergência no arquivo irrelevante,
+cegueira no que decide. **Teste de fatia tem de nomear o caminho EXATO**; casar por substring aprova
+a fatia errada com a mesma cor de verde.
+
+### A metade que o Codex viu: conferir a SEGUNDA leitura não é conferir
+
+O gerador lia os arquivos e o guard lia de **novo**. Duas leituras são duas medições: o
+`esperado(...)` sai da primeira e a aprovação vem da segunda, e nada as obriga a concordar. A
+correção é a proveniência carregar os **bytes**, e `conferirSincronia` receber as fontes **sem a
+raiz** — não tem como reler, e quem garante isso é o compilador, não um comentário.
+
+Daí duas portas novas, as duas do tipo *ausente ≠ zero*: **fatia vazia aborta** (não ter conferido
+nada não é ter conferido e aprovado — fecha o modo futuro que esqueça de declarar proveniência) e
+**o mesmo arquivo lido com bytes diferentes na mesma execução aborta** (a corrida acontecendo;
+escolher qual leitura vale é escolher qual metade do veredito é a verdadeira).
+
+Mesma doutrina do #2427, achado no mesmo dia noutro gate: *procedência vira argumento obrigatório*.
+
+### E a sonda do próprio laço de falsificação mentiu primeiro
+
+A primeira rodada do laço abortou sozinha (`exit 8`) e essa é a parte que vale contar: o controle
+media "testes verdes" contando linhas com `✓`, e o reporter agrega o arquivo numa linha só —
+devolveu **1** onde havia **177**. O laço recusou em vez de aprovar com dado ruim, e a sonda passou
+a ler o número que a suíte reporta. Um controle que mede errado para BAIXO só custa uma rodada; se
+medisse errado para cima, teria avalizado sete sabotagens sem rodar nenhuma.
+
+Fechado em #2435 (issue #2414). O #2422 tinha atacado só a sobra — comparando o mapa por entrada,
+mas mantendo o modo canária conferindo um arquivo que ele não lê — e foi fechado sem mergear.

--- a/scripts/canaria-leitor-do-repo.ts
+++ b/scripts/canaria-leitor-do-repo.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path';
 import { removerComentarios } from '@/lib/gates/limpeza-fonte';
 
 import { localizarCanarias } from './canaria-contrato-bump-gate';
-import type { LeitorCanariasDoRepo } from './sonda-versao-sql';
+import { relIndex, type LeitorCanariasDoRepo } from './sonda-versao-sql';
 
 /**
  * O leitor que a CLI e a prova executada compartilham.
@@ -28,7 +28,10 @@ import type { LeitorCanariasDoRepo } from './sonda-versao-sql';
  * COMPARTILHADO (`removerComentarios`) — regex local não sabe o que é string e apagaria o miolo do
  * arquivo antes da medição.
  */
-export const lerCanariasDoRepo: LeitorCanariasDoRepo = (raiz, edge) =>
-  localizarCanarias(
-    removerComentarios(readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8')),
-  );
+export const lerCanariasDoRepo: LeitorCanariasDoRepo = (raiz, edge) => {
+  const caminho = relIndex(edge);
+  // UMA leitura, e os bytes saem junto: é este `index.ts` que o guard de sincronia confere contra a
+  // `origin/main`, e conferir uma SEGUNDA leitura aprovaria bytes que o marcador não atravessou.
+  const bytes = readFileSync(join(raiz, caminho), 'utf8');
+  return { canarias: localizarCanarias(removerComentarios(bytes)), fonte: { caminho, bytes } };
+};

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -118,14 +118,25 @@ SOBREVIVE | ORDER BY por posicao (inerte: edge e a 1a col) | s/ORDER BY l\.edge;
 # ⚠️ O `r.status ?? 127` do `gitReal` (spawn morto por sinal/timeout ⇒ fail-CLOSED) NÃO tem mutação
 #    aqui: `git` fora de repo devolve 128, não `null`, e forjar um spawn morto viraria teste do
 #    Node. É limite CONHECIDO da medição, não cobertura silenciosa.
-PEGA      | guard de sincronia desligado no main                   | s/conferirSincronia\(deps\.raiz, edges, semRede === true, deps\.git\)/{ aviso: null }/
+PEGA      | guard de sincronia desligado no main (modo sonda)      | s/conferirSincronia\(fontesDoEsperado\(levaSondada\), semRede === true, deps\.git\)/{ aviso: null }/
 PEGA      | divergencia vira warning que se le e ignora            | s/if \(ausentes\.length > 0 \|\| divergentes\.length > 0\) \{/if (false) {/
-PEGA      | comparacao de conteudo INVERTIDA (igual=divergente)    | s/r\.stdout !== readFileSync/r.stdout === readFileSync/
+PEGA      | fatia VAZIA passa (guard decorativo em silencio)       | s/if \(fontes\.length === 0\) \{/if (false) {/
+PEGA      | comparacao de conteudo INVERTIDA (igual=divergente)    | s/if \(r\.stdout !== bytes\)/if (r.stdout === bytes)/
 PEGA      | bump nao-mergeado deixa de contar como divergencia     | s/ausentes\.push\(caminho\)/void caminho/
-PEGA      | fatia perde o mapa (so o versao.ts e conferido)        | s/, ARQ_MAPA\]/]/
+# A fatia deixou de ser LISTA e virou o que o resolvedor registrou ter lido (#2414, 2026-09-09).
+# As mutações abaixo sabotam a PROVENIENCIA — o eixo onde a fatia agora pode ficar cega. As duas
+# direções importam: a que TIRA o mapa do modo sonda (sub-inclusão, veredito falso) e a que tira o
+# `index.ts` do modo canária, que era o furo MEDIDO: `contrato:` não mergeado saía como esperado.
+PEGA      | fatia do modo sonda perde o mapa (so versao.ts)        | s/proveniencia: \[\{ caminho: relVersao\(edge\), bytes: textoVersao \}, \.\.\.fonteMapa\],/proveniencia: [{ caminho: relVersao(edge), bytes: textoVersao }],/
+PEGA      | fatia do modo sonda perde o versao.ts (so o mapa)      | s/proveniencia: \[\{ caminho: relVersao\(edge\), bytes: textoVersao \}, \.\.\.fonteMapa\],/proveniencia: [...fonteMapa],/
+# A CORRIDA que o parecer Codex nomeou: a proveniencia deixa de ser o que o LEITOR usou e vira uma
+# SEGUNDA leitura do disco. Compila, e o veredito continua saindo — mas o que o guard aprova nao e
+# mais o que o marcador atravessou. So pega quem tenha um leitor que discorde do disco.
+PEGA      | proveniencia vira 2a leitura do disco (a corrida)      | s/const doIndex: FonteDoEsperado = lido\.fonte;/const doIndex: FonteDoEsperado = { caminho: relIndex(reg.edge), bytes: readFileSync(join(raiz, relIndex(reg.edge)), 'utf8') };/
+PEGA      | leitura discordante na mesma execucao passa em silencio| s/if \(brigando\.length > 0\) \{/if (false) {/
 PEGA      | fetch some: compara contra retrato velho por padrao    | s/const f = git\(\['fetch', REMOTO, RAMO_DEPLOYADO\]\);/const f = { status: 0, stdout: '', stderr: '' };/
 PEGA      | fetch que falha degrada em vez de abortar              | s/if \(f\.status !== 0\) \{/if (false) {/
-PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/conferirSincronia\(deps\.raiz, edges, semRede === true/conferirSincronia(deps.raiz, edges, true/
+PEGA      | --sem-rede passa a valer SEMPRE (guard vira opt-in)    | s/fontesDoEsperado\(levaSondada\), semRede === true/fontesDoEsperado(levaSondada), true/
 # O `cwd` do `gitReal`. O #2227 tirou a ref `origin/main` herdada do checkout (a causa do
 # `mutation-check` vermelho em todo PR — docs/historico/teste-que-afirma-o-checkout.md) e pôs um
 # repo fixture no lugar. Esta linha é o que transforma esse conserto em COBERTURA: com a asserção
@@ -222,7 +233,13 @@ PEGA      | inalcancavel deixa de barrar (401 = bundle velho)| s/const barradas 
 PEGA      | a leva PADRAO passa a incluir a inalcancavel     | s/^      : CANARIAS\.filter\(\(c\) => c\.inalcancavel === null\)/      : CANARIAS/
 # ── a CLI: flag sem sentido é RECUSADA, não ignorada; e o guard de sincronia vale igual ──
 PEGA      | --canaria sem leitor deixa de recusar            | s/if \(deps\.lerCanarias === undefined\)/if (false)/
-PEGA      | guard de sincronia cego no modo canaria          | s/\[\.\.\.new Set\(leva\.map\(\(c\) => c\.edge\)\)\],/[],/
+PEGA      | guard de sincronia cego no modo canaria          | s/conferirSincronia\(fontesDoEsperado\(leva\), semRede === true, deps\.git\)/conferirSincronia([], semRede === true, deps.git)/
+# O FURO MEDIDO em 2026-09-09: o marcador da canária sai do literal `contrato:` no `index.ts`, e
+# esse arquivo não estava na fatia. `--canaria copilot-analyze --sem-rede` com o contrato trocado no
+# working tree saiu `exit 0`, 9 545 bytes de SQL, carregando o marcador FABRICADO — a canária no ar
+# responderia o contrato antigo e o `CANARIA DE OUTRA FATIA` se leria como deploy pendente.
+PEGA      | fatia da canaria perde o index.ts (o FURO de 2026-09-09) | s/resolvidas\.push\(\{ \.\.\.reg, marcador: achada\.contrato, proveniencia: \[doIndex\] \}\);/resolvidas.push({ ...reg, marcador: achada.contrato, proveniencia: [] });/
+PEGA      | canaria por REFERENCIA perde o versao.ts do marcador     | s/proveniencia: \[doIndex, \{ caminho: relVersao\(reg\.edge\), bytes: texto \}\],/proveniencia: [doIndex],/
 PEGA      | --caro aceito em silencio no modo canaria        | s/^    if \(caras\.length > 0\)/    if (false)/
 PEGA      | --so-leitura aceito em silencio (leitura sem mapa)| s/if \(soLeitura === true\)/if (false)/
 PEGA      | canaria repetida na leva (dispara duas vezes)    | s/if \(repetidasC\.length > 0\)/if (false)/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -5,13 +5,13 @@ import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
-import { localizarCanarias } from './canaria-contrato-bump-gate';
-import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+import { lerCanariasDoRepo } from './canaria-leitor-do-repo';
 
 import {
   CANARIAS,
+  conferirSincronia,
   escaparParaFormat,
-  fatiaDaVerdade,
+  fontesDoEsperado,
   gerarSqlDaLeva,
   gerarSqlDasCanarias,
   gitReal,
@@ -972,10 +972,16 @@ function gitFalso(opts: {
   };
 }
 
-/** O estado SADIO: `origin/main` byte-a-byte igual ao disco, do qual cada teste sabota UMA coisa. */
+/**
+ * O estado SADIO: `origin/main` byte-a-byte igual ao disco, do qual cada teste sabota UMA coisa.
+ *
+ * Ele parte da PROVENIÊNCIA da leva, e não de uma lista escrita à mão: fixture montado por lista
+ * própria concorda com a implementação por coincidência, e passa a discordar em silêncio no dia em
+ * que o marcador ganha uma dependência nova — que é o defeito medido em 2026-09-09.
+ */
 function espelho(raiz: string, edges: string[]): Record<string, string> {
   return Object.fromEntries(
-    fatiaDaVerdade(edges).map((c) => [c, readFileSync(join(raiz, c), 'utf8')]),
+    fontesDoEsperado(resolverLeva(raiz, edges)).map((f) => [f.caminho, f.bytes]),
   );
 }
 
@@ -1248,11 +1254,13 @@ describe('parsearArgs — a flag do efeito legado', () => {
 // MODO CANÁRIA
 // ==========================================================================================
 
-/** O leitor REAL — o mesmo que a CLI injeta. Testar com um leitor de mentira provaria o dublê. */
-const lerCanariasReal: LeitorCanariasDoRepo = (raiz, edge) =>
-  localizarCanarias(
-    removerComentarios(readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8')),
-  );
+/**
+ * O leitor REAL — literalmente o que a CLI injeta, importado, não recriado.
+ *
+ * Até esta leva era uma CÓPIA da regra, e cópia da regra é o defeito que o módulo compartilhado
+ * existe para impedir: a suíte seguiria verde julgando um leitor que não é o que o operador roda.
+ */
+const lerCanariasReal: LeitorCanariasDoRepo = lerCanariasDoRepo;
 
 /**
  * Um `index.ts` de mentira que hospeda a canária no arm que a `chave` do registro nomeia.
@@ -1350,7 +1358,7 @@ describe('registro de canárias — o marcador SAI do repo, nunca do registro', 
     expect(leva).toHaveLength(alcancaveis.length);
     for (const c of leva) {
       expect(c.marcador, `${c.nome} sem marcador`).not.toBe('');
-      const emitido = lerCanariasReal(RAIZ_REPO, c.edge).find((e) => e.chave === c.chave);
+      const emitido = lerCanariasReal(RAIZ_REPO, c.edge).canarias.find((e) => e.chave === c.chave);
       expect(emitido, `${c.nome} não está no index.ts em ${c.chave}`).toBeDefined();
       if (c.campoMarcador === 'contrato') {
         expect(emitido?.contrato, `${c.nome} não bate com o index.ts`).toBe(c.marcador);
@@ -1886,6 +1894,208 @@ describe('CLI do modo canária — as flags sem sentido são RECUSADAS, não ign
     expect(rc).toBe(1);
     expect(saida).toHaveLength(0);
     expect(erros.join('\n')).toMatch(/DESSINCRONIZADO/);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// A FATIA DA VERDADE DEPENDE DO MODO — e acompanha quem RESOLVE o marcador.
+//
+// MEDIDO EM 2026-09-09, contra o repo real, com a CLI de verdade:
+//
+//   · SUB-inclusão (o furo): o marcador da canária sai do literal `contrato: "..."` no `index.ts`
+//     da edge, e esse arquivo NÃO estava na fatia. Trocando `tudo-ou-nada-normalizar-v1` por
+//     `FABRICADO-NAO-MERGEADO-v9` no working tree, `--canaria copilot-analyze --sem-rede` saiu
+//     `exit 0`, com 9 545 bytes de SQL carregando o marcador FABRICADO, e zero menção a
+//     DESSINCRONIZADO. A canária no ar responderia o contrato ANTIGO, o veredito sairia
+//     `CANARIA DE OUTRA FATIA`, e isso se lê como deploy pendente — a MESMA classe de veredito
+//     falso do incidente de 2026-09-05 que este guard existe para fechar.
+//
+//   · SOBRE-inclusão: o modo canária não lê o mapa de fingerprints — `grep -c -i fingerprint` nos
+//     ~20 KB de SQL emitido por `--canaria copilot-analyze omie-analytics-sync:doc_ambiguo_probe
+//     omie-financeiro generate-tactical-plan --sem-rede` deu 0. Conferir arquivo que não participa
+//     do resultado não fecha veredito falso nenhum: só produz bloqueio (e o `sonda:fingerprint`
+//     EXIGE regravar esse mapa quando qualquer `_shared/` muda, então o bloqueio é rotina).
+//
+// O teste que existia antes desta leva passava por ACIDENTE: `gitEspelho(RAIZ_REPO,
+// 'copilot-analyze')` diverge todo caminho que CONTÉM o nome, e pegava o `versao.ts` — que, para
+// uma canária de `campoMarcador: 'contrato'`, não alimenta o `esperado(...)`. Divergência no
+// arquivo irrelevante, cegueira no que decide. Por isso os testes abaixo nomeiam o caminho EXATO.
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+
+/** `git` espelho da `raiz`, divergindo nos caminhos EXATOS pedidos (nunca por substring). */
+function gitDivergindoEm(raiz: string, divergentes: string[]): ExecutorGit {
+  const alvo = new Set(divergentes);
+  return (args) => {
+    if (args[0] === 'fetch') return { status: 0, stdout: '', stderr: '' };
+    if (args[0] === 'rev-parse') return { status: 0, stdout: 'abc123456789\n', stderr: '' };
+    if (args[0] === 'log') return { status: 0, stdout: '2026-09-01 10:00:00 +0000\n', stderr: '' };
+    if (args[0] === 'show') {
+      const caminho = args[1].slice(args[1].indexOf(':') + 1);
+      if (alvo.has(caminho)) return { status: 0, stdout: '// outro conteúdo\n', stderr: '' };
+      try {
+        return { status: 0, stdout: readFileSync(join(raiz, caminho), 'utf8'), stderr: '' };
+      } catch {
+        return { status: 1, stdout: '', stderr: 'no such path' };
+      }
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}
+
+/** Roda a CLI contra o repo REAL, com o leitor de canárias de verdade. Devolve o que ela emitiu. */
+function rodarCli(argv: string[], git: ExecutorGit) {
+  const saida: string[] = [];
+  const erros: string[] = [];
+  const codigo = main(argv, {
+    raiz: RAIZ_REPO,
+    escrever: (t) => saida.push(t),
+    erro: (t) => erros.push(t),
+    git,
+    lerCanarias: lerCanariasReal,
+  });
+  return { codigo, saida: saida.join(''), erros: erros.join('\n') };
+}
+
+const IDX = (edge: string) => `supabase/functions/${edge}/index.ts`;
+const VER = (edge: string) => `supabase/functions/${edge}/versao.ts`;
+const MAPA = 'supabase/functions/_shared/sonda-fingerprints.ts';
+
+describe('modo canária: a fatia SEGUE o `index.ts`, que é de onde o marcador sai', () => {
+  it('CONTROLE: espelho fiel emite o SQL — a suíte não é sempre-vermelha', () => {
+    const r = rodarCli(['--canaria', 'copilot-analyze'], gitDivergindoEm(RAIZ_REPO, []));
+    expect(r.codigo).toBe(0);
+    expect(r.saida).toContain('AS veredito');
+  });
+
+  it('o FURO de 2026-09-09: `contrato:` fora da main não emite SQL', () => {
+    const r = rodarCli(
+      ['--canaria', 'copilot-analyze'],
+      gitDivergindoEm(RAIZ_REPO, [IDX('copilot-analyze')]),
+    );
+    expect(r.codigo).toBe(1);
+    expect(r.saida).toBe(''); // ZERO bytes: nada de SQL parcial
+    expect(r.erros).toMatch(/DESSINCRONIZADO/);
+    expect(r.erros).toContain(IDX('copilot-analyze'));
+  });
+
+  it('`index.ts` que só existe NESTE branch aborta — a edge no ar não hospeda essa canária', () => {
+    const git: ExecutorGit = (args) => {
+      if (args[0] === 'show' && args[1].endsWith(IDX('copilot-analyze'))) {
+        return { status: 128, stdout: '', stderr: "fatal: path ... does not exist in 'origin/main'" };
+      }
+      return gitDivergindoEm(RAIZ_REPO, [])(args);
+    };
+    const r = rodarCli(['--canaria', 'copilot-analyze'], git);
+    expect(r.codigo).toBe(1);
+    expect(r.saida).toBe('');
+    expect(r.erros).toContain('não existe em origin/main');
+  });
+
+  it('a canária que serve por REFERÊNCIA leva o `versao.ts` junto — é de lá que o literal sai', () => {
+    const r = rodarCli(
+      ['--canaria', 'generate-tactical-plan'],
+      gitDivergindoEm(RAIZ_REPO, [VER('generate-tactical-plan')]),
+    );
+    expect(r.codigo).toBe(1);
+    expect(r.saida).toBe('');
+    expect(r.erros).toContain(VER('generate-tactical-plan'));
+  });
+
+  it('cada canária confere o SEU `index.ts`: o da vizinha divergente não trava a leva', () => {
+    const r = rodarCli(
+      ['--canaria', 'copilot-analyze'],
+      gitDivergindoEm(RAIZ_REPO, [IDX('omie-financeiro')]),
+    );
+    expect(r.codigo).toBe(0);
+    expect(r.saida).toContain('AS veredito');
+  });
+
+  it('canária de `contrato` NÃO leva o `versao.ts`: ele não alimenta o marcador dela', () => {
+    // O par do teste acima. Sem ESTE, "a fatia acompanha o marcador" passaria com a fatia velha
+    // (que leva o `versao.ts` de toda edge) — e a sobre-inclusão seguiria de pé no modo canária.
+    const r = rodarCli(
+      ['--canaria', 'copilot-analyze'],
+      gitDivergindoEm(RAIZ_REPO, [VER('copilot-analyze')]),
+    );
+    expect(r.codigo).toBe(0);
+    expect(r.saida).toContain('AS veredito');
+  });
+
+  it('o mapa de fingerprints NÃO entra: o SQL da canária não carrega fingerprint nenhum', () => {
+    const r = rodarCli(['--canaria', 'copilot-analyze'], gitDivergindoEm(RAIZ_REPO, [MAPA]));
+    expect(r.codigo).toBe(0);
+    // A razão POSITIVA de o mapa poder sair: ele não alimenta o `esperado(...)` desta leva.
+    expect(r.saida.toLowerCase()).not.toContain('fingerprint');
+    expect(r.saida).toContain('AS veredito');
+  });
+
+  it('confere os BYTES que a geração usou, não uma segunda leitura do disco', () => {
+    // O parecer Codex de 2026-09-09: enquanto o gerador lê os arquivos e o guard lê de novo, há uma
+    // CORRIDA entre as duas leituras — o `esperado(...)` sai de uma e a aprovação vem da outra.
+    // Aqui o leitor devolve bytes que o disco não tem (como se o arquivo tivesse sido regravado
+    // entre as duas), e a `origin/main` é o disco, fiel. Guard que relesse o disco acharia tudo
+    // igual e aprovaria; guard que confere o que atravessou o marcador RECUSA.
+    const regravadoDepois: LeitorCanariasDoRepo = (raiz, edge) => {
+      const real = lerCanariasReal(raiz, edge);
+      if (edge !== 'copilot-analyze') return real;
+      return { ...real, fonte: { ...real.fonte, bytes: `${real.fonte.bytes}// gravado depois\n` } };
+    };
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(['--canaria', 'copilot-analyze'], {
+      raiz: RAIZ_REPO,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+      git: gitDivergindoEm(RAIZ_REPO, []),
+      lerCanarias: regravadoDepois,
+    });
+    expect(rc).toBe(1);
+    expect(saida.join('')).toBe('');
+    expect(erros.join('\n')).toContain(IDX('copilot-analyze'));
+  });
+
+  it('o MESMO arquivo lido com bytes diferentes na mesma execução aborta — a corrida acontecendo', () => {
+    // `omie-analytics-sync` hospeda DUAS canárias, então o `index.ts` dela é lido duas vezes numa
+    // leva que peça as duas. Se as leituras discordarem, escolher uma é escolher qual metade do
+    // veredito é a verdadeira — e a escolha seria silenciosa.
+    let n = 0;
+    const instavel: LeitorCanariasDoRepo = (raiz, edge) => {
+      const real = lerCanariasReal(raiz, edge);
+      if (edge !== 'omie-analytics-sync') return real;
+      n += 1;
+      return { ...real, fonte: { ...real.fonte, bytes: `${real.fonte.bytes}// leitura ${n}\n` } };
+    };
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const rc = main(
+      ['--canaria', 'omie-analytics-sync:doc_ambiguo_probe', 'omie-analytics-sync:transferencia_probe'],
+      {
+        raiz: RAIZ_REPO,
+        escrever: (t) => saida.push(t),
+        erro: (t) => erros.push(t),
+        git: gitDivergindoEm(RAIZ_REPO, []),
+        lerCanarias: instavel,
+      },
+    );
+    expect(rc).toBe(1);
+    expect(saida.join('')).toBe('');
+    expect(erros.join('\n')).toMatch(/bytes DIFERENTES dentro desta execução/);
+    expect(erros.join('\n')).toContain(IDX('omie-analytics-sync'));
+  });
+
+  it('fatia VAZIA aborta: não ter conferido nada não é ter conferido e aprovado', () => {
+    // A porta que fecha o modo NOVO que esquecer de registrar proveniência. Sem ela, o guard vira
+    // decorativo em silêncio — e silêncio, aqui, se lê como "o disco está na main".
+    const msg = msgDoErro(() => conferirSincronia([], false, gitDivergindoEm(RAIZ_REPO, [])));
+    expect(msg).toMatch(/fatia VAZIA/);
+    expect(msg).toMatch(/Nenhum SQL foi emitido/);
+  });
+
+  it('no modo SONDA o mesmo mapa divergente segue abortando — lá ele É metade do esperado', () => {
+    const r = rodarCli(['copilot-analyze'], gitDivergindoEm(RAIZ_REPO, [MAPA]));
+    expect(r.codigo).toBe(1);
+    expect(r.saida).toBe('');
+    expect(r.erros).toContain(MAPA);
   });
 });
 

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -37,18 +37,44 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { ARQ_MAPA, lerMapaCommitado } from './sonda-fingerprint';
+import { ARQ_MAPA, parsearMapa } from './sonda-fingerprint';
+
+/**
+ * Um arquivo que ALIMENTOU o `esperado(...)`, com os BYTES que a geração de fato usou.
+ *
+ * Os bytes viajam junto com o caminho de propósito. O guard confere o que a GERAÇÃO leu, não o que
+ * um segundo `readFileSync` devolveria: duas leituras do mesmo arquivo são duas MEDIÇÕES, o SQL sai
+ * da primeira, e conferir a segunda aprova bytes que ninguém emitiu. Desde que a proveniência
+ * carrega os bytes, `conferirSincronia` não recebe mais a `raiz` — não tem como reler, e é o
+ * compilador que garante isso, não um comentário.
+ */
+export interface FonteDoEsperado {
+  readonly caminho: string;
+  readonly bytes: string;
+}
 
 /** Uma edge da leva, com o marcador do `versao.ts` dela e o fingerprint da FONTE dela. */
 export interface EdgeSondada {
   edge: string;
   versao: string;
   fonte: string;
+  /** Os arquivos LIDOS para chegar em `versao` e `fonte` — a fatia que o guard confere. */
+  proveniencia: readonly FonteDoEsperado[];
+}
+
+/** Caminho do `versao.ts` de uma edge, RELATIVO à raiz do repo (é assim que o `git show` pede). */
+function relVersao(edge: string): string {
+  return `supabase/functions/${edge}/versao.ts`;
+}
+
+/** Caminho do `index.ts` de uma edge, RELATIVO à raiz — onde mora o `contrato:` da canária. */
+export function relIndex(edge: string): string {
+  return `supabase/functions/${edge}/index.ts`;
 }
 
 /** Caminho do `versao.ts` de uma edge, a partir da raiz do repo. */
 function caminhoVersao(raiz: string, edge: string): string {
-  return join(raiz, 'supabase', 'functions', edge, 'versao.ts');
+  return join(raiz, relVersao(edge));
 }
 
 /**
@@ -75,7 +101,18 @@ export function extrairVersao(fonte: string): string | null {
  * veredito — é veredito FALSO, e aqui o falso seria POSITIVO.
  */
 export function resolverLeva(raiz: string, edges: string[]): EdgeSondada[] {
-  const mapa = lerMapaCommitado(raiz);
+  // UMA leitura do mapa, e os bytes ficam: são eles que o guard confere. `lerMapaCommitado` leria
+  // de novo lá, e o `esperado(...)` teria saído da leitura de cá.
+  const bytesMapa = (() => {
+    try {
+      return readFileSync(join(raiz, ARQ_MAPA), 'utf8');
+    } catch {
+      return null;
+    }
+  })();
+  const mapa = bytesMapa === null ? {} : parsearMapa(bytesMapa);
+  const fonteMapa: FonteDoEsperado[] =
+    bytesMapa === null ? [] : [{ caminho: ARQ_MAPA, bytes: bytesMapa }];
   const semSensor: string[] = [];
   const semMarcador: string[] = [];
   const semFingerprint: string[] = [];
@@ -98,7 +135,15 @@ export function resolverLeva(raiz: string, edges: string[]): EdgeSondada[] {
       semFingerprint.push(edge);
       continue;
     }
-    resolvidas.push({ edge, versao, fonte: mapa[edge] });
+    resolvidas.push({
+      edge,
+      versao,
+      fonte: mapa[edge],
+      // O `versao.ts` DESTA edge (os bytes de que `versao` saiu) e o mapa (de que `fonte` saiu).
+      // Nada mais: `supabase/config.toml` decide PARA ONDE a sonda vai, não o que ela espera, e um
+      // ref velho falha ALTO (404 do gateway) em vez de virar "bundle velho".
+      proveniencia: [{ caminho: relVersao(edge), bytes: textoVersao }, ...fonteMapa],
+    });
   }
 
   const problemas: string[] = [];
@@ -202,14 +247,42 @@ export function gitReal(raiz: string): ExecutorGit {
 }
 
 /**
- * Os arquivos que ALIMENTAM o `esperado(edge, versao_esperada, fonte_esperada)` — nada além.
+ * A fatia da verdade: os arquivos que ALIMENTARAM o `esperado(...)`, com os bytes que alimentaram.
  *
- * A fatia é fechada de propósito: é exatamente o conjunto cujo retrato velho vira VEREDITO falso.
+ * Ela não é uma LISTA — é o que o resolvedor registrou ter lido. A lista mantida à parte da lógica
+ * de leitura foi o defeito medido em 2026-09-09, e nas DUAS direções: sobrava o mapa de
+ * fingerprints no modo canária (que não o lê: `grep -c fingerprint` nos ~20 KB de SQL emitido deu
+ * 0, então conferi-lo só produzia bloqueio) e faltava o `index.ts`, de onde o `contrato:` da
+ * canária realmente sai — um `contrato:` não mergeado saía como marcador esperado, o guard não
+ * notava, e o veredito `CANARIA DE OUTRA FATIA` se lia como deploy pendente. Fatia derivada da
+ * leitura não tem como divergir da leitura: quem acrescentar uma dependência ao marcador a
+ * acrescenta aqui pelo mesmo gesto.
+ *
  * `supabase/config.toml` fica de fora porque o `project_ref` não entra na comparação — ele decide
  * PARA ONDE a sonda vai, e um ref velho falha ALTO (404 do gateway), não vira "bundle velho".
  */
-export function fatiaDaVerdade(edges: string[]): string[] {
-  return [...edges.map((e) => `supabase/functions/${e}/versao.ts`), ARQ_MAPA];
+export function fontesDoEsperado(
+  resolvidas: ReadonlyArray<{ readonly proveniencia: readonly FonteDoEsperado[] }>,
+): FonteDoEsperado[] {
+  const porCaminho = new Map<string, string>();
+  const brigando: string[] = [];
+  for (const f of resolvidas.flatMap((r) => r.proveniencia)) {
+    const antes = porCaminho.get(f.caminho);
+    if (antes === undefined) porCaminho.set(f.caminho, f.bytes);
+    else if (antes !== f.bytes && !brigando.includes(f.caminho)) brigando.push(f.caminho);
+  }
+  if (brigando.length > 0) {
+    throw new Error(
+      `o mesmo arquivo foi lido com bytes DIFERENTES dentro desta execução: ` +
+        `${brigando.join(', ')}. É a corrida acontecendo — alguém gravou o arquivo entre duas ` +
+        'leituras, e o `esperado(...)` saiu de uma delas. Escolher qual conferir é escolher qual ' +
+        'metade do veredito é a verdadeira. Repita com o working tree parado. ' +
+        'Nenhum SQL foi emitido.',
+    );
+  }
+  return [...porCaminho]
+    .map(([caminho, bytes]) => ({ caminho, bytes }))
+    .sort((a, b) => a.caminho.localeCompare(b.caminho));
 }
 
 /** O que o guard concluiu. `aviso` só existe no caminho `--sem-rede`, que degradou de propósito. */
@@ -220,9 +293,15 @@ export interface ResultadoSincronia {
 /**
  * Confere que a fatia da verdade no working tree é IDÊNTICA à de `origin/main`, ou LANÇA.
  *
- * Fail-CLOSED em cinco portas, e nenhuma delas degrada para warning: um aviso que se lê e ignora
+ * Recebe as FONTES (caminho + bytes), não a raiz e uma lista de edges. Duas consequências, e as
+ * duas são o desenho: a fatia passa a depender do MODO — quem resolveu o marcador é quem diz o que
+ * o alimentou — e não há como reler o disco daqui, porque a raiz não chega. O que se confere é o
+ * que se emitiu.
+ *
+ * Fail-CLOSED em seis portas, e nenhuma delas degrada para warning: um aviso que se lê e ignora
  * devolve exatamente o veredito falso de 2026-09-05, só que com uma linha de texto por cima.
  *
+ *  0. fatia VAZIA ⇒ aborta: não ter conferido nada não é ter conferido e aprovado.
  *  1. `git` que não responde (binário ausente, timeout, não é repo) ⇒ aborta.
  *  2. `fetch` que falha ⇒ aborta nomeando `--sem-rede`, a única escada explícita.
  *  3. `origin/main` que não existe nem depois do fetch ⇒ aborta: não há com o que comparar, e
@@ -243,11 +322,21 @@ export interface ResultadoSincronia {
  * mais que o defeito que o guard fecha. A flag é explícita justamente para não ser o padrão.
  */
 export function conferirSincronia(
-  raiz: string,
-  edges: string[],
+  fontes: readonly FonteDoEsperado[],
   semRede: boolean,
   git: ExecutorGit,
 ): ResultadoSincronia {
+  // Porta 0 — fatia VAZIA. Não ter conferido nada não é ter conferido e aprovado: um modo novo que
+  // esqueça de registrar proveniência faria o guard passar em silêncio, e silêncio aqui se lê como
+  // "o disco está na main". É o `ausente ≠ zero` do money-path aplicado à própria fatia.
+  if (fontes.length === 0) {
+    throw new Error(
+      'fatia VAZIA: nenhum arquivo foi registrado como fonte do `esperado(...)`, então não há o ' +
+        'que comparar com a ' +
+        `${REF_DEPLOYADA} — e ausência de dado não é aprovação. Quem resolve o marcador tem de ` +
+        'declarar de que arquivos ele saiu (`proveniencia`). Nenhum SQL foi emitido.',
+    );
+  }
   if (!semRede) {
     const f = git(['fetch', REMOTO, RAMO_DEPLOYADO]);
     if (f.status !== 0) {
@@ -274,13 +363,14 @@ export function conferirSincronia(
 
   const ausentes: string[] = [];
   const divergentes: string[] = [];
-  for (const caminho of fatiaDaVerdade(edges)) {
+  for (const { caminho, bytes } of fontes) {
     const r = git(['show', `${REF_DEPLOYADA}:${caminho}`]);
     if (r.status !== 0) {
       ausentes.push(caminho);
       continue;
     }
-    if (r.stdout !== readFileSync(join(raiz, caminho), 'utf8')) divergentes.push(caminho);
+    // `bytes`, e não um `readFileSync` daqui: o que se confere tem de ser o que se EMITIU.
+    if (r.stdout !== bytes) divergentes.push(caminho);
   }
 
   if (ausentes.length > 0 || divergentes.length > 0) {
@@ -332,6 +422,14 @@ export interface OpcoesLeva {
   soDisparo?: boolean;
   /** Emite SÓ os blocos de leitura — o recorte que o agente roda no `psql-ro`. */
   soLeitura?: boolean;
+  /**
+   * A leva JÁ resolvida, quando quem chama precisa que o SQL saia dos MESMOS bytes que conferiu.
+   *
+   * É o caso da CLI: ela resolve, entrega a proveniência ao guard de sincronia e passa a leva de
+   * volta aqui. Sem isto, resolver de novo relê o disco — e o que o guard aprovou não seria,
+   * necessariamente, o que o SQL emitiu. Omitido, resolve daqui (o caminho dos testes de unidade).
+   */
+  resolvida?: readonly EdgeSondada[];
 }
 
 /**
@@ -909,7 +1007,11 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
   const janelaMin = validarJanela(opts.janelaMin);
   const grupos = separar(opts.edges, opts.caras ?? []);
   // Resolve a leva INTEIRA antes de emitir qualquer coisa: uma edge sem sensor derruba o SQL todo.
-  resolverLeva(opts.raiz, opts.edges);
+  // E resolve UMA vez: os dois grupos saem desta leitura. Antes eram três `resolverLeva` — três
+  // leituras do mesmo `versao.ts` na mesma chamada, e o guard conferia uma quarta.
+  const todas = opts.resolvida ?? resolverLeva(opts.raiz, opts.edges);
+  const porEdge = new Map(todas.map((e) => [e.edge, e]));
+  const daLista = (edges: string[]): EdgeSondada[] => edges.map((e) => porEdge.get(e)!);
   const ref = lerProjectRef(opts.raiz);
   const partes: string[] = [];
   // Os recortes escolhem QUAIS blocos saem; o número de cada um continua cravado no próprio bloco,
@@ -919,7 +1021,7 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
   const querLeitura = !opts.soDisparo;
 
   if (grupos.baratas.length > 0) {
-    const leva = resolverLeva(opts.raiz, grupos.baratas);
+    const leva = daLista(grupos.baratas);
     if (querDisparo) {
       partes.push(
         `-- PASSO 1 — dispara as ${leva.length} edge(s) baratas da leva. É o bloco do FOUNDER: lê o\n` +
@@ -941,7 +1043,7 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
   }
 
   if (grupos.caras.length > 0) {
-    const leva = resolverLeva(opts.raiz, grupos.caras);
+    const leva = daLista(grupos.caras);
     if (querDisparo) {
       partes.push(
         `-- PASSO 3 — dispara as ${leva.length} edge(s) CARAS, com trava.\n` +
@@ -1142,6 +1244,13 @@ const SIMBOLO_VERSAO = 'VERSAO';
 /** Uma canária do registro com o marcador que o REPO diz que ela emite hoje. */
 export interface CanariaResolvida extends CanariaRegistrada {
   readonly marcador: string;
+  /**
+   * Os arquivos LIDOS para chegar em `marcador`: o `index.ts` da edge sempre (é onde mora o
+   * `contrato:`, e onde `localizarCanarias` acha a chave e a FORMA), e o `versao.ts` só quando a
+   * canária serve por REFERÊNCIA — aí o literal está lá. O mapa de fingerprints não entra: o modo
+   * canária não o lê, e conferir o que não alimenta o resultado só produz bloqueio.
+   */
+  readonly proveniencia: readonly FonteDoEsperado[];
 }
 
 /**
@@ -1154,10 +1263,23 @@ export interface CanariaResolvida extends CanariaRegistrada {
  * carregar, e os cenários do eval voltariam a devolver `SQL_VAZIO`. Quem executa como CLI resolve
  * o leitor real no fim deste arquivo.
  */
-export type LeitorCanariasDoRepo = (
-  raiz: string,
-  edge: string,
-) => ReadonlyArray<{ chave: string; contrato: string | null; simbolo: string | null }>;
+export type LeitorCanariasDoRepo = (raiz: string, edge: string) => CanariasDoIndex;
+
+/**
+ * O que o leitor devolve: as canárias achadas E os bytes do `index.ts` de que elas saíram.
+ *
+ * A `fonte` vem do LEITOR, e não de um `readFileSync` do lado de cá, porque é ele quem sabe o que
+ * leu — e porque o que o guard confere tem de ser o que o marcador atravessou. Quando os dois
+ * lados leem por conta própria, o `esperado(...)` sai de uma leitura e a aprovação da outra.
+ */
+export interface CanariasDoIndex {
+  readonly canarias: ReadonlyArray<{
+    chave: string;
+    contrato: string | null;
+    simbolo: string | null;
+  }>;
+  readonly fonte: FonteDoEsperado;
+}
 
 /** Pastas de `supabase/functions/` que podem hospedar canária (toda pasta com `index.ts`). */
 function edgesDoRepo(raiz: string): string[] {
@@ -1188,7 +1310,7 @@ function conferirRegistroCompleto(raiz: string, ler: LeitorCanariasDoRepo): void
   for (const edge of edgesDoRepo(raiz)) {
     const bruto = readFileSync(join(raiz, 'supabase', 'functions', edge, 'index.ts'), 'utf8');
     if (!/canary\s*:\s*true/.test(bruto)) continue;
-    for (const c of ler(raiz, edge)) {
+    for (const c of ler(raiz, edge).canarias) {
       if (!registradas.has(`${edge} ${c.chave}`)) {
         forasteiras.push(`${edge} (${c.chave} -> ${c.contrato ?? `versao: ${c.simbolo ?? '?'}`})`);
       }
@@ -1238,7 +1360,12 @@ export function resolverCanarias(
   const resolvidas: CanariaResolvida[] = [];
   for (const nome of nomes) {
     const reg = porNome.get(nome)!;
-    const achada = ler(raiz, reg.edge).find((c) => c.chave === reg.chave);
+    const lido = ler(raiz, reg.edge);
+    // O `index.ts` entra na proveniência ANTES de sabermos se a canária resolve: é dele que sai a
+    // chave, a FORMA e (em 7 das 8) o próprio marcador. Um `index.ts` fora da main é exatamente o
+    // caso que passava batido — a canária no ar responde o contrato ANTIGO.
+    const doIndex: FonteDoEsperado = lido.fonte;
+    const achada = lido.canarias.find((c) => c.chave === reg.chave);
     if (achada === undefined) {
       semMarcador.push(`${nome} (o index.ts de ${reg.edge} não hospeda canária em ${reg.chave})`);
       continue;
@@ -1257,7 +1384,7 @@ export function resolverCanarias(
         );
         continue;
       }
-      resolvidas.push({ ...reg, marcador: achada.contrato });
+      resolvidas.push({ ...reg, marcador: achada.contrato, proveniencia: [doIndex] });
       continue;
     }
 
@@ -1287,11 +1414,18 @@ export function resolverCanarias(
       }
     })();
     const versao = texto === null ? null : extrairVersao(texto);
-    if (versao === null) {
+    if (versao === null || texto === null) {
       semMarcador.push(`${nome} (versao.ts sem \`export const VERSAO = "..."\` legível)`);
       continue;
     }
-    resolvidas.push({ ...reg, marcador: versao });
+    // Só ESTA forma leva o `versao.ts`: é a única em que o literal do marcador mora lá. Para uma
+    // canária de `contrato`, o `versao.ts` da mesma edge pode divergir da main sem produzir
+    // veredito falso nenhum — conferi-lo seria o bloqueio pelo bloqueio.
+    resolvidas.push({
+      ...reg,
+      marcador: versao,
+      proveniencia: [doIndex, { caminho: relVersao(reg.edge), bytes: texto }],
+    });
   }
 
   const pendencias: string[] = [];
@@ -1558,8 +1692,28 @@ export function gerarSqlDasCanarias(opts: OpcoesCanaria): string {
     opts.nomes.length > 0
       ? opts.nomes
       : CANARIAS.filter((c) => c.inalcancavel === null).map((c) => c.nome);
-  const leva = resolverCanarias(opts.raiz, pedidas, opts.ler);
-  const ref = lerProjectRef(opts.raiz);
+  return gerarSqlDeCanariasResolvidas(
+    opts.raiz,
+    resolverCanarias(opts.raiz, pedidas, opts.ler),
+    janelaMin,
+  );
+}
+
+/**
+ * O SQL de uma leva JÁ resolvida — a metade que a CLI usa, para resolver uma vez só.
+ *
+ * A separação não é estética: o guard de sincronia confere a proveniência da leva que ele recebeu,
+ * e o SQL tem de sair DESSA MESMA leva. Enquanto `main` resolvia por um lado e `gerarSqlDasCanarias`
+ * resolvia por dentro, havia duas leituras do `index.ts` na mesma execução — uma aprovada, outra
+ * emitida, e nada obrigando as duas a concordar.
+ */
+export function gerarSqlDeCanariasResolvidas(
+  raiz: string,
+  leva: readonly CanariaResolvida[],
+  janelaMinValidada: number,
+): string {
+  const janelaMin = janelaMinValidada;
+  const ref = lerProjectRef(raiz);
   const baratas = leva.filter((c) => !c.fluxoRealSeVelho);
   const caras = leva.filter((c) => c.fluxoRealSeVelho);
   const partes: string[] = [];
@@ -1823,17 +1977,15 @@ export function main(argv: string[], deps: DependenciasCli): number {
         edges.length > 0
           ? edges
           : CANARIAS.filter((c) => c.inalcancavel === null).map((c) => c.nome);
+      // UMA resolução: o guard confere os bytes DESTA leva, e é DESTA leva que o SQL sai. Resolver
+      // duas vezes (uma para conferir, outra para gerar) é aprovar uma leitura e emitir a outra.
       const leva = resolverCanarias(deps.raiz, nomes, deps.lerCanarias);
-      sql = gerarSqlDasCanarias({ raiz: deps.raiz, nomes, janelaMin, ler: deps.lerCanarias });
-      // O guard de sincronia vale IGUAL aqui, sobre as EDGES das canárias pedidas: o marcador
-      // esperado é lido do DISCO, e disco atrás de `origin/main` produz o mesmo falso da sonda —
+      // O guard de sincronia vale IGUAL aqui, sobre a PROVENIÊNCIA do marcador — o `index.ts` de
+      // onde o `contrato:` sai, e o `versao.ts` só quando a canária serve por referência. O
+      // marcador é lido do DISCO, e disco atrás de `origin/main` produz o mesmo falso da sonda:
       // "canária de outra fatia" contra um repo local velho, não contra o bundle que está no ar.
-      ({ aviso } = conferirSincronia(
-        deps.raiz,
-        [...new Set(leva.map((c) => c.edge))],
-        semRede === true,
-        deps.git,
-      ));
+      ({ aviso } = conferirSincronia(fontesDoEsperado(leva), semRede === true, deps.git));
+      sql = gerarSqlDeCanariasResolvidas(deps.raiz, leva, validarJanela(janelaMin));
     } else {
       const recusa = guardEfeitoLegado(edges, permitirEfeitoLegado === true, deps.edgesComRele ?? []);
       if (recusa !== null) {
@@ -1844,8 +1996,17 @@ export function main(argv: string[], deps: DependenciasCli): number {
       // texto e a da leva é mais específica: uma edge sem `versao.ts` deve ouvir "sem sensor", não
       // "não existe em origin/main". Nada é escrito até as DUAS passarem — `gerarSqlDaLeva` só
       // monta a string, e é este `escrever` lá embaixo que emite.
-      sql = gerarSqlDaLeva({ raiz: deps.raiz, edges, caras, janelaMin, soDisparo, soLeitura });
-      ({ aviso } = conferirSincronia(deps.raiz, edges, semRede === true, deps.git));
+      const levaSondada = resolverLeva(deps.raiz, edges);
+      ({ aviso } = conferirSincronia(fontesDoEsperado(levaSondada), semRede === true, deps.git));
+      sql = gerarSqlDaLeva({
+        raiz: deps.raiz,
+        edges,
+        caras,
+        janelaMin,
+        soDisparo,
+        soLeitura,
+        resolvida: levaSondada,
+      });
     }
   } catch (e) {
     deps.erro(`❌ ${(e as Error).message}`);


### PR DESCRIPTION
## O defeito

O guard `conferirSincronia` (#2405) recusa emitir SQL de sondagem enquanto o working tree divergir
da `origin/main` na fatia que vira o `esperado(...)`. A fatia era uma **LISTA mantida à parte da
lógica de leitura** — `fatiaDaVerdade(edges)`: os `versao.ts` das edges pedidas + o mapa de
fingerprints. Por isso errava nos **dois** sentidos no modo `--canaria`. Medido em 2026-09-09, com
a CLI real:

**SUB-inclusão (o furo).** O marcador da canária sai do literal `contrato: "..."` no
`supabase/functions/<edge>/index.ts` (via `resolverCanarias` → `localizarCanarias`), e esse arquivo
não estava na fatia. Trocando `tudo-ou-nada-normalizar-v1` por um valor fabricado no working tree:

```
SABOTADO_exit=0
stdout_bytes=9545
marcador_FABRICADO_no_SQL=1
stderr_diz_DESSINCRONIZADO=0
```

A canária no ar responderia o contrato **antigo**, o veredito sairia `CANARIA DE OUTRA FATIA`, e
isso se lê como deploy pendente. É exatamente a classe de veredito falso do incidente de 2026-09-05
que este guard existe para fechar — o desfecho é redeployar money-path à toa.

**SOBRE-inclusão.** O modo canária não lê o mapa de fingerprints: `grep -c -i fingerprint` nos
~20 KB de SQL emitido por `--canaria copilot-analyze omie-analytics-sync:doc_ambiguo_probe
omie-financeiro generate-tactical-plan --sem-rede` deu **0**. Conferir arquivo que não participa do
resultado não fecha veredito falso nenhum; só produz bloqueio — e o `sonda:fingerprint` **exige**
regravar esse mapa quando qualquer `_shared/` muda, então o bloqueio é rotina.

O teste que existia passava por **acidente**: `gitEspelho(RAIZ_REPO, 'copilot-analyze')` diverge
todo caminho que *contém* o nome, e pegava o `versao.ts` — que, para uma canária de
`campoMarcador: 'contrato'`, não alimenta o `esperado(...)`. Divergência no arquivo irrelevante,
cegueira no que decide.

## A correção

A fatia deixa de ser lista e passa a ser **o que o resolvedor registrou ter lido**. `resolverLeva` e
`resolverCanarias` devolvem, junto do marcador, a `proveniencia`: os arquivos de que ele saiu, **com
os bytes**. Fatia derivada da leitura não tem como divergir da leitura — quem acrescentar uma
dependência ao marcador a acrescenta à fatia pelo mesmo gesto.

| modo | fatia |
|---|---|
| sonda | `versao.ts` da edge + o mapa (o `esperado` carrega o fingerprint) |
| canária, `campoMarcador: 'contrato'` | `index.ts` da edge |
| canária, `campoMarcador: 'versao'` | `index.ts` **e** `versao.ts` (o literal mora lá) |

É a doutrina do #2427 (*"procedência vira argumento obrigatório"*) aplicada ao gerador da sonda.

**Os bytes viajam junto** porque o parecer Codex de 2026-09-09 nomeou a segunda metade: o gerador
lia os arquivos e o guard lia de **novo**, e entre as duas leituras havia corrida — o `esperado(...)`
saía de uma e a aprovação vinha da outra. Agora `conferirSincronia` recebe as fontes e **não a
raiz**: não tem como reler, e é o compilador que garante isso, não um comentário. A CLI resolve uma
vez, entrega a proveniência ao guard e passa a mesma leva ao gerador
(`gerarSqlDeCanariasResolvidas`, `OpcoesLeva.resolvida`).

Duas portas fail-closed novas, ambas do tipo *ausente ≠ zero*:

- **fatia VAZIA aborta** — não ter conferido nada não é ter conferido e aprovado; fecha o modo
  futuro que esqueça de registrar proveniência;
- **o mesmo arquivo lido com bytes diferentes na mesma execução aborta** — é a corrida acontecendo,
  e escolher qual leitura conferir é escolher qual metade do veredito é a verdadeira.

**O guard NÃO afrouxou.** O `index.ts` divergente agora RECUSA (antes passava), e o mapa segue
conferido no modo sonda, onde ele é de fato metade do `esperado(...)`.

## Evidência

**O furo, fechado — mesmo gesto, mesma CLI, depois da correção:**

```
CONTROLE  exit=0  bytes=9546
SABOTADO  exit=1  stdout_bytes=0  marcador_FABRICADO_no_SQL=0
          stderr_diz_DESSINCRONIZADO=1  stderr_nomeia_o_index=1
          stderr_menciona_fingerprints=0
```

**Falsificação** — 7 sabotagens, todas VERMELHAS, com controle verde e não-vazio na **mesma
invocação** do laço (o script aborta antes do primeiro `sed` se o controle não for verde):

```
controle: exit=0  testes_verdes=177
✅ fatia da canaria perde o index.ts (o FURO)      — VERMELHO
✅ canaria por REFERENCIA perde o versao.ts        — VERMELHO
✅ fatia do modo sonda perde o mapa                — VERMELHO
✅ guard confere 2a leitura do disco (a corrida)   — VERMELHO
✅ fatia VAZIA passa (guard decorativo)            — VERMELHO
✅ leitura discordante passa em silencio           — VERMELHO
✅ guard de sincronia cego no modo canaria         — VERMELHO
controle final: exit=0 verdes=177
```

A primeira rodada desse laço **abortou sozinha** (`exit 8`): a sonda de controle contava linhas com
`✓` e o reporter agrega o arquivo numa linha só, devolvendo 1 onde havia 177. O guard recusou em vez
de aprovar com dado ruim — a sonda passou a ler o número que a suíte reporta.

**Demais gates:** `bun run typecheck` exit 0 · `bun lint` exit 0 (75 warnings pré-existentes, 0
erros) · 177/177 na suíte do arquivo, pós-rebase · `mutcheck --seco` 100/100 cirúrgicos, 0 problemas.

**12 testes novos**, todos pela CLI (`main(...)`) exigindo código 1 **e** stdout de ZERO bytes,
nomeando o caminho EXATO (nunca por substring), com CONTROLE verde no mesmo `describe`. 7 mutações
novas no `.mut`.

`lerCanariasReal` no teste deixa de ser uma **cópia** da regra e passa a importar
`lerCanariasDoRepo` — cópia da regra é o defeito que o módulo compartilhado existe para impedir.

## Nota sobre o #2422

Aquele PR foi **fechado** (superado pelo #2425) e a sobre-inclusão seguia de pé. Ele atacava só
metade — comparava o mapa por entrada, mantendo o modo canária conferindo um arquivo que ele não
lê — e não tocava a sub-inclusão, que é o furo que produz veredito falso.

Contexto: issue #2414 · `docs/historico/prova-que-parou-de-ver-o-gerador.md` · PRs #2405/#2425/#2427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)