### PR TITLE
fix(gates): dois primos liam a saída COLORIDA do git e o silêncio virava aprovação — a cor passa a ser fixada na origem

### DIFF
--- a/.claude/hooks/pr-duplicata-guard.sh
+++ b/.claude/hooks/pr-duplicata-guard.sh
@@ -56,6 +56,13 @@
 # Fail-open TOTAL: sem jq/git → exit 0; fetch falha → segue com refs locais; sem merge-base → exit 0;
 # arquivo ausente da main → pula (nada a duplicar ali). AVISA via additionalContext com
 # permissionDecision=allow — NUNCA bloqueia (PR legítimo que ESTENDE trabalho recém-mergeado existe).
+# ⚠️ `--no-color` NÃO é enfeite: a via 2 ("fui EU que introduzi") sai do prefixo `^+` do diff, e com
+# cor o ESC vem ANTES do `+` — o `grep` casa zero, `add_ids` sai vazio e o hook CALA. Fail-OPEN, no
+# pior sentido: o silêncio é indistinguível do "nada a avisar". O git não colore em pipe por default
+# mas obedece color.ui/color.diff=always de QUALQUER camada de config — e aqui ele roda na máquina do
+# founder, com o ~/.gitconfig DELE. Medido: `diff` humano COLORE; `--name-only`, `show <rev>:<path>`,
+# `merge-base` e `branch --show-current` saem limpos (a flag no `--name-only` é cinto-e-suspensório,
+# para não depender da versão do git). Classe: docs/historico/gate-que-le-saida-colorida.md.
 # Testes: scripts/test-pr-duplicata-guard.sh (roda no CI via `bun run test:hooks`).
 set -u
 
@@ -111,7 +118,7 @@ if [ "$modo" = commit ]; then
 fi
 
 # shellcheck disable=SC2086  # $alvo é UMA palavra (HEAD/--cached) ou vazio de propósito (árvore)
-mine="$(git diff --name-only "$mb" $alvo 2>/dev/null)" || exit 0
+mine="$(git diff --no-color --name-only "$mb" $alvo 2>/dev/null)" || exit 0
 [ -n "$mine" ] || exit 0
 
 # Identificador significativo: ≥12 chars, com underscore OU corcova camelCase.
@@ -134,7 +141,7 @@ while IFS= read -r f; do
   base_c="$(git show "$mb:$f" 2>/dev/null)" || base_c=""
 
   # shellcheck disable=SC2086  # idem: $alvo é palavra única ou vazio intencional
-  add_ids="$(git diff "$mb" $alvo -- "$f" 2>/dev/null | grep '^+' | grep -v '^+++' | _ids)"
+  add_ids="$(git diff --no-color "$mb" $alvo -- "$f" 2>/dev/null | grep '^+' | grep -v '^+++' | _ids)"
   [ -n "$add_ids" ] || continue
 
   novos="$(comm -23 <(printf '%s\n' "$add_ids") <(printf '%s\n' "$base_c" | _ids) 2>/dev/null)"

--- a/docs/historico/gate-que-le-saida-colorida.md
+++ b/docs/historico/gate-que-le-saida-colorida.md
@@ -98,6 +98,47 @@ Falsificado com controle verde na mesma invocação (`FALSIFICACAO_FIM ok`): có
 guard voltando a ler o log → vermelho · guard que sempre aprova → vermelho · fail-closed removido →
 vermelho.
 
