### PR TITLE
test(db-aplicar): a 2ª classe de incompatibilidade seguia descoberta — e nenhum guard tinha CONTROLE

### DIFF
--- a/.claude/skills/lovable-db-operator/SKILL.md
+++ b/.claude/skills/lovable-db-operator/SKILL.md
@@ -142,8 +142,11 @@ relê o catálogo e dá `RAISE EXCEPTION` se o objeto não existir **ou existir 
 (constraint `NOT VALID`, índice `indisvalid=false`, view que perdeu `security_invoker`). Ele roda no
 mesmo Run de quem colou, então **uma migration que não pegou não termina em silêncio** — ela aborta
 na cara do founder, com o motivo escrito. Custa algumas linhas e é a defesa em profundidade da
-falha-mãe desta skill. Envolva a migration em `BEGIN; … COMMIT;` explícito: sem o wrapper a
-postcondição continua gritando, mas pode gritar sobre um estado meio-aplicado (medido em PG17).
+falha-mãe desta skill. **O wrapper `BEGIN; … COMMIT;` depende do CAMINHO** — não é mais regra
+única: para colar no SQL Editor/MCP, envolva (sem ele a postcondição continua gritando, mas pode
+gritar sobre um estado meio-aplicado — medido em PG17); para `bun run db:aplicar`, **não** envolva
+— a transação é do executor, e ele recusa o arquivo que traga envelope. `CREATE INDEX
+CONCURRENTLY` não roda em transação alguma, então só existe pelo caminho de cima.
 
 O predicado é **o mesmo** da query de validação do Passo 4, invertido (`IF NOT EXISTS (…) THEN RAISE
 EXCEPTION`). Template por tipo de objeto, critério de suficiência de cada um, as regras anti-teatro

