### PR TITLE
fix(pendencias): o guard do cron de sonda julgava pelo DISCO — worktree defasado recebia um UPDATE que desativava edge aprovada

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1126,7 +1126,12 @@ jobs:
     # dado vestida de reprovação. Medido em 2026-09-07 sobre 28 runs: 346s a 533s — o pior já
     # consumia 89% do teto de 10min, um runner lento de distância do mesmo falso-vermelho. 15min
     # devolve a folga sem esconder regressão.
-    timeout-minutes: 15
+    # 2026-09-10: 6 PRs seguidos entre 531s e 873s (#2462 a 27s do corte) — o job cresceu ~60% em
+    # 3 dias, um contrato por PR. No #2464 ele foi CANCELADO no último contrato (`valor-helpers`),
+    # com os 44s do contrato novo; sem folga, todo PR seguinte perderia o sinal. Quem pesa é
+    # `sonda-versao-sql.mut` (103 mutações, 7m26s ≈ metade do job). 25min volta a ~60% de uso; o
+    # conserto de fundo é o fan-out por contrato, como o `validate` fez no #2346.
+    timeout-minutes: 25
     # issues:write p/ o sensor abaixo abrir/fechar a Issue `mutcheck-cobertura`; contents:read p/ checkout.
     permissions:
       contents: read

--- a/docs/historico/sonda-le-worktree-defasado.md
+++ b/docs/historico/sonda-le-worktree-defasado.md
@@ -198,3 +198,39 @@ medisse errado para cima, teria avalizado sete sabotagens sem rodar nenhuma.
 
 Fechado em #2435 (issue #2414). O #2422 tinha atacado só a sobra — comparando o mapa por entrada,
 mas mantendo o modo canária conferindo um arquivo que ele não lê — e foi fechado sem mergear.