+## Os primos no `git`: mesma classe, mas **fail-OPEN**
+
+**2026-09-09, mesmo dia.** A varredura por primos achou dois gates decidindo pelo prefixo `^-`/`^+`
+da saída **humana** do `git`. A diferença com o caso do vitest é o SENTIDO da falha, e é a pior:
+lá o gate reprovava (barulhento, alguém investiga); aqui a lista sai vazia, e vazio é **aprovação**.
+
+| gate | decide | onde roda | com cor |
+|---|---|---|---|
+| `scripts/lovable-revert-scan.sh` | "o bot REVERTEU um merge recente?" | CI (`lovable-watch.yml`) | `reversao=false` — some o alarme que ele existe para dar |
+| `.claude/hooks/pr-duplicata-guard.sh` | "esse símbolo já foi entregue na main?" | máquina do founder | cala — indistinguível de "nada a avisar" |
+
+O git não colore em pipe por default, então nada disso aparece em teste local. Mas ele obedece
+`color.ui`/`color.diff=always` de **qualquer** camada: o `~/.gitconfig` de quem roda (o hook roda na
+máquina do founder), a config do repo, e `GIT_CONFIG_PARAMETERS` no ambiente — que um runner ou um
+wrapper pode carregar sem ninguém escrever uma linha de config.
+
+**Medido, comando a comando** (não suposto — a correção certa depende de qual sai sujo):
+
+| comando | com `color.ui=always` |
+|---|---|
+| `git diff` (humano), `git show <sha>` | **COLOREM** |
+| `git diff --name-only`, `git log --pretty=%H/%s`, `git show <rev>:<path>`, `rev-parse`, `merge-base`, `branch --show-current` | saem limpos |
+
+Daí a ordem de preferência: **saída de máquina quando existir** (`--name-only`, `--pretty`,
+`--numstat`, `<rev>:<path>`) e `--no-color` onde o diff humano é mesmo a fonte. `--no-color` é flag
+do subcomando e vence config de qualquer camada, inclusive `GIT_CONFIG_PARAMETERS` (medido); `-c
+color.ui=false` também vence, mas é mais fácil de perder num refactor.
+
+**O que trava a recaída.** Os dois testes (`test-lovable-revert-scan.sh`, `test-pr-duplicata-guard.sh`,
+ambos no `bun run test:hooks`) rodam o **mesmo cenário** com a cor ligada e exigem o **mesmo
+veredito** — no revert-scan pelas três vias (ambiente, `color.ui`, `color.diff`); no hook, o stub de
+git passou a colorir como o git real, e **só o `diff` de conteúdo**: colorir o `--name-only` ali
+tornaria a flag load-bearing por ficção, e o stub estaria mentindo a favor do hook.
+
+A falsificação tem **controle verde na mesma invocação** e um segundo eixo que costuma faltar: a
+cópia sabotada tem de **calar com cor e continuar avisando sem cor**. Sem esse par, um `sed` que
+destruísse o script inteiro entregaria o mesmo vermelho e seria creditado como prova. A sabotagem
+do `--no-color` no `--name-only` ficou **de fora de propósito**: ali a flag é cinto-e-suspensório
+contra versão futura do git, então sabotá-la ficaria verde — e sabotagem verde significa
+"redundante", que aqui é a resposta certa, não um teste cego.
+
 ## Regra
 
 **Gate não lê a saída formatada para humano quando existe saída de máquina.** Se a ferramenta tem

--- a/scripts/lovable-revert-scan.sh
+++ b/scripts/lovable-revert-scan.sh
@@ -16,6 +16,15 @@
 # amostra das linhas quando há hit (exit 0 também — quem decide é quem lê o stdout; erro de git
 # → exit != 0 e o step do CI fica vermelho, visível). Filtra linha trivial (curta/só pontuação)
 # e COMENTÁRIO puro — o bot apaga comentário-aviso legitimamente sem reverter o gate (deploy.md).
+#
+# ⚠️ `--no-color` NÃO é enfeite: a decisão sai do prefixo `^-`/`^+` da saída do git, e com cor o
+# ESC vem ANTES do sinal — o `grep` casa zero, a lista sai vazia e o scan conclui "sem reversão".
+# É fail-OPEN: o silêncio vira aprovação, e some justo o alarme que este script existe para dar.
+# O git não colore em pipe por default, mas obedece color.ui/color.diff=always de QUALQUER camada
+# de config, inclusive `GIT_CONFIG_PARAMETERS` no ambiente do runner. Medido: `diff` humano e
+# `show <sha>` COLOREM; `--name-only`, `--pretty=%H/%s` e `rev-parse` saem limpos (a flag no
+# `--name-only` é cinto-e-suspensório, para não depender da versão do git). Classe em
+# docs/historico/gate-que-le-saida-colorida.md; falsificado em test-lovable-revert-scan.sh.
 # Falso-negativo aceito: reversão só-de-comentário/1-linha-curta escapa daqui, mas continua
 # coberta pela Issue genérica de path sensível. Testes: scripts/test-lovable-revert-scan.sh.
 set -u
