### PR TITLE
test(varredura): 6 gates que varrem as 721 migrations corriam contra o teto de RENDER — declaram o seu

### DIFF
--- a/docs/historico/flaky-sob-carga-teto-e-custo.md
+++ b/docs/historico/flaky-sob-carga-teto-e-custo.md
@@ -1,9 +1,11 @@
 # Flaky "sob carga": o teto que você LÊ não é o que governa — e "é a máquina" esconde um número
 
 **Classe:** um teste pisca quando a M2 8GB está saturada, passa isolado, e a explicação sedutora é
-"é a máquina, sobe o timeout". Nas duas instâncias abaixo essa explicação estava **errada**: medir o
+"é a máquina, sobe o timeout". Nas instâncias **1 e 2** essa explicação estava **errada**: medir o
 trabalho real devolveu um número acionável — um teto na camada errada e um custo algorítmico. A
-carga só revelou; ela não foi a causa.
+carga só revelou; ela não foi a causa. Nas instâncias **3 e 4** a carga era real — e mesmo assim
+"sobe o timeout" continuava errado, porque o que subiu foi o teto **da fonte** (o `it` que varre),
+não o global: medir é que diz qual dos dois.
 
 **Discriminante (a pergunta que decide, ANTES de tocar em qualquer timeout):**
 *quanto tempo o trabalho real leva, e contra qual teto ele corre?* São duas medidas distintas, e
@@ -103,6 +105,36 @@ medida, separando carga · repo · detector — as três hipóteses que o timeou
 Descartados com medição, não com suposição: motor de JS (bun e node concordam), memória (pico de
 219MB), custo do detector (2,05 ms/fonte, estável), e cache incremental — memoizar `acharColapsos`
 baratearia o **2º** `it`, deixando o 1º, que é o gargalo, intacto.
+
+## Instância 4 — reincidência em `authz-*`: a triagem por MEDIÇÃO cortou 33 candidatos em 2
+
+Mesma classe da instância 3, arquivos diferentes: `scripts/authz-funcoes.test.ts` (4 `it`) e
+`scripts/authz-gate-check.test.ts` (2), que varrem as **721 migrations** (7,7 MiB) do repo. O `it`
+da grafia sem parêntese estourou com **33.788ms** contra o `testTimeout: 20000`, sob load 50+.
+
+Uma varredura estática achou **33 arquivos** da classe. Medir na suíte completa deixou **2**: fora o
+`erro-colapsado` (já conforme), só esses passam de 3s — o 4º colocado tem 15× de folga. De novo:
+contar sítios prevê exposição, só medir prevê qual estoura.
+
+Dois números que a instância 3 não tinha:
+
+- **O corpo é SÍNCRONO e o vitest não o interrompe no meio** — só constata o estouro quando ele
+  retorna. Por isso a duração relatada (33.788ms) passa do próprio teto (20.000ms): lê como
+  contradição, mas é o teste inteiro tendo rodado antes de ser reprovado.
+- **A contenção escala com a carga além do 4× medido lá:** o mesmo `it` deu 3.889ms e 5.194ms sob
+  load ~30, 11.580ms numa terceira execução e 33.788ms em load 50+ — **8,7×** de espalhamento
+  dentro do mesmo regime "suíte completa". O teto cobre o pior EVENTO observado, não a mediana.
+
+Fix: 120 ms/migration com piso `Math.max(20_000, …)` — 2,6× o pior evento, a mesma folga
+proporcional que o precedente guarda sobre o evento que o originou. Aplicado aos 4 `it` do describe,
+não só aos caros: o mais barato saltou de 933ms para 2.499ms entre duas execuções, e calibrar quatro
+números sem dado independente para cada um seria precisão fingida.
+
+Convivência com decisão anterior: o `authz-gate-check` já fora tocado pela mesma classe em
+2026-09-07, e a saída de lá foi **memoizar** (`doRepo()`), com o comentário recusando o teto. Isso
+não é desfeito: aquela decisão recusou o teto como SUBSTITUTO de remover a duplicação, e a
+duplicação segue removida — o teto cobre a UMA varredura que sobra, irredutível. Antes de subir
+teto, foi conferido que não havia o defeito da instância 2 (nenhum `new RegExp` recompilado em laço).
 
 ## A receita
 