+
+## Recorrência (2026-09-10): o guard da allowlist no `pendencias:deploy` — e o remédio era um UPDATE
+
+O `pendencias:deploy` nasceu em volta desta lição (`REF_MAIN`: "o instrumento lê a ref, não a
+árvore"). A seção do cron de sonda, que veio depois, reintroduziu o disco por um `import`:
+`SONDA_CRON_ALVOS` era a allowlist que decidia "intruso". Num worktree 10 commits atrás,
+`omie-desconto-backfill` estava na main e ativa no banco (migration da onda 5 aplicada), mas não no
+disco. Saída: exit 2, stdout vazio, e o remédio pronto para colar —
+`UPDATE public.deploy_sonda_alvos SET ativo = false WHERE edge IN ('omie-desconto-backfill')`.
+Desfaria uma migration aplicada e tiraria do cron uma edge provada.
+
+**Por que escapou:** `git show` tem cara de I/O; um `import { CONST }` tem cara de código. A
+varredura por "leitura do repo" procura `readFileSync`/`git show` e não enxerga o import de DADO.
+Num sensor que julga contra a ref, **todo import de dado do repo é uma segunda fonte de verdade.**
+
+**A torção nova — o remédio impresso é escrita por procuração.** O sensor não apaga nada, mas entrega
+ao humano o SQL que apaga, e a causa mais frequente (worktree defasado, ~30 no repo) recebia o
+remédio mais destrutivo. Vale para o remédio o padrão de [script que apaga](sonda-ausente-em-script-que-apaga.md):
+o destrutivo só sai quando a evidência vem da AUTORIDADE (a ref); o disco só NOMEIA a defasagem.
+O espelho estava no mesmo lugar: o aviso "falta o INSERT" também vinha do disco, e com o worktree
+ADIANTADO mandava ativar edge que a main não aprovou.
+
+**O fix:** a allowlist é lida de `origin/main` pela AST do TS — regex não serve, porque o arquivo
+cita o slug num comentário, e um regex aprovaria por comentário. Forma desconhecida, texto truncado
+ou array vazio → `ALLOWLIST_ILEGIVEL` (exit 2): uma lista MENOR que a real reproduz o incidente por
+outro caminho. O remédio passa a ser por ramo: `ALVO_SEM_APROVACAO` (fora da ref e do disco →
+UPDATE); `ALVO_SO_NO_WORKTREE` (fora da ref, dentro do disco → exit 2 sem UPDATE — sincronizar
+desempata entre remoção na main e entrega não mergeada); `ALLOWLIST_DEFASADA` (só aviso, com N
+commits atrás/M à frente).
+
+**A prova:** reproduzido contra prod, read-only, com a allowlist velha no disco — antes: exit 2 +
+UPDATE; depois: exit 0 (o mesmo veredito do controle com o disco em dia), zero UPDATE, aviso
+nomeando a defasagem. Falsificação versionada em `scripts/mutcheck.d/pendencias-deploy-allowlist-ref.mut`
+(uma mutação por camada). O irmão desta classe no `sonda:sql` — o `guardEfeitoLegado` também lê a
+allowlist do disco, e ali o furo é fail-OPEN (edge aprovada escapa da recusa do POST legado) — ficou
+como tarefa separada.

--- a/scripts/mutcheck.d/pendencias-deploy-allowlist-e2e.mut
+++ b/scripts/mutcheck.d/pendencias-deploy-allowlist-e2e.mut
@@ -1,0 +1,11 @@
+# Poder do teste PONTA A PONTA do `pendencias:deploy` sobre a allowlist do cron de sonda — as camadas
+# que os unitários (`pendencias-deploy-allowlist-ref.mut`) não alcançam, porque injetam o leitor:
+# o `git fetch` de `lerEsperados` (sem ele, a allowlist "da main" sai de uma `origin/main` que ninguém
+# buscou e o incidente de 2026-09-10 volta por outro caminho) e a fiação do `main()`.
+# Harness trazido pela sessão paralela `sharp-bohr-931460` (repo remoto + clone parado + psql falso).
+# @src: scripts/pendencias-deploy.ts
+# @test: scripts/pendencias-deploy-allowlist.test.ts
+# Rode: scripts/mutcheck.sh scripts/pendencias-deploy.ts scripts/pendencias-deploy-allowlist.test.ts scripts/mutcheck.d/pendencias-deploy-allowlist-e2e.mut
+PEGA | fetch pulado: a main velha julga os intrusos         | s/const fetch = git\(\['fetch', '--quiet', 'origin', 'main'\]\);/const fetch = { ok: true, saida: '' };/
+PEGA | main() entrega o disco como a allowlist da ref       | s/const secao = secaoSondaCron\(estadoPorEdge, psql, allowlists\);/const secao = secaoSondaCron(estadoPorEdge, psql, { ...allowlists, ref: allowlists.disco });/
+PEGA | ILEGIVEL engolido no main() vira lista vazia         | s/allowlists = lerAllowlists\(\);/try { allowlists = lerAllowlists(); } catch { allowlists = { ref: [], disco: [], worktree: null }; }/

--- a/scripts/mutcheck.d/pendencias-deploy-allowlist-ref.mut
+++ b/scripts/mutcheck.d/pendencias-deploy-allowlist-ref.mut
@@ -1,0 +1,27 @@
+# Poder de discriminação da suíte sobre a allowlist do cron de sonda no `pendencias:deploy`.
+# O incidente de 2026-09-10: o guard de intrusos comparava o banco com o import do DISCO; num
+# worktree 10 commits atrás, `omie-desconto-backfill` (na main e ativa no banco) virou "intrusa" e o
+# relatório imprimiu `UPDATE … SET ativo = false` — desfazer migration aplicada e tirar do cron uma
+# edge provada. Cada mutação abaixo devolve UMA camada da correção ao estado quebrado; a suíte tem de
+# ficar vermelha em todas. Baseline verde na MESMA invocação é do harness (aborta se já está vermelha).
+# @src: scripts/pendencias-deploy.ts
+# @test: scripts/pendencias-deploy.test.ts
+# Rode: scripts/mutcheck.sh scripts/pendencias-deploy.ts scripts/pendencias-deploy.test.ts scripts/mutcheck.d/pendencias-deploy-allowlist-ref.mut
+PEGA | guard volta a julgar pelo DISCO (o incidente)        | s/alvosForaDoRepo\(ativos, allowlists\.ref\)/alvosForaDoRepo(ativos, allowlists.disco)/
+PEGA | "falta o INSERT" volta a vir do disco               | s/allowlistDoRepo: allowlists\.ref,/allowlistDoRepo: allowlists.disco,/
+PEGA | edge so no worktree ganha o UPDATE                   | s/const semAprovacao = intrusos\.filter\(\(e\) => !noDisco\.has\(e\)\);/const semAprovacao = intrusos;/
+PEGA | ref lida do HEAD em vez de origin/main              | s/const texto = ler\(REF_MAIN, ARQ_ALLOWLIST\);/const texto = ler('HEAD', ARQ_ALLOWLIST);/
+PEGA | ref e disco trocados na borda                        | s/ref: extrairAlvosDaAllowlist\(texto\), disco: disco\.map\(\(a\) => a\.edge\)/ref: disco.map((a) => a.edge), disco: extrairAlvosDaAllowlist(texto)/
+PEGA | git show que falha vira allowlist vazia              | s/if \(texto === null\) \{/if (texto === null) { return { ref: [], disco: [], worktree: null };/
+PEGA | texto truncado passa (sem diagnostico de sintaxe)    | s/if \(sintaxe\.length > 0\) \{/if (false) {/
+PEGA | const local conta como a allowlist exportada         | s/if \(!st\.modifiers\?\.some\(\(m\) => m\.kind === ts\.SyntaxKind\.ExportKeyword\)\) continue;/void 0;/
+PEGA | elemento que nao e objeto e pulado, nao recusado     | s/if \(!ts\.isObjectLiteralExpression\(el\)\) throw ilegivel\(/if (!ts.isObjectLiteralExpression(el)) continue; void (/
+PEGA | objeto com spread e pulado, nao recusado             | s/if \(ts\.isSpreadAssignment\(p\)\) throw ilegivel\(/if (ts.isSpreadAssignment(p)) continue; void (/
+PEGA | edge vinda de identificador e aceita                 | s/!ts\.isStringLiteralLike\(p\.initializer\)\) \{/!(ts.isStringLiteralLike(p.initializer) || ts.isIdentifier(p.initializer))) {/
+PEGA | objeto sem edge e pulado, nao recusado               | s/if \(edge === null\) throw ilegivel\(/if (edge === null) continue; void (/
+PEGA | slug fora do formato e aceito                        | s/if \(!SLUG_EDGE\.test\(edge\)\) throw/if (false) throw/
+PEGA | array vazio vira "nenhuma aprovada"                  | s/if \(edges\.length === 0\) throw/if (edges.length < 0) throw/
+PEGA | git que falha vira "0 atras" (ausente vira zero)     | s/if \(!r\.ok\) return null;/if (!r.ok) return { aFrente: 0, atras: 0 };/
+PEGA | a frente e atras trocados                            | s/aFrente: Number\(m\[1\]\), atras: Number\(m\[2\]\)/aFrente: Number(m[2]), atras: Number(m[1])/
+PEGA | worktree atrasado nao manda sincronizar              | s/if \(w\.atras > 0\) \{/if (w.atras > 99) {/
+PEGA | aviso de defasagem some                              | s/if \(defasagem\) linhas\.push\(defasagem\);/void defasagem;/

--- a/scripts/pendencias-deploy-allowlist.test.ts
+++ b/scripts/pendencias-deploy-allowlist.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Ponta a ponta: o CLI inteiro julga os intrusos do cron de sonda contra a allowlist da MAIN
+ * RECÉM-BUSCADA — nunca contra o disco, nem contra uma `origin/main` que ninguém buscou.
+ *
+ * Harness trazido pela sessão `sharp-bohr-931460`, que atacou o mesmo defeito em paralelo e checou
+ * este CLI de fora (2026-09-10). Os unitários de `pendencias-deploy.test.ts` injetam o leitor e a
+ * allowlist; o que só aparece aqui é a BORDA: o `git fetch` de `lerEsperados` (sem ele, a allowlist
+ * "da main" sai de uma ref velha e o incidente volta por outro caminho) e a fiação do `main()`.
+ *
+ * O cenário é montado de verdade, sem mock do CLI: um repo "remoto" cuja main anda para C2 DEPOIS
+ * do clone, um clone parado em C1 (o `origin/main` dele diz C1 até alguém buscar), e um psql falso
+ * que responde só às consultas que o CLI tem direito de fazer. O CLI roda como subprocesso, pelo
+ * mesmo `bun` que o /fecho usa.
+ *
+ * O "disco" que o CLI compara é o `import` DESTE repo (a árvore do script), não o do clone — por
+ * isso as edges do cenário saem de `DO_DISCO`. A allowlist de C1 só vira "a da main" se o fetch
+ * for pulado: é ela que faz o fetch pulado reprovar.
+ */
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SONDA_CRON_ALVOS } from '../supabase/functions/_shared/sonda-cron-alvos';
+import {
+  SQL,
+  SQL_SAUDE_COLETOR,
+  SQL_SAUDE_CRON_SONDA,
+  SQL_SEM_IDENTIDADE,
+  SQL_SONDA_CRON_ALVOS,
+  SQL_SONDA_CRON_ATESTACOES,
+  SQL_SONDA_CRON_DISPAROS,
+  SQL_SONDA_CRON_MOTIVOS,
+} from './pendencias-deploy';
+
+const CLI = join(__dirname, 'pendencias-deploy.ts');
+const FP = 'a'.repeat(64);
+const EDGE_NOVA = 'edge-nova-na-main';
+const DO_DISCO = SONDA_CRON_ALVOS.map((a) => a.edge);
+/** Listada no disco real, em C1 e em C2: com o defeito OU sem ele, só é intrusa a que o teste plantar. */
+const LEGITIMA = DO_DISCO[0];
+/** Aprovada no disco real e ausente da main do cenário: o espelho do incidente. */
+const SO_NO_DISCO = DO_DISCO[1];
+const ORDEM_DE_ESCRITA = 'UPDATE public.deploy_sonda_alvos';
+
+const criados: string[] = [];
+afterEach(() => {
+  for (const d of criados.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync(
+    'git',
+    ['-c', 'user.email=t@t', '-c', 'user.name=t', '-c', 'commit.gpgsign=false', ...args],
+    { cwd, encoding: 'utf8' },
+  );
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} falhou: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function escrever(raiz: string, arquivos: Record<string, string>): void {
+  for (const [rel, texto] of Object.entries(arquivos)) {
+    mkdirSync(dirname(join(raiz, rel)), { recursive: true });
+    writeFileSync(join(raiz, rel), texto);
+  }
+}
+
+/** A forma do arquivo real: tipo anotado, controle compartilhado por constante, comentário no meio. */
+function allowlistTs(edges: string[]): string {
+  return [
+    'type AlvoSondaCron = { edge: string; desde: string | null; controles: readonly unknown[] };',
+    'const CRON = { metodo: "POST", headers: { "x-cron-secret": "$CRON_SECRET" }, corpo: "{}", nota: "x" };',
+    'export const SONDA_CRON_ALVOS: readonly AlvoSondaCron[] = [',
+    '  // { edge: "comentada-nao-conta", desde: null, controles: [CRON] },',
+    ...edges.map((e) => `  { edge: "${e}", desde: null, controles: [CRON] },`),
+    '];',
+    '',
+  ].join('\n');
+}
+
+/** Um executável no papel do `psql-ro`: SQL que o cenário não previu = falha ALTA, nunca vazio. */
+function psqlFalso(dir: string, ativosNoBanco: string[]): string {
+  const respostas: Record<string, string> = {
+    [SQL_SAUDE_COLETOR]: '5.0\n',
+    [SQL]: `edge-a|v1.0-a|${FP}|sonda|2026-09-10 12:00Z|1.00\n`,
+    [SQL_SEM_IDENTIDADE]: '',
+    [SQL_SONDA_CRON_ALVOS]: ativosNoBanco.map((e) => `${e}\n`).join(''),
+    [SQL_SAUDE_CRON_SONDA]: '30.0\n',
+    [SQL_SONDA_CRON_DISPAROS]: '',
+    [SQL_SONDA_CRON_ATESTACOES]: '',
+    [SQL_SONDA_CRON_MOTIVOS]: '',
+  };
+  const arqRespostas = join(dir, 'respostas.json');
+  writeFileSync(arqRespostas, JSON.stringify(respostas));
+  const exe = join(dir, 'psql-falso');
+  writeFileSync(
+    exe,
+    [
+      '#!/usr/bin/env bun',
+      "import { readFileSync } from 'node:fs';",
+      `const respostas = JSON.parse(readFileSync(${JSON.stringify(arqRespostas)}, 'utf8'));`,
+      'const sql = process.argv[process.argv.length - 1];',
+      'if (!Object.hasOwn(respostas, sql)) {',
+      "  console.error('psql-falso: SQL que o cenário não previu: ' + sql.slice(0, 160));",
+      '  process.exit(3);',
+      '}',
+      'process.stdout.write(respostas[sql]);',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(exe, 0o755);
+  return exe;
+}
+
+/**
+ * `remoto` é o GitHub: a main dele anda para C2 DEPOIS do clone. `local` é a worktree defasada,
+ * clonada em C1 e nunca mais buscada — até o CLI buscar.
+ */
+function montarCenario(opts: {
+  allowlistC1: string[];
+  allowlistMain: string | string[];
+  ativosNoBanco: string[];
+}): { local: string; psql: string } {
+  const base = mkdtempSync(join(tmpdir(), 'pendencias-allowlist-'));
+  criados.push(base);
+  const remoto = join(base, 'remoto');
+  mkdirSync(remoto);
+  git(remoto, 'init', '-q');
+  git(remoto, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  escrever(remoto, {
+    'supabase/functions/_shared/sonda-fingerprints.ts':
+      `export const SONDA_FINGERPRINTS: Record<string, string> = {\n  "edge-a": "${FP}",\n};\n`,
+    'supabase/functions/edge-a/versao.ts': 'export const VERSAO = "v1.0-a";\n',
+    'supabase/functions/_shared/sonda-cron-alvos.ts': allowlistTs(opts.allowlistC1),
+  });
+  git(remoto, 'add', '-A');
+  git(remoto, 'commit', '-q', '-m', 'C1: onde o clone para');
+
+  const local = join(base, 'local');
+  git(base, 'clone', '-q', remoto, local);
+
+  escrever(remoto, {
+    'supabase/functions/_shared/sonda-cron-alvos.ts':
+      typeof opts.allowlistMain === 'string' ? opts.allowlistMain : allowlistTs(opts.allowlistMain),
+  });
+  git(remoto, 'commit', '-q', '--allow-empty', '-am', 'C2: a main anda depois do clone');
+
+  return { local, psql: psqlFalso(base, opts.ativosNoBanco) };
+}
+
+function rodarCli(local: string, psql: string): { status: number | null; stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = { ...process.env, PSQL_RO: psql };
+  delete env.PENDENCIAS_TOLERAR_NUNCA_ATESTADA;
+  const r = spawnSync('bun', [CLI], { cwd: local, encoding: 'utf8', env, timeout: 60_000 });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('pendencias:deploy ponta a ponta — a allowlist que julga é a da main RECÉM-BUSCADA', () => {
+  it('pré-condição: o cenário depende de edges que o disco real tem e de uma que ele NÃO tem', () => {
+    expect(DO_DISCO.length).toBeGreaterThan(1);
+    expect(DO_DISCO).not.toContain(EDGE_NOVA);
+    expect(DO_DISCO).not.toContain('edge-intrusa');
+  });
+
+  it('o incidente: edge que a main e o banco têm, e o disco não conhece, NÃO vira intrusa', () => {
+    const { local, psql } = montarCenario({
+      allowlistC1: [LEGITIMA],
+      allowlistMain: [LEGITIMA, EDGE_NOVA],
+      ativosNoBanco: [LEGITIMA, EDGE_NOVA],
+    });
+    const r = rodarCli(local, psql);
+    // Evidência POSITIVA de que o CLI chegou à seção e passou pelo ramo certo: sem ela, um crash
+    // anterior também "não emitiria o UPDATE" e o teste passaria por cegueira. ASCII (lição #1483).
+    expect(r.stdout).toContain('2 edge(s) ativa(s), 0 tick(s) recente(s)');
+    expect(r.stdout).toContain('ALLOWLIST_DEFASADA');
+    expect(r.stdout).toContain('1 commit(s)');
+    expect(`${r.stdout}${r.stderr}`).not.toContain(ORDEM_DE_ESCRITA);
+    expect(r.status).toBe(0);
+  }, 60_000);
+
+  it('o espelho: edge que SÓ o disco aprova e o banco ativou → exit 2 SEM a ordem de escrita', () => {
+    const { local, psql } = montarCenario({
+      allowlistC1: [LEGITIMA, SO_NO_DISCO],
+      allowlistMain: [LEGITIMA],
+      ativosNoBanco: [LEGITIMA, SO_NO_DISCO],
+    });
+    const r = rodarCli(local, psql);
+    expect(r.stderr).toContain('ALVO_SO_NO_WORKTREE');
+    expect(r.stderr).toContain(SO_NO_DISCO);
+    expect(`${r.stdout}${r.stderr}`).not.toContain(ORDEM_DE_ESCRITA);
+    expect(r.status).toBe(2);
+  }, 60_000);
+
+  it('controle positivo: intrusa de verdade (nem main, nem disco) sai COM a ordem — o harness enxerga o UPDATE', () => {
+    const { local, psql } = montarCenario({
+      allowlistC1: [LEGITIMA],
+      allowlistMain: [LEGITIMA, EDGE_NOVA],
+      ativosNoBanco: [LEGITIMA, 'edge-intrusa'],
+    });
+    const r = rodarCli(local, psql);
+    expect(r.stderr).toContain('ALVO_SEM_APROVACAO');
+    expect(r.stderr).toContain(`${ORDEM_DE_ESCRITA} SET ativo = false WHERE edge IN ('edge-intrusa');`);
+    expect(r.status).toBe(2);
+  }, 60_000);
+
+  it('allowlist da main ILEGÍVEL: exit 2 de mecânica, e NENHUMA ordem de escrita', () => {
+    // Spread é a forma de um refactor futuro que o leitor não segue. Sem lista confiável não há
+    // intruso a julgar — e ordem de escrita em prod a partir de leitura parcial é o defeito.
+    const ilegivel = [
+      `const ONDA_1 = [{ edge: "${LEGITIMA}", desde: null, controles: [] }];`,
+      'export const SONDA_CRON_ALVOS = [...ONDA_1];',
+      '',
+    ].join('\n');
+    const { local, psql } = montarCenario({
+      allowlistC1: [LEGITIMA],
+      allowlistMain: ilegivel,
+      ativosNoBanco: [LEGITIMA, EDGE_NOVA],
+    });
+    const r = rodarCli(local, psql);
+    expect(r.stderr).toContain('ALLOWLIST_ILEGIVEL');
+    expect(`${r.stdout}${r.stderr}`).not.toContain(ORDEM_DE_ESCRITA);
+    expect(r.status).toBe(2);
+  }, 60_000);
+});

--- a/scripts/pendencias-deploy.test.ts
+++ b/scripts/pendencias-deploy.test.ts
@@ -27,17 +27,29 @@ import {
   type SondaSemIdentidade,
 } from './lib/pendencias-deploy';
 import {
+  ARQ_ALLOWLIST,
   CRON_COLETOR,
+  estadoDoWorktree,
+  extrairAlvosDaAllowlist,
   formatarSemIdentidade,
   FORMATO_JSON,
+  lerAllowlists,
   lerArgIds,
   lerArgJson,
   MIGRATION_LEDGER,
+  REF_MAIN,
+  secaoSondaCron,
   serializarRelatorio,
   SQL,
   SQL_SAUDE_COLETOR,
+  SQL_SAUDE_CRON_SONDA,
   SQL_SEM_IDENTIDADE,
+  SQL_SONDA_CRON_ALVOS,
+  SQL_SONDA_CRON_ATESTACOES,
+  SQL_SONDA_CRON_DISPAROS,
+  SQL_SONDA_CRON_MOTIVOS,
 } from './pendencias-deploy';
+import { SONDA_CRON_ALVOS } from '../supabase/functions/_shared/sonda-cron-alvos';
 
 const ESPERADOS: Record<string, Esperado> = {
   'edge-a': { fonte: 'aaa111', versao: 'v1.0-a' },
@@ -820,5 +832,221 @@ describe('--json — o contrato que o Passo 3 do /fecho lê', () => {
     expect(sh).toContain('!= "$LEDGER_FORMATO"');
     // e só CONFERE com a 2ª chave (fonte observado == esperado da REF) absolve
     expect(sh).toContain('[ "$l_estado" = "CONFERE" ] && [ "$l_obs" = "$esperado" ]');
+  });
+});
+
+/**
+ * A allowlist do cron vem da MESMA ref que o resto do sensor (incidente de 2026-09-10).
+ *
+ * Um worktree 10 commits atrás tinha a allowlist do DISCO sem `omie-desconto-backfill`; a main e o
+ * banco já a tinham (migration da onda 5 aplicada). O guard comparava banco × import do disco, viu
+ * "intruso" e imprimiu o remédio: `UPDATE … SET ativo = false` — desfazer uma migration aplicada e
+ * tirar do cron uma edge provada. Worktree defasado é o caso COMUM num repo com ~30 worktrees.
+ *
+ * As edges fictícias abaixo existem na "ref" do teste e NÃO no import real do disco — é o que
+ * reproduz o disco atrasado sem depender de qual commit o worktree está.
+ */
+const UPDATE_MARCA = 'UPDATE public.deploy_sonda_alvos SET ativo = false';
+
+const lerBanco =
+  (ativos: string[], extra: { disparos?: string; atestacoes?: string } = {}) =>
+  (sql: string): string => {
+    if (sql === SQL_SONDA_CRON_ALVOS) return `${ativos.join('\n')}\n`;
+    if (sql === SQL_SAUDE_CRON_SONDA) return '12.5\n';
+    if (sql === SQL_SONDA_CRON_DISPAROS) return extra.disparos ?? '';
+    if (sql === SQL_SONDA_CRON_ATESTACOES) return extra.atestacoes ?? '';
+    if (sql === SQL_SONDA_CRON_MOTIVOS) return '';
+    throw new Error(`SQL inesperado no teste: ${sql.slice(0, 60)}`);
+  };
+
+const ATRAS_10 = { aFrente: 0, atras: 10 };
+const SEM_ESTADO = new Map<string, string>();
+
+describe('secaoSondaCron — o guard compara o banco com a allowlist da REF, não a do disco', () => {
+  it('(a) disco ATRASADO, ref e banco com a edge → sem mecânica, sem UPDATE, e o aviso nomeia a defasagem', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['monthly-report', 'edge-aprovada-na-main']), {
+      ref: ['monthly-report', 'edge-aprovada-na-main'],
+      disco: ['monthly-report'],
+      worktree: ATRAS_10,
+    });
+    expect(s.mecanica).toBeNull();
+    const tudo = s.linhas.join('\n');
+    expect(tudo).not.toContain(UPDATE_MARCA);
+    // prova POSITIVA do ramo certo, não só ausência do errado
+    expect(tudo).toContain('ALLOWLIST_DEFASADA');
+    expect(tudo).toContain('edge-aprovada-na-main');
+    expect(tudo).toContain('10 commit(s)');
+    expect(tudo).toContain('sincronize antes de medir');
+  });
+
+  it('(b) edge ativa no banco e AUSENTE na ref (e no disco) → mecânica com o UPDATE, só dela', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['monthly-report', 'edge-intrusa']), {
+      ref: ['monthly-report'],
+      disco: ['monthly-report'],
+      worktree: { aFrente: 0, atras: 0 },
+    });
+    expect(s.mecanica).not.toBeNull();
+    expect(s.mecanica).toContain('ALVO_SEM_APROVACAO');
+    expect(s.mecanica).toContain(`${UPDATE_MARCA} WHERE edge IN ('edge-intrusa');`);
+    expect(s.mecanica).not.toContain('ALVO_SO_NO_WORKTREE');
+  });
+
+  it('edge fora da ref mas DENTRO do disco → mecânica SEM UPDATE: nomeia o worktree e manda sincronizar', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['monthly-report', 'edge-em-voo']), {
+      ref: ['monthly-report'],
+      disco: ['monthly-report', 'edge-em-voo'],
+      worktree: { aFrente: 2, atras: 0 },
+    });
+    expect(s.mecanica).not.toBeNull();
+    expect(s.mecanica).toContain('ALVO_SO_NO_WORKTREE');
+    expect(s.mecanica).toContain('edge-em-voo');
+    expect(s.mecanica).toContain('2 commit(s)');
+    expect(s.mecanica).not.toContain(UPDATE_MARCA);
+    expect(s.mecanica).not.toContain('ALVO_SEM_APROVACAO');
+  });
+
+  it('as duas classes juntas → o UPDATE lista SÓ a que falta também no disco', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['edge-em-voo', 'edge-intrusa', 'monthly-report']), {
+      ref: ['monthly-report'],
+      disco: ['monthly-report', 'edge-em-voo'],
+      worktree: ATRAS_10,
+    });
+    expect(s.mecanica).toContain('ALVO_SEM_APROVACAO');
+    expect(s.mecanica).toContain('ALVO_SO_NO_WORKTREE');
+    expect(s.mecanica).toContain(`${UPDATE_MARCA} WHERE edge IN ('edge-intrusa');`);
+  });
+
+  it('o aviso "falta o INSERT" vem da REF: disco ADIANTADO não manda ativar edge que a main não aprovou', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['monthly-report']), {
+      ref: ['monthly-report', 'edge-aprovada-na-main'],
+      disco: ['monthly-report', 'edge-em-voo'],
+      worktree: { aFrente: 1, atras: 1 },
+    });
+    expect(s.mecanica).toBeNull();
+    const tudo = s.linhas.join('\n');
+    expect(tudo).toContain('edge-aprovada-na-main: na allowlist do repo');
+    expect(tudo).not.toContain('edge-em-voo: na allowlist do repo');
+    // e nenhuma edge do import real do disco vaza para o julgamento
+    expect(tudo).not.toContain('sonda-relay: na allowlist do repo');
+  });
+
+  it('disco igual à ref → nenhum aviso de defasagem (silêncio aqui é o certo)', () => {
+    const s = secaoSondaCron(SEM_ESTADO, lerBanco(['monthly-report']), {
+      ref: ['monthly-report'],
+      disco: ['monthly-report'],
+      worktree: ATRAS_10,
+    });
+    expect(s.mecanica).toBeNull();
+    expect(s.linhas.join('\n')).not.toContain('ALLOWLIST_DEFASADA');
+  });
+});
+
+describe('estadoDoWorktree — quantos commits separam o worktree de origin/main', () => {
+  it('lê `rev-list --left-right --count HEAD...origin/main` (esquerda = à frente, direita = atrás)', () => {
+    let pedido: string[] = [];
+    const w = estadoDoWorktree((args) => {
+      pedido = args;
+      return { ok: true, saida: '3\t10' };
+    });
+    expect(w).toEqual({ aFrente: 3, atras: 10 });
+    expect(pedido).toEqual(['rev-list', '--left-right', '--count', `HEAD...${REF_MAIN}`]);
+  });
+
+  it('git que falha ou saída fora do formato → null (ausente ≠ zero: nunca "0 atrás")', () => {
+    expect(estadoDoWorktree(() => ({ ok: false, saida: '' }))).toBeNull();
+    expect(estadoDoWorktree(() => ({ ok: true, saida: 'lixo' }))).toBeNull();
+    expect(estadoDoWorktree(() => ({ ok: true, saida: '' }))).toBeNull();
+  });
+});
+
+const ALLOWLIST_FIXTURE = (corpo: string): string => `
+type Alvo = { edge: string; desde: string | null; nota?: string };
+// { edge: "fantasma-no-topo" }
+export const SONDA_CRON_ALVOS: readonly Alvo[] = [
+${corpo}
+];
+export function slugs(): ReadonlySet<string> {
+  return new Set(SONDA_CRON_ALVOS.map((a) => a.edge));
+}
+`;
+
+describe('extrairAlvosDaAllowlist — lê a allowlist da ref pela AST, e só a forma que sabe ler', () => {
+  it('o arquivo REAL: o parser concorda com o import (contrato pinado ao formato de verdade)', () => {
+    const texto = readFileSync(join(__dirname, '..', ARQ_ALLOWLIST), 'utf8');
+    const lidos = extrairAlvosDaAllowlist(texto);
+    expect(lidos).toEqual(SONDA_CRON_ALVOS.map((a) => a.edge));
+    expect(lidos).toContain('omie-desconto-backfill');
+    expect(lidos.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('comentário e string que CITAM um slug não aprovam ninguém', () => {
+    const texto = ALLOWLIST_FIXTURE(
+      [
+        '  { edge: "edge-a", desde: null },',
+        '  // { edge: "fantasma-comentario", desde: null },',
+        '  { edge: "edge-b", desde: null, nota: \'{ edge: "fantasma-string" }\' },',
+      ].join('\n'),
+    );
+    expect(extrairAlvosDaAllowlist(texto)).toEqual(['edge-a', 'edge-b']);
+  });
+
+  it('entrada multi-linha é lida como a de uma linha só', () => {
+    const texto = ALLOWLIST_FIXTURE('  {\n    edge: "edge-a",\n    desde: null,\n  },\n  { edge: "edge-b", desde: null },');
+    expect(extrairAlvosDaAllowlist(texto)).toEqual(['edge-a', 'edge-b']);
+  });
+
+  // Cada forma ruim vem DEPOIS de uma entrada válida: sozinha, ela também cairia no "array vazio" e
+  // o teste ficaria verde por outra camada — a que ele diz testar poderia sumir sem ninguém ver.
+  const VALIDA = '  { edge: "edge-valida", desde: null },\n';
+  it.each([
+    ['edge vinda de identificador (com cara de slug)', `${VALIDA}  { edge: omie, desde: null },`],
+    ['elemento espalhado', `${VALIDA}  ...OUTRA_LISTA,`],
+    ['objeto com spread', `${VALIDA}  { ...BASE, edge: "edge-a", desde: null },`],
+    ['elemento que não é objeto', `${VALIDA}  "edge-a",`],
+    ['objeto sem edge', `${VALIDA}  { desde: null },`],
+    ['slug fora do formato de edge', `${VALIDA}  { edge: "Edge A", desde: null },`],
+    ['array vazio (ausente ≠ zero)', ''],
+  ])('%s → ALLOWLIST_ILEGIVEL (fail-closed, nunca uma lista menor)', (_nome, corpo) => {
+    expect(() => extrairAlvosDaAllowlist(ALLOWLIST_FIXTURE(corpo))).toThrow(/ALLOWLIST_ILEGIVEL/);
+  });
+
+  it('texto TRUNCADO → ALLOWLIST_ILEGIVEL: a lista parcial viraria intruso falso e o UPDATE destrutivo', () => {
+    const inteiro = ALLOWLIST_FIXTURE('  { edge: "edge-a", desde: null },\n  { edge: "edge-b", desde: null },');
+    const truncado = inteiro.slice(0, inteiro.indexOf('"edge-b"') + 3);
+    expect(() => extrairAlvosDaAllowlist(truncado)).toThrow(/ALLOWLIST_ILEGIVEL/);
+  });
+
+  it('sem o export (ou só um const local) → ALLOWLIST_ILEGIVEL', () => {
+    expect(() => extrairAlvosDaAllowlist('export const OUTRA = [];')).toThrow(/ALLOWLIST_ILEGIVEL/);
+    expect(() => extrairAlvosDaAllowlist('const SONDA_CRON_ALVOS = [{ edge: "edge-a" }];')).toThrow(
+      /ALLOWLIST_ILEGIVEL/,
+    );
+  });
+});
+
+describe('lerAllowlists — a borda: ref pelo git, disco só para o diagnóstico', () => {
+  const TEXTO = ALLOWLIST_FIXTURE('  { edge: "edge-da-main", desde: null },');
+  const gitOk = () => ({ ok: true, saida: '0\t4' });
+
+  it('lê o arquivo NA REF (origin/main), e o disco vem do import — cada lista no seu campo', () => {
+    const pedidos: string[] = [];
+    const a = lerAllowlists(
+      (rev, caminho) => {
+        pedidos.push(`${rev}:${caminho}`);
+        return TEXTO;
+      },
+      [{ edge: 'edge-do-disco' }],
+      gitOk,
+    );
+    expect(pedidos).toEqual([`${REF_MAIN}:${ARQ_ALLOWLIST}`]);
+    expect(a.ref).toEqual(['edge-da-main']);
+    expect(a.disco).toEqual(['edge-do-disco']);
+    expect(a.worktree).toEqual({ aFrente: 0, atras: 4 });
+  });
+
+  it('`git show` que falha → ALLOWLIST_ILEGIVEL (mecânica), nunca "allowlist vazia"', () => {
+    // a marca do RAMO (git show), não só a da classe: texto vazio que chegasse ao parser também
+    // lançaria ALLOWLIST_ILEGIVEL, mas pelo motivo errado
+    expect(() => lerAllowlists(() => null, [{ edge: 'edge-do-disco' }], gitOk)).toThrow(/ALLOWLIST_ILEGIVEL.*git show/);
   });
 });

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -566,6 +566,10 @@ export function estadoDoWorktree(gitFn: typeof git = git): EstadoWorktree | null
  *
  * LANÇA (⇒ exit 2) se o `git show` falhar: sem a allowlist da main não se sabe o que o banco pode
  * sondar, e tratar a falha como lista vazia transformaria TODA edge ativa em intrusa com UPDATE.
+ *
+ * Duas árvores, uma suposição: o `disco` é o import da árvore do SCRIPT; o git (ref, `rev-list`)
+ * roda no cwd. No uso real (raiz da worktree, como o /fecho chama) são a mesma; rodando o CLI de
+ * outro repo, só o diagnóstico da defasagem mistura as duas — o julgamento continua sendo da ref.
  */
 export function lerAllowlists(
   ler: (rev: string, caminho: string) => string | null = lerNaRev,

--- a/scripts/pendencias-deploy.ts
+++ b/scripts/pendencias-deploy.ts
@@ -68,6 +68,8 @@ import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import ts from 'typescript';
+
 import {
   atribuirSondasSemIdentidade,
   DATA_ECO_COM_IDENTIDADE,
@@ -456,6 +458,195 @@ export function lerEsperados(): Record<string, Esperado> {
 }
 
 /**
+ * ── A allowlist do cron de sonda, lida NA REF ─────────────────────────────────────────────────
+ *
+ * Incidente de 2026-09-10: o guard de intrusos comparava o banco com o `import` de
+ * `SONDA_CRON_ALVOS` — o DISCO — enquanto o resto deste CLI julga contra a ref. Num worktree 10
+ * commits atrás, `omie-desconto-backfill` estava na main e ativa no banco (migration da onda 5
+ * aplicada), mas não no disco: virou "intrusa", e o relatório imprimiu o remédio pronto para colar
+ * — `UPDATE … SET ativo = false`, desfazendo a migration e tirando do cron uma edge provada. Duas
+ * fontes de verdade no mesmo sensor; a mais frequente das causas (worktree defasado, ~30 no repo)
+ * recebia o remédio mais destrutivo. O disco agora só NOMEIA a defasagem; quem julga é a ref.
+ */
+export const ARQ_ALLOWLIST = 'supabase/functions/_shared/sonda-cron-alvos.ts';
+
+const EXPORT_ALLOWLIST = 'SONDA_CRON_ALVOS';
+const SLUG_EDGE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Commits entre o worktree e a ref: `aFrente` = só no worktree, `atras` = só na main. */
+export interface EstadoWorktree {
+  aFrente: number;
+  atras: number;
+}
+
+/** Só `ref` julga. `disco` (o import desta árvore) existe para NOMEAR a defasagem, nunca para decidir. */
+export interface Allowlists {
+  ref: string[];
+  disco: string[];
+  worktree: EstadoWorktree | null;
+}
+
+function nomeDaPropriedade(nome: ts.PropertyName): string | null {
+  return ts.isIdentifier(nome) || ts.isStringLiteralLike(nome) ? nome.text : null;
+}
+
+/**
+ * Os slugs de `SONDA_CRON_ALVOS` num TEXTO do arquivo — pela AST do TS, sem executar nada.
+ *
+ * Texto porque a ref não está no disco; AST e não regex porque o arquivo CITA slugs em comentário
+ * (a entrada da onda 5 vem depois de um parágrafo que nomeia `omie-desconto-backfill`) e um regex
+ * aprovaria edge por comentário. Para a AST, comentário é trivia e string de `nota` não é propriedade.
+ *
+ * LANÇA `ALLOWLIST_ILEGIVEL` para toda forma que não seja `{ edge: "<slug>", … }` literal, para
+ * texto que não parseia e para o array vazio. Uma lista MENOR que a real é o pior erro possível
+ * aqui: a edge omitida vira intrusa e o relatório imprime o UPDATE que desativa edge aprovada — o
+ * incidente de novo, por outro caminho. Formato novo na main exige ensinar este parser no mesmo PR
+ * (o teste que o compara com o import real reprova antes).
+ */
+export function extrairAlvosDaAllowlist(fonte: string): string[] {
+  const ilegivel = (motivo: string) => new Error(`ALLOWLIST_ILEGIVEL: ${ARQ_ALLOWLIST} — ${motivo}`);
+
+  // Texto truncado ainda vira árvore (o parser do TS se recupera) — e a árvore de um corte no meio
+  // do array é uma lista MENOR com cara de lista inteira. O diagnóstico de sintaxe é o que a separa.
+  const sintaxe = ts.transpileModule(fonte, { reportDiagnostics: true }).diagnostics ?? [];
+  if (sintaxe.length > 0) {
+    throw ilegivel(`texto que não parseia: ${ts.flattenDiagnosticMessageText(sintaxe[0].messageText, ' ')}`);
+  }
+
+  const arquivo = ts.createSourceFile(ARQ_ALLOWLIST, fonte, ts.ScriptTarget.ESNext, true);
+  const trecho = (n: ts.Node) => n.getText(arquivo).replace(/\s+/g, ' ').slice(0, 80);
+  let array: ts.ArrayLiteralExpression | null = null;
+  for (const st of arquivo.statements) {
+    if (!ts.isVariableStatement(st)) continue;
+    if (!st.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) continue;
+    for (const d of st.declarationList.declarations) {
+      if (!ts.isIdentifier(d.name) || d.name.text !== EXPORT_ALLOWLIST) continue;
+      if (!d.initializer || !ts.isArrayLiteralExpression(d.initializer)) {
+        throw ilegivel(`\`${EXPORT_ALLOWLIST}\` não é um array literal`);
+      }
+      array = d.initializer;
+    }
+  }
+  if (array === null) throw ilegivel(`sem \`export const ${EXPORT_ALLOWLIST}\``);
+
+  const edges: string[] = [];
+  for (const el of array.elements) {
+    if (!ts.isObjectLiteralExpression(el)) throw ilegivel(`entrada que não é objeto literal: ${trecho(el)}`);
+    let edge: string | null = null;
+    for (const p of el.properties) {
+      if (ts.isSpreadAssignment(p)) throw ilegivel(`entrada com spread: ${trecho(el)}`);
+      if (nomeDaPropriedade(p.name) !== 'edge') continue;
+      if (!ts.isPropertyAssignment(p) || !ts.isStringLiteralLike(p.initializer)) {
+        throw ilegivel(`\`edge\` que não é string literal: ${trecho(p)}`);
+      }
+      edge = p.initializer.text;
+    }
+    if (edge === null) throw ilegivel(`entrada sem \`edge\`: ${trecho(el)}`);
+    if (!SLUG_EDGE.test(edge)) throw ilegivel(`slug fora do formato de edge: "${edge}"`);
+    edges.push(edge);
+  }
+  if (edges.length === 0) throw ilegivel('array vazio — ausente ≠ zero: "nenhuma aprovada" e "não li" têm a mesma cara');
+  return edges;
+}
+
+/**
+ * Quantos commits separam o worktree da ref. `null` quando o git não responde ou responde fora do
+ * formato — ausente ≠ zero: o diagnóstico diz "não consegui contar", nunca "0 atrás".
+ */
+export function estadoDoWorktree(gitFn: typeof git = git): EstadoWorktree | null {
+  const r = gitFn(['rev-list', '--left-right', '--count', `HEAD...${REF_MAIN}`]);
+  if (!r.ok) return null;
+  const m = /^(\d+)\s+(\d+)$/.exec(r.saida.trim());
+  return m ? { aFrente: Number(m[1]), atras: Number(m[2]) } : null;
+}
+
+/**
+ * A allowlist da REF (que julga) e a do disco (que só nomeia a defasagem). Chame DEPOIS de
+ * `lerEsperados()`, que faz o fetch: a ref lida aqui é a recém-buscada.
+ *
+ * LANÇA (⇒ exit 2) se o `git show` falhar: sem a allowlist da main não se sabe o que o banco pode
+ * sondar, e tratar a falha como lista vazia transformaria TODA edge ativa em intrusa com UPDATE.
+ */
+export function lerAllowlists(
+  ler: (rev: string, caminho: string) => string | null = lerNaRev,
+  disco: readonly { edge: string }[] = SONDA_CRON_ALVOS,
+  gitFn: typeof git = git,
+): Allowlists {
+  const texto = ler(REF_MAIN, ARQ_ALLOWLIST);
+  if (texto === null) {
+    throw new Error(
+      `ALLOWLIST_ILEGIVEL: \`git show ${REF_MAIN}:${ARQ_ALLOWLIST}\` falhou — sem a allowlist da main ` +
+        'não sei o que o banco pode sondar (ausente ≠ vazia).',
+    );
+  }
+  return { ref: extrairAlvosDaAllowlist(texto), disco: disco.map((a) => a.edge), worktree: estadoDoWorktree(gitFn) };
+}
+
+/**
+ * A causa PROVÁVEL da defasagem, pelo que o git contou. Heurística: havendo commit de diferença, ele
+ * é o palpite; edição local não commitada só é nomeada quando não há commit de diferença (worktree
+ * atrás E com a allowlist editada sai como "atrás" — raro, e o "só na main/só no worktree" ao lado
+ * continua dizendo exatamente O QUE diverge).
+ */
+export function diagnosticoWorktree(w: EstadoWorktree | null): string {
+  if (w === null) return `não consegui contar os commits entre o seu worktree e ${REF_MAIN}`;
+  if (w.atras > 0) {
+    const frente = w.aFrente > 0 ? ` (e ${w.aFrente} à frente)` : '';
+    return `seu worktree está ${w.atras} commit(s) atrás de ${REF_MAIN}${frente} — sincronize antes de medir`;
+  }
+  if (w.aFrente > 0) return `seu worktree está ${w.aFrente} commit(s) à frente de ${REF_MAIN} — entrega ainda não mergeada`;
+  return `seu worktree não tem commit de diferença para ${REF_MAIN} — a divergência é edição NÃO commitada`;
+}
+
+/**
+ * O remédio depende de ONDE a edge intrusa falta. Só a que falta na ref E no disco recebe o
+ * UPDATE: nada que este worktree veja a aprova. A que o disco aprova e a main não é ambígua — sua
+ * entrega ainda não mergeada (banco adiantado) ou uma remoção na main que o worktree não viu — e
+ * desativar às cegas pode desfazer o que está a um merge de ser certo. Sincronizar desempata: se a
+ * main removeu, o disco perde a edge e a próxima leitura já imprime o UPDATE.
+ */
+function mecanicaDosIntrusos(intrusos: string[], a: Allowlists): string {
+  const noDisco = new Set(a.disco);
+  const semAprovacao = intrusos.filter((e) => !noDisco.has(e));
+  const soNoWorktree = intrusos.filter((e) => noDisco.has(e));
+  const partes: string[] = [];
+  if (semAprovacao.length > 0) {
+    partes.push(
+      `ALVO_SEM_APROVACAO — o banco sonda edge(s) que ${REF_MAIN} NÃO aprovou: ${semAprovacao.join(', ')}. ` +
+        'Só a allowlist da main teve todos os closures históricos executados (`bun run sonda:cron-prova`). ' +
+        `Desative no banco: UPDATE public.deploy_sonda_alvos SET ativo = false WHERE edge IN ('${semAprovacao.join("','")}');`,
+    );
+  }
+  if (soNoWorktree.length > 0) {
+    partes.push(
+      `ALVO_SO_NO_WORKTREE — o banco sonda edge(s) que o SEU worktree aprova e ${REF_MAIN} NÃO: ` +
+        `${soNoWorktree.join(', ')} (${diagnosticoWorktree(a.worktree)}). NÃO desative a partir desta leitura: ` +
+        `rode de novo depois de sincronizar com ${REF_MAIN} — se a main REMOVEU a edge, o sensor passa a imprimir ` +
+        'o UPDATE; se a aprovação é entrega ainda não mergeada, o banco foi adiantado antes do merge, e o ' +
+        'default-deny vale pela main até lá.',
+    );
+  }
+  return partes.join('\n   ');
+}
+
+/** Aviso (não reprova): a allowlist do disco difere da da ref. Igual → null — silêncio é o certo. */
+function avisoAllowlistDefasada(a: Allowlists): string | null {
+  const ref = new Set(a.ref);
+  const disco = new Set(a.disco);
+  const soNaMain = [...ref].filter((e) => !disco.has(e)).sort();
+  const soNoWorktree = [...disco].filter((e) => !ref.has(e)).sort();
+  if (soNaMain.length === 0 && soNoWorktree.length === 0) return null;
+  const diferencas = [
+    ...(soNaMain.length > 0 ? [`só na main: ${soNaMain.join(', ')}`] : []),
+    ...(soNoWorktree.length > 0 ? [`só no seu worktree: ${soNoWorktree.join(', ')}`] : []),
+  ];
+  return (
+    `   ⚠️  ALLOWLIST_DEFASADA — a allowlist do seu worktree difere da de ${REF_MAIN} (${diferencas.join('; ')}); ` +
+    `${diagnosticoWorktree(a.worktree)}. Este julgamento usou a de ${REF_MAIN}; o código do sensor é o do seu worktree.`
+  );
+}
+
+/**
  * O contexto que só o git responde.
  *
  * `parCoerente`: o commit mais ANTIGO em que a entrada `"edge": "fonte"` aparece no mapa é onde
@@ -582,10 +773,14 @@ function imprimir(rel: Relatorio, linhasSemIdentidade: string[]): void {
  * repo antes de o founder colar a migration, e reprovar por isso transformaria uma entrega em voo
  * num bloqueio para todas as sessões. A mecânica de verdade (cron parado, banco fora do repo) só
  * se aplica quando a F2 JÁ está no ar, porque só aí o silêncio significa alguma coisa.
+ *
+ * "O repo", aqui, é a allowlist de `origin/main` (`allowlists.ref`) — a mesma ref do resto do CLI.
+ * O disco só entra para escolher o remédio e nomear a defasagem (ver `lerAllowlists`).
  */
 export function secaoSondaCron(
   estadoPorEdge: Map<string, string>,
   ler: (sql: string) => string,
+  allowlists: Allowlists,
 ): { linhas: string[]; achados: number; mecanica: string | null } {
   const linhas: string[] = [];
   let ativos: string[];
@@ -607,17 +802,9 @@ export function secaoSondaCron(
     return { linhas: [], achados: 0, mecanica: `leitura da sonda por cron falhou — ${(e as Error).message}` };
   }
 
-  const doRepo = SONDA_CRON_ALVOS.map((a) => a.edge);
-  const intrusos = alvosForaDoRepo(ativos, doRepo);
+  const intrusos = alvosForaDoRepo(ativos, allowlists.ref);
   if (intrusos.length > 0) {
-    return {
-      linhas: [],
-      achados: 0,
-      mecanica:
-        `o banco sonda edge(s) que o repo NÃO aprovou: ${intrusos.join(', ')}. ` +
-        'Só a allowlist do repo teve todos os closures históricos executados (`bun run sonda:cron-prova`). ' +
-        `Desative no banco: UPDATE public.deploy_sonda_alvos SET ativo = false WHERE edge IN ('${intrusos.join("','")}');`,
-    };
+    return { linhas: [], achados: 0, mecanica: mecanicaDosIntrusos(intrusos, allowlists) };
   }
 
   const saude = semChatter(ler(SQL_SAUDE_CRON_SONDA));
@@ -676,7 +863,7 @@ export function secaoSondaCron(
 
   const r = julgarSondaCron({
     ativosNoBanco: ativos,
-    allowlistDoRepo: doRepo,
+    allowlistDoRepo: allowlists.ref,
     ticksRecentes,
     disparos,
     atestacoes,
@@ -690,6 +877,8 @@ export function secaoSondaCron(
     `\n🕒 SONDA POR CRON — ${ativos.length} edge(s) ativa(s), ${ticksRecentes.length} tick(s) recente(s), ` +
       `${respondidos}/${disparos.length} disparo(s) atestado(s)`,
   );
+  const defasagem = avisoAllowlistDefasada(allowlists);
+  if (defasagem) linhas.push(defasagem);
   for (const a of r.achados) linhas.push(`   🔴 ${a.classe} · ${a.edge}: ${a.detalhe}`);
   for (const aviso of r.avisos) linhas.push(`   ⚠️  ${aviso}`);
   if (r.achados.length === 0 && r.avisos.length === 0) {
@@ -720,6 +909,16 @@ export function main(argv: string[] = []): number {
   }
   if (Object.keys(esperados).length === 0) {
     console.error('❌ MECÂNICA: mapa de fingerprints VAZIO. Rode `bun run sonda:fingerprint`.');
+    return 2;
+  }
+
+  // Depois do fetch de `lerEsperados`: a allowlist que julga o banco é a da MESMA ref do mapa.
+  let allowlists: Allowlists;
+  try {
+    allowlists = lerAllowlists();
+  } catch (e) {
+    // formato que ESTE parser não conhece costuma ser worktree velho lendo main nova
+    console.error(`❌ MECÂNICA: ${(e as Error).message}\n   (${diagnosticoWorktree(estadoDoWorktree())})`);
     return 2;
   }
 
@@ -811,7 +1010,7 @@ export function main(argv: string[] = []): number {
 
   // A sonda por cron (F3): lê os 2 últimos ticks e liga cada resposta ao disparo por `request_id`.
   const estadoPorEdge = new Map(rel.vereditos.map((v) => [v.edge, v.estado as string]));
-  const secao = secaoSondaCron(estadoPorEdge, psql);
+  const secao = secaoSondaCron(estadoPorEdge, psql, allowlists);
   if (secao.mecanica !== null) {
     console.error(`❌ MECÂNICA: ${secao.mecanica}`);
     return 2;


### PR DESCRIPTION
## O incidente (medido em 2026-09-10 ~23:05Z)

`bun scripts/pendencias-deploy.ts --json` num worktree **10 commits atrás** de `origin/main` saiu **exit 2**, stdout vazio, com:

```
❌ MECÂNICA: o banco sonda edge(s) que o repo NÃO aprovou: omie-desconto-backfill. […]
Desative no banco: UPDATE public.deploy_sonda_alvos SET ativo = false WHERE edge IN ('omie-desconto-backfill');
```

A premissa era falsa: a edge estava na allowlist da main (`f4578bbff`) **e** ativa no banco (migration `20260909222423_deploy_sonda_alvos_onda5.sql` aplicada). Só o disco estava velho. O remédio impresso **desfaria uma migration aplicada** e tiraria do cron uma edge de money-path que passou pela prova, e worktree defasado é o caso COMUM, não o raro.

## Causa

`secaoSondaCron` usava `SONDA_CRON_ALVOS`, um **import do disco**, em dois lugares, enquanto o resto do sensor julga contra `origin/main`:
1. o guard de intrusos (`alvosForaDoRepo`) → falso intruso + `UPDATE` destrutivo;
2. o `julgarSondaCron` (aviso "falta o INSERT") → com o disco **adiantado**, mandava ativar em prod uma edge que a main não aprovou (o espelho fail-OPEN).

## O que muda

- **A allowlist é lida da ref** (`git show origin/main:…`, depois do fetch de `lerEsperados`) **pela AST do TS**, sem executar nada. Regex não serve: o arquivo cita `omie-desconto-backfill` num comentário. Só aceita `{ edge: "<slug>" }` literal. Spread, identificador, objeto sem `edge`, slug inválido, **texto truncado** (diagnóstico de sintaxe) ou array vazio → `ALLOWLIST_ILEGIVEL`, exit 2. `git show` falhando → exit 2, nunca "allowlist vazia".
- **Remédio por ramo** (marcas ASCII):
  - `ALVO_SEM_APROVACAO`: fora da ref **e** do disco → exit 2 **com** o `UPDATE`;
  - `ALVO_SO_NO_WORKTREE`: fora da ref, **dentro** do disco → exit 2 **sem** `UPDATE`. Sincronizar desempata: se a main removeu a edge, a próxima leitura imprime o `UPDATE`;
  - `ALLOWLIST_DEFASADA`: disco ≠ ref sem intruso → só **aviso**, nomeando a causa (`seu worktree está N commit(s) atrás de origin/main — sincronize antes de medir`). O veredito segue normal, contra a ref.
- O exit 2 continua onde a mecânica não é confiável. Mudaram o diagnóstico e o remédio.
- **CI:** o teto do `mutation-check` sobe de 15 para 25 min. O job já rodava a 97% do corte (531–873 s nos 6 PRs anteriores) e foi **cancelado no último contrato** neste PR, com os 44 s do contrato novo. Medição no comentário do `ci.yml`. O `sonda-versao-sql.mut` (103 mutações, 7m26s) é quase metade do job.

## Prova

- **Reproduzido contra prod (read-only)**, com a allowlist de `f4578bbff^` no disco, ref e banco com a edge:
  - antes: `exit 2`, stdout 0 bytes, 1 `UPDATE`;
  - depois: `exit 0` (o mesmo veredito do controle com o disco em dia), 23 KB de JSON com `pendencias-deploy/1`, **0 `UPDATE`**, aviso `ALLOWLIST_DEFASADA — só na main: omie-desconto-backfill`.
- **Unitários** (`scripts/pendencias-deploy.test.ts`, +22): RED visto pelo motivo certo (21 falhando | 85 passando) → GREEN 106/106.
- **Ponta a ponta** (`scripts/pendencias-deploy-allowlist.test.ts`): harness da sessão paralela `sharp-bohr-931460`, que atacou o mesmo defeito, parou e checou este CLI de fora. É um repo remoto cuja main anda **depois** do clone, um clone parado, um psql falso que falha alto para SQL imprevisto, e o CLI como subprocesso. Cobre o que os unitários não alcançam: o `git fetch` (pulado, a allowlist "da main" sai de ref velha e o incidente volta) e a fiação do `main()`.
- **Falsificação versionada, controle verde na mesma invocação** (baseline do `mutcheck`), rodada em `LC_ALL=C` **e** `pt_BR.UTF-8`:
  - `pendencias-deploy-allowlist-ref.mut`: **18/18** pegas, 0 sobreviventes, 0 inválidas;
  - `pendencias-deploy-allowlist-e2e.mut`: **3/3** (fetch pulado · `main()` entrega o disco como ref · `ALLOWLIST_ILEGIVEL` engolido).
- `tsc -p tsconfig.scripts.json` e eslint: rc=0. Suíte dos 2 arquivos: 125/125 nos dois locales.

## Para o founder decidir (se discordar)

- No ramo `ALVO_SO_NO_WORKTREE` segui a regra 2 do brief ao pé da letra: disco e ref divergem → **não** imprime o `UPDATE`. A alternativa, "a main é a autoridade", é uma linha em `mecanicaDosIntrusos`.
- O teto do `mutation-check` (15 → 25 min) é mudança de CI. O job não é required; subir o teto só evita o cancelamento que apaga o sinal.

## Follow-ups (fora deste PR)

- `scripts/sonda-versao-sql.ts` lê a mesma allowlist do disco no `guardEfeitoLegado`. Lá é **fail-OPEN**: com o worktree atrasado, uma edge aprovada escapa da recusa do POST legado. Virou chip.
- **Sha fixado** (sugestão da sessão parceira): `origin/main` é ref compartilhada entre worktrees, e um fetch alheio entre as leituras (mapa, `versao.ts`, `git log`, allowlist) mistura duas mains no mesmo relatório. É pré-existente. Para o guard, ler uma main *mais nova* nunca é o lado perigoso.
- Fan-out do `mutation-check` por contrato, como o `validate` no #2346.

Registro: `docs/historico/sonda-le-worktree-defasado.md` §"Recorrência (2026-09-10)".

## Chip não clicado no fecho — prompt durável

Chip **"Fatiar o mutation-check do CI por contrato"** (sessão silly-sutherland-94f981). O chip morre com a sessão arquivada; o texto abaixo é o destino durável.

> Repo Afiação. O job `mutation-check` de `.github/workflows/ci.yml` roda `bun run mutcheck` (= `bash scripts/mutcheck-all.sh`), que executa TODOS os contratos `scripts/mutcheck.d/*.mut` em SÉRIE, a cada PR. O custo cresce um contrato por PR, e o job não é required.
>
> **Medição (2026-09-10):** duração do job nos 6 PRs anteriores ao #2464 entre 531s e 873s (o #2462 ficou a 27s do corte de 15 min). No #2464 o passo dos contratos foi CANCELADO aos 14m40s, já no último contrato (`valor-helpers`); o contrato novo custou só 44s. Quem pesa é `scripts/mutcheck.d/sonda-versao-sql.mut` (103 mutações, 7m26s, quase metade do job). Paliativo aplicado no #2464: `timeout-minutes` 15 → 25.
>
> **O que fazer:** (1) antes, `git fetch && git log origin/main -- .github/workflows/ci.yml scripts/mutcheck-all.sh` e `gh pr list`, porque o `ci.yml` é arquivo QUENTE; (2) fan-out por contrato em matriz ou N fatias estáveis, com o precedente do `validate` no #2346, e considere isolar o `sonda-versao-sql.mut`; (3) preserve o selftest, o `MUTCHECK_RESUMO`, os passos da Issue `mutcheck-cobertura` (agregue antes de decidir) e a prova por consumidor; (4) `cancelled` NUNCA vira verde, reuse o agregador do `ci.yml`; (5) prove executando, com uma fatia sabotada vermelha e controle verde no mesmo run, sem tornar o job required. Responda ao founder em português brasileiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