@@ -30,7 +39,7 @@ minlen="${LRS_MIN_LEN:-12}"
 subj="$(git log -1 --pretty=%s "$sha")" || exit 1
 printf '%s' "$subj" | grep -qE '\(#[0-9]+\)[[:space:]]*$' && exit 0
 
-changed="$(git diff --name-only "$sha^" "$sha" | grep -E "$patterns" || true)"
+changed="$(git diff --no-color --name-only "$sha^" "$sha" | grep -E "$patterns" || true)"
 [ -n "$changed" ] || exit 0
 
 substantiva() {
@@ -42,13 +51,13 @@ substantiva() {
 
 while IFS= read -r f; do
   [ -n "$f" ] || continue
-  removed="$(git diff "$sha^" "$sha" -- "$f" | grep '^-' | grep -v '^---' | cut -c2- | substantiva | sort -u)"
+  removed="$(git diff --no-color "$sha^" "$sha" -- "$f" | grep '^-' | grep -v '^---' | cut -c2- | substantiva | sort -u)"
   [ -n "$removed" ] || continue
   merges="$(git log --since="$window" --first-parent -E --grep='\(#[0-9]+\)[[:space:]]*$' --pretty='%H' "$sha^" -- "$f" || true)"
   [ -n "$merges" ] || continue
   while IFS= read -r m; do
     [ -n "$m" ] || continue
-    added="$(git show "$m" -- "$f" | grep '^+' | grep -v '^+++' | cut -c2- | substantiva | sort -u)"
+    added="$(git show --no-color --format= "$m" -- "$f" | grep '^+' | grep -v '^+++' | cut -c2- | substantiva | sort -u)"
     [ -n "$added" ] || continue
     hits="$(comm -12 <(printf '%s\n' "$removed") <(printf '%s\n' "$added"))"
     [ -n "$hits" ] || continue

--- a/scripts/mutcheck.d/pr-duplicata-guard.mut
+++ b/scripts/mutcheck.d/pr-duplicata-guard.mut
@@ -74,7 +74,7 @@ PEGA      | Markdown passa a ser ignorado         | s{\*\.svg \|}{*.svg | *.md |
 # Fechadas tornando o stub sensível a `origin/main` e à presença de `MB` nos diffs.
 PEGA      | merge-base usa a ref errada           | s{^(mb=.*)origin/main}{$1origin/master}
 PEGA      | diff de nomes perde a merge-base      | s{--name-only "\$mb" \$alvo}{--name-only \$alvo}
-PEGA      | diff de conteudo perde a merge-base   | s{git diff "\$mb" \$alvo -- "\$f"}{git diff \$alvo -- "\$f"}
+PEGA      | diff de conteudo perde a merge-base   | s{git diff --no-color "\$mb" \$alvo -- "\$f"}{git diff --no-color \$alvo -- "\$f"}
 
 # TTL do dedupe: sem ele o silêncio vira PERMANENTE naquela branch — fechado pelo caso 12b.
 PEGA      | silencio do dedupe nunca expira       | s{^    if \[ -f "\$marca" \] && \[ -z "\$\(find.*}{    if [ -f "\$marca" ]; then}

--- a/scripts/test-lovable-revert-scan.sh
+++ b/scripts/test-lovable-revert-scan.sh
@@ -192,8 +192,10 @@ _sabota() {
   else echo "  FAIL  $nome → alarme sobreviveu; a flag não está sob teste | out='$out'"; fail=1; fi
 }
 
+# shellcheck disable=SC2016  # sed: o padrão é literal do script alvo, expandir aqui o quebraria
 _sabota "sem --no-color no \`git diff\` (mata a lista 'removed')" \
   's|git diff --no-color "$sha^"|git diff "$sha^"|'
+# shellcheck disable=SC2016  # idem: literal do script alvo
 _sabota "sem --no-color no \`git show\` (mata a lista 'added')" \
   's|git show --no-color --format= "$m"|git show "$m"|'
 # O 3º `--no-color` (o do `git diff --name-only` da linha do `changed`) NÃO entra aqui de
@@ -203,7 +205,6 @@ _sabota "sem --no-color no \`git show\` (mata a lista 'added')" \
 
 SCAN_ATUAL=""
 COR_ENV=""
-cd "$base"
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi

--- a/scripts/test-lovable-revert-scan.sh
+++ b/scripts/test-lovable-revert-scan.sh
@@ -44,7 +44,15 @@ commit_pr() {
 # commit_direto <arquivo> <msg> — simula commit do bot (sem "(#N)")
 commit_direto() { git add "$1" && git commit -qm "$2"; }
 
-run_scan() { LRS_PATTERNS='^supabase/functions/' bash "$SCAN" 2>/dev/null; }
+# COR_ENV injeta a cor pelo AMBIENTE; SCAN_ATUAL aponta para uma CÓPIA sabotada. A fonte em
+# disco NUNCA é mutada: outra worktree (ou um vitest concorrente) leria o arquivo quebrado, e esse
+# vermelho é justamente o que ninguém consegue reproduzir depois.
+COR_ENV=""
+SCAN_ATUAL=""
+run_scan() {
+  # shellcheck disable=SC2086  # COR_ENV é lista KEY=VAL (ou vazia), precisa expandir em palavras
+  env $COR_ENV LRS_PATTERNS="^supabase/functions/" bash "${SCAN_ATUAL:-$SCAN}" 2>/dev/null
+}
 
 expect_hit() {  # <nome> <token1> <token2>
   local nome="$1" t1="$2" t2="$3" out
@@ -113,6 +121,89 @@ commit_pr supabase/functions/edge-x/index.ts "docs(edge): aviso" 105
 { printf 'const base = 1;\n' > supabase/functions/edge-x/index.ts; }
 commit_direto supabase/functions/edge-x/index.ts "Changes"
 expect_mudo "remocao de COMENTARIO puro nao conta (bot apaga aviso sem reverter gate)"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# COR: o veredito não pode depender de o git estar colorindo
+#
+# A decisão sai do prefixo `^-`/`^+` da saída do git. Com cor o ESC vem ANTES do sinal, o `grep`
+# casa ZERO, a lista sai vazia e o scan conclui "sem reversão" — fail-OPEN: some justamente o
+# alarme que ele existe para dar. Medido antes do conserto: o caso-alvo abaixo saía MUDO nas três
+# vias. O git não colore em pipe por default, mas obedece color.ui/color.diff=always de QUALQUER
+# camada: o AMBIENTE (GIT_CONFIG_PARAMETERS, que o runner do CI pode carregar) e a config do
+# repo/global. Classe: docs/historico/gate-que-le-saida-colorida.md.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+echo "── cor LIGADA não pode mudar o veredito ──"
+
+# cenario_alvo <dir> — o mesmo caso-alvo do topo. O scan é read-only, então UM repo serve de
+# controle E de sabotagem: a única variável entre eles passa a ser o script, nunca o cenário.
+cenario_alvo() {
+  mkrepo "$1"
+  { printf 'const base = 1;\nif (!precoValidado) { throw new Error("gate"); }\nconst guardaDePreco = validaContraOmie(pedido);\n' > supabase/functions/edge-x/index.ts; }
+  commit_pr supabase/functions/edge-x/index.ts "fix(edge): blinda o gate de preco [money-path]" 100
+  { printf 'const base = 1;\n' > supabase/functions/edge-x/index.ts; }
+  commit_direto supabase/functions/edge-x/index.ts "Changes"
+}
+ALVO_PR="#100"
+ALVO_F="supabase/functions/edge-x/index.ts"
+
+cenario_alvo "$base/cor"
+
+COR_ENV="GIT_CONFIG_PARAMETERS='color.ui=always'"
+expect_hit "cor pelo AMBIENTE (GIT_CONFIG_PARAMETERS) — a via do runner" "$ALVO_PR" "$ALVO_F"
+COR_ENV=""
+
+git config color.ui always
+expect_hit "cor por color.ui na config do repo" "$ALVO_PR" "$ALVO_F"
+git config --unset color.ui
+
+git config color.diff always
+expect_hit "cor por color.diff (a chave específica do diff)" "$ALVO_PR" "$ALVO_F"
+git config --unset color.diff
+
+echo "── falsificação: a fixação de cor é LOAD-BEARING ──"
+# CONTROLE PRIMEIRO, e ele ABORTA as sabotagens se não estiver verde: sabotar um arnês que já está
+# vermelho aprova TUDO — toda sabotagem produz o vermelho exigido e o gate anuncia sucesso
+# (docs/historico/falsificacao-sem-linha-de-base.md). Este controle é a CÓPIA (não o alvo em
+# disco), com a cor LIGADA, no MESMO repo e na MESMA invocação das sabotagens: nada muda entre
+# ele e elas exceto o `sed`.
+cp "$SCAN" "$base/copia.sh"
+SCAN_ATUAL="$base/copia.sh"
+COR_ENV="GIT_CONFIG_PARAMETERS='color.ui=always'"
+
+controle_ok=0
+if printf '%s' "$(run_scan)" | grep -qF "REVERSAO"; then
+  controle_ok=1
+  echo "  ok    base  | CONTROLE: cópia intacta + cor ligada → REVERSAO (há verde de onde sair)"
+else
+  echo "  FAIL  CONTROLE vermelho ANTES da 1ª sabotagem — nada abaixo provaria coisa alguma"; fail=1
+fi
+
+# _sabota <nome> <expr-sed> — quebra UMA fixação de cor na cópia e exige que o alarme SUMA.
+_sabota() {
+  local nome="$1" expr="$2" out
+  [ "$controle_ok" -eq 1 ] || return 0
+  sed "$expr" "$SCAN" > "$base/copia.sh"
+  if cmp -s "$SCAN" "$base/copia.sh"; then
+    echo "  FAIL  sed obsoleto | $nome — a sabotagem não mudou NADA (o teste estaria cego)"; fail=1
+    return 0
+  fi
+  out="$(run_scan)"
+  if [ -z "$out" ]; then echo "  ok    sabot | $nome → alarme SUMIU (a flag é load-bearing)"
+  else echo "  FAIL  $nome → alarme sobreviveu; a flag não está sob teste | out='$out'"; fail=1; fi
+}
+
+_sabota "sem --no-color no \`git diff\` (mata a lista 'removed')" \
+  's|git diff --no-color "$sha^"|git diff "$sha^"|'
+_sabota "sem --no-color no \`git show\` (mata a lista 'added')" \
+  's|git show --no-color --format= "$m"|git show "$m"|'
+# O 3º `--no-color` (o do `git diff --name-only` da linha do `changed`) NÃO entra aqui de
+# propósito: `--name-only` foi MEDIDO saindo limpo mesmo com color.ui=always, então a flag ali é
+# cinto-e-suspensório contra versão futura do git — sabotá-la ficaria VERDE, e sabotagem verde
+# sinaliza "redundante", que aqui é a resposta certa e intencional (não um teste cego).
+
+SCAN_ATUAL=""
+COR_ENV=""
+cd "$base"
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -56,6 +56,16 @@ case "$1" in
     # do conjunto em produção, calando o guard. (lacuna da 2ª opinião, Codex 2026-08-19)
     case " $* " in *" MB "*) ;; *) exit 128 ;; esac
     a="$(_alvo "$@")"
+    # COR — modela o git REAL, medido: `diff` de conteúdo COLORE sob color.ui/color.diff=always
+    # (de config OU de GIT_CONFIG_PARAMETERS no ambiente) e obedece `--no-color` acima de tudo;
+    # `--name-only` sai LIMPO mesmo com always. Colorir o `--name-only` aqui tornaria a flag dele
+    # load-bearing por FICÇÃO — o stub mentiria a favor do hook, que é o oposto de um teste.
+    _nc=""; case " $* " in *" --no-color "*) _nc=1 ;; esac
+    _cor() {
+      if [ -n "${GIT_STUB_COLOR:-}" ] && [ -z "$_nc" ]; then
+        ESC=$(printf '\033'); sed "s/^/${ESC}[32m/; s/\$/${ESC}[m/"
+      else cat; fi
+    }
     case "$*" in
       *--name-only*)
         case "$a" in
@@ -67,9 +77,9 @@ case "$1" in
         f=""
         for x in "$@"; do f="$x"; done
         case "$a" in
-          head)   cat "$STUBDIR/diff_$(_slug "$f")"    2>/dev/null || true ;;
-          cached) cat "$STUBDIR/dcached_$(_slug "$f")" 2>/dev/null || true ;;
-          wt)     cat "$STUBDIR/dwt_$(_slug "$f")"     2>/dev/null || true ;;
+          head)   cat "$STUBDIR/diff_$(_slug "$f")"    2>/dev/null | _cor || true ;;
+          cached) cat "$STUBDIR/dcached_$(_slug "$f")" 2>/dev/null | _cor || true ;;
+          wt)     cat "$STUBDIR/dwt_$(_slug "$f")"     2>/dev/null | _cor || true ;;
         esac ;;
     esac ;;
   show)
