### PR TITLE
fix(backfill): a unicidade era medida num universo filtrado — e a escrita podia atropelar outro writer

### DIFF
--- a/db/aplicar-desconto-backfill-rpc.sql
+++ b/db/aplicar-desconto-backfill-rpc.sql
@@ -50,6 +50,7 @@ AS $fn$
 DECLARE
   v_pedidas   integer := 0;
   v_aplicadas integer := 0;
+  v_ja_apuradas integer := 0;
 BEGIN
   IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
     RAISE EXCEPTION 'desconto_backfill_aplicar: p_linhas tem de ser um array jsonb (veio %)',
@@ -82,16 +83,32 @@ BEGIN
        -- no plano, não uma entrada com null. Aceitar null aqui deixaria um bug do chamador
        -- apagar apuração já feita, em massa e sem sinal.
        AND pl.desconto_valor IS NOT NULL
+       -- SO ESCREVE O QUE AINDA NAO FOI APURADO. Sem isto, um writer que preencha a linha entre a
+       -- leitura que montou o plano e esta escrita seria SOBRESCRITO -- e sem divergencia visivel,
+       -- porque o trio (SKU, qtd, preco) continua batendo: o guard de base nao ve mudanca de
+       -- desconto. Reapurar nao e' inofensivo: o valor do plano foi lido ANTES, e o do outro
+       -- writer pode ser mais novo. Repetir o mesmo plano segue idempotente no que importa (a
+       -- linha ja tem o valor); o que muda e' que a corrida deixa de ter vencedor por sorte.
+       AND oi.desconto_valor IS NULL
      RETURNING 1
   )
   SELECT count(*) INTO v_aplicadas FROM aplicado;
 
   -- O chamador precisa das DUAS contagens. Só "aplicadas" não distingue "o plano tinha 40 linhas
   -- e 40 foram escritas" de "tinha 900 e 40 foram escritas porque 860 mudaram no meio do caminho".
+  -- `recusadas` agora junta DOIS fatos: base mudou desde a leitura, e linha ja apurada por outro
+  -- writer. O chamador precisa dos dois separados para nao ler "corrida perdida" como "acervo
+  -- inconsistente" -- consertos opostos.
+  SELECT count(*) INTO v_ja_apuradas
+    FROM jsonb_to_recordset(p_linhas) AS x(id uuid)
+    JOIN public.order_items oi ON oi.id = x.id
+   WHERE oi.desconto_valor IS NOT NULL;
+
   RETURN jsonb_build_object(
-    'pedidas',   v_pedidas,
-    'aplicadas', v_aplicadas,
-    'recusadas', v_pedidas - v_aplicadas
+    'pedidas',      v_pedidas,
+    'aplicadas',    v_aplicadas,
+    'recusadas',    v_pedidas - v_aplicadas,
+    'ja_apuradas',  v_ja_apuradas
   );
 END
 $fn$;

--- a/db/test-desconto-backfill-aplicar.sh
+++ b/db/test-desconto-backfill-aplicar.sh
@@ -98,12 +98,42 @@ eq "F4 preço NULL dos DOIS lados casa (IS NOT DISTINCT FROM), não é descartad
 F5=$(Pq -c "SELECT desconto_valor IS NULL FROM public.order_items WHERE id='$L5';")
 eq "F5 plano com desconto null NÃO escreve (não apaga apuração alheia)" "$F5" "t"
 F6=$(echo "$R" | tr -d ' ')
-eq "F6 contagens: 5 pedidas, 2 aplicadas, 3 recusadas" "$F6" '{"pedidas":5,"aplicadas":2,"recusadas":3}'
+eq "F6 contagens: 5 pedidas, 2 aplicadas, 3 recusadas, 2 já apuradas" "$F6" '{"pedidas":5,"aplicadas":2,"recusadas":3,"ja_apuradas":2}'
 
 # Idempotência: reaplicar o MESMO plano não acumula nem alterna.
 Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
 F7=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L1';")
 eq "F7 reaplicar o mesmo plano é idempotente" "$F7" "10"
