### PR TITLE
test(db-aplicar): a prova do caminho por onde TODA migration entra rodava só no laptop

### DIFF
--- a/db/nucleo-ci.txt
+++ b/db/nucleo-ci.txt
@@ -54,6 +54,14 @@ db/test-sales_orders_omie_hash_unique.sh    5
 # repo, e nesse caso a INTERAÇÃO entre as duas deixa de ser verificada em silêncio. O número aqui
 # é o que faz esse silêncio virar vermelho.
 db/test-pedido-edicao-atomica.sh           54
+# O caminho pelo qual TODA mudança de banco entra em produção: `db:aplicar` + `aplicar_sql()`.
+# Tentativa gravada FORA da transação, recibo DENTRO; marcador positivo de fim; sha reconferido
+# pelo banco; e as duas classes de SQL que não cabem na transação do script (envelope e
+# `CREATE INDEX CONCURRENTLY`) recusadas antes de tocar no banco.
+# Entrou aqui porque a ausência já custou: o #2421 quebrou TODA migration com envelope e passou
+# verde no CI. Tinha duas camadas — as fixtures não cobriam a classe com `BEGIN;` (#2441), e a
+# prova rodava só no laptop, presa a um PGBIN de Homebrew. Portada para o pg-harness aqui.
+db/test-db-aplicar.sh                      36
 
 # ── Eixo 4 — CONCORRÊNCIA / TOCTOU ────────────────────────────────────────────────
 # A janela entre dois round-trips PostgREST, com uma chamada HTTP que cria pedido de

--- a/db/test-db-aplicar.sh
+++ b/db/test-db-aplicar.sh
@@ -83,8 +83,27 @@ cleanup() {
 trap cleanup EXIT
 
 # ─── cluster ─────────────────────────────────────────────────────────────────────────────
-"$PGBIN/initdb" -D "$DATA" -U postgres --locale=C >/dev/null 2>&1
-"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -c listen_addresses=localhost" -l "$WORK/pg.log" -w start >/dev/null 2>&1
+# `-k "$WORK"`: o diretório do socket unix. Sem ele o postmaster usa o default COMPILADO, que
+# no PGDG (Ubuntu) é /var/run/postgresql — inexistente para o usuário do runner, e o servidor
+# não sobe. Conectamos por TCP, mas o postmaster cria o socket de qualquer jeito e ABORTA se
+# não puder. É o que reprovou a 1ª tentativa desta prova no CI; as 16 provas que já rodavam lá
+# passam `-k /tmp` pelo mesmo motivo. Aqui vai $WORK, que é por-prova: /tmp é compartilhado e
+# duas provas na mesma porta lógica brigariam pelo mesmo arquivo de socket.
+#
+# E a saída NÃO é mais descartada. Com `>/dev/null 2>&1` + `set -e`, um cluster que não sobe
+# matava o script MUDO: log vazio, exit 1, e o runner do núcleo imprimindo "── últimas linhas ──"
+# seguido de nada. Falha silenciosa é a pior classe de todas — a que não deixa nem por onde
+# começar. Cada ramo abaixo DIZ o que quebrou, com o que o Postgres respondeu.
+if ! "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C > "$WORK/initdb.log" 2>&1; then
+  echo "ERRO: initdb falhou (PGBIN=$PGBIN)"; tail -c 800 "$WORK/initdb.log"; exit 1
+fi
+if ! "$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k $WORK -c listen_addresses=localhost" \
+       -l "$WORK/pg.log" -w start > "$WORK/pgctl.log" 2>&1; then
+  echo "ERRO: o cluster de teste não subiu na porta $PORT (PGBIN=$PGBIN)"
+  echo "── pg_ctl ──"; tail -c 400 "$WORK/pgctl.log"
+  echo "── postmaster ──"; tail -c 800 "$WORK/pg.log" 2>/dev/null
+  exit 1
+fi
 
 PSQL="$PGBIN/psql -X -v ON_ERROR_STOP=1 -h localhost -p $PORT -U postgres -d postgres"
 q() { "$PGBIN/psql" -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null | tr -d ' \n'; }

--- a/db/test-db-aplicar.sh
+++ b/db/test-db-aplicar.sh
@@ -24,9 +24,16 @@
 # ╚═════════════════════════════════════════════════════════════════════════════════════════╝
 set -euo pipefail
 
+# Esta prova está em `db/nucleo-ci.txt` (job `provas-sql`): roda no caminho OBRIGATÓRIO do merge,
+# em modo normal, com mínimo de asserts declarado lá. Encolhê-la reprova o CI até alguém baixar
+# aquele número — e aí a perda de cobertura fica no diff, que é o ponto. O `--falsificar` continua
+# sendo local: ele sabota uma cópia e não é o que o runner executa.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PGVER=17
-PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+# PGBIN resolvido por PLATAFORMA (macOS Homebrew / Linux PGDG), com conferência POSITIVA da
+# major — não `-x`, que um initdb de outra versão satisfaz. Hardcodar /opt/homebrew era a única
+# coisa que mantinha esta prova FORA do CI: o runner é ubuntu e o caminho não existe lá.
+# shellcheck disable=SC1091  # o gate roda sem -x; o helper é versionado ao lado, em db/lib/
+. "$REPO_ROOT/db/lib/pg-harness.sh"
 PORT="${PGPORT_TEST:-5481}"
 BOOT="$REPO_ROOT/db/claude-rw-bootstrap.sql"
 APLICAR="$REPO_ROOT/scripts/db-aplicar.sh"
@@ -56,8 +63,18 @@ ok()   { PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
 nok()  { FAIL=$((FAIL+1)); printf '  ❌ %s — %s\n' "$1" "$2"; }
 eq()   { if [ "$2" = "$3" ]; then ok "$1"; else nok "$1" "esperado '$3', veio '$2'"; fi; }
 
-[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
 [ -f "$BOOT" ] || { echo "bootstrap ausente: $BOOT"; exit 1; }
+
+# SONDA de `shasum`, com resposta POSITIVA. É a única dependência do `db-aplicar.sh` que este
+# teste exerce e que o pg-harness não cobre — e é a que muda de plataforma: no macOS vem com o
+# sistema, no Linux vem do pacote `perl`. `command -v` não basta (presente-porém-quebrada
+# esvazia o guard igual): exigimos o hash CONHECIDO de uma entrada conhecida. Sem isso, a falta
+# apareceria lá dentro como "sha256 com formato inesperado", que culpa o arquivo errado.
+SHA_VAZIO="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+[ "$(printf '' | shasum -a 256 2>/dev/null | awk '{print $1}')" = "$SHA_VAZIO" ] || {
+  echo "ERRO: 'shasum -a 256' não respondeu o hash conhecido da entrada vazia."
+  echo "  O scripts/db-aplicar.sh depende dele para a identidade do que aplica."
+  echo "  Debian/Ubuntu: apt-get install -y perl   (shasum vem no pacote perl)"; exit 1; }
 
 cleanup() {
   "$PGBIN/pg_ctl" -D "$DATA" -m immediate stop >/dev/null 2>&1 || true
@@ -70,9 +87,9 @@ trap cleanup EXIT
 "$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -c listen_addresses=localhost" -l "$WORK/pg.log" -w start >/dev/null 2>&1
 
 PSQL="$PGBIN/psql -X -v ON_ERROR_STOP=1 -h localhost -p $PORT -U postgres -d postgres"
-q() { $PGBIN/psql -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null | tr -d ' \n'; }
+q() { "$PGBIN/psql" -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null | tr -d ' \n'; }
 # q() esmaga espaco e quebra de linha — serve para escalar, nao para corpo de funcao.
-q_bruto() { $PGBIN/psql -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null; }
+q_bruto() { "$PGBIN/psql" -X -A -t -h localhost -p "$PORT" -U postgres -d postgres -c "$1" 2>/dev/null; }
 
 # ─── fixture: o mínimo do Supabase que o bootstrap referencia ─────────────────────────────
 $PSQL >/dev/null 2>&1 <<'SQL'


### PR DESCRIPTION
"O #2421 passou verde no CI" tinha duas camadas. A primeira — fixtures que não cobriam a classe com envelope — caiu no [#2441](https://github.com/LucasSardenbergL/afiacao/pull/2441). Esta é a segunda, e é a mais burra: **a prova nunca rodou no CI**.

```
PGBIN="/opt/homebrew/opt/postgresql@17/bin"
```

Caminho de macOS/Homebrew, hardcoded. O runner é ubuntu; ali esse caminho não existe e o teste sairia com "brew install". Não dava para adicionar ao `nucleo-ci.txt` sem portar antes — e o repo **já tem** o helper canônico para isso, adotado pelas 16 provas que hoje rodam no job `provas-sql`. Este era um dos ~268 arquivos que ainda traziam a linha do laptop.

## O que muda

**1. `db/lib/pg-harness.sh` no lugar do caminho fixo.** Ele resolve macOS/Homebrew, `/usr/local`, PGDG Linux (`/usr/lib/postgresql/17/bin` — exatamente o que o `ci.yml` instala) e o PATH, cada candidato com conferência **positiva** da major. Sai junto o `[ -x "$PGBIN/initdb" ]`, que o harness já faz melhor: `-x` é satisfeito por um `initdb` de *outra* versão, e veredito sobre o Postgres errado é pior que ausência.

**2. Sonda de `shasum -a 256` com resposta positiva** — o hash conhecido da entrada vazia. É a única dependência do `db-aplicar.sh` que este teste exerce e que o harness não cobre, e é a que muda de plataforma (no Linux vem do pacote `perl`). `command -v` não bastaria: presente-porém-quebrada esvazia o guard igual. Sem a sonda, a falta apareceria lá dentro como `sha256 com formato inesperado`, culpando o arquivo errado.

**3. Entrada no `db/nucleo-ci.txt`**, eixo 3 (atomicidade), mínimo **36 asserts** — medido executando, não estimado.

**4. Aspas em `$PGBIN/psql`** nas duas funções de query. Com o `PGBIN` vindo de `source`, o shellcheck deixa de saber que não tem espaço — e tem razão.

## Verificação

`db/roda-nucleo-ci.sh` completo — é o que o job `provas-sql` executa:

```
✅ test-db-aplicar                              asserts=36   (≥36) 13s
SQL_PROOF_OK provas=17/17 server_version_num=170010
```

Os quatro cenários, exit capturado pelado (sem `| tail` engolindo o código):

| cenário | asserções | exit |
|---|---|---|
| normal · `LC_TESTE=C` | 36 | 0 |
| normal · `LC_TESTE=pt_BR.UTF-8` | 36 | 0 |
| `--falsificar` · `LC_TESTE=C` | 24 | 0 |
| `--falsificar` · `LC_TESTE=pt_BR.UTF-8` | 24 | 0 |

`bun run lint:shell`: 0 achados em 411 arquivos.

## O que não pude medir daqui

O `shasum` no runner ubuntu. Ele vem do pacote `perl` e a expectativa é que esteja lá, mas isso é expectativa, não medição — e o CI deste PR é o primeiro lugar onde a resposta aparece. É exatamente por isso que a sonda do item 2 existe: se faltar, o vermelho **diz o que instalar** em vez de virar um erro confuso de hash lá dentro. Nenhum outro caminho novo é introduzido: `git`, `psql` e `initdb` já são exercidos por provas que rodam verdes nesse mesmo job.

## Coordenação

Rebaseado sobre o [#2442](https://github.com/LucasSardenbergL/afiacao/pull/2442), que mergeou no meio do trabalho e tocou o mesmo arquivo (guards de `CREATE INDEX CONCURRENTLY`). Ele **não** portou o `PGBIN` nem entrou no núcleo — os trabalhos são complementares, e o mínimo de asserts aqui já conta os dele (32 → 36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