@@ -413,7 +423,39 @@ _deve_avisar "encadeado lê índice/árvore (não o HEAD vazio)" "$out"
 out="$(_hook "$ENC" 'git commit -am "wip" && gh pr create --fill')"
 _deve_avisar "encadeado não é silenciado pelo dedupe (contém create)" "$out"
 
-echo "== 16. fail-open TOTAL: o hook nunca sai não-zero =="
+echo "== 16. COR: o veredito não pode depender de o git estar colorindo =="
+# A via 2 ("fui EU que introduzi") sai do `grep '^+'` sobre o diff. Com cor o ESC vem ANTES do
+# `+`: o grep casa ZERO, `add_ids` sai vazio e o hook CALA — fail-OPEN no pior sentido, porque o
+# silêncio é indistinguível de "nada a avisar". Este hook roda na máquina do FOUNDER, com o
+# ~/.gitconfig dele: um `color.ui = always` em qualquer camada bastava para desligar o guard sem
+# que ninguém percebesse. Classe: docs/historico/gate-que-le-saida-colorida.md.
+_base; _main; rm -rf "$CACHE"
+out="$(_hook "$MINE" "$CRIAR")"
+_deve_avisar "controle: cenário base SEM cor avisa (há verde de onde sair)" "$out"
+
+rm -rf "$CACHE"
+out="$(_hook "$MINE GIT_STUB_COLOR=1" "$CRIAR")"
+_deve_avisar "cor LIGADA no git NÃO muda o veredito" "$out"
+
+# Falsificação em DOIS eixos, e é o par que prova: a cópia sem `--no-color` tem de CALAR com cor
+# — e continuar AVISANDO sem cor. Só o segundo eixo separa "o silêncio veio da COR" de "o `sed`
+# quebrou o hook por outro motivo"; sem ele, uma sabotagem que destruísse o script inteiro
+# entregaria o mesmo vermelho e seria creditada como prova (falsificacao-sem-linha-de-base.md).
+# shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
+sed 's|git diff --no-color "$mb" $alvo -- "$f"|git diff "$mb" $alvo -- "$f"|' \
+  "$HOOK" > "$stub/sem-no-color.sh"
+if cmp -s "$HOOK" "$stub/sem-no-color.sh"; then
+  _bad "sabotagem 'sem --no-color' não mudou nada (padrão sed obsoleto — o teste estaria cego)"
+else
+  rm -rf "$CACHE"
+  out="$(HOOK_ATUAL=$stub/sem-no-color.sh _hook "$MINE" "$CRIAR")"
+  _deve_avisar "CONTROLE da sabotagem: cópia sem --no-color, SEM cor, ainda avisa" "$out"
+  rm -rf "$CACHE"
+  out="$(HOOK_ATUAL=$stub/sem-no-color.sh _hook "$MINE GIT_STUB_COLOR=1" "$CRIAR")"
+  _deve_calar "sabotagem 'sem --no-color' + cor → CALA (a flag é load-bearing)" "$out"
+fi
+
+echo "== 17. fail-open TOTAL: o hook nunca sai não-zero =="
 if [ -s "$stub/exit-nao-zero.log" ]; then
   _bad "hook saiu não-zero: $(head -1 "$stub/exit-nao-zero.log")"
 else


### PR DESCRIPTION
## O problema

Dois gates decidiam lendo o prefixo `^-` / `^+` da saída **humana** do `git`. É a classe do #2438
(`docs/historico/gate-que-le-saida-colorida.md`), mas com o sinal invertido — e por isso pior:

| gate | decide | onde roda | com a cor ligada |
|---|---|---|---|
| `scripts/lovable-revert-scan.sh` | "o bot do Lovable REVERTEU um merge recente?" | CI (`lovable-watch.yml:63`) | `reversao=false` — **some o alarme que ele existe para dar** |
| `.claude/hooks/pr-duplicata-guard.sh` | "esse símbolo já foi entregue na main?" | máquina do founder | cala — indistinguível de "nada a avisar" |

Lá o gate reprovava (barulhento, alguém investiga). Aqui a lista sai **vazia**, e vazio é
**aprovação**: fail-OPEN. O git não colore em pipe por default — então nada disso aparece em teste
local —, mas obedece `color.ui`/`color.diff=always` de **qualquer** camada: o `~/.gitconfig` de quem
roda (o hook roda na máquina do founder), a config do repo, e `GIT_CONFIG_PARAMETERS` no ambiente,
que um runner ou wrapper pode carregar sem ninguém escrever uma linha de config.

**Reproduzido antes do conserto:** o mesmo cenário sai com o bloco `REVERSAO` completo sem cor, e
**totalmente mudo** com `GIT_CONFIG_PARAMETERS="'color.ui=always'"`.