+
+echo "═══ I · concorrência: linha JÁ APURADA não é sobrescrita ═══"
+
+# Achado da 2ª opinião (Codex), confirmado no código: o UPDATE comparava SKU/qtd/preço mas não
+# exigia `desconto_valor IS NULL`. Um writer que preenchesse a linha entre a leitura que montou o
+# plano e esta escrita seria sobrescrito — SEM divergência visível, porque o trio continua batendo.
+P -q -c "UPDATE public.order_items SET desconto_valor = 55 WHERE id='$L1';" >/dev/null
+RJ=$(Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);")
+I1=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L1';")
+eq "I1 linha já apurada por outro writer NÃO é sobrescrita" "$I1" "55"
+I2=$(echo "$RJ" | tr -d ' ')
+eq "I2 e o motivo vem SEPARADO de 'base mudou'" "$I2" '{"pedidas":1,"aplicadas":0,"recusadas":1,"ja_apuradas":1}'
+P -q -c "UPDATE public.order_items SET desconto_valor = NULL WHERE id='$L1';" >/dev/null
+
+# Falsificação: sem o guard, a sobrescrita acontece — é o dano que I1 barra.
+SABI="/tmp/sabotado-concorrencia-${SLUG}.sql"
+sed 's/       AND oi.desconto_valor IS NULL/       AND true/' "$MIG" > "$SABI"
+if ! grep -q "AND true" "$SABI"; then
+  bad "I3.0 a sabotagem do guard de concorrência NÃO alterou o arquivo — assert seria teatro"
+else
+  ok "I3.0 (controle da sabotagem) o guard de concorrência foi removido de fato"
+  P -q -f "$SABI" >/dev/null
+  P -q -c "UPDATE public.order_items SET desconto_valor = 55 WHERE id='$L1';" >/dev/null
+  Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
+  I3=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L1';")
+  if [ "$I3" = "10" ]; then ok "I3 sem o guard, a apuração de outro writer é SOBRESCRITA — I1 tem dente"; PASS=$((PASS+1));
+  else bad "I3 sem o guard não houve sobrescrita (veio [$I3]) — I1 pode passar por inércia"; fi
+  P -q -f "$MIG" >/dev/null
+  P -q -c "UPDATE public.order_items SET desconto_valor = NULL WHERE id='$L1';" >/dev/null
+fi
 
 echo "═══ G · ACL: escrita de money-path fechada na fronteira ═══"
 G1=$(Pq -c "SELECT has_function_privilege('anon','public.desconto_backfill_aplicar(jsonb)','EXECUTE');")
@@ -158,11 +188,16 @@ fi
 
 # H3 — o guard do plano-null some: um bug do chamador passaria a APAGAR apuração em massa.
 SAB3="/tmp/sabotado3-${SLUG}.sql"
-sed 's/       AND pl.desconto_valor IS NOT NULL/       AND true/' "$MIG" > "$SAB3"
-if ! grep -q "AND true" "$SAB3"; then
-  bad "H3.0 a sabotagem do guard de null NÃO alterou o arquivo — assert seria teatro"
+sed -e 's/       AND pl.desconto_valor IS NOT NULL/       AND true/' \
+    -e 's/       AND oi.desconto_valor IS NULL/       AND true/' "$MIG" > "$SAB3"
+# DOIS guards protegem este eixo desde o achado de concorrência (Codex): `pl...IS NOT NULL` barra
+# o plano que manda null, e `oi...IS NULL` barra o UPDATE de linha já apurada. Sabotar UM só deixa
+# o outro segurando — e o assert leria "não houve dano" como "o guard tem dente", que é o inverso.
+# Por isso a sabotagem remove os dois: o que se mede é se ALGUÉM ainda protege o eixo.
+if [ "$(grep -c 'AND true' "$SAB3")" -ne 2 ]; then
+  bad "H3.0 a sabotagem NÃO removeu os DOIS guards — com um de pé o assert mediria o guard errado"
 else