--- a/.claude/skills/lovable-db-operator/references/postcondicao-embutida.md
+++ b/.claude/skills/lovable-db-operator/references/postcondicao-embutida.md
@@ -31,10 +31,20 @@ Medido em PG17.10 local, mesma migration (constraint criada `NOT VALID` + postco
 | uma única string (simple-query), sem `BEGIN;` | 1 | não (transação implícita desfaz) |
 | **`BEGIN; … COMMIT;` explícito** | 3 | não |
 
-> **Regra:** envolva a migration em `BEGIN; … COMMIT;` explícito. É a única forma de o **arquivo**
-> garantir a atomicidade por si — sem depender de o cliente mandar tudo numa string só. Sem o
-> wrapper, a postcondição continua gritando (o que já é a maior parte do ganho), mas pode gritar
-> **sobre um estado meio-aplicado**.
+> **Regra (depende do CAMINHO, desde 2026-09-09):**
+> - **SQL Editor / MCP:** envolva em `BEGIN; … COMMIT;`. Ali nenhum executor garante atomicidade,
+>   então é a única forma de o **arquivo** garanti-la por si.
+> - **`bun run db:aplicar`:** **não** envolva. A transação é do executor (ele abre, grava o recibo
+>   dentro e fecha), e `aplicar_sql()` roda o corpo por `EXECUTE`, onde comando de transação é
+>   proibido — o script recusa o envelope antes de tocar o banco. Recusa também o que não roda em
+>   transação alguma (`RECUSA_FORA_DE_TRANSACAO`, p.ex. `CREATE INDEX CONCURRENTLY`).
+>
+> Em qualquer caminho, o **alarde** da postcondição é incondicional — é a maior parte do ganho.
+>
+> ⚠️ **A atomicidade "do arquivo" é menor do que parece.** Medido no corpus em 2026-09-09: das 112
+> migrations com `BEGIN;`, só **12** são emolduradas ponta-a-ponta — 18 trazem `SELECT` de
+> verificação DEPOIS do `COMMIT;` e 1 tem DDL ANTES do `BEGIN;`. O wrapper cobre o que está
+> dentro dele, não o arquivo.
 >
 > O exemplo canônico (`20260829081556`) **não** tem o wrapper — copie dele a lógica do assert,
 > não a moldura. As outras (`…_b_cleanup_dups_oben`, `…_fecha_product_costs`,

--- a/db/fixtures/db-aplicar-cic.sql
+++ b/db/fixtures/db-aplicar-cic.sql
@@ -1,0 +1,7 @@
+-- Fixture do db/test-db-aplicar.sh — comando que não roda dentro de transação NENHUMA.
+-- Este executor DEVE RECUSÁ-LA com o marcador RECUSA_FORA_DE_TRANSACAO: o recibo só é atômico
+-- porque há uma transação, e CREATE INDEX CONCURRENTLY a proíbe. Não há conserto no executor —
+-- o arquivo tem de ir pelo Caminho A (MCP/SQL Editor).
+CREATE TABLE IF NOT EXISTS public.fixture_aplicar_cic (id int PRIMARY KEY, chave text);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS fixture_aplicar_cic_chave
+  ON public.fixture_aplicar_cic (chave);

--- a/db/fixtures/db-aplicar-corpo-de-funcao.sql
+++ b/db/fixtures/db-aplicar-corpo-de-funcao.sql
@@ -1,0 +1,21 @@
+-- Fixture do db/test-db-aplicar.sh — o CONTROLE dos dois guards de moldura. DEVE APLICAR.
+--
+-- Prova, num arquivo só, que os guards não são recusa cega:
+--   1. `BEGIN` (sem ponto-e-vírgula) e `END;` em COLUNA 0 dentro de $$ NÃO são moldura de
+--      transação — é o fecho de bloco PL/pgSQL, e recusá-lo reprovaria 81 arquivos do repo;
+--   2. `REFRESH MATERIALIZED VIEW CONCURRENTLY` NÃO é o `CREATE INDEX CONCURRENTLY` — ele roda
+--      normalmente, e 10 migrations do repo o usam exatamente assim, dentro de função.
+--
+-- A matview citada não existe de propósito: PL/pgSQL é late-bound, então `CREATE FUNCTION`
+-- passa. O que se prova aqui é o guard TEXTUAL, não o corpo da função.
+CREATE TABLE IF NOT EXISTS public.fixture_aplicar_corpo (id int PRIMARY KEY, marca text NOT NULL);
+
+CREATE OR REPLACE FUNCTION public.fixture_corpo_refresca()
+RETURNS void LANGUAGE plpgsql AS $funcao$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY public.fixture_matview_inexistente;
+END;
+$funcao$;
+
+INSERT INTO public.fixture_aplicar_corpo (id, marca) VALUES (1, 'controle-verde')
+  ON CONFLICT DO NOTHING;

--- a/db/test-db-aplicar.sh
+++ b/db/test-db-aplicar.sh
@@ -2,7 +2,7 @@
 # ╔═════════════════════════════════════════════════════════════════════════════════════════╗
 # ║   PROVA PG17 — db/claude-rw-bootstrap.sql + scripts/db-aplicar.sh                       ║
 # ║   Rode:  bash db/test-db-aplicar.sh > /tmp/t.log 2>&1; echo $?                          ║
-# ║          bash db/test-db-aplicar.sh --falsificar    (5 sabotagens, exige VERMELHO)      ║
+# ║          bash db/test-db-aplicar.sh --falsificar    (9 sabotagens, exige VERMELHO)      ║
 # ║   Exit:  0 verde · 1 asserção vermelha · 3 CONTROLE podre (a falsificação nem começou)  ║
 # ║                                                                                         ║
 # ║   Prova, EXECUTANDO (PL/pgSQL e psql são late-bound; criar não é rodar):                ║
@@ -37,6 +37,8 @@ FIX_ERRO="db/fixtures/db-aplicar-erro.sql"
 # caso em que a transformação não transformava nada. Fixture que não representa a classe real
 # de entrada é teste cego, e o custo foi quebrar TODA migration com envelope sem ninguém ver.
 FIX_ENVELOPE="db/fixtures/db-aplicar-envelope.sql"
+FIX_CIC="db/fixtures/db-aplicar-cic.sql"
+FIX_CORPO="db/fixtures/db-aplicar-corpo-de-funcao.sql"
 WORK="$(mktemp -d "/tmp/pgtest-db-aplicar.XXXXXX")"
 DATA="$WORK/data"
 # Locale é PARÂMETRO, não constante: `db-aplicar.sh` distingue falha-limpa (4) de
@@ -69,6 +71,8 @@ trap cleanup EXIT
 
 PSQL="$PGBIN/psql -X -v ON_ERROR_STOP=1 -h localhost -p $PORT -U postgres -d postgres"
 q() { $PGBIN/psql -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null | tr -d ' \n'; }
+# q() esmaga espaco e quebra de linha — serve para escalar, nao para corpo de funcao.
+q_bruto() { $PGBIN/psql -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null; }
 
 # ─── fixture: o mínimo do Supabase que o bootstrap referencia ─────────────────────────────
 $PSQL >/dev/null 2>&1 <<'SQL'
@@ -289,6 +293,34 @@ SHIM_ERRADO="$WORK/psql-rw-errado"
 R7=0; ( cd "$REPO_ROOT" && AFIACAO_PSQL_RW="$SHIM_ERRADO" bash "$ALVO" "$FIX_OK" ) >/dev/null 2>&1 || R7=$?
 eq "A7 papel errado sai 6, não 0" "$R7" "6"
 
+echo "▶ A11/A12 — a 2ª classe de incompatibilidade, e o CONTROLE dos dois guards"
+# A10 (acima) cobre a MOLDURA, que tem conserto: tirar o envelope. A11 cobre a classe que NÃO
+# tem — CREATE INDEX CONCURRENTLY não roda em transação alguma, e o recibo só é atômico porque
+# há uma. Casamos o MARCADOR ASCII: "saiu 2" também é arquivo não-commitado, sha torto e sonda.
+eq "A11 CREATE INDEX CONCURRENTLY é recusado com exit 2" "$(rc_de "$FIX_CIC")" "2"
+if grep -q 'RECUSA_FORA_DE_TRANSACAO' "$WORK/out.log"; then
+  ok "A11 recusou pelo ramo CERTO (RECUSA_FORA_DE_TRANSACAO)"
+else
+  nok "A11 marcador" "exit 2 veio de OUTRO ramo — 'recusou' não é 'recusou por isto'"
+fi
+
+# A12 — o CONTROLE, e a asserção que mais importa: sem ela, um guard que recusasse TUDO passaria
+# em A10 e A11 com louvor. Alarme de guard tem DOIS lados, e só este mede o lado de baixo.
+# `BEGIN` (sem `;`) e `END;` em coluna 0 dentro de $$ são fecho de bloco PL/pgSQL — 81 arquivos
+# do repo os têm. `REFRESH MATERIALIZED VIEW CONCURRENTLY` não é `CREATE INDEX CONCURRENTLY` —
+# 10 migrations o usam e ele roda em transação normalmente.
+eq "A12 corpo de função com BEGIN/END; e REFRESH MV CONCURRENTLY APLICA" \
+   "$(rc_de "$FIX_CORPO")" "0"
+
+# A12b — o eixo POR FORA. Tudo acima mede o que o SCRIPT decidiu; este mede o que o BANCO
+# guardou. Sensor que só consulta a máquina vigiada herda o defeito dela: se alguém reintroduzir
+# transformação do corpo (o `desenvelopar-transacao.awk` revertido em #2434 era exatamente
+# isso), os guards seguem verdes e só esta comparação vê o corpo mudar. Ver S9.
+norm_corpo() { sed '/^[[:space:]]*$/d'; }   # só a quebra que o $-quote acrescenta; indentação NÃO
+CORPO_DB="$(q_bruto "select prosrc from pg_proc where oid='public.fixture_corpo_refresca()'::regprocedure" | norm_corpo || true)"
+CORPO_ARQ="$(awk '/AS \$funcao\$$/{f=1;next} /^\$funcao\$;$/{f=0} f' "$FIX_CORPO" | norm_corpo)"
+eq "A12b o corpo GUARDADO pelo Postgres é byte-a-byte o do arquivo" "$CORPO_DB" "$CORPO_ARQ"
+
 else
 # ═════════════════════════════════════════════════════════════════════════════════════════
 echo "▶ CONTROLE (sem sabotagem, na cópia) — tem de estar VERDE antes de sabotar"
@@ -380,6 +412,75 @@ fi
 # que o desenho inteiro existe para impedir.
 eq "S5 e a tabela do envelope NÃO nasceu nem assim" \
    "$(q "select to_regclass('public.fixture_aplicar_envelope') is null")" "t"
+
+echo "▶ S6 — guard de não-transacional desligado: CREATE INDEX CONCURRENTLY vai ao banco"
+$PSQL -c "DELETE FROM public.db_aplicacoes" >/dev/null 2>&1
+# shellcheck disable=SC2016  # aspas simples de proposito: o perl casa com o TEXTO-FONTE do script
+if sabota 's/^if \[ -n "\$FORA_TX" \]; then/if false; then/m'; then
+  S6="$(rc_de "$FIX_CIC")"
+  if [ "$S6" = "4" ]; then
+    ok "S6 vermelho: sem o guard, o PG recusa o CONCURRENTLY dentro de transação (4 ≠ 2)"
+  else
+    nok "S6" "esperava exit 4 (o banco barrando); veio '$S6'"
+  fi
+fi
+
+echo "▶ S7 — guard ALARGADO para casar END; (a SOBRE-recusa) — o CONTROLE tem de cair"
+# S5/S6 provam que os guards PEGAM o que devem. Só S7 prova que A12 morde quando um guard passa
+# a pegar o que NÃO deve. `END;` é sinônimo de COMMIT no top level, mas fecha bloco PL/pgSQL e
+# aparece em coluna 0 dentro de $funcao$ — incluí-lo recusaria 81 arquivos legítimos do repo.
+# Se A12 seguisse verde aqui, ela não estaria medindo nada.
+$PSQL -c "DELETE FROM public.db_aplicacoes" >/dev/null 2>&1
+if sabota 's/\(BEGIN\|COMMIT\|ROLLBACK\|START TRANSACTION\)/(BEGIN|COMMIT|ROLLBACK|END|START TRANSACTION)/'; then
+  S7="$(rc_de "$FIX_CORPO")"
+  if [ "$S7" = "2" ]; then
+    ok "S7 vermelho: guard alargado RECUSA o controle legítimo (2) — A12 mede de verdade"
+  else
+    nok "S7" "esperava exit 2 (controle recusado por END;); veio '$S7'"
+  fi
+fi
+
+echo "▶ S8 — transformação no CLIENTE: o BANCO é o freio, e é por isso que peel não mora aqui"
+# aplicar_sql() RE-CALCULA o sha256 do corpo recebido e compara com o declarado. Qualquer
+# transformação feita pelo cliente quebra a cadeia — foi o que derrubou o desenvelopamento do
+# #2421. Exigimos a marca ASCII 'sha divergente': "falhou" sozinho não diz por quê.
+$PSQL -c "DELETE FROM public.db_aplicacoes" >/dev/null 2>&1
+# shellcheck disable=SC2016  # aspas simples de proposito: o perl casa com o TEXTO-FONTE do script
+if sabota 's/^  cat "\$SNAP"$/  sed "\/^END;\$\/d" "\$SNAP"/m'; then
+  S8="$(rc_de "$FIX_CORPO")"
+  if [ "$S8" = "4" ] && grep -q 'sha divergente' "$WORK/out.log"; then
+    ok "S8 vermelho: o banco recusou a transformação do cliente (sha divergente, exit 4)"
+  else
+    nok "S8" "esperava exit 4 COM 'sha divergente'; veio '$S8' (marca ausente = outra falha)"
+  fi
+fi
+
+echo "▶ S9 — transformação SERVER-SIDE: a única que o sha NÃO pega, e que só A12b enxerga"
+# O sha é conferido DENTRO de aplicar_sql. Uma transformação aplicada DEPOIS dessa conferência
+# passa por todos os guards do cliente, pelo ledger e pelo próprio sha — e é onde um peel teria
+# de morar. S8 mostra que nenhuma sabotagem do cliente derruba A12b; sem S9, A12b seria verde
+# por INALCANÇÁVEL. A transformação escolhida some com a indentação: o corpo segue VÁLIDO e a
+# função é criada normalmente. É a corrupção silenciosa de verdade.
+cp "$APLICAR" "$ALVO"   # esta sabotagem é no BOOTSTRAP; $ALVO ainda carrega a do S8
+BOOT_SAB="$WORK/bootstrap-sabotado.sql"
+perl -pe 's/^  EXECUTE p_sql;$/  EXECUTE regexp_replace(p_sql, E\x27\\n  \x27, E\x27\\n\x27, \x27g\x27);/' "$BOOT" > "$BOOT_SAB"
+if cmp -s "$BOOT" "$BOOT_SAB"; then
+  nok "S9 sabotagem inerte" "o padrão não casou com 'EXECUTE p_sql;' no bootstrap"
+else
+  $PSQL -c "DROP FUNCTION IF EXISTS public.fixture_corpo_refresca();
+            DROP TABLE IF EXISTS public.fixture_aplicar_corpo;
+            DELETE FROM public.db_aplicacoes" >/dev/null 2>&1
+  $PSQL -f "$BOOT_SAB" >/dev/null 2>&1
+  S9="$(rc_de "$FIX_CORPO")"
+  C_DB="$(q_bruto "select prosrc from pg_proc where oid='public.fixture_corpo_refresca()'::regprocedure" | sed '/^[[:space:]]*$/d' || true)"
+  C_ARQ="$(awk '/AS \$funcao\$$/{f=1;next} /^\$funcao\$;$/{f=0} f' "$FIX_CORPO" | sed '/^[[:space:]]*$/d')"
+  if [ "$S9" = "0" ] && [ "$C_DB" != "$C_ARQ" ]; then
+    ok "S9 vermelho: peel no servidor aplica LIMPO (0) e só A12b vê o corpo ter mudado"
+  else
+    nok "S9" "esperava apply 0 com corpo DIFERENTE; veio rc='$S9', corpo $([ "$C_DB" = "$C_ARQ" ] && echo IGUAL || echo diferente)"
+  fi
+  $PSQL -f "$BOOT" >/dev/null 2>&1   # devolve a função verdadeira
+fi
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════════════════

--- a/docs/agent/database.md
+++ b/docs/agent/database.md
@@ -80,7 +80,9 @@ envelhece mal: ninguém a revisa, porque parece lei da física.
 
 1. **idempotente** (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`, `UPDATE … WHERE col IS NULL`) —
    re-rodar não pode estragar;
-2. **transacional** (`BEGIN; … COMMIT;` explícito) — sem meio-aplicado;
+2. **transacional** — sem meio-aplicado. **Quem fornece a transação depende do caminho:** pelo
+   SQL Editor/MCP é o ARQUIVO (`BEGIN; … COMMIT;` explícito); pelo `bun run db:aplicar` é o
+   EXECUTOR, e aí o arquivo **não** leva envelope — ele é recusado se levar;
 3. **com postcondição** `DO $post$` que dá `RAISE EXCEPTION` se não pegar — a migration aborta
    sozinha em vez de terminar em silêncio;
 4. **pré-voo `psql-ro` 🟢** — o predicado da postcondição conferido ANTES, contra a prod.

--- a/docs/superpowers/specs/2026-09-09-atomicidade-migration-db-aplicar-design.md
+++ b/docs/superpowers/specs/2026-09-09-atomicidade-migration-db-aplicar-design.md
@@ -1,0 +1,79 @@
+# De quem é a atomicidade da migration — e a cobertura que a recusa não trouxe
+
+**2026-09-09.** Decidido com medição do corpus (716 migrations) + 2ª opinião Codex (gpt-6-astra,
+max, 556s/184k tokens). **A decisão em si já aterrissou por outra sessão** (#2421 → #2434); este
+documento registra o raciocínio e delimita o que ficou faltando, que é o que esta entrega faz.
+
+## O conflito
+
+Dois caminhos de escrita ATIVOS, com exigências OPOSTAS sobre os mesmos bytes:
+
+| Caminho | Quem garante a atomicidade | O que exige do arquivo |
+|---|---|---|
+| **A** — SQL Editor / MCP `query_database` | ninguém que se possa nomear | **precisa** de `BEGIN; … COMMIT;` |
+| **B** — `bun run db:aplicar` | o executor (abre a transação, grava o recibo nela) | **proíbe** — `EXECUTE` recusa comando de transação |
+
+`aplicar_sql` roda o corpo por `EXECUTE p_sql` dentro do `BEGIN;` do próprio `db-aplicar.sh`.
+Arquivo com envelope ⇒ `ERROR: EXECUTE of transaction commands is not implemented`. O sha256 do
+ledger é sobre os bytes exatos ⇒ **não existe "duas versões do arquivo"**.
+
+## O que a medição mostrou (e refutou)
+
+- `BEGIN;`/`COMMIT;` em coluna 0 **fora** de dollar-quote: **115/115**, pareados. **Dentro**: zero.
+  **Zero `PROCEDURE`** no corpus ⇒ `COMMIT;` dentro de `$$` nunca é legítimo aqui.
+- A mina é só o **`END;`** — sinônimo de `COMMIT` no top level, mas fecha bloco PL/pgSQL e aparece
+  em coluna 0 **dentro** de `$function$` (linha 272 de `20260908163659_…`). Um strip que o inclua
+  decapita o corpo em silêncio.
+- **Só 12 de 112** arquivos com envelope são emoldurados ponta-a-ponta: 18 têm `SELECT` de
+  verificação **depois** do `COMMIT;`, 1 tem DDL **antes** do `BEGIN;`.
+  ⇒ **A atomicidade "do arquivo" que a doutrina afirmava já era parcial na prática.**
+
+## A decisão (aterrissou em #2434): detectar e recusar, nunca transformar
+
+O wrapper passa a ser decidido pelo **destino**: obrigatório no Caminho A, recusado no `db:aplicar`.
+Vence descascar pela **assimetria dos erros** — falso-positivo do detector custa uma recusa que um
+humano lê; falso-negativo cai no erro do PG, alto e transacionalmente limpo; **nenhuma direção
+corrompe bytes**. Um descascador tem a terceira direção, silenciosa. E teria de morar DENTRO de
+`aplicar_sql` (no cliente, o que roda deixa de ser o que o sha registrou — foi o que #2421 tentou
+e o banco recusou), isto é, superfície nova na função `SECURITY DEFINER` mais poderosa do banco.
+
+## O que ESTA entrega acrescenta
+
+A recusa entrou **sem teste e sem fixture**, e cobrindo só uma das duas classes.
+
+1. **`RECUSA_FORA_DE_TRANSACAO`** — 2ª classe de incompatibilidade, que nenhuma correção no
+   executor resolve: `CREATE INDEX CONCURRENTLY` não roda em transação alguma, e o recibo só é
+   atômico porque há uma. Não pode casar `REFRESH MATERIALIZED VIEW CONCURRENTLY` (10 arquivos).
+2. **Marcador ASCII** na recusa existente — a mensagem é acentuada, e casar `transação` faria a
+   prova refém do locale (lição #1483).
+3. **3 fixtures + A10/A11/A12/A12b**, incluindo o **controle** (corpo de função com `BEGIN`/`END;`
+   em coluna 0 + `REFRESH MV CONCURRENTLY`) — sem ele, um guard que recusasse TUDO passaria.
+4. **A12b, o eixo POR FORA:** compara o corpo que o **Postgres guardou** (`prosrc`) com o do
+   arquivo. Os demais asserts medem o que o SCRIPT decidiu; sensor que só consulta a máquina
+   vigiada herda o defeito dela.
+5. **Reconciliação dos 3 pontos de doutrina** — `SKILL.md`, `postcondicao-embutida.md` §1 e o
+   envelope do `database.md` não mencionavam `db:aplicar`: quem lesse a skill hoje escreveria
+   migration com envelope e bateria na recusa.
+
+### Falsificação (todas exigem VERMELHO, com controle verde na mesma invocação)
+
+`S5` guard de envelope desligado → o PG recusa (4) · `S6` guard de CIC desligado → (4) ·
+`S7` guard alargado para casar `END;` → o **controle** cai (2), provando que A12 mede ·
+`S8` transformação no CLIENTE → o banco recusa (`sha divergente`), provando que ele é o freio
+final · `S9` transformação **SERVER-SIDE** → aplica limpo (0) e **só A12b vê o corpo mudar**.
+
+`S9` existe porque nenhuma sabotagem do cliente derruba A12b: sem ela, A12b seria verde por
+**inalcançável** — verde por não medir nada.
+
+## Limites declarados
+
+- **Sub-detecção é de propósito:** `END;` NÃO é detectado (ambíguo com bloco PL/pgSQL). Arquivo que
+  feche o envelope com `END;` falha com o erro do PG — alto e limpo.
+- **O ledger não é à prova do próprio escritor:** `claude_rw` tem `GRANT UPDATE` nele
+  (`db/claude-rw-bootstrap.sql:179`), de propósito — é como o script marca `falhou` quando a função
+  abortou. Trilha honesta, não inviolável. Fora do escopo.
+- **`FOR UPDATE` trava por `p_id`, não por sha:** dois `db:aplicar` simultâneos do mesmo arquivo
+  ganham ids distintos e **ambos executam**; só depois o índice único deixa um virar `aplicada`.
+  "Re-aplicar é no-op" vale em SEQUÊNCIA, não sob concorrência. Fora do escopo; registrado.
+- **A asserção de `search_path` do harness é fraca:** confere `proconfig IS NOT NULL`, então trocar
+  o `search_path` por lixo passa. Fora do escopo; registrado.

--- a/docs/superpowers/specs/2026-09-09-atomicidade-migration-db-aplicar-design.md
+++ b/docs/superpowers/specs/2026-09-09-atomicidade-migration-db-aplicar-design.md
@@ -39,31 +39,35 @@ e o banco recusou), isto é, superfície nova na função `SECURITY DEFINER` mai
 
 ## O que ESTA entrega acrescenta
 
-A recusa entrou **sem teste e sem fixture**, e cobrindo só uma das duas classes.
+A decisão e a prova da recusa do ENVELOPE aterrissaram por outras sessões (#2421 → #2434 →
+`516fcfbe5`). Ficaram de fora três coisas:
 
-1. **`RECUSA_FORA_DE_TRANSACAO`** — 2ª classe de incompatibilidade, que nenhuma correção no
-   executor resolve: `CREATE INDEX CONCURRENTLY` não roda em transação alguma, e o recibo só é
-   atômico porque há uma. Não pode casar `REFRESH MATERIALIZED VIEW CONCURRENTLY` (10 arquivos).
-2. **Marcador ASCII** na recusa existente — a mensagem é acentuada, e casar `transação` faria a
-   prova refém do locale (lição #1483).
-3. **3 fixtures + A10/A11/A12/A12b**, incluindo o **controle** (corpo de função com `BEGIN`/`END;`
-   em coluna 0 + `REFRESH MV CONCURRENTLY`) — sem ele, um guard que recusasse TUDO passaria.
-4. **A12b, o eixo POR FORA:** compara o corpo que o **Postgres guardou** (`prosrc`) com o do
-   arquivo. Os demais asserts medem o que o SCRIPT decidiu; sensor que só consulta a máquina
-   vigiada herda o defeito dela.
-5. **Reconciliação dos 3 pontos de doutrina** — `SKILL.md`, `postcondicao-embutida.md` §1 e o
-   envelope do `database.md` não mencionavam `db:aplicar`: quem lesse a skill hoje escreveria
-   migration com envelope e bateria na recusa.
+1. **`RECUSA_FORA_DE_TRANSACAO`** — a classe que NÃO tem conserto. A recusa do envelope se
+   resolve tirando o `BEGIN;`; `CREATE INDEX CONCURRENTLY` não roda em transação alguma, e o
+   recibo só é atômico porque há uma. O padrão é ancorado em CREATE/DROP/REINDEX para não casar
+   `REFRESH MATERIALIZED VIEW CONCURRENTLY` (10 arquivos o usam legitimamente).
+2. **O CONTROLE (A12) + a sabotagem que o prova (S7).** A10/A11 mostram que os guards pegam o
+   que devem; um guard que recusasse TUDO passaria nas duas. A12 é a fixture que tem de APLICAR:
+   corpo de função com `BEGIN`/`END;` em coluna 0 dentro de `$funcao$` (81 arquivos do repo têm)
+   e `REFRESH MV CONCURRENTLY`. S7 alarga o guard para casar `END;` e exige que A12 caia.
+3. **A12b, o eixo POR FORA** — compara o corpo que o **Postgres guardou** (`prosrc`) com o do
+   arquivo. Todo o resto mede o que o SCRIPT decidiu, e sensor que só consulta a máquina vigiada
+   herda o defeito dela.
+4. **A doutrina**, que não mencionava `db:aplicar` em lugar nenhum: `SKILL.md`,
+   `postcondicao-embutida.md` §1 e o envelope do `database.md` seguiam mandando envolver em
+   `BEGIN; … COMMIT;`. Quem lesse a skill escreveria migration com envelope e bateria na recusa.
 
 ### Falsificação (todas exigem VERMELHO, com controle verde na mesma invocação)
 
-`S5` guard de envelope desligado → o PG recusa (4) · `S6` guard de CIC desligado → (4) ·
-`S7` guard alargado para casar `END;` → o **controle** cai (2), provando que A12 mede ·
-`S8` transformação no CLIENTE → o banco recusa (`sha divergente`), provando que ele é o freio
-final · `S9` transformação **SERVER-SIDE** → aplica limpo (0) e **só A12b vê o corpo mudar**.
+`S6` guard de CIC desligado → o PG recusa (4) · `S7` guard alargado para `END;` → o **controle**
+cai (2), provando que A12 mede · `S8` transformação no CLIENTE → o banco recusa (`sha divergente`)
+— foi o que derrubou o #2421 · `S9` transformação **SERVER-SIDE** → aplica limpo (0), passa por
+todo guard e por todo o ledger, e **só A12b vê o corpo mudar**.
 
-`S9` existe porque nenhuma sabotagem do cliente derruba A12b: sem ela, A12b seria verde por
-**inalcançável** — verde por não medir nada.
+S8 e S9 juntos são o argumento de por que A12b existe: nenhuma sabotagem do cliente a derruba, e
+sem S9 ela seria verde por **inalcançável** — verde por não medir nada.
+
+Prova: PG17.10, locales `C` e `pt_BR.UTF-8`, normal (36 ✅) e `--falsificar` (24 ✅), zero ❌.
 
 ## Limites declarados
 

--- a/scripts/db-aplicar.sh
+++ b/scripts/db-aplicar.sh
@@ -111,6 +111,30 @@ if grep -qiE '^[[:space:]]*(BEGIN|COMMIT|ROLLBACK|START TRANSACTION)[[:space:]]*
    proibidos. Remova o envelope: o SQL feito para o \`db:aplicar\` não leva \`BEGIN;\`/\`COMMIT;\`.
    (Migration para colar no SQL Editor leva — são caminhos diferentes.)"
 fi
+
+# ── RECUSAR comando que não roda em transação NENHUMA ──────────────────────────────────
+# A recusa acima é sobre a MOLDURA do arquivo, e tem conserto: tirar o envelope. Esta é outra
+# classe, e não tem — `CREATE INDEX CONCURRENTLY` não roda dentro de transação alguma, nem a
+# deste script. Como o recibo SÓ é atômico porque existe uma transação, os dois requisitos são
+# mutuamente exclusivos: este arquivo tem de ir pelo SQL Editor/MCP, e ponto.
+# Sem o guard, o erro chega cru do Postgres — depois de já ter gravado tentativa no ledger.
+#
+# Comentários de linha saem ANTES de casar, para não recusar arquivo que só MENCIONA o comando
+# num comentário. Remover texto apenas REDUZ casamento, então o engano cai no lado seguro: o
+# não-detectado vira o erro do PG, alto e com a transação desfeita.
+# E o padrão NÃO pode casar `REFRESH MATERIALIZED VIEW CONCURRENTLY` — 10 migrations do repo o
+# usam legitimamente, dentro de função, e ele roda em transação normalmente. Por isso cada
+# alternativa é ancorada em CREATE/DROP/REINDEX, nunca no `CONCURRENTLY` solto.
+FORA_TX="$(sed 's/--.*$//' "$SNAP" | tr '\n' ' ' | grep -oEi \
+  'CREATE[[:space:]]+(UNIQUE[[:space:]]+)?INDEX[[:space:]]+CONCURRENTLY|DROP[[:space:]]+INDEX[[:space:]]+CONCURRENTLY|REINDEX[^;]{0,80}CONCURRENTLY' \
+  | head -2 | tr '\n' ' ' || true)"
+if [ -n "$FORA_TX" ]; then
+  morre 2 "RECUSA_FORA_DE_TRANSACAO — comando que não roda dentro de transação nenhuma (nem a
+   deste script): $FORA_TX
+   Não é ajustável aqui: o recibo só é atômico porque há uma transação, e este comando a proíbe.
+   Vá pelo SQL Editor/MCP. Lá a postcondição embutida importa ainda mais — um CREATE INDEX
+   CONCURRENTLY que falha DEIXA o índice inválido para trás (é o assert de indisvalid)."
+fi
 case "$SHA" in
   *[!0-9a-f]*|'') morre 2 "sha256 com formato inesperado para $ARQUIVO" ;;
 esac


### PR DESCRIPTION
`#2434` trocou o desenvelopamento por recusa; `516fcfbe5` provou a recusa do **envelope**.
Três coisas ficaram de fora — são estas.

## 1. A classe que não tem conserto — `RECUSA_FORA_DE_TRANSACAO`

Recusa de envelope tem conserto: tire o `BEGIN;`. `CREATE INDEX CONCURRENTLY` **não tem** — ele não
roda dentro de transação nenhuma, nem a deste script, e o recibo só é atômico porque existe uma.
São mutuamente exclusivos. Sem guard, o erro chega cru do Postgres **depois** de já ter gravado
tentativa no ledger.

O padrão é ancorado em `CREATE`/`DROP`/`REINDEX` de propósito: `REFRESH MATERIALIZED VIEW
CONCURRENTLY` aparece em **10 migrations** do repo, dentro de função, e roda em transação
normalmente. Recusar `CONCURRENTLY` solto quebraria todas.

## 2. O CONTROLE — alarme de guard tem DOIS lados

A10/A11 provam que os guards **pegam** o que devem. Um guard que recusasse TUDO passaria nas duas
com louvor. **A12** é a fixture que tem de **APLICAR**: corpo de função com `BEGIN` e `END;` em
**coluna 0** dentro de `$funcao$` — 81 arquivos do repo têm — mais `REFRESH MV CONCURRENTLY`.
**S7** alarga o guard para casar `END;` e exige que A12 **caia**. Sem S7, A12 não mede nada.

`END;` é a mina de verdade: é sinônimo de `COMMIT` no top level, mas fecha bloco PL/pgSQL. Na
migration que originou tudo isso ele está na linha 272, coluna 0, dentro de `$function$`.

## 3. A12b — o eixo POR FORA

Todo o resto mede o que o **script** decidiu. A12b compara o corpo que o **Postgres guardou**
(`prosrc`) com o do arquivo. Sensor que só consulta a máquina vigiada herda o defeito dela.

**S8** e **S9** juntos são o argumento de por que ela existe:

| sabotagem | o que acontece | quem pega |
|---|---|---|
| transformação no **cliente** | `sha divergente`, exit 4 | o **banco** — foi o que derrubou o `#2421` |
| transformação **server-side** | aplica **limpo** (0), passa por todo guard e todo o ledger | **só A12b** |

Sem S9, A12b seria verde por **inalcançável** — verde por não medir nada.

## 4. A doutrina não mencionava `db:aplicar` em lugar nenhum

`SKILL.md`, `postcondicao-embutida.md` §1 e o envelope do `database.md` seguiam mandando envolver
em `BEGIN; … COMMIT;`. Quem lesse a skill hoje escreveria migration com envelope e bateria na
recusa. Agora o wrapper depende do **caminho**.

E fica registrado o que a medição do corpus (716 migrations) mostrou: das **112** com `BEGIN;`, só
**12** são emolduradas ponta-a-ponta — 18 têm `SELECT` de verificação **depois** do `COMMIT;`, 1 tem
DDL **antes** do `BEGIN;`. A atomicidade "do arquivo" sempre foi menor do que o texto afirmava.

## Prova

PG17.10, locales `C` **e** `pt_BR.UTF-8`, nos dois modos:

```
[C]            NORMAL rc=0 36 ✅ 0 ❌ FIM_PROVA_OK | FALSIFIC rc=0 24 ✅ 0 ❌ FIM_PROVA_OK
[pt_BR.UTF-8]  NORMAL rc=0 36 ✅ 0 ❌ FIM_PROVA_OK | FALSIFIC rc=0 24 ✅ 0 ❌ FIM_PROVA_OK
```

`bun run lint:shell` ✅ 0 achados · `bun run claude:size` ✅ dentro do orçamento.

## Fora do escopo, registrados no spec

- O ledger não é à prova do próprio escritor: `claude_rw` tem `GRANT UPDATE` nele
  (`db/claude-rw-bootstrap.sql:179`), **de propósito** — é como o script marca `falhou` quando a
  função abortou. Trilha honesta, não inviolável.
- `FOR UPDATE` trava por `p_id`, não por sha: dois `db:aplicar` simultâneos do mesmo arquivo ganham
  ids distintos e **ambos executam**. "Re-aplicar é no-op" vale em SEQUÊNCIA, não sob concorrência.
- A asserção de `search_path` do harness confere `proconfig IS NOT NULL` — trocar o `search_path`
  por lixo passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)