## O conserto — medido comando a comando, não suposto

Qual flag vai onde depende de quem realmente suja a saída:

| comando | com `color.ui=always` |
|---|---|
| `git diff` (humano), `git show <sha>` | **COLOREM** |
| `git diff --name-only`, `git log --pretty=%H/%s`, `git show <rev>:<path>`, `rev-parse`, `merge-base`, `branch --show-current` | saem limpos |

Daí a ordem: **saída de máquina quando existir** (`--name-only`, `--pretty`, `<rev>:<path>`) e
`--no-color` onde o diff humano é mesmo a fonte. No `git show` entrou também `--format=`, que
descarta o header do commit e deixa só o diff. `--no-color` é flag do subcomando e vence config de
qualquer camada, inclusive `GIT_CONFIG_PARAMETERS` (medido).

Nos dois `--name-only` a flag entrou como **cinto-e-suspensório** — eles saem limpos hoje, e isso
está escrito no ponto de uso para não virar falsa segurança.

## A falsificação

Ambas as suítes rodam no `bun run test:hooks`, com **controle verde na mesma invocação**
(`docs/historico/falsificacao-sem-linha-de-base.md`) — sabotar um arnês já vermelho aprovaria tudo.

- **`test-lovable-revert-scan.sh`**: o mesmo cenário com cor por **três vias** (ambiente,
  `color.ui`, `color.diff`) tem de dar o mesmo veredito. Controle = cópia intacta + cor ligada →
  `REVERSAO`; ele **aborta** as sabotagens se não estiver verde. Duas sabotagens exigem que o
  alarme **suma**.
- **`test-pr-duplicata-guard.sh`**: o stub de git passou a colorir como o git real — e **só o
  `diff` de conteúdo**: colorir o `--name-only` ali tornaria a flag load-bearing por ficção, com o
  stub mentindo a favor do hook. A sabotagem exige **dois eixos**: calar com cor **e continuar
  avisando sem cor**. Sem esse par, um `sed` que destruísse o hook daria o mesmo vermelho e seria
  creditado como prova.
- A sabotagem do `--no-color` no `--name-only` ficou **de fora de propósito**: ali a flag é
  redundante hoje, então ficaria verde — e sabotagem verde significa "redundante", que aqui é a
  resposta certa, não um teste cego.

Prova extra, contra a **fonte real** (não só a cópia): baseline verde das duas suítes → sabotagem do
`--no-color` nos arquivos de produção → **ambas vermelhas** → `cmp` confirma a restauração.

## Verificação

`lint:shell` (0 achados em 411 arquivos) · `typecheck` · `test` (`Tests 8756 passed | 1 skipped`,
`Test Files 824 passed`) · `test:hooks` — todos verdes, os quatro rodados sobre esta versão.

Varredura: **zero** primos remanescentes de `git diff|show` alimentando `grep` de prefixo `^-`/`^+`
sem `--no-color`.

Fora de escopo, verificado e **já registrado** no doc pelo #2438: o `FORCE_COLOR: '0'` de
`scripts/exclusividade-medir.ts:118` é inócuo (a decisão ali é só pelo exit code) mas não é receita
— `tinyrainbow` testa `"FORCE_COLOR" in env` (presença literal) e `picocolors` testa
`!!env.FORCE_COLOR` (`"0"` é truthy): as duas **ligam** a cor. Não tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
