### PR TITLE
fix(fluxo-caixa): o previsto somava o valor CHEIO do título com baixa parcial — a parte já baixada está no saldo âncora

### DIFF
--- a/src/services/__tests__/getFluxoCaixa.test.ts
+++ b/src/services/__tests__/getFluxoCaixa.test.ts
@@ -164,13 +164,32 @@ const mov = (
   omie_codigo_lancamento: 1000 + i,
 });
 
-const titulo = (i: number, dia: string, valor: number): Row => ({
+/**
+ * Título de CR. `saldo` é COMPUTADO aqui pela MESMA regra da coluna GERADA do banco
+ * (`valor_documento - COALESCE(valor_recebido, 0)`, confirmada em prod via psql-ro
+ * 2026-09-09) em vez de ser um campo livre: fixture que escolhe `saldo` à mão pode
+ * afirmar um estado que o Postgres nunca produz, e aí o teste prova a fixture, não a tela.
+ */
+const titulo = (i: number, dia: string, valor: number, recebido = 0): Row => ({
   id: `cr-${String(i).padStart(6, '0')}`,
   company: 'oben',
   data_vencimento: dia,
   data_recebimento: null,
   valor_documento: valor,
-  valor_recebido: 0,
+  valor_recebido: recebido,
+  saldo: valor - recebido,
+  status_titulo: 'A VENCER',
+});
+
+/** Título de CP — mesma regra do `saldo` gerado, com `valor_pago` no lugar de `valor_recebido`. */
+const tituloPagar = (i: number, dia: string, valor: number, pago = 0): Row => ({
+  id: `cp-${String(i).padStart(6, '0')}`,
+  company: 'oben',
+  data_vencimento: dia,
+  data_pagamento: null,
+  valor_documento: valor,
+  valor_pago: pago,
+  saldo: valor - pago,
   status_titulo: 'A VENCER',
 });
 
@@ -178,6 +197,8 @@ const somaRealizadoEntradas = (fluxo: { entradas_realizadas: number }[]) =>
   fluxo.reduce((s, d) => s + d.entradas_realizadas, 0);
 const somaPrevistoEntradas = (fluxo: { entradas_previstas: number }[]) =>
   fluxo.reduce((s, d) => s + d.entradas_previstas, 0);
+const somaPrevistoSaidas = (fluxo: { saidas_previstas: number }[]) =>
+  fluxo.reduce((s, d) => s + d.saidas_previstas, 0);
 
 describe('getFluxoCaixa — caixa REALIZADO (fin_movimentacoes)', () => {
   beforeEach(() => {
@@ -344,9 +365,7 @@ describe('getFluxoCaixa — caixa PREVISTO (fin_contas_receber / fin_contas_paga
   });
 
   it('erro no CP LANÇA', async () => {
-    state.db.fin_contas_pagar = [
-      { ...titulo(0, '2026-03-01', 10), data_pagamento: null, valor_pago: 0 },
-    ];
+    state.db.fin_contas_pagar = [tituloPagar(0, '2026-03-01', 10)];
     state.falharNaRequisicao.fin_contas_pagar = 1;
 
     await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
@@ -369,5 +388,40 @@ describe('getFluxoCaixa — caixa PREVISTO (fin_contas_receber / fin_contas_paga
     const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
 
     expect(somaPrevistoEntradas(fluxo)).toBe(25000);
+  });
+
+  // ── Baixa PARCIAL: a 4ª forma de a projeção mentir, e a única que mente pra CIMA ──
+  // As três acima subnotificavam (página perdida, ordem instável, capa de 1.000). Esta
+  // INFLA: um título parcialmente baixado segue com status ABERTO, mas a parte já
+  // recebida entrou na conta e já está no `saldo_atual` de `fin_contas_correntes` — a
+  // ÂNCORA da projeção. Somar `valor_documento` cheio conta esse dinheiro duas vezes.
+  // Mesmo eixo (dupla contagem no tempo) da correção do saldo projetado do FluxoCaixaTab,
+  // um degrau abaixo: lá era a semana, aqui é o título.
+
+  it('CR com baixa PARCIAL entra pelo SALDO, não pelo valor cheio', async () => {
+    // doc 1.000, recebido 400 ⇒ saldo 600. Os 400 já estão no saldo da conta corrente:
+    // prever 1.000 os conta de novo.
+    state.db.fin_contas_receber = [titulo(0, '2026-03-10', 1000, 400)];
+
+    expect(somaPrevistoEntradas(await getFluxoCaixa('oben', INICIO, FIM))).toBe(600);
+  });
+
+  it('CP com baixa PARCIAL entra pelo SALDO, não pelo valor cheio', async () => {
+    state.db.fin_contas_pagar = [tituloPagar(0, '2026-03-10', 1000, 400)];
+
+    expect(somaPrevistoSaidas(await getFluxoCaixa('oben', INICIO, FIM))).toBe(600);
+  });
+
+  it('título SEM baixa segue pelo valor cheio — a troca não muda o caso de hoje (#396)', async () => {
+    // Contrapeso do par acima: hoje `valor_recebido` é 0 em 100% do universo (o LIST do
+    // Omie não traz a baixa), então saldo == valor_documento e o previsto NÃO muda. Sem
+    // este caso, um bug que zerasse o previsto passaria pelos dois testes de parcial.
+    state.db.fin_contas_receber = [titulo(0, '2026-03-10', 1000)];
+    state.db.fin_contas_pagar = [tituloPagar(0, '2026-03-11', 700)];
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaPrevistoEntradas(fluxo)).toBe(1000);
+    expect(somaPrevistoSaidas(fluxo)).toBe(700);
   });
 });

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -363,7 +363,7 @@ export async function getFluxoCaixa(
     buscarTodasPaginas(`CR do fluxo de caixa (${company})`, (from, to) => {
       let q = supabase
         .from("fin_contas_receber")
-        .select("data_vencimento, data_recebimento, valor_documento, valor_recebido, status_titulo")
+        .select("data_vencimento, saldo, status_titulo")
         .gte("data_vencimento", dataInicio)
         .lte("data_vencimento", dataFim);
       if (company !== 'all') q = q.eq("company", company);
@@ -372,7 +372,7 @@ export async function getFluxoCaixa(
     buscarTodasPaginas(`CP do fluxo de caixa (${company})`, (from, to) => {
       let q = supabase
         .from("fin_contas_pagar")
-        .select("data_vencimento, data_pagamento, valor_documento, valor_pago, status_titulo")
+        .select("data_vencimento, saldo, status_titulo")
         .gte("data_vencimento", dataInicio)
         .lte("data_vencimento", dataFim);
       if (company !== 'all') q = q.eq("company", company);
@@ -398,11 +398,34 @@ export async function getFluxoCaixa(
     return fluxoMap.get(d)!;
   };
 
+  // PREVISTO = `saldo` (coluna GERADA em prod: `valor_documento - COALESCE(valor_recebido/pago, 0)`),
+  // nunca `valor_documento`. Um título com BAIXA PARCIAL continua com status ABERTO, mas a parte
+  // já baixada JÁ entrou na conta — e portanto já está no `saldo_atual` de `fin_contas_correntes`,
+  // que é a ÂNCORA da projeção desta tela. Somar o valor CHEIO conta essa parte duas vezes: é o
+  // mesmo eixo da dupla contagem corrigida no saldo projetado do FluxoCaixaTab (nível da SEMANA),
+  // um degrau abaixo — no nível do TÍTULO. Achado da 2ª opinião Codex, deixado fora daquele escopo
+  // de propósito. `saldo` é também a fonte de `somarSaldoAberto` (canônica de "aberto": DSO, KPIs
+  // de /financeiro/gestao, resumo), então as duas leituras param de divergir por construção.
+  //
+  // ⚠️ HOJE a troca é NUMERICAMENTE INERTE, e isso é medição, não esperança: o LIST do Omie não
+  // traz a baixa (#396), então `valor_recebido`/`valor_pago` são 0 em 100% do universo — medido
+  // 2026-09-09 via psql-ro: ZERO linhas com `saldo <> valor_documento` em 44.526 CR + 16.125 CP,
+  // RECEBIDO/PAGO inclusive. Ela é defesa em profundidade: o dia em que o ingest passar a gravar a
+  // baixa, esta tela já estará certa em vez de inflar o previsto em silêncio. Enquanto #396 não
+  // for resolvida, nenhuma baixa parcial chega aqui — o gatilho do defeito é o INGEST, não a tela.
+  //
+  // Por que aqui NÃO degrada para `null`/"—" como em `procedencia-baixa.ts` (#2437): aquele helper
+  // separa dois casos e este é o PRIMEIRO — "quem soma `saldo` FILTRANDO status", que o guard de
+  // `titulo-status.ts` protege. O segundo (coluna de baixa exibida CRUA: cards Recebido/Pago, a
+  // coluna Saldo por linha, o CSV) é que vira "—", porque ali nenhum filtro de status conserta o
+  // número. Aqui o filtro já exclui RECEBIDO/PAGO, que é onde `saldo == valor de face` mentiria;
+  // o que sobra é o valor de face de título ABERTO — o melhor fato disponível, não uma fabricação.
+  // Quando a rota `mf` passar a ingerir a baixa, esta soma fica certa sem mudar uma linha.
   for (const cr of crData) {
     if (cr.data_vencimento) {
       const day = ensureDay(cr.data_vencimento);
       if (cr.status_titulo && ['A VENCER', 'ATRASADO', 'VENCE HOJE'].includes(cr.status_titulo)) {
-        day.entradas_previstas += cr.valor_documento || 0;
+        day.entradas_previstas += cr.saldo ?? 0;
       }
     }
   }
@@ -411,7 +434,7 @@ export async function getFluxoCaixa(
     if (cp.data_vencimento) {
       const day = ensureDay(cp.data_vencimento);
       if (cp.status_titulo && ['A VENCER', 'ATRASADO', 'VENCE HOJE'].includes(cp.status_titulo)) {
-        day.saidas_previstas += cp.valor_documento || 0;
+        day.saidas_previstas += cp.saldo ?? 0;
       }
     }
   }


### PR DESCRIPTION
## O defeito

`getFluxoCaixa` montava entradas/saídas **previstas** somando `valor_documento` dos títulos com status aberto. Um título com **baixa parcial** continua com status aberto, mas a parte já baixada **já entrou na conta** — e portanto já está no `saldo_atual` de `fin_contas_correntes`, que é a **âncora** da projeção (`FluxoCaixaTab.tsx:38` → `let acumulado = saldoCC || 0`, e as semanas somam o previsto por cima).

Somar o valor cheio conta esse dinheiro **duas vezes**. É o mesmo eixo (dupla contagem no tempo) corrigido no saldo projetado do `FluxoCaixaTab` — um degrau abaixo: lá era a **semana**, aqui é o **título**. Achado da 2ª opinião Codex naquele PR, deixado fora do escopo de propósito.

## A correção

Fonte do previsto passa a ser a coluna `saldo`, verificada em prod (psql-ro, 2026-09-09) como **coluna GERADA stored**:

| tabela | expressão |
|---|---|
| `fin_contas_receber.saldo` | `valor_documento - COALESCE(valor_recebido, 0)` |
| `fin_contas_pagar.saldo` | `valor_documento - COALESCE(valor_pago, 0)` |

É de fato o **restante em aberto** — e é a mesma fonte de `somarSaldoAberto`, a canônica de "aberto" (DSO, KPIs de `/financeiro/gestao`, resumo). As duas leituras param de divergir por construção.

Os `.select()` também perderam as colunas que ficaram **mortas** no corpo da função (`data_recebimento`/`valor_recebido`, `data_pagamento`/`valor_pago`, `valor_documento`).

## ⚠️ Hoje o número NÃO muda — e isso é medição, não esperança

Medido via psql-ro em **todo o universo** (não só na janela da tela):

- **Zero** linhas com `saldo <> valor_documento` — em 44.526 CR + 16.125 CP, `RECEBIDO`/`PAGO` inclusive.
- `valor_recebido` / `valor_pago` = **0,00 em 100%** das linhas, em todos os status.

A causa é a **issue #396**: o LIST do Omie não traz a baixa, então o ingest nunca popula essas colunas. Ou seja: **o gatilho do defeito é o INGEST, não esta tela**. Enquanto #396 não for resolvida, nenhuma baixa parcial chega aqui e a troca é numericamente inerte.

O valor deste PR é **defesa em profundidade**: no dia em que o ingest passar a gravar a baixa, esta tela já estará certa em vez de inflar o previsto em silêncio — e o defeito voltaria justo pelo caminho que ninguém estaria olhando.

**Impacto nos KPIs "Previsto Entrar"/"Previsto Sair"** (`FluxoCaixaTab.tsx:27-32`) e na projeção acumulada: **R$ 0,00 hoje**, pela medição acima. Passa a ser diferente de zero exatamente quando aparecer a primeira baixa parcial.

## Teste

`src/services/__tests__/getFluxoCaixa.test.ts` — 3 casos novos:

- **CR com baixa parcial** (doc 1.000, recebido 400) ⇒ previsto **600**, não 1.000.
- **CP com baixa parcial** (doc 1.000, pago 400) ⇒ previsto **600**.
- **Título sem baixa** ⇒ segue pelo valor cheio (contrapeso: sem ele, um bug que **zerasse** o previsto passaria pelos dois primeiros).

A fixture **computa** `saldo` pela mesma regra da coluna gerada (`valor - recebido`) em vez de aceitar um campo livre: fixture que escolhe `saldo` à mão pode afirmar um estado que o Postgres nunca produz, e aí o teste provaria a fixture, não a tela.

### Falsificação

Controle verde na **mesma invocação**, abortando antes do primeiro `sed`; uma **camada por vez**:

```
CONTROLE VERDE (Tests 17 passed)          ← antes do 1º sed; sem isto, sempre-vermelha aprova tudo
  [1-codigo-pre-PR]        ✅ VERMELHO — /expected 1000 to be 600/
  [2-select-CR-sem-saldo]  ✅ VERMELHO — /expected +?0 to be 600/
  [3-acumulador-CR]        ✅ VERMELHO — /expected +?0 to be 600/
  [4-acumulador-CP]        ✅ VERMELHO — /expected +?0 to be 700/
CONTROLE FINAL VERDE → MARCADOR_FALSIFICACAO_OK
```

A camada **2** existe por causa da armadilha registrada neste mesmo arquivo: somar coluna **fora do `.select()`** zera o número em produção e o mock antigo aprovava. Como o mock hoje **projeta** as colunas pedidas, esquecer `saldo` no select fica vermelho — provado, não presumido. A camada **4** derruba só os 2 testes de CP (15 seguem verdes), provando que o caso do CP não é coberto de carona pelo do CR.

Duas passadas foram necessárias: na 1ª, três marcas não casaram porque o vitest imprime `expected +0`, e eu escrevera `expected 0`. As sabotagens estavam vermelhas pelo motivo certo — quem estava errada era a régua. Corrigida e re-rodada.

## Relação com o #2437 (mesma data)

O #2437 degrada para "—" quem **exibe a coluna de baixa crua** (cards Recebido/Pago, coluna Saldo por linha, CSV). `procedencia-baixa.ts` separa esse caso do outro explicitamente:

> O guard por STATUS é irmão, não substituto: ele protege quem soma `saldo` filtrando status; aqui o consumidor exibe a coluna crua, e nenhum filtro de status a conserta.

`getFluxoCaixa` é o **primeiro** caso — soma filtrando status, e o filtro já exclui `RECEBIDO`/`PAGO`, que é onde `saldo == valor de face` mentiria. O que sobra é o valor de face de título **aberto**: o melhor fato disponível, não uma fabricação. Por isso aqui não vira "—". Deixei esse raciocínio no comentário do código, para o revisor daquele PR não precisar reconstruí-lo.

## Fora de escopo (de propósito)

`getFluxoCaixa` filtra o previsto por `['A VENCER','ATRASADO','VENCE HOJE']` **inline**, enquanto o módulo usa `OPEN_TITLE_STATUSES` (seis valores — inclui `'PARCIAL'`, o fallback que o ingest grava justamente na baixa parcial). É o eixo do **recall**, não o da dupla contagem, e misturar os dois no mesmo PR embaralha a leitura. Também dormente: os três valores extras têm zero linhas em prod hoje.

## Validação

- `bun run typecheck` — `TYPECHECK_RC=0` (rc propagado, não "saída vazia")
- `bunx eslint` nos dois arquivos — `LINT_RC=0`
- `bunx vitest run getFluxoCaixa.test.ts` — 17 passed
- Semântica de `saldo`, universo de baixas e NULLs — psql-ro, 2026-09-09

## 2ª opinião Codex — retroativa (fecho da sessão, 2026-09-10)

Este PR é money-path e mergeou **sem** a 2ª opinião que o CLAUDE.md exige sempre nesses casos — falha de processo desta sessão. O consult rodou no fecho, em modo *challenge*:

`=== PARECER CODEX (modelo gpt-6-astra · reasoning max · tentativa 1 · 542s · 144.948 tokens) ===`

**Veredito: AJUSTAR — preservar `saldo`.** Triagem, cada item conferido na `main`:

| Achado | Veredito |
|---|---|
| O acumulado da tela soma o realizado passado por cima do saldo de hoje (5.000 → 6.000 em vez de 5.600) | 🚫 **Obsoleto.** O Codex rodou num worktree anterior ao `eee71c80f`, que já corrigiu isso: `fluxo-caixa-semanas.ts` faz `ancora += sem.deltaFuturo` (só o futuro). Na `main`, este PR + o `eee71c80f` dão 5.600 no cenário dele |
| Saldo negativo (baixa > documento, status aberto) entra como entrada negativa; no CP, vira entrada fantasma | ✅ Procede, dormente (#396) → chip abaixo |
| 6 sabotagens passam 17/17 — a específica deste PR: `saldo \|\| valor_documento` ressuscita o valor cheio quando o saldo é 0 | ✅ Procede → chip abaixo |
| Estorno com `valor_recebido` defasado subestima o previsto | 🚫 É dado velho no banco; nenhum código desta função o corrige |
| Âncora (resumo) e fluxo carregados em momentos diferentes em `FinanceiroDashboard.tsx` | 📌 Plausível, **não verificado por mim**. Condicionado à ingestão da baixa — vira trabalho quando o ingest passar a gravar `valor_recebido` (#396) |
| Remover as colunas não lidas do select | ✅ Sem risco |
| Não degradar para `null` (vs #2437) | ✅ Defensável: previsto nominal de título aberto |

### Errata — duas frases deste PR prometem mais do que entregam

O comentário no código e a descrição acima dizem:

1. *"Quando a rota `mf` passar a ingerir a baixa, esta soma fica certa sem mudar uma linha."* — **Falso.** Ingerir a baixa acorda o caso do saldo negativo e o da coerência temporal âncora×fluxo.
2. *"`saldo` é também a fonte de `somarSaldoAberto`… então as duas leituras param de divergir por construção."* — **Inexato.** Convergem na **coluna**, mas divergem no **filtro de status** (3 aqui contra os 6 de `OPEN_TITLE_STATUSES`).

O conserto do texto no código está no chip abaixo.

## Pendências derivadas

Chip é **perecível** — some quando a sessão é arquivada —, então o prompt completo fica aqui, e é daqui que se reabre o trabalho se o chip se perder.

- ✔ **Separar "SHA atrás" de "bundle atrás" no monitor-deploy** — alarme falso de "Publish pendente", achado ao verificar o Publish deste PR. Já iniciado em sessão própria em 2026-09-10.

<details><summary>🔘 <b>Alinhar status e fechar lacunas do previsto do fluxo</b> — status (3 contra 6), saldo negativo, errata do comentário e as 6 sabotagens verdes</summary>

Responda em português brasileiro. Repo Afiação, MONEY-PATH — antes de tocar código leia `docs/agent/money-path.md` e `docs/agent/financeiro.md` (recorte por grep; o money-path.md tem ~157 KB). Siga o CLAUDE.md: 2ª opinião Codex SEMPRE no money-path, via `scripts/codex-async.sh` em background — com o worktree SINCRONIZADO com a main.

Alvo: `src/services/financeiroService.ts` (`getFluxoCaixa`) e `src/services/__tests__/getFluxoCaixa.test.ts`. Um PR só.

**Contexto.** O #2458 trocou a fonte do previsto para `saldo` (coluna GERADA: `valor_documento - COALESCE(valor_recebido/pago, 0)`). Não reverta. Tudo abaixo é DORMENTE: `valor_recebido`/`valor_pago` = 0 em 100% do universo (#396) — diga no PR que o número de hoje não muda, e remeça via psql-ro (`-v ON_ERROR_STOP=1` + marcador positivo de fim).

**Armadilha de staleness.** O Codex do #2458 leu um worktree anterior ao `eee71c80f` e apontou um acumulado que já foi corrigido (`fluxo-caixa-semanas.ts`, `ancora += sem.deltaFuturo`). Não reabra. `git fetch` e trabalhe sobre `origin/main` antes de medir.

1. **Status.** Troque as listas inline `['A VENCER','ATRASADO','VENCE HOJE']` por `isOpenTitleStatus(...)` de `src/lib/financeiro/titulo-status.ts` (6 valores, com os fallbacks `'ABERTO'`/`'VENCIDO'`/`'PARCIAL'` do ingest). Seguro só por causa do #2458. Os 3 extras tinham ZERO linhas. Na tela só `'ABERTO'`/`'PARCIAL'` com vencimento futuro mudam algo — registre, não mexa no tab.
2. **Saldo negativo.** Proposta: `Math.max(0, saldo ?? 0)` (precedente: `supabase/functions/fin-valor-cockpit/index.ts`). Avalie com o Codex e justifique.
3. **Errata do comentário** — as duas frases listadas na seção "Errata" do #2458.
4. **As 6 sabotagens que o Codex achou verdes**, cada uma VERMELHA depois: (prioridade) `saldo || valor_documento` → teste doc 1000, recebido 1000, `'A VENCER'` → previsto 0 · sem filtro de status → `'RECEBIDO'`/`'CANCELADO'` não entram · só `'A VENCER'` → `'ATRASADO'`/`'VENCE HOJE'` entram · `ensureDay(dataInicio)` → o previsto cai no dia do vencimento · `=` no lugar de `+=` no CP → 2 títulos no mesmo dia somam · `saldo_previsto` zerado → verifique se tem consumidor (campo morto? reporte, não remova). Fixtures `titulo()`/`tituloPagar()` já computam `saldo`; status fixo `'A VENCER'` — sobrescreva com spread.

**Falsificação.** Controle verde na MESMA invocação, abortando antes do 1º `sed`; uma camada por vez; case a marca exata (`expected +0 to be …`, com o `+`). Commite antes. O `heavy` aborta com rc=1 após 900s na fila sem rodar a suíte: exija `Tests N passed`.

**Fora do escopo:** coerência temporal âncora×fluxo em `FinanceiroDashboard.tsx` — espera a ingestão da baixa (#396).

PR auto-mergeia; arme `scripts/pr-watch.sh`. Depois do merge, só Publish (skill `lovable-deploy-verify`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