--- a/scripts/authz-funcoes.test.ts
+++ b/scripts/authz-funcoes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, onTestFailed } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { AUTHZ_FUNCOES_FECHADAS, type FuncaoFechada } from './authz-funcoes-fechadas';
@@ -596,10 +596,52 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
     .filter((f) => f.endsWith('.sql'))
     .map((f) => ({ file: f, sql: readFileSync(join(process.cwd(), 'supabase', 'migrations', f), 'utf8') }));
 
+  // ORÇAMENTO DA VARREDURA — medido 2026-09-09 nesta M2 8GB. O regime que decide é a suíte
+  // COMPLETA: fora do runner e isolado medem o CUSTO, só a suíte mede a CONTENÇÃO entre workers
+  // (passo 0 da receita em docs/historico/flaky-sob-carga-teto-e-custo.md).
+  //
+  // Os 4 `it` deste describe varrem as 721 migrations (7,7 MiB) do repo REAL — os dois do meio 4×
+  // cada, uma por função sabotada. O da grafia sem parêntese é o 3º teste mais lento de toda a
+  // suíte (8,1k testes), atrás só dos dois de `erro-colapsado-em-vazio-gate.test.ts`, que por isso
+  // já declaram orçamento próprio. Medido, do mais limpo ao mais real:
+  //   2,67–2,84 ms/migration fora do runner (bun/JSC) · 1,40–1,99 isolado no vitest ·
+  //   5,39 e 7,20 sob a suíte COMPLETA (duas execuções, load ~30) · 46,86 no incidente de
+  //   2026-09-09 com a máquina em load 50+ — 33.788ms, que estourou o `testTimeout: 20000` global
+  //   e derrubou a suíte inteira. O corpo é SÍNCRONO: o vitest não o interrompe no meio, só
+  //   constata o estouro quando ele retorna — por isso a duração relatada passa do próprio teto.
+  //
+  // O teto é POR MIGRATION e não um número fixo porque a causa que aperta sozinha é o repo
+  // crescer: assim ele acompanha o denominador sem afrouxar o custo UNITÁRIO, que é o que denuncia
+  // regressão do detector. Piso `Math.max(20_000, …)` para nunca ficar ABAIXO do global — teto
+  // menor que o de cima ENCURTA a folga em vez de ampliá-la (instância 1 do doc acima). Subir o
+  // `testTimeout` global era a tentação errada: afrouxaria os outros ~8.130 testes para acomodar 5.
+  const MS_POR_MIGRATION_TETO = 120; // 2,6× o pior evento REAL (46,86), a folga que o precedente guarda
+  const ORCAMENTO_VARREDURA_MS = Math.max(20_000, migrations.length * MS_POR_MIGRATION_TETO);
+
+  // `Test timed out in Nms` não nomeia causa nenhuma — e teto maior só ajuda se PRESERVA o
+  // diagnóstico. Na falha, isto separa as três hipóteses que o timeout nu confunde.
+  function armarDiagnosticoDeVarredura(): void {
+    const inicio = performance.now();
+    onTestFailed(() => {
+      const ms = performance.now() - inicio;
+      console.error(
+        `\n[authz-funcoes] varredura: ${migrations.length} migrations em ${Math.round(ms)}ms = ` +
+          `${(ms / migrations.length).toFixed(2)} ms/migration ` +
+          `(orçamento ${ORCAMENTO_VARREDURA_MS}ms a ${MS_POR_MIGRATION_TETO} ms/migration).\n` +
+          `  Referência 2026-09-09: 2,67 fora do runner · 1,99 isolado · 7,20 na suíte · 46,86 em load 50+.\n` +
+          `  ms/migration DENTRO da referência → foi CARGA da máquina; o detector está íntegro.\n` +
+          `  ms/migration ACIMA da referência  → é o DETECTOR (auditGrantsFuncoes), e teto maior só esconde.\n` +
+          `  migrations muito acima de 721     → o REPO cresceu; suba MS_POR_MIGRATION_TETO só se o\n` +
+          `                                      custo unitário continuar dentro da referência.`,
+      );
+    });
+  }
+
   it('as migrations do repo não têm reabertura de função (zero ERROS)', () => {
+    armarDiagnosticoDeVarredura();
     const erros = auditGrantsFuncoes(migrations, AUTHZ_FUNCOES_FECHADAS).filter((f) => f.level === 'error');
     expect(erros.map((e) => `${e.codigo} ${e.funcao} ${e.file}`)).toEqual([]);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   /** Tira todo REVOKE da migration que DROPa `fn`. `REVOKE ALL` **e** `REVOKE EXECUTE`: as duas
    *  formas convivem no repo (a 20260723150000 usa ALL; a 20260704120000, EXECUTE), e sabotar só
@@ -616,6 +658,7 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
   // Sem este teste, o verde acima seria indistinguível de "o detector não olhou nada". Estas 4 são
   // as que recriam DENTRO da própria migration-âncora — a forma que motivou a âncora inclusiva.
   it('o detector ENXERGA os DROP+CREATE que moram na âncora (não está inerte)', () => {
+    armarDiagnosticoDeVarredura();
     const alvo = [
       'public.get_ultimos_precos_cliente',
       'public.get_regua_preco',
@@ -628,7 +671,7 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
       );
       expect(r.length, fn).toBeGreaterThan(0);
     }
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   /** Reescreve o `DROP FUNCTION <fn>(args)` REAL para a grafia SEM parêntese, e tira o REVOKE da
    *  mesma migration. É a sabotagem do #2001 aplicada à grafia nova: se o detector voltasse a
@@ -648,6 +691,7 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
   // Anti-inércia da grafia NOVA, contra o repo REAL — não contra fixture. Sem isto, os casos
   // sintéticos acima seriam compatíveis com "o detector novo nunca roda no pipeline de verdade".
   it('a grafia SEM parêntese é enxergada no repo REAL (não só em fixture)', () => {
+    armarDiagnosticoDeVarredura();
     const alvo = [
       'public.get_ultimos_precos_cliente',
       'public.get_regua_preco',
@@ -671,7 +715,7 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
       );
       expect(r.length, fn).toBeGreaterThan(0);
     }
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   // A 5ª recriação do contrato, e ela documenta o MODELO em vez de escondê-lo: o DROP+CREATE de
   // `reposicao_pos_candidatos` está na 20260814000125, ANTERIOR à âncora dela (a 20260814022626,
@@ -679,13 +723,14 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
   // foi reestabelecido DEPOIS dela. Se um dia a âncora recuar, este teste vira vermelho e obriga
   // a revisitar a entrada, em vez de deixar a lacuna passar como silêncio.
   it('DROP+CREATE ANTERIOR à âncora não acusa — o ACL foi reestabelecido depois', () => {
+    armarDiagnosticoDeVarredura();
     const fn = 'public.reposicao_pos_candidatos';
     const r = auditGrantsFuncoes(semRevokeNaMigrationDoDrop(fn), AUTHZ_FUNCOES_FECHADAS).filter(
       (f) => f.funcao === fn,
     );
     expect(r).toEqual([]);
     expect(AUTHZ_FUNCOES_FECHADAS[fn].fechadaPor! > '20260814000125').toBe(true);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 });
 
 // ══════════════════════════════════════════════════════════════════════════════════════════

--- a/scripts/authz-gate-check.test.ts
+++ b/scripts/authz-gate-check.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, onTestFailed } from 'vitest';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { auditAuthz, auditCompleto, type Migration } from './authz-gate-check';
@@ -558,6 +558,37 @@ END $r$;`;
 describe('AUTHZ_REESCRITAS_CONHECIDAS — a baseline não pode ser decoração', () => {
   const dirMig = join(import.meta.dirname, '..', 'supabase', 'migrations');
 
+  // ORÇAMENTO DA VARREDURA — medido 2026-09-09 nesta M2 8GB, mesma classe e mesmo denominador do
+  // describe "contra o repo REAL" de authz-funcoes.test.ts (ver o comentário longo de lá).
+  //   1,93 e 2,93 ms/migration isolado no vitest · 4,83 e 7,00 sob a suíte COMPLETA (load ~30).
+  // O `it` que paga o `doRepo()` é o 4º teste mais lento da suíte inteira; sob o fator de contenção
+  // observado no irmão em load 50+ (~6,5×) ele bateria nos ~30s, contra o `testTimeout: 20000`.
+  //
+  // Isto NÃO desfaz a decisão de 2026-09-07 registrada logo abaixo: aquela recusou o teto como
+  // SUBSTITUTO de remover a duplicação — e a duplicação foi removida, é o que `doRepo()` memoiza.
+  // O que sobra é UMA varredura, custo irredutível desta classe, e é ele que o teto cobre. Se um
+  // canário novo voltar a computar por fora do `doRepo()`, o custo dobra e o alarme certo continua
+  // sendo a memoização, não subir este número.
+  const qtdMigrations = readdirSync(dirMig).filter((f) => f.endsWith('.sql')).length; // só LISTA
+  const MS_POR_MIGRATION_TETO = 120; // mesma calibração do irmão: 2,6× o pior evento real medido
+  const ORCAMENTO_VARREDURA_MS = Math.max(20_000, qtdMigrations * MS_POR_MIGRATION_TETO);
+
+  // Teto maior só ajuda se PRESERVA o diagnóstico: `Test timed out in Nms` não nomeia causa.
+  function armarDiagnosticoDeVarredura(): void {
+    const inicio = performance.now();
+    onTestFailed(() => {
+      const ms = performance.now() - inicio;
+      console.error(
+        `\n[authz-gate-check] varredura: ${qtdMigrations} migrations em ${Math.round(ms)}ms = ` +
+          `${(ms / qtdMigrations).toFixed(2)} ms/migration (orçamento ${ORCAMENTO_VARREDURA_MS}ms).\n` +
+          `  Referência 2026-09-09: 2,93 isolado · 7,00 sob a suíte completa.\n` +
+          `  DENTRO da referência → foi CARGA; o detector está íntegro.\n` +
+          `  ACIMA da referência  → é o DETECTOR (auditCompleto), ou o doRepo() deixou de memoizar\n` +
+          `                         e a varredura está rodando duas vezes — teto maior só esconde.`,
+      );
+    });
+  }
+
   it('toda entrada aponta para migration que EXISTE e função que está no AUTHZ_MANIFEST', () => {
     const quebradas = AUTHZ_REESCRITAS_CONHECIDAS.filter(
       (r) => !existsSync(join(dirMig, r.arquivo)) || !AUTHZ_MANIFEST[r.funcao],
@@ -598,18 +629,20 @@ describe('AUTHZ_REESCRITAS_CONHECIDAS — a baseline não pode ser decoração',
   };
 
   it('nenhuma entrada da baseline foi SUPERADA por um CREATE posterior (baseline não podada)', () => {
+    armarDiagnosticoDeVarredura();
     // O prazo de uma entrada não é uma data: é a chegada de um CREATE parseável posterior, que
     // devolve a medição à Parte A. Passado esse ponto a entrada não protege mais nada e ainda
     // desvia o alarme do `authz:audit:prod` para o arquivo errado — foi assim que o MD5_DIVERGIU
     // de `get_defasagem_cliente` ficou aberto de 05/09 a 07/09 culpando uma migration inocente.
     const obsoletas = doRepo().filter((f) => f.msg.includes('REESCRITA_BASELINE_OBSOLETA'));
     expect(obsoletas.map((f) => `${f.file}::${f.fn}`)).toEqual([]);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 
   it('o repo real não tem NENHUMA reescrita de função do manifest fora da baseline', () => {
+    armarDiagnosticoDeVarredura();
     // O canário do estado atual: se um PR novo introduzir o padrão sobre função do manifest,
     // este teste cai junto com o `authz:check` — e a mensagem diz qual arquivo.
     const naoMedidas = doRepo().filter((f) => f.msg.includes('REESCRITA_VIVA_NAO_MEDIDA'));
     expect(naoMedidas.map((f) => `${f.file}::${f.fn}`)).toEqual([]);
-  });
+  }, ORCAMENTO_VARREDURA_MS);
 });


### PR DESCRIPTION
## O que

O `testTimeout: 20000` do [vitest.config.ts](vitest.config.ts) foi calibrado no #271 para cold-start de **render**, e o próprio comentário de lá avisa que ele não é orçamento de gate que varre o repo:

> Gate de varredura NOVO que encoste em 10s deve declarar o seu teto (3º arg do `it`, POR FONTE), não subir este: subir aqui afrouxaria os outros 8.132 testes para acomodar 2.

Seis `it` estavam nessa situação sem declarar nada — os 4 do describe "contra o repo REAL" de [authz-funcoes.test.ts](scripts/authz-funcoes.test.ts) e os 2 que pagam o `doRepo()` em [authz-gate-check.test.ts](scripts/authz-gate-check.test.ts). Todos varrem as **721 migrations** (7,7 MiB) do repo.

**O global não sobe.** Segue o padrão de `erro-colapsado-em-vazio-gate.test.ts`: teto **por migration**, com piso `Math.max(20_000, …)` para nunca ficar abaixo do global — teto menor que o de cima encurta a folga em vez de ampliá-la (instância 1 do histórico).

## Medição (2026-09-09, M2 8GB)

O regime que decide é a **suíte completa**: fora do runner e isolado medem o *custo*, só a suíte mede a *contenção entre workers*.

| regime | `a grafia SEM parêntese` | ms/migration |
|---|---|---|
| fora do runner (bun/JSC), 3× | 1.925 · 2.048 · 2.036ms | 2,67–2,84 |
| vitest isolado, 3× | 1.009 · 1.317 · 1.432ms | 1,40–1,99 |
| **suíte completa**, 3× | **3.889 · 5.194 · 11.580ms** | 5,39–16,06 |
| suíte completa, load 50+ | **33.788ms** (o incidente) | 46,86 |

Espalhamento de **8,7× dentro do mesmo regime** — por isso o teto cobre o pior *evento*, não a mediana. Calibrado em **120 ms/migration** (86.520ms): 2,6× o pior evento, a mesma folga proporcional que o precedente guarda sobre o evento que o originou.

Na execução final os dois alvos bateram **11.659ms** e **11.580ms** — já acima do limiar de 10s que o config define como gatilho para declarar teto próprio.

## Escopo decidido por medição, não por contagem

Uma varredura achou **33 arquivos** da classe "teste que varre o repo". Medir deixou **2**: fora o `erro-colapsado` (já conforme), só esses passam de 3s na suíte completa — o 4º colocado tem 15× de folga. É a lição da instância 3: *contar sítios prevê exposição, só medir prevê qual estoura*.

Antes de subir teto foi conferido que não havia o defeito da instância 2 (nenhum `new RegExp` recompilado em laço). E o `authz-gate-check` já fora tocado pela classe em 2026-09-07, quando a saída foi **memoizar**: isso não é desfeito — aquela decisão recusou o teto como *substituto* de remover a duplicação, e a duplicação segue removida; o teto cobre a uma varredura que sobra.

## Falsificação (nos dois sentidos, com controle verde na mesma invocação)

| passo | resultado |
|---|---|
| controle, antes do 1º `sed` | rc=0 ✅ |
| **teto=1** (o 3º arg governa mesmo?) | rc=1, `Test timed out in 1ms` **10×**, 5 vermelhos ✅ |
| controle 2 (restauração íntegra) | rc=0 ✅ |
| **asserção sabotada** (o teto cegou?) | rc=1, **0 falhas por timeout**, 9 vermelhos com a marca `não alterou nenhuma migration` ✅ |
| controle final | rc=0, `git diff` vazio ✅ |

O guard abortou antes de sabotar numa primeira tentativa em que o controle não estava verde — e distinguir *vermelho* de *"vitest não coletou os arquivos"* (ausência de dado) foi o que evitou concluir errado.

## Validação

`bun run test` monolítico, **exit 0**:

```
 Test Files  817 passed (817)
      Tests  8653 passed | 1 skipped (8654)
   Duration  276.70s
BUN_RUN_TEST_EXIT=0
```

`bun run typecheck` → `TYPECHECK_EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)