### PR TITLE
docs(deploy-verify): o Publish pelo MCP medido com `src/` real — e "ATRASADO" não responde se o PR está no ar

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -1015,6 +1015,29 @@ continua valendo para provar que um **conteúdo específico** está no ar; para 
 o mecanismo é uma env do host de build, que não é nossa e pode sumir sem aviso. E **passe a URL com `https://`**: sem esquema, o `curl` (sem `-L`) volta vazio e o monitor reporta
 falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
 
+⚠️ **`exit 3` responde "o ar É a `origin/main`?" — NÃO "o PR X está no ar?" (medido 2026-09-10).**
+O monitor compara por IGUALDADE, e com o auto-merge fechando PR em minutos a `main` anda enquanto
+você espera o Publish: ele passa a dizer "Publish pendente" **com o commit-alvo já servido**. No
+Publish do #2459 o #2445 mergeou 38 s depois do ANTES; com o ar já em `eee71c80`, o monitor seguiu em
+`ATRASADO` (rc 3) — com o #2459 **e** o #2458 no ar, e um delta ar→main sem nenhum arquivo em `src/`.
+Para a pergunta sobre UM PR, a checagem é ancestralidade:
+
+```bash
+git fetch origin
+PR=$(gh pr view <n> --json mergeCommit --jq .mergeCommit.oid)   # o SQUASH na main
+AR=<sha-do-ar>                                                  # o `ar=` que o monitor imprimiu
+git merge-base --is-ancestor "$PR" "$AR"; rc=$?
+# 0 = o PR está no ar · 1 = não está · 128 = SHA que o clone não conhece → NÃO CONSEGUI medir
+```
+
+As duas armadilhas fabricam "fora do ar", e as duas foram medidas no #2459: **rc 128 não é 1** — um
+`if …; then no-ar; else fora-do-ar; fi` lê como veredito um SHA que o clone não conhece (sem `fetch`,
+prefixo errado); e **o SHA é o do squash, nunca o head do branch** — o head (`a93c101ee`) existe no
+clone e dá rc **1** limpo, com cara de veredito, enquanto o squash (`eee71c80f`) dá 0. A mesma medição
+derrubou o critério "rc 3 → 0" como prova de Publish: com a `main` andando, `ar == main` fica
+inalcançável, e a transição que conta é a do `ar=` (e do entry). Detalhe em
+[`docs/historico/piloto-deploy-mcp-lovable.md`](../../../docs/historico/piloto-deploy-mcp-lovable.md) §"2ª medição".
+
 ## Referências
 - CLAUDE.md §"Deploy do FRONTEND (app) — Publish MANUAL no Lovable" (a técnica dos bytes; armadilha do chunk de nome inesperado)
 - CLAUDE.md §"Edge functions — caminho oficial Lovable" (deploy via chat, ler do repo, verbatim)
@@ -1171,4 +1194,10 @@ falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
   módulo carimbo+hashes de nome (com sabotagem exigindo vermelho), 51/317 chunks byte-idênticos como
   controle de determinismo, 12/12 amostrados idênticos. Cobertura honesta: **64 dos 317**. N=1 e o
   diff era 100% docs — não fala por Publish que carrega mudança de `src/`.
+  **Medido em 2026-09-10 (N=2, o 1º com `src/`):** Publish do #2459 (`eee71c80f`, 11 arquivos de
+  runtime em `src/`) pelo mesmo `deploy_project` — sentinela exclusiva de **exit 1**
+  (+`CONTROLE_POSITIVO_OK`) a **exit 0** no chunk da página (`FinanceiroDashboard-*`,
+  +`CONTROLE_NEGATIVO_OK`), carimbo `895b93ee` → `eee71c80`. Prova o CANAL e o CONTEÚDO com `src/`
+  real; **não** o verbatim desse build (só a sentinela, sem diff contra build local) nem exclui um
+  clique humano no mesmo minuto. Rendeu a lição da ancestralidade (§Smoke E2E autônomo).
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/docs/historico/piloto-deploy-mcp-lovable.md
+++ b/docs/historico/piloto-deploy-mcp-lovable.md
@@ -2,7 +2,8 @@
 
 > **Três camadas medidas, por experimentos separados.** §Passos 1-3 = **edge** (`send_message`,
 > 2026-09-07). §Camada 2 = **Publish do frontend** (`deploy_project`, 2026-09-08), que fecha nos
-> bytes a metade que a edge deixou aberta. §Camada 3 = **migration** (`query_database`, 2026-09-07),
+> bytes a metade que a edge deixou aberta — medida de novo em 2026-09-10, agora com mudança REAL de
+> `src/` (§"2ª medição"). §Camada 3 = **migration** (`query_database`, 2026-09-07),
 > medida em ambiente descartável: o canal **funciona**, com semântica transacional completa — e é
 > justamente por isso que ela **continua fora** da regra do CLAUDE.md. A recomendação é manter a
 > regra como está, e o porquê está lá.
@@ -550,11 +551,128 @@ publica. O modo de falha "o agente melhorou o código no caminho" tem, nesta cam
 menor — e os bytes acima o descartam para os 64 chunks medidos, o que a Camada 1 não pôde fazer para
 nenhum dos 8 arquivos.
 
+### 2ª medição (2026-09-10) — um Publish que carrega mudança REAL de `src/`
+
+A primeira ressalva do §"O que a Camada 2 NÃO autoriza", logo abaixo, era a mais pesada: N = 1, e um
+diff **100% docs**, em que a única entrada variável do build foi o carimbo. Esta medição é o caso que
+ela dizia não cobrir. E ela responde a uma pergunta **diferente** da 1ª — isso vem antes dos números,
+porque decide o que cada uma pode afirmar:
+
+| medição | pergunta | como se prova |
+|---|---|---|
+| 1ª — 2026-09-08, diff só de docs | nada mudou **além do carimbo**? (o VERBATIM) | normalizar carimbo + hashes de nome e comparar ANTES × DEPOIS |
+| 2ª — 2026-09-10, `src/` real | o **CONTEÚDO** da mudança chegou aos bytes servidos? | sentinela exclusiva do PR: ausente no ANTES → presente no DEPOIS |
+
+O método da 1ª não se aplica tal e qual. Lá, depois de normalizar carimbo e hashes de nome, ANTES e
+DEPOIS tinham de sair **idênticos** — e saíram. Com código novo eles divergem **por desenho** nos
+chunks que carregam a mudança, então "divergiu" deixa de ser sinal; o que separaria "mudou porque
+devia" de "mudou porque alguém mexeu no caminho" é comparar contra um build LOCAL do mesmo commit. Não
+foi feito (ver o NÃO prova, no fim desta seção).
+
+**O que foi publicado.** O #2459 (squash `eee71c80f`) toca **11 arquivos de runtime em `src/`** (+4
+de teste) — entre eles `src/components/financeiro/dashboard/FluxoCaixaTab.tsx`, o novo
+`fluxo-caixa-semanas.ts` e `src/services/financeiroService.ts`. O Publish é atômico, então subiu o
+intervalo inteiro `895b93ee..eee71c80` — **12 commits**, com o #2458 (`f00109b7d`, que também toca
+`financeiroService.ts`) no meio. Contagens medidas no git (`git rev-list --count`, `git diff
+--name-only … -- src/`), não relembradas.
+
+**A sentinela, provada exclusiva antes de tocar a rede.** `Saldo projetado a partir do saldo em conta
+de hoje` — texto de UI renderizado, sem aspas nas pontas — tem **0** ocorrências em `src/` no pai
+(`f4578bbff`) e no commit que o ar servia (`895b93ee`), e **1** arquivo no novo (`FluxoCaixaTab.tsx`).
+Escapa das três armadilhas de sentinela do Passo 4 da `lovable-deploy-verify` (não-exclusiva, 2º
+emissor na lib, delimitada).
+
+**ANTES — 20:02:07 GMT-3 (23:02:07Z)**, marcadores da sessão que executou:
+
+- `monitor-deploy.sh https://steu.lovable.app` → **rc 3**, `ar=895b93ee`, `main=eee71c80`;
+- `verify-frontend.sh --pai f4578bbff --novo eee71c80f 'Saldo projetado a partir do saldo em conta de hoje'`
+  → **exit 1**, com `✓ sentinela exclusiva: 0 ocorrências em f4578bbff · 1 arquivo(s) em eee71c80f`,
+  `LIB_SEM_A_SENTINELA`, 335 chunks (closure 335 · precache 327), entry `index-BVxIPEOW.js` e
+  `CONTROLE_POSITIVO_OK` — que é o que faz o `exit 1` valer "ausente", e não "sonda cega".
+
+**A AÇÃO — só o MCP**, com autorização explícita do founder na sessão (o Publish continua sendo
+alavanca dele — `docs/agent/deploy.md` §"O que continua sendo do founder"):
+
+```
+mcp__lovable__deploy_project(project_id: 8f005805-000a-42b7-88a1-9683f785fab6)
+→ {"status":"pending","deployment_id":"8e2022ad-dd11-43ca-bca9-45add2acc328","url":"https://steu.lovable.app"}
+```
+
+Só `project_id`, sem `name` — a mesma decisão da 1ª: `name` re-slugaria o domínio canônico.
+
+**DEPOIS — 20:03:09 GMT-3**, na 2ª tentativa de um poll de 20 s (≈ 1 min depois do ANTES):
+
+- `monitor-deploy.sh` → `ar=eee71c80` — exatamente o squash do #2459 — e entry `index-BVxIPEOW` →
+  `index-CpcoKz2r`;
+- `verify-frontend.sh` com a **mesma** sentinela e os mesmos `--pai`/`--novo` → **exit 0**:
+  `✅ ALVO em /assets/FinanceiroDashboard-DD8-ffbj.js` — o chunk da página que o PR mudou, e não um
+  chunk qualquer — e `CONTROLE_NEGATIVO_OK`.
+
+Três observáveis se moveram juntos, e não são da mesma natureza: o **carimbo** é o commit que o host
+de build **declara** ter compilado (vem de env, via `resolveCommitSha()`); o **hash do entry** diz que
+o bundle mudou, não o quê; a **sentinela** é CONTEÚDO do PR nos bytes. Só a terceira responde à
+pergunta desta medição — as outras duas são coerência. E note o que **não** serviu de critério: o rc
+do monitor. A `main` já estava em `70fc305f` desde 24 s antes do DEPOIS (lição de método, abaixo),
+então `ar == main` era inalcançável naquele minuto. O critério da 1ª medição (rc 3 → 0) só funcionou
+lá porque a `main` ficou parada.
+
+**Re-conferido às 23:14Z do mesmo dia**, só `curl` (2 requests), ao registrar esta seção: o ar segue
+em `eee71c80` — nenhum Publish posterior moveu o carimbo. E a mesma leitura é o caso da lição de
+método:
+
+```console
+$ bash .claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh https://steu.lovable.app
+[2026-09-10T20:14:11] main=70fc305f  ar=eee71c80  deploy-novo=nao
+  ⚠️ ATRASADO: ar serve eee71c80, main em 70fc305f → Publish pendente
+MONITOR_RC=3
+```
+
+**O que a 2ª medição PROVA:**
+
+- o canal `deploy_project` publica build com mudança de `src/` — **N = 2** no total, o **1º com
+  `src/`**, de novo sem colagem humana;
+- o **CONTEÚDO** da mudança está nos bytes servidos: sentinela exclusiva ausente → presente, com
+  controle **positivo** no ANTES (o `exit 1` era enxergar e não achar) e **negativo** no DEPOIS (o
+  `exit 0` não é o script dando verde para tudo).
+
+**O que NÃO prova:**
+
+- **que o bundle inteiro seja byte-idêntico a um build local da `main`.** Só a sentinela foi
+  conferida — uma string, num chunk. O VERBATIM atestado na 1ª (64/317 chunks) é de um build sem
+  código novo e **não se estende** a este;
+- **que ninguém tenha clicado Publish naquele minuto.** O `deployment_id` amarra o deploy à chamada,
+  como na 1ª; a alternativa segue implausível, mas não excluída;
+- **adoção.** Bytes servidos são disponibilidade: o SW do PWA só troca de build quando o cliente
+  clica.
+
+**Lição de método — "ATRASADO" responde se o ar É a `main`, não se o PR ESTÁ no ar.** O #2445
+mergeou às 23:02:45Z — **38 s depois do ANTES e 24 s antes do DEPOIS**: a `main` andou *dentro* do
+minuto de espera. O `monitor-deploy.sh` compara o ar com `origin/main` por **igualdade** e passou a
+dizer "ATRASADO → Publish pendente" **com o commit-alvo já servido**. Ele não está errado — responde
+"o ar == `origin/main`?". Erra quem lê ali a resposta de "o PR X está no ar?", e com o auto-merge
+fechando PR em minutos a `main` andar durante a espera é o caso **comum**, não o raro. Para um PR, a
+pergunta é de **ancestralidade** — medida na mesma leitura acima, e com controle:
+
+```console
+eee71c80f (#2459) ancestral do ar? rc=0
+f00109b7d (#2458) ancestral do ar? rc=0
+controle: 70fc305f3 (#2445, main) ancestral do ar? rc=1
+```
+
+E o "Publish pendente" nem apontava para algo a publicar no app: o delta ar→main (só o #2445) tem
+**0** arquivo em `src/` — CI, `scripts/`, docs e uma entrada nova em `package.json#scripts`. A
+receita, com as duas armadilhas que a fazem fabricar "fora do ar" (rc 128 lido como 1; head do branch
+no lugar do squash), mora na `lovable-deploy-verify` §"Smoke E2E autônomo".
+
 ### O que a Camada 2 NÃO autoriza
 
 - **N = 1**, e o diff era **100% docs**. Este resultado **não fala** por um Publish que carrega
   mudança real de `src/` — que é o caso normal, e onde o agente teria o que "melhorar". O verbatim
   atestado aqui é o de um build cuja única entrada variável foi o carimbo.
+  **Atualizado em 2026-09-10:** o caso com `src/` real foi medido (§"2ª medição", acima — o #2459,
+  11 arquivos de runtime; N = 2). O que ficou medido é o **CANAL** e o **CONTEÚDO**; o que esta
+  ressalva segue dizendo, e segue verdadeiro, é que o **VERBATIM** só foi atestado no build sem
+  código novo.
 - **A amostra do verbatim é 64/317**, não a totalidade.
 - **A janela é de menos de 1 minuto** entre a chamada e a transição. O `deployment_id` devolvido
   amarra o deploy à chamada, e o ANTES foi medido 00:43:21Z com o ar ainda em `bb9d8d2e` — mas com
@@ -746,8 +864,8 @@ corrigir.
   decisão do founder em conversa própria, não efeito colateral de um piloto. Esta sessão teve a tentação concreta: o disparo da sonda é um
   `INSERT`, e `query_database` o resolveria sem o founder. Não foi usado — usá-lo mediria um canal
   não-testado **com** outro, e contaminaria o veredito.
-- **`deploy_project` (o Publish do frontend) era outra camada, e foi MEDIDA em 2026-09-08** —
-  §Camada 2; e a **migration** em 2026-09-07 — §Camada 3. As três camadas manuais do Lovable são
+- **`deploy_project` (o Publish do frontend) era outra camada, e foi MEDIDA em 2026-09-08** — e de
+  novo em 2026-09-10, com `src/` real — §Camada 2; e a **migration** em 2026-09-07 — §Camada 3. As três camadas manuais do Lovable são
   independentes, e o resultado de uma não se estende às outras.
 - **N = 1.** Uma edge, uma chamada, um ANTES conhecido. Isso é estritamente mais forte que a medição
   de 2026-09-06 (8 edges, ANTES desconhecido, transição não observável), e é o que faltava para


### PR DESCRIPTION
## O que muda

**Docs-only** — `docs/historico/piloto-deploy-mcp-lovable.md` e `.claude/skills/lovable-deploy-verify/SKILL.md`. Nenhum código, nenhum deploy pendente.

O piloto da Camada 2 (Publish por `mcp__lovable__deploy_project`) tinha **N=1 com diff 100% docs** e dizia com todas as letras que não falava por um Publish com mudança real de `src/`. Esse caso foi medido em 2026-09-10 e agora está registrado.

### 1. `piloto-deploy-mcp-lovable.md` — subseção "2ª medição" na Camada 2
- **Publicado:** o #2459 (squash `eee71c80f`) — **11 arquivos de runtime em `src/`** (+4 testes). O Publish levou o intervalo `895b93ee..eee71c80` (**12 commits**, com o #2458 junto). Contagens medidas no git.
- **ANTES (23:02:07Z):** `monitor-deploy.sh` rc 3 (`ar=895b93ee`); `verify-frontend.sh --pai f4578bbff --novo eee71c80f '<sentinela exclusiva>'` → **exit 1** + `CONTROLE_POSITIVO_OK`.
- **AÇÃO:** `deploy_project(project_id)` só, sem `name` → `deployment_id 8e2022ad-…` (autorizado pelo founder na sessão).
- **DEPOIS (≈1 min):** `ar=eee71c80`, entry `index-BVxIPEOW → index-CpcoKz2r`; mesma sentinela → **exit 0** em `FinanceiroDashboard-DD8-ffbj.js` + `CONTROLE_NEGATIVO_OK`.
- **Prova:** o canal publica build com `src/` (N=2, o 1º com `src/`), e o **CONTEÚDO** da mudança está nos bytes servidos.
- **NÃO prova:** que o bundle inteiro seja byte-idêntico a um build local (só a sentinela foi conferida — o verbatim da 1ª medição era de build sem código); nem exclui um clique humano no mesmo minuto; nem adoção.
- A ressalva original ("N = 1… não fala por `src/`") **fica**, atualizada com o que agora está medido.

### 2. `lovable-deploy-verify` — §Estado atualizado + receita de ANCESTRALIDADE no §Smoke E2E
O #2445 mergeou **38 s depois do ANTES**: a main andou dentro do minuto de espera, e o `monitor-deploy.sh` (igualdade com `origin/main`) seguiu em **"ATRASADO → Publish pendente" com o PR já servido** — reproduzido ao vivo às 23:14Z, com o delta ar→main sem **nenhum** arquivo em `src/`. Para "o PR X está no ar?" a checagem é `git merge-base --is-ancestor <squash-do-PR> <sha-do-ar>`, com duas armadilhas medidas: **rc 128 ≠ 1** (SHA desconhecido não é "fora do ar") e **head do branch ≠ squash** (`a93c101ee` dá rc 1 limpo; `eee71c80f` dá 0). A mesma medição derruba "rc 3 → 0" como critério de Publish com a main andando.

## Evidência (exit 0 capturado, não inferido)

| verificação | resultado |
|---|---|
| `bun run docs:indice` | exit 0 |
| `bun run docs:links` | exit 0 (758 docs) — **falsificado** no link novo: sabotado `../../` → rc 1 nomeando `SKILL.md:1039`; restaurado → rc 0 |
| `bun run docs:citacoes` | exit 0 |
| `bash .claude/skills/lovable-deploy-verify/evals/run.sh` | `✅ evals lovable-deploy-verify: OK`, rc 0 |
| receita extraída do próprio SKILL.md | 0 / 1 / 128 nos três ramos; placeholder cru aborta sem veredito; sabotagem squash→head vira rc 1 |

Não toca o CLAUDE.md (orçamento de tamanho) nem cria doc novo em `docs/historico/`.



## Pendência com destino — chip "Ensinar ancestralidade ao monitor-deploy.sh"

Registrado pelo `/fecho` da sessão: o chip foi criado e, até o fecho, **não tinha sido clicado**. Chip é destino perecível (some com a sessão arquivada), então o prompt dele fica aqui, verbatim, para ser reaberto numa sessão nova se o chip se perder.

<details>
<summary>Prompt auto-contido do chip (copiar para uma sessão nova)</summary>

```text
Responda SEMPRE em português brasileiro. Repo Afiação (/Users/lucassardenberg/Projetos/afiacao). Leia CLAUDE.md, docs/agent/deploy.md e a skill `.claude/skills/lovable-deploy-verify/SKILL.md` §"Smoke E2E autônomo" antes de tocar em qualquer coisa.

## Contexto (medido em 2026-09-10, registrado no PR #2463 — docs-only)
O script `.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh` (58 linhas) responde "o ar == origin/main?" comparando por IGUALDADE (`[ "$AIR_SHA" = "$MAIN_SHA" ]`) e, se diferente, imprime "⚠️ ATRASADO … → Publish pendente" com exit 3. Com o auto-merge fechando PR em minutos, a main anda durante a espera do Publish, e o monitor passa a acusar "Publish pendente" com o PR-alvo JÁ servido. Medido: Publish do #2459 (squash `eee71c80f`) às 23:03Z; o #2445 (`70fc305f3`) mergeou às 23:02:45Z; às 23:14Z o monitor deu `ar=eee71c80 main=70fc305f` rc 3 — com o #2459 e o #2458 no ar, e o delta ar→main com 0 arquivo em `src/` (só CI, scripts/, docs e uma entrada nova em `package.json#scripts`). Hoje a SKILL.md documenta a checagem MANUAL por ancestralidade (receita no §Smoke E2E autônomo, adicionada no #2463). Esta tarefa é tornar isso mecânico no script.

## O que fazer
1. Modo por PR: flag opcional (ex.: `--pr <n>`) que resolve o SQUASH na main com `gh pr view <n> --json mergeCommit --jq .mergeCommit.oid` e decide por `git merge-base --is-ancestor "$PR" "$AR"`, com os TRÊS ramos explícitos: rc 0 = o PR está no ar · rc 1 = não está · qualquer outro (128 = SHA desconhecido no clone) = NÃO CONSEGUI MEDIR, com exit code PRÓPRIO — nunca "fora do ar". Armadilhas medidas que o código precisa evitar: (a) rc 128 lido como 1 fabrica "fora do ar"; (b) usar `headRefOid` em vez de `mergeCommit` dá rc 1 LIMPO num PR que está no ar (medido no #2459: head `a93c101ee` → 1, squash `eee71c80f` → 0). PR não mergeado (mergeCommit null) também tem de cair no ramo "não consegui", não no "fora do ar".
2. Modo igualdade (o atual): quando ar ≠ main mas o ar é ancestral da main, diga quantos commits atrás e quantos tocam o que entra no bundle — para "ATRASADO" com 0 commit relevante não se ler como "Publish pendente". Atenção: `evals/classify.sh` marca `frontend=SIM` para qualquer mudança em `package.json`, inclusive só `scripts` (medido nesse delta) — a camada se decide por ALCANCE (docs/agent/deploy.md, bullet "Tocou `src/` ⇒ falta Publish é FALSO").
3. Fetch engolido: a linha `git fetch origin main --quiet 2>/dev/null || true` faz o script comparar com uma `origin/main` velha em silêncio se o fetch falhar. No modo `--pr`, falha de fetch deve ser fail-CLOSED (não consegui medir); no modo igualdade, no mínimo avisar.
4. Estado compartilhado: `deploy-novo` lê/grava `~/.config/afiacao/deploy-monitor.state`, único para TODAS as worktrees/sessões da máquina — medido: uma sessão que nunca rodou o monitor viu `deploy-novo=nao` porque outra sessão já tinha gravado o entry novo. Decida (e documente) se o estado vira por-chamador ou se a saída passa a dizer que é relativo à última checagem de QUALQUER sessão.

## Regras do repo que se aplicam
- Testes no harness da skill: `bash .claude/skills/lovable-deploy-verify/evals/run.sh` (gate de CI `evals:deploy-verify`) e `--falsify` (`evals:deploy-verify:falsificacao`); há fixtures locais em `evals/verify-frontend-eval.sh` que servem de modelo. Falsificação exige CONTROLE verde na MESMA invocação antes de sabotar, marcadores ASCII de caixa fixa, e commit antes de falsificar (CLAUDE.md, armadilha "Teste SQL negativo").
- `bun run lint:shell` (shellcheck) — confira se cobre `.claude/skills/**/scripts/`.
- Se nascer gate novo no CI, o censo de `docs/agent/deploy.md` (bloco `gates:frescura`) precisa acompanhar (`bun run gates:frescura`).
- Ao terminar, atualize a SKILL.md §Smoke E2E autônomo para apontar a flag nova no lugar da receita manual, e rode `bun run docs:links`, `bun run docs:citacoes`, `bun run docs:indice`.
- PR não-draft auto-mergeia no `validate`; arme `scripts/pr-watch.sh <nº>` em background.
```

</details>

## Pendência com destino — chip "Catalogar word-splitting do zsh no hook de shell"

Detectado no próprio `/fecho` desta sessão: um `set -- $linha` abortou no zsh (sem word splitting de expansão não-citada) e o exit 1 coincidiu com o código de "main vermelha" do laço de espera — só o marcador `MAIN_VERMELHA` ausente do log evitou o falso veredito. O catálogo `docs/historico/evidencia-positiva-shell.md` não cobre word splitting (0 ocorrências em 2026-09-10). Prompt verbatim do chip:

<details>
<summary>Prompt auto-contido do chip (copiar para uma sessão nova)</summary>

```text
Responda SEMPRE em português brasileiro. Repo Afiação (/Users/lucassardenberg/Projetos/afiacao). Leia CLAUDE.md (armadilhas "Validação só conta com EVIDÊNCIA POSITIVA" e "Gate textual limpa comentário com o stripper COMPARTILHADO") e docs/historico/evidencia-positiva-shell.md antes de tocar em qualquer coisa.

## O caso (medido em 2026-09-10, no /fecho da sessão do PR #2463)
O Bash tool deste ambiente roda em /bin/zsh. Um laço de espera de CI fazia:
  linha=$(gh run list ... --jq '"\(.databaseId) \(.status) \(.conclusion)"')
  set -- $linha; id=$1; st=$2; co=${3:-}
Em bash, `set -- $linha` quebra a string em 3 palavras. Em zsh NÃO (sem SH_WORD_SPLIT, expansão não-citada não sofre word splitting): `$1` recebeu a linha inteira, `$2` ficou unset e o `set -u` abortou com "(eval):16: 2: parameter not set" — exit 1. Esse exit 1 era, por coincidência, o código que o próprio script reservava para "MAIN_VERMELHA": quem lesse só a notificação ("failed with exit code 1") concluiria "main vermelha". O que salvou foi o marcador positivo MAIN_VERMELHA AUSENTE do log. Sem `set -u`, o mesmo erro seria SILENCIOSO: `st` vazio nunca casa "completed" e o laço esperaria até o teto. E `for x in $lista` em zsh itera UMA vez com a string inteira — a "contagem 0/1 = enumeração quebrada" do CLAUDE.md por outro caminho. A correção usada na hora foi rodar o laço como script `.sh` com `bash` explícito.

Medido em 2026-09-10: o catálogo docs/historico/evidencia-positiva-shell.md cita "zsh" 19× e tem 0 ocorrência de `word.?split|SH_WORD_SPLIT`; nenhum hook em .claude/hooks/ trata word splitting.

## O que fazer
1. Registrar a classe no catálogo docs/historico/evidencia-positiva-shell.md, com o caso acima e as formas corretas: script `.sh` rodado com `bash` (ou `bash -c '…'` com aspas SIMPLES), `read -r id st co <<< "$linha"` (portável bash/zsh), ou `${=linha}` (zsh-only).
2. Rede estrutural: já existe um hook PreToolUse de Bash que emite o aviso `PIPESTATUS-BASHISM-NO-ZSH` (procure a mensagem em .claude/hooks/). Estender (ou criar irmão) para AVISAR — não bloquear, há usos legítimos — `set -- $var` e `for … in $var` NÃO citados em comando que vai rodar no zsh, com o idioma correto na mensagem. Cuidado com falso-positivo quando o texto roda no bash (heredoc de script, `bash -c '…'`, arquivo `.sh`) — o hook do PIPESTATUS já distingue esses casos; se precisar limpar comentário, use o stripper compartilhado de shell (`removerComentariosShell` de `@/lib/gates/limpeza-shell`), nunca regex local.
3. Testes no `bun run test:hooks`, com falsificação (controle verde na MESMA invocação antes de sabotar, marcadores ASCII de caixa fixa, commit antes de falsificar). Casos mínimos: `set -- $linha` avisa; `read -r a b <<< "$linha"` não avisa; dentro de `bash -c '…'` não avisa.
4. Se o hook entrar no censo de gates, `bun run gates:frescura` precisa passar (docs/agent/deploy.md, bloco `gates:frescura`).
5. PR não-draft (auto-merge no `validate`) e `scripts/pr-watch.sh <nº>` em background.
```

</details>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
