### PR TITLE
docs(fecho): a medição do passo 3 envelhece enquanto a sessão decide — re-medir antes de ENVIAR

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -310,6 +310,20 @@ Se a sessão tocou edge: ela está NO AR? (Evidência: o veredito do script acim
 da conversa, e não "o Lovable disse Active".) **Pendente → DEPLOYE AQUI, nesta sessão**, não
 escreva um recado sobre isso:
 
+⚠️ **RE-MEÇA imediatamente antes de ENVIAR — a medição do passo 3 envelhece enquanto você decide.**
+O veredito `DESATUALIZADA`/`DIVERGE_P1` sai da última sonda gravada, que pode ter **horas**; e o cron
+de sondagem (`37 */2 * * *`) grava uma nova a qualquer momento, inclusive entre a sua medição e o seu
+envio. Medido em 2026-09-10: o fecho leu às 00:51Z uma sonda de **23:32Z** (`DIVERGE_P1`, v1.0), o
+cron sondou às **00:57Z** já com a v1.1 no ar — outra sessão havia deployado — e o envio ao Lovable
+saiu às ~01:16Z, **19 min depois de a pendência ter deixado de existir**. Não houve dano (o agente
+conferiu os 12 `sha256` e publicou o mesmo bundle), mas foi deploy redundante, que é a classe do
+`docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md` — e com ~30 worktrees a pendência que
+você mediu é frequentemente de OUTRA sessão, que também está fechando e também vai deployar.
+
+É o mesmo reflexo do `gh pr create` (CLAUDE.md §Multi-sessão: "RE-conferir imediatamente antes"), e
+custa um comando: rode `pendencias:deploy` de novo **depois** de montar o pacote e **antes** do
+`send_message`. Exit 0 ⇒ **não envie**: alguém chegou primeiro, e isso é desfecho ✅, não ❌.
+
 ```bash
 PEND=$(mktemp -t pend)                                     # único por invocação: /tmp/pend.json colide entre worktrees
 bun scripts/pendencias-deploy.ts --json > "$PEND"          # quem julga é o LEDGER


### PR DESCRIPTION
## O que aconteceu

No fecho de hoje eu mesmo caí nisto. Linha do tempo **medida**:

| hora (UTC) | evento |
|---|---|
| 23:32Z | sonda → `DIVERGE_P1` — `omie-desconto-backfill` servindo **v1.0** |
| 00:51Z | o fecho leu **essa** sonda (idade 1.31h) e classificou `DESATUALIZADA` |
| 00:57Z | o cron sondou de novo → `CONFERE`, **v1.1 já no ar** (outra sessão deployou) |
| ~01:16Z | eu enviei o deploy ao Lovable — **19 min depois de a pendência ter deixado de existir** |

**Sem dano:** o agente do Lovable conferiu os 12 `sha256` contra `895b93eeb`, todos bateram, e
publicou o mesmo bundle (0.9 créditos). Mas foi **deploy redundante** — a classe de
[deploy-redundante-ledger-e-cron-de-sonda.md](docs/historico/deploy-redundante-ledger-e-cron-de-sonda.md).

## Por que é estrutural, e não descuido meu

O veredito do passo 3 sai da **última sonda gravada**, que pode ter horas. O cron (`37 */2 * * *`)
grava uma nova a qualquer momento — inclusive entre a medição e o envio. E com ~30 worktrees, a
pendência que o fecho mede é frequentemente de **outra** sessão, que também está fechando e também
vai deployar. O passo 3 mandava deployar sem mandar re-medir.

## A correção

Um comando, e é o mesmo reflexo que o CLAUDE.md §Multi-sessão já exige antes do \`gh pr create\`
("RE-conferir imediatamente antes"): rodar \`pendencias:deploy\` **depois** de montar o pacote e
**antes** do \`send_message\`. Exit 0 ⇒ não envie — alguém chegou primeiro, e isso é desfecho ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Pendência aberta (prompt durável do chip "Guard do pendencias:deploy lê allowlist do disco")

> Chip é destino perecível — morre com a sessão. O prompt fica aqui.

**Medido em 2026-09-10 ~23:05Z**, no 2º fecho desta sessão: `bun scripts/pendencias-deploy.ts --json` num
worktree **10 commits atrás** de `origin/main` saiu **exit 2**, stdout vazio, com
`o banco sonda edge(s) que o repo NÃO aprovou: omie-desconto-backfill … Desative no banco: UPDATE public.deploy_sonda_alvos SET ativo = false …`.

A premissa era **falsa**: `f4578bbff` pôs a edge na allowlist (`_shared/sonda-cron-alvos.ts`, 2 ocorrências em `origin/main`) e a migration
`20260909222423_deploy_sonda_alvos_onda5.sql` a ativou no banco (psql-ro: `ativo` = 1). Só o WORKING TREE estava velho (0 ocorrências no HEAD local).
Após `git checkout --detach origin/main`, o mesmo comando saiu exit 1 com o veredito correto.

**Causa (~linha 610):** `const doRepo = SONDA_CRON_ALVOS.map((a) => a.edge);` — import estático do DISCO, enquanto o resto do sensor
trabalha contra a REF (o JSON carrega `"ref": "origin/main"`). Duas fontes de verdade no mesmo sensor.

**Por que é grave:** o exit 2 é o fail-closed certo; o problema é o REMÉDIO impresso — uma escrita em prod que **desfaria uma migration
aplicada** e tiraria do cron uma edge de money-path aprovada. Com ~30 worktrees, worktree defasado é o caso COMUM.

**O que fazer:** (1) comparar o banco com a allowlist da MESMA REF que o resto do sensor usa, não com o import do disco; (2) se REF e disco
divergirem, dizer "worktree N commits atrás — sincronize antes de medir" e NÃO imprimir o `UPDATE` (ele só é remédio quando a edge falta
TAMBÉM na REF); (3) teste + falsificação com controle verde na mesma invocação — disco atrasado não pode sugerir UPDATE; edge ausente na REF
continua exit 2 com o UPDATE; sabotar a correção exige vermelho; casar a MARCA do ramo (ASCII, caixa fixa).
**Armadilhas:** arquivo QUENTE (`gh pr list` antes de tocar); não afrouxar o fail-closed; `git show` da REF falhando é mecânica (exit 2),
nunca "allowlist vazia".
