### PR TITLE
chore(sonda): regerar a sonda de `omie-desconto-backfill` para a fonte de v1.1

### DIFF
--- a/db/sonda-omie-desconto-backfill.sql
+++ b/db/sonda-omie-desconto-backfill.sql
@@ -28,7 +28,7 @@ SELECT format($sonda$
 --          1: nada a colar. Espere ~10s pela resposta HTTP. É SELECT puro —
 --          roda no read-only: cole no chat, ou em ~/.config/afiacao/psql-ro
 WITH esperado(edge, versao_esperada, fonte_esperada) AS (VALUES
-  ('omie-desconto-backfill', 'v1.0-backfill-oben-ttm', 'd09a10f83d4fff48aa81194a43c3642310d0c1a8acd42b36795e5fbdfe7602f3')
+  ('omie-desconto-backfill', 'v1.1-unicidade-no-universo-completo', 'e6fefcf6e87b93f2dc054580bbeea645760d76f765345d6d49bbe05f1a18d368')
 ),
 recentes AS (
   -- A JANELA. O filtro textual roda ANTES do cast de propósito: um corpo não-JSON no meio da


### PR DESCRIPTION
## O que

O [#2448](https://github.com/LucasSardenbergL/afiacao/pull/2448) mudou `omie-desconto-backfill/index.ts` **horas depois** da 1ª atestação ([#2447](https://github.com/LucasSardenbergL/afiacao/pull/2447)). O `/fecho` desta sessão pegou pelo `edges-pendentes.sh`:

```
DESATUALIZADA  omie-desconto-backfill  no ar d09a10f8… ≠ main e6fefcf6… — BUNDLE VELHO SERVINDO
```

Ou seja: o instrumento fez exatamente o que existe para fazer — mostrar bundle velho **servindo**, que é a falha silenciosa que o gatilho antigo (`git log` cru) nunca via.

## O que foi feito nesta sessão

1. **Redeploy** pelo chat do Lovable (`pendencias:pacote` → `send_message` verbatim). O gate de ordem passou antes: a RPC `desconto_backfill_aplicar` já existia em prod rodando o corpo da última migration. Os **12 hashes conferiram** contra `895b93eeb`; nada editado, nada invocado com corpo, nada agendado.
2. **Sonda** regerada e aplicada pelo envelope (`db:aplicar`, tentativa #24 → recibo).
3. **Medição**, lida por fora pelo `psql-ro`:

```
          edge          | request_id | status | versao_respondida                   | veredito
------------------------+------------+--------+-------------------------------------+-------------------
 omie-desconto-backfill |      74614 |    200 | v1.1-unicidade-no-universo-completo | DEPLOY CONFIRMADO
```

`fonte` respondida = `e6fefcf6e87b93f2dc054580bbeea645760d76f765345d6d49bbe05f1a18d368`, igual à da main.

## O arquivo

Sobrescrito, não duplicado: a sonda vale para a fonte de **agora**, e a anterior fica na história do git. Bytes verbatim de `bun run sonda:sql omie-desconto-backfill --so-disparo`.

## Atrito que isto expõe

`bun run db:aplicar` **recusa reaplicar o mesmo sha** (exit 3) — correto para um envelope de migration, que é o que ele é. Mas sonda é repetível por natureza, então toda mudança de fonte da edge exige um commit novo só para mudar os bytes. Funcionou (dois PRs em ~1h), mas o caminho merece desenho próprio: ou uma exceção declarada para SQL efêmero, ou um `sonda:aplicar` que não passe pelo ledger de migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Anexo — pendência com destino durável

Este anexo existe porque um chip só vira trabalho quando o founder clica, e chip não clicado morre com a sessão. O texto abaixo é o destino durável da pendência; o chip é só o atalho.

### Chip aberto: "Tirar dos scripts de sonda o 'founder cola no SQL Editor'"

Dois scripts imprimem instruções que mandam o founder colar SQL no SQL Editor do Lovable num caso em que a sessão do agente **já tem caminho próprio** desde 2026-09-08. O texto estava certo quando foi escrito e envelheceu em silêncio; o custo é que todo agente que lê a saída herda a limitação e devolve ao founder uma tarefa que deveria executar.

**Os dois textos:**

1. `scripts/sonda-versao-sql.ts` — cabeçalho do PASSO 1: *"É o bloco do FOUNDER: lê o vault e faz INSERT, e o wrapper read-only recusa os dois."* A segunda metade é verdadeira e deve ficar (o `psql-ro` recusa mesmo). *"É o bloco do FOUNDER"* é a parte que envelheceu.
2. `scripts/pendencias-deploy.ts` — o remédio impresso: `→ sonda (founder cola no SQL Editor): bun run sonda:sql <edge>`

**Por que envelheceram:** `bun run db:aplicar` passa por `public.aplicar_sql`, descrita em `db/claude-rw-bootstrap.sql` como "uma função SECURITY DEFINER que executa SQL arbitrário com os privilégios de `postgres`". Ela alcança o vault e faz o INSERT — as duas coisas que o texto diz serem impossíveis. Provado duas vezes hoje: #2447 e este PR.

**O que fazer:** reescrever os dois textos nomeando o caminho real, sem apagar a ressalva (que continua valendo para quem só tem o `psql-ro`). A colagem no SQL Editor vira o fallback, não o default.

**Cuidados:** há testes que casam esses textos por string — `git grep -n "bloco do FOUNDER"` e `git grep -n "founder cola no SQL Editor"` acham todos os pontos, incluindo `.claude/skills/fecho/SKILL.md`, docs e possivelmente `scripts/mutcheck.d/sonda-versao-sql.mut`. `bun run test` e `bun run typecheck` verdes antes do PR.

### Segunda pendência, mesma família: `db:aplicar` × sonda repetível

Descrita acima na seção "Atrito que isto expõe". Vale um desenho próprio, e o gatilho para virar chip é a terceira vez que uma sonda exigir commit novo só por mudança de fonte — hoje foram duas.


### Chip aberto: "Pôr omie-desconto-backfill no cron de sonda"

A edge está **fora** da allowlist de `supabase/functions/_shared/sonda-cron-alvos.ts`. Sem prova passiva, toda sessão que fechar depois de um PR tocar essa edge a vê como pendente e precisa sondar à mão — foi o que aconteceu duas vezes hoje (#2447 e este PR), e é o padrão que gerou 35 chips duplicados em 06–08/09.

**Pré-condição obrigatória:** `bun run sonda:cron-prova` exige zero efeito. Crítico aqui, porque a edge reescreve `order_items.desconto_valor`. A evidência de que passa está em `supabase/functions/omie-desconto-backfill/index.ts:97-104` — probe tratado antes do `createClient` e de qualquer chamada ao Omie, com `classificarSonda` fail-closed. **Confirme rodando a prova**, não pelo texto. Uma edge de escrita sondada por cron a cada 2h sem essa garantia seria um backfill não pedido a cada 2h.

**Modelo:** a onda 4 é a mais recente — `sonda-cron-onda4` e `db/aplicar-sonda-alvos-onda4.sql`. Se a onda exigir SQL, vai por `bun run db:aplicar` (commite o `.sql` em `db/` antes), com `--ensaio` primeiro.
