### PR TITLE
fix(financeiro): o caixa realizado somava as duas óticas do mesmo pagamento — e as previsões junto

### DIFF
--- a/src/services/__tests__/getFluxoCaixa.test.ts
+++ b/src/services/__tests__/getFluxoCaixa.test.ts
@@ -69,8 +69,23 @@ function makeBuilder(tabela: string) {
   const filtros: Array<(r: Row) => boolean> = [];
   const ordem: string[] = [];
   let janela: { from: number; to: number } | null = null;
+  // As colunas PEDIDAS. O mock antigo ignorava o `.select()` e devolvia a linha inteira —
+  // então um filtro sobre coluna NÃO selecionada passava verde aqui e virava `undefined` em
+  // produção. No caso desta suíte isso não é hipotético: filtrar por `categoria_descricao`
+  // sem incluí-la no select ZERA o fluxo realizado, e o mock antigo aprovava (11/11). Achado
+  // da revisão Codex. Projetar é o que dá dente ao teste.
+  let colunas: string[] | null = null;
+  const projetar = (r: Row): Row => {
+    if (!colunas) return r;
+    const out: Row = {};
+    for (const c of colunas) if (c in r) out[c] = r[c];
+    return out;
+  };
   const builder = {
-    select: (_cols: string) => builder,
+    select: (cols: string) => {
+      colunas = cols.split(',').map((c) => c.trim()).filter(Boolean);
+      return builder;
+    },
     eq: (col: string, val: unknown) => {
       filtros.push((r) => r[col] === val);
       return builder;
@@ -111,9 +126,10 @@ function makeBuilder(tabela: string) {
       const ordenadas = ordenarComoPostgres(casadas, ordem, n);
       // PostgREST real: a capa de 1.000 vale SEMPRE — sem range capa em 1.000, e
       // com range a janela nunca passa de 1.000 linhas.
-      const rows = janela
+      const rows = (janela
         ? ordenadas.slice(janela.from, Math.min(janela.to + 1, janela.from + 1000))
-        : ordenadas.slice(0, 1000);
+        : ordenadas.slice(0, 1000)
+      ).map(projetar);
       return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
     },
   };
@@ -130,12 +146,21 @@ const INICIO = '2026-01-01';
 const FIM = '2026-12-31';
 
 /** Movimento de caixa realizado. `valor` distinto por linha: pular ou duplicar altera a soma. */
-const mov = (i: number, dia: string, valor: number, tipo = 'E'): Row => ({
+const mov = (
+  i: number,
+  dia: string,
+  valor: number,
+  tipo = 'E',
+  // Default = a ótica BANCÁRIA, que é a única que conta como caixa realizado. Antes as
+  // fixtures não tinham categoria nenhuma, então a suíte inteira era cega para a ótica.
+  categoria_descricao = tipo === 'E' ? 'CONTA_CORRENTE_REC' : 'CONTA_CORRENTE_PAG',
+): Row => ({
   id: `mov-${String(i).padStart(6, '0')}`,
   company: 'oben',
   data_movimento: dia,
   tipo,
   valor,
+  categoria_descricao,
   omie_codigo_lancamento: 1000 + i,
 });
 
@@ -160,6 +185,80 @@ describe('getFluxoCaixa — caixa REALIZADO (fin_movimentacoes)', () => {
     state.falharNaRequisicao = {};
     state.dataNullNaRequisicao = {};
     state.requisicoes = {};
+  });
+
+  // O mock TEM de respeitar o `.select()`. Sem este caso, a projeção acrescentada acima não
+  // é exercida por teste nenhum: os casos de ótica filtram na QUERY (`.in`), que enxerga a
+  // linha inteira, e o helper não lê `categoria_descricao`. Medido ao falsificar — sabotar a
+  // projeção deixava a suíte VERDE.
+  //
+  // O que ele protege é concreto: a query não seleciona `categoria_descricao`, então mover o
+  // filtro de ótica para o helper faria o campo chegar `undefined`, o filtro rejeitaria tudo
+  // e o caixa realizado viraria ZERO em produção — com o mock cego aprovando a mudança.
+  it('o mock devolve SÓ as colunas do .select() — coluna não pedida chega undefined', async () => {
+    state.db.fin_movimentacoes = [mov(1, '2026-03-10', 500, 'E')];
+
+    const { supabase } = await import('@/integrations/supabase/client');
+    const { data } = await supabase
+      .from('fin_movimentacoes')
+      .select('data_movimento, tipo, valor, omie_codigo_lancamento')
+      .eq('company', 'oben');
+
+    expect(data?.[0]).toBeDefined();
+    expect(data![0].valor).toBe(500);
+    // a coluna EXISTE na linha semeada, mas não foi pedida — não pode vazar
+    expect('categoria_descricao' in data![0]).toBe(false);
+  });
+
+  // ── ÓTICA: o Omie devolve o MESMO pagamento duas vezes ───────────────────────────────
+  // Estes casos não existiam, e por isso a dobra viveu em produção: as fixtures antigas não
+  // tinham `categoria_descricao`, então nenhum teste podia distinguir uma ótica da outra.
+  it('o MESMO pagamento nas duas óticas conta UMA vez — a bancária', async () => {
+    // Um pagamento de R$ 500: o lançamento do título (dia 10) e o crédito em conta (dia 11,
+    // D+1 de compensação). Somar os dois daria 1.000 e ainda espalharia caixa por 2 dias.
+    state.db.fin_movimentacoes = [
+      mov(1, '2026-03-10', 500, 'E', 'CONTA_A_RECEBER'),
+      mov(1, '2026-03-11', 500, 'E', 'CONTA_CORRENTE_REC'),
+    ];
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaRealizadoEntradas(fluxo)).toBe(500);
+    expect(fluxo.find((d) => d.data === '2026-03-11')?.entradas_realizadas).toBe(500);
+    expect(fluxo.find((d) => d.data === '2026-03-10')?.entradas_realizadas ?? 0).toBe(0);
+  });
+
+  it('PREVISÃO não é caixa realizado', async () => {
+    // `PREVISAO_*` é tipo 'E', valor>0 e TEM título — passa por todo filtro do helper.
+    // Por negação (`NOT LIKE 'CONTA_A_%'`) entraria como dinheiro que entrou. Não entrou.
+    state.db.fin_movimentacoes = [
+      mov(1, '2026-03-10', 700, 'E', 'PREVISAO_PEDIDO_VENDA'),
+      mov(2, '2026-03-10', 300, 'E', 'PREVISAO_ORDEM_SERVICO'),
+      mov(3, '2026-03-10', 100, 'E', 'CONTA_CORRENTE_REC'),
+    ];
+
+    expect(somaRealizadoEntradas(await getFluxoCaixa('oben', INICIO, FIM))).toBe(100);
+  });
+
+  it('as duas óticas do lado PAGAR também contam uma vez', async () => {
+    state.db.fin_movimentacoes = [
+      mov(1, '2026-03-10', 800, 'S', 'CONTA_A_PAGAR'),
+      mov(1, '2026-03-10', 800, 'S', 'CONTA_CORRENTE_PAG'),
+    ];
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+    expect(fluxo.reduce((s, d) => s + d.saidas_realizadas, 0)).toBe(800);
+  });
+
+  it('baixas PARCIAIS na ótica bancária somam — não se deduplica por título', async () => {
+    // Duas baixas reais do mesmo título (nCodBaixa distinto no Omie). Deduplicar por título
+    // aqui perderia metade do caixa: são dois eventos bancários, não duas óticas de um.
+    state.db.fin_movimentacoes = [
+      { ...mov(1, '2026-03-10', 400, 'E'), id: 'mov-a' },
+      { ...mov(1, '2026-03-20', 600, 'E'), id: 'mov-b' },
+    ];
+
+    expect(somaRealizadoEntradas(await getFluxoCaixa('oben', INICIO, FIM))).toBe(1000);
   });
 
   it('erro numa página LANÇA — página perdida não vira fim da tabela', async () => {

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -429,9 +429,26 @@ export async function getFluxoCaixa(
   const movimentos = await buscarTodasPaginas(
     `movimentações do fluxo de caixa (${company})`,
     (from, to) => {
+      // ALLOWLIST POSITIVA de ótica. O Omie devolve o MESMO pagamento duas vezes — uma como
+      // lançamento do TÍTULO (`CONTA_A_*`) e outra como lançamento na CONTA CORRENTE
+      // (`CONTA_CORRENTE_*`) — e sem este filtro as duas somavam. Medido em ago/2026:
+      // entradas R$ 832,9 mil contra R$ 371,3 mil da ótica bancária (+124,3%); saídas
+      // +106,3%. Caixa REALIZADO é dinheiro que entrou/saiu da conta, então aqui vale a
+      // ótica bancária — que é a OPOSTA da usada em `v_titulo_baixas` (lá a pergunta é
+      // "quando o título foi baixado", e quem responde é a ótica do título).
+      // Sem fallback para a ótica do título: ausência de movimento bancário significa que o
+      // dinheiro não entrou na conta, não que entrou por outra via.
+      // A allowlist é POSITIVA porque `PREVISAO_PEDIDO_VENDA`/`PREVISAO_ORDEM_SERVICO`
+      // também são `tipo='E'` com valor>0 e título preenchido: por negação, PREVISÃO entraria
+      // como caixa realizado (R$ 0,34 M hoje) — dinheiro que não entrou.
+      // O filtro mora na QUERY, não no helper: o `.select()` abaixo não traz
+      // `categoria_descricao`, e filtrar no helper por uma coluna não selecionada ZERA o
+      // realizado em produção (armadilha achada pela revisão Codex — o mock do teste ignorava
+      // o `.select()` e aprovava essa versão quebrada).
       let q = supabase
         .from('fin_movimentacoes')
         .select('data_movimento, tipo, valor, omie_codigo_lancamento')
+        .in('categoria_descricao', ['CONTA_CORRENTE_REC', 'CONTA_CORRENTE_PAG'])
         .gte('data_movimento', dataInicio)
         .lte('data_movimento', dataFim);
       if (company !== 'all') q = q.eq('company', company);


### PR DESCRIPTION
## O defeito

`getFluxoCaixa` lia `fin_movimentacoes` sem filtrar `categoria_descricao`, e o Omie devolve o
**mesmo pagamento sob duas óticas** — o lançamento do TÍTULO (`CONTA_A_*`) e o da CONTA
CORRENTE (`CONTA_CORRENTE_*`). As duas somavam.

Medido na PROD (agosto/2026, só movimentos com título, que é o universo do helper):

| | hoje | só ótica bancária | inflação |
|---|---|---|---|
| entradas | R$ 832,9 mil | R$ 371,3 mil | **+124,3%** |
| saídas | R$ 107,5 mil | R$ 52,1 mil | **+106,3%** |

E um segundo defeito no mesmo lugar: `PREVISAO_PEDIDO_VENDA` (437 linhas, R$ 0,32 M) e
`PREVISAO_ORDEM_SERVICO` (100, R$ 0,02 M) são `tipo='E'`, `valor>0` e **têm título** — passavam
por todo filtro do helper e entravam como caixa **realizado**. Dinheiro que não entrou.

Continuação do #2423, que corrigiu a mesma dobra em `v_titulo_baixas`. Este consumidor lê a
tabela DIRETO e não passa por aquela view.

## A ótica aqui é a OPOSTA à do #2423

Caixa realizado é dinheiro que entrou/saiu da conta ⇒ `CONTA_CORRENTE_*`. Em `v_titulo_baixas`
a pergunta é "quando o título foi baixado", e quem responde é a ótica do TÍTULO. É o ponto que
a revisão Codex levantou: **uma ótica canônica não serve a perguntas diferentes**. A assimetria
está documentada no ponto de uso, dos dois lados.

**Sem fallback** para a ótica do título: ausência de movimento bancário significa que o dinheiro
não entrou na conta, não que entrou por outra via. (Em `v_titulo_baixas` o fallback existe e é
declarado em `origem_baixa` — lá a pergunta comporta proxy, aqui não.)

**Allowlist positiva**, não negação: por negação (`NOT LIKE 'CONTA_A_%'`) as PREVISÕES entrariam.

## O achado que mais importa é sobre o TESTE

O mock de `getFluxoCaixa.test.ts` fazia `select: (_cols) => builder` — **ignorava as colunas
pedidas** e devolvia a linha inteira. Isso não é hipotético aqui: a query não seleciona
`categoria_descricao`, então mover o filtro para o *helper* faria o campo chegar `undefined`,
o filtro rejeitaria tudo e **o caixa realizado viraria ZERO em produção** — com o mock
aprovando a mudança. A revisão Codex executou a variante e mediu: 11/11 com o mock cego,
5/11 com ele projetando.

O mock agora projeta só as colunas do `.select()`, e há um caso que **exercita a projeção** —
sem ele a correção do mock seria defesa sem prova (medido: ao falsificar, sabotar a projeção
deixava a suíte verde).

## Prova

`bunx vitest run src/services/__tests__/getFluxoCaixa.test.ts` — 5 casos novos: as duas óticas
do mesmo pagamento contando uma vez (com o D+1 de compensação), previsão fora do realizado, o
mesmo no lado pagar, baixas parciais na ótica bancária **somando** (deduplicar por título ali
perderia metade do caixa — são dois eventos, não duas óticas), e a projeção do mock.

Falsificação, com controle verde na mesma invocação:

| sabotagem | resultado |
|---|---|
| F1 sem a allowlist na query | **vermelho** |
| F2 allowlist virou negação (previsão entra) | **vermelho** |
| F3 mock volta a ignorar o `.select()` | **vermelho** |

Gates: `typecheck` 0 · `test` 824 arquivos / 8.761 testes.

## ⚠️ O que este PR NÃO resolve

O mapeamento achou **mais três** consumidores que leem `fin_movimentacoes` direto e ainda somam
as duas óticas:

1. **`src/pages/FinanceiroConciliacao.tsx:119`** — as duas óticas viram 2 itens da fila casando
   o mesmo título; como 21,3% dos pares divergem em VALOR, uma pode cair em `divergencia` e a
   outra em `conciliado`. (Tem outros defeitos próprios: upsert `onConflict:'id'` sem `id` no
   payload, e `fin_movimentacoes.conciliado` nunca é atualizado.)
2. **`fin_calcular_confiabilidade`** (PL/pgSQL) — `total_mov` dobrado alimenta o score do
   cockpit. Não foi encontrado chamador em `src/`, edges ou cron.
3. **skill `cfo-colacor`**, `01-caixa-13-semanas.sql` — dobra + previsões + transferências.

E, na mesma tela deste PR, um erro de eixo diferente que a revisão Codex apontou:
`FluxoCaixaTab.tsx:38` inicia o acumulado no saldo atual da conta e depois soma de novo as
semanas passadas, que já estão nesse saldo (janela de −6 meses). Está registrado como tarefa
separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