-  ok "H3.0 (controle da sabotagem) o guard de plano-null foi removido de fato"
+  ok "H3.0 (controle da sabotagem) os dois guards do eixo foram removidos de fato"
   P -q -f "$SAB3" >/dev/null
   P -q -c "UPDATE public.order_items SET desconto_valor = 99 WHERE id='$L1';" >/dev/null
   Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":null,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null

--- a/supabase/functions/_shared/sonda-fingerprints.ts
+++ b/supabase/functions/_shared/sonda-fingerprints.ts
@@ -41,7 +41,7 @@ export const FONTE_SHA256: Record<string, string> = {
   "omie-analytics-sync": "a11020a5a937b0a37d2e49e0935b2f9f02599e9710104bc6e2853e2602769a0e",
   "omie-aplicar-parametros": "132174780a3175d470853b88833b8e366fcce36cfa2608ec3308bea2cb75518c",
   "omie-cliente": "fade69529ee1b7d62c65c640c98af721bf9df1030c078c93ec5c9dd55eaae92f",
-  "omie-desconto-backfill": "d09a10f83d4fff48aa81194a43c3642310d0c1a8acd42b36795e5fbdfe7602f3",
+  "omie-desconto-backfill": "e6fefcf6e87b93f2dc054580bbeea645760d76f765345d6d49bbe05f1a18d368",
   "omie-financeiro": "5fca4eaab0e30de52d28ec7a79eb40c337eb835364628e9b7177c72b4d8420b6",
   "omie-malha-sync": "346aaa13fa16bab1f19085e39e2461e23a5d9ca189ef9afaf25030f163ec44cb",
   "omie-nfe-recebimento": "e69f5f4fe0c581043237e33d55bef413b245f7e264ae88138f5439a1f49cdb4c",

--- a/supabase/functions/omie-desconto-backfill/index.ts
+++ b/supabase/functions/omie-desconto-backfill/index.ts
@@ -32,6 +32,10 @@ import {
   type MotivoRecusa,
 } from "../_shared/desconto-backfill.ts";
 import { avaliarPagina, MAX_PAGINAS_PEDIDOS, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
+// `fetchAll` porque o PostgREST capa em 1.000 linhas em SILÊNCIO: uma leitura truncada aqui
+// tiraria irmãos do universo e a unicidade voltaria a ser medida sobre conjunto incompleto —
+// o mesmo defeito por outro caminho.
+import { fetchAll } from "../_shared/paginate.ts";
 import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 const OMIE_API_URL = "https://app.omie.com.br/api/v1";
@@ -144,6 +148,7 @@ Deno.serve(async (req) => {
       pedidos_sem_pai_local: 0,
       linhas_oferecidas: 0,
       linhas_apuradas: 0,
+      ja_apuradas_puladas: 0,
       recusa_ambiguo: 0,
       recusa_sem_correspondencia: 0,
       recusa_base_indeterminada: 0,
@@ -151,7 +156,8 @@ Deno.serve(async (req) => {
       escrita_pedida: 0,
       escrita_aplicada: 0,
       escrita_recusada_base_mudou: 0,
-      pedidos_incoerentes: 0,
+      // Conta LINHAS, não pedidos — o retry é por linha. O nome anterior mentia na unidade.
+      linhas_em_pedido_incoerente: 0,
     };
 
     let pagina = paginaInicial;
@@ -177,7 +183,15 @@ Deno.serve(async (req) => {
       for (const linha of linhas) {
         const { data: d1, error: e1 } = await db.rpc("desconto_backfill_aplicar", { p_linhas: [linha] });
         if (e1) {
-          contagem.pedidos_incoerentes++;
+          // Só a violação CONHECIDA da trigger de coerência (23514, check_violation) vira
+          // contador. Antes, QUALQUER erro caía aqui — timeout, permissão, indisponibilidade —
+          // e a edge terminava HTTP 200 depois de uma falha sistêmica, com a contagem parecendo
+          // apenas "alguns pedidos incoerentes". Erro que não sei nomear propaga. (Codex)
+          const sqlstate = (e1 as { code?: string }).code;
+          if (sqlstate !== "23514") {
+            throw new Error(`escrita recusada (SQLSTATE ${sqlstate ?? "desconhecida"}): ${e1.message}`);
+          }
+          contagem.linhas_em_pedido_incoerente++;
           continue;
         }
         const r1 = d1 as { aplicadas?: number; recusadas?: number } | null;
@@ -228,25 +242,42 @@ Deno.serve(async (req) => {
       for (const p of pais ?? []) idPorHash.set(String(p.hash_payload), String(p.id));
 
       const idsPedido = [...idPorHash.values()];
-      const { data: linhasDb, error: errLinhas } = idsPedido.length === 0
-        ? { data: [], error: null }
-        : await db
-          .from("order_items")
-          .select("id, sales_order_id, omie_codigo_produto, quantity, unit_price")
+      // ⚠️ SEM `.is("desconto_valor", null)` aqui, e a ausência é o ponto. A conciliação decide
+      // por UNICIDADE do trio (SKU, quantidade, preço) dos dois lados; calcular essa unicidade
+      // sobre um conjunto já filtrado é medi-la em outro universo. Um pedido com duas linhas do
+      // mesmo trio, uma já apurada, entregaria só a outra — que passaria a parecer ÚNICA e
+      // receberia um desconto que pode ser o do irmão. Não morde na primeira passada (tudo é
+      // NULL), morde em toda RETOMADA — e o job é retomável por desenho.
+      //
+      // Então: lê TODAS as linhas dos pedidos, concilia sobre o conjunto completo, e só depois
+      // descarta as que já têm desconto. Achado da 2ª opinião (Codex), confirmado no código.
+      const linhasDb = await fetchAll<{
+        id: string; sales_order_id: string; omie_codigo_produto: number | string | null;
+        quantity: number | string | null; unit_price: number | string | null;
+        desconto_valor: number | string | null;
+      }>((de, ate) =>
+        db.from("order_items")
+          .select("id, sales_order_id, omie_codigo_produto, quantity, unit_price, desconto_valor")
           .in("sales_order_id", idsPedido)
-          .is("desconto_valor", null);
-      if (errLinhas) throw new Error(`linhas: ${errLinhas.message}`);
+          .order("id", { ascending: true })
+          .range(de, ate)
+      , "order_items do backfill de desconto");
 
       const porPedido = new Map<string, LinhaLocal[]>();
-      for (const l of linhasDb ?? []) {
+      // `jaApuradas`: as linhas que entram na CONCILIAÇÃO (para a unicidade ser medida no universo
+      // certo) mas NÃO na escrita. Reapurar uma linha já preenchida sobrescreveria trabalho de
+      // outro writer com um valor lido depois — e o UPDATE tem seu próprio guard para isso.
+      const jaApuradas = new Set<string>();
+      for (const l of linhasDb) {
         const k = String(l.sales_order_id);
-        const lista = porPedido.get(k);
         const item: LinhaLocal = {
           id: String(l.id),
           omie_codigo_produto: l.omie_codigo_produto,
           quantity: l.quantity,
           unit_price: l.unit_price,
         };
+        if (l.desconto_valor !== null && l.desconto_valor !== undefined) jaApuradas.add(item.id);
+        const lista = porPedido.get(k);
         if (lista) lista.push(item);
         else porPedido.set(k, [item]);
       }
@@ -261,6 +292,8 @@ Deno.serve(async (req) => {
         if (locais.length === 0) continue;
 
         const plano = conciliarDescontosPedido(locais, pedido.det ?? []);
+        // O denominador conta o que foi OFERECIDO à conciliação; as já apuradas entram nela (pela
+        // unicidade) mas saem da escrita, e são contadas à parte para os dois números fecharem.
         contagem.linhas_oferecidas += locais.length;
         contagem.linhas_apuradas += plano.apurados.length;
         // Mapa tipado pelo próprio union em vez de uma cadeia de `else if`: com o `else` final,
@@ -278,6 +311,7 @@ Deno.serve(async (req) => {
 
         const porId = new Map(locais.map((l) => [l.id, l]));
         for (const a of plano.apurados) {
+          if (jaApuradas.has(a.id)) { contagem.ja_apuradas_puladas++; continue; }
           const base = porId.get(a.id)!;
           // A base viaja JUNTO do valor: a RPC reexige que a linha ainda seja a mesma na hora do
           // UPDATE. Entre esta leitura e a escrita, o sync ou uma edição podem ter mudado o preço.

--- a/supabase/functions/omie-desconto-backfill/versao.ts
+++ b/supabase/functions/omie-desconto-backfill/versao.ts
@@ -4,7 +4,7 @@
 // Esta edge nasce COM sensor: cada execução devolve o denominador (alvos, apurados, e as recusas
 // por motivo) e o `cursor` de onde parou. "Rodou e não deu erro" não é sinal de nada aqui — o
 // modo de falha característico do backfill é apurar POUCO e parecer bem-sucedido.
-export const VERSAO = "v1.0-backfill-oben-ttm";
+export const VERSAO = "v1.1-unicidade-no-universo-completo";
 
 // O que a sonda prova quando responde: que o bundle no ar conhece a régua de conciliação por trio.
 // A edge é de EFEITO (escreve `order_items.desconto_valor`), então a sonda NUNCA escreve: ela

--- a/supabase/migrations/20260908220625_desconto_backfill_aplicar.sql
+++ b/supabase/migrations/20260908220625_desconto_backfill_aplicar.sql
@@ -35,6 +35,7 @@ AS $fn$
 DECLARE
   v_pedidas   integer := 0;
   v_aplicadas integer := 0;
+  v_ja_apuradas integer := 0;
 BEGIN
   IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
     RAISE EXCEPTION 'desconto_backfill_aplicar: p_linhas tem de ser um array jsonb (veio %)',
@@ -67,16 +68,32 @@ BEGIN
        -- no plano, não uma entrada com null. Aceitar null aqui deixaria um bug do chamador
        -- apagar apuração já feita, em massa e sem sinal.
        AND pl.desconto_valor IS NOT NULL
+       -- SO ESCREVE O QUE AINDA NAO FOI APURADO. Sem isto, um writer que preencha a linha entre a
+       -- leitura que montou o plano e esta escrita seria SOBRESCRITO -- e sem divergencia visivel,
+       -- porque o trio (SKU, qtd, preco) continua batendo: o guard de base nao ve mudanca de
+       -- desconto. Reapurar nao e' inofensivo: o valor do plano foi lido ANTES, e o do outro
+       -- writer pode ser mais novo. Repetir o mesmo plano segue idempotente no que importa (a
+       -- linha ja tem o valor); o que muda e' que a corrida deixa de ter vencedor por sorte.
+       AND oi.desconto_valor IS NULL
      RETURNING 1
   )
   SELECT count(*) INTO v_aplicadas FROM aplicado;
 
   -- O chamador precisa das DUAS contagens. Só "aplicadas" não distingue "o plano tinha 40 linhas
   -- e 40 foram escritas" de "tinha 900 e 40 foram escritas porque 860 mudaram no meio do caminho".
+  -- `recusadas` agora junta DOIS fatos: base mudou desde a leitura, e linha ja apurada por outro
+  -- writer. O chamador precisa dos dois separados para nao ler "corrida perdida" como "acervo
+  -- inconsistente" -- consertos opostos.
+  SELECT count(*) INTO v_ja_apuradas
+    FROM jsonb_to_recordset(p_linhas) AS x(id uuid)
+    JOIN public.order_items oi ON oi.id = x.id
+   WHERE oi.desconto_valor IS NOT NULL;
+
   RETURN jsonb_build_object(
-    'pedidas',   v_pedidas,
-    'aplicadas', v_aplicadas,
-    'recusadas', v_pedidas - v_aplicadas
+    'pedidas',      v_pedidas,
+    'aplicadas',    v_aplicadas,
+    'recusadas',    v_pedidas - v_aplicadas,
+    'ja_apuradas',  v_ja_apuradas
   );
 END
 $fn$;


### PR DESCRIPTION
A 2ª opinião (Codex, gpt-6-astra max · 422s · 152k tokens) reprovou o código **antes da primeira escrita**. Os três achados se confirmaram no código, e o veredito conjunto foi: **não rodar o backfill com esta versão.**

## 1. Unicidade num universo filtrado — o pior, e é meu

A leitura local fazia `.is("desconto_valor", null)` **antes** de conciliar. Mas a conciliação decide por **unicidade do trio** (SKU, quantidade, preço) dos dois lados — e medir essa unicidade sobre um conjunto já filtrado é medi-la em outro universo.

Um pedido com duas linhas do mesmo trio, uma já apurada, entregaria só a outra. Ela passaria a parecer **única** e receberia um desconto que pode ser o do irmão. Isso derruba exatamente a garantia que o módulo existe para dar.

Não morde na primeira passada (tudo é NULL). Morde em **toda retomada** — e o job é retomável por desenho.

Agora lê todas as linhas dos pedidos com `fetchAll` (o PostgREST capa em 1.000 em silêncio, e uma leitura truncada reproduz o mesmo defeito por outro caminho), concilia sobre o conjunto completo, e só então descarta as já apuradas — contadas à parte.

## 2. Corrida com outro writer

O `UPDATE` comparava a base econômica mas não exigia `oi.desconto_valor IS NULL`. Quem preenchesse a linha entre a leitura que montou o plano e a escrita seria **sobrescrito, sem divergência visível**: o trio continua batendo, então o guard de base não vê nada.

`ja_apuradas` volta separado de `recusadas` — "corrida perdida" e "acervo mudou" têm consertos opostos.

## 3. Fail-loud no retry

Qualquer erro da RPC individual virava `pedidos_incoerentes++` — inclusive timeout, permissão e indisponibilidade. A edge terminava **HTTP 200 depois de falha sistêmica**. Agora só a violação conhecida da trigger (SQLSTATE `23514`) vira contador; o resto propaga. E o nome mudou: ele conta **linhas**, não pedidos.

## O que a prova revelou

Ao falsificar o guard de concorrência, o assert `H3` ficou verde por motivo errado: o eixo passou a ter **dois guards independentes**, e sabotar um deixava o outro segurando. O teste leria "não houve dano" como "o guard tem dente" — o inverso. A sabotagem agora remove os dois: o que se mede é se **alguém** ainda protege.

| Gate | Resultado |
|---|---|
| `db/test-desconto-backfill-aplicar.sh` | **25 asserts** (era 20), 0 falhas |
| `db/test-desconto-valor-escritores.sh` | 19 asserts, 0 falhas |
| `test:edges` · `authz:check` · `lint:shell` | 1084/0 · exit 0 · 0 achados |

VERSAO: `v1.0-backfill-oben-ttm` → `v1.1-unicidade-no-universo-completo`.

## ⚠️ Depois do merge

A RPC precisa ser **reaplicada** (`bun run db:aplicar db/aplicar-desconto-backfill-rpc.sql`) e a edge **redeployada** — a versão em produção é a de antes destas correções.

🤖 Generated with [Claude Code](https://claude.com/claude-code)