### PR TITLE
fix(deploy-verify): dois caminhos para um exit 5 falso — alias sem ./ no vite.config e carimbo duplicado no entry

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -1046,8 +1046,8 @@ inalcançável, e a transição que conta é a do `ar=` (e do entry). Detalhe em
 ✅ **SHA atrás ≠ bundle atrás — o monitor PROVA o delta antes de pedir Publish (2026-09-10).** O caso
 acima (ar `eee71c80`, delta sem `src/`) agora sai **exit 5 `SINCRONIZADO_EM_BUNDLE`**. Só rebaixa se
 TODO elo responder positivamente — senão fica `ATRASADO` com a marca do elo em `motivo:`:
-fetch ok (`FETCH_FALHOU`) · o carimbo resolve e é **ancestral** da main (`CARIMBO_NAO_RESOLVE`,
-`NAO_ANCESTRAL`) · `git diff --no-renames` sai 0 e não vazio (`DIFF_FALHOU`, `DELTA_VAZIO`) · todo arquivo
+fetch ok (`FETCH_FALHOU`) · o entry tem UM carimbo só e ele resolve e é **ancestral** da main
+(`CARIMBO_AMBIGUO`, `CARIMBO_NAO_RESOLVE`, `NAO_ANCESTRAL`) · `git diff --no-renames` sai 0 e não vazio (`DIFF_FALHOU`, `DELTA_VAZIO`) · todo arquivo
 é INERTE na tabela de `classify.sh --bundle` (`ALCANCA_BUNDLE`, `SEM_CLASSIFICACAO`) ·
 [`scripts/alcance-bundle.py`](scripts/alcance-bundle.py) prova na main que nada do bundle importa de fora
 da tabela, que o build é `vite build` puro e que o `package.json` só mudou em scripts fora do pipeline
@@ -1251,4 +1251,16 @@ de que um Publish aconteceu continua sendo a mudança do `ar=`/entry, não a tra
   imports/refs de caminho por regex (relativo, `@/`, `/public`, glob, `new URL` relativo, `url()` de
   CSS, strings `./` dos configs de build); leitura por nome COMPUTADO (`readFileSync(dir + x)`) no
   `vite.config` escaparia — hoje o config não lê arquivo nenhum.
+- [x] **Dois caminhos para um exit 5 FALSO, fechados no mesmo dia (2026-09-10, pós-#2465).** A 2ª
+  opinião do Codex (`challenge` só sobre "exit 5 falso") voltou **exit 75 — cota esgotada**, plano
+  declarado no token `prolite`; consult não-money-path ⇒ adiado, e o intervalo coberto pelo
+  **Caminho B** (auto-challenge nos mesmos eixos). **REVISÃO INDEPENDENTE PENDENTE**: rodar o mesmo
+  prompt quando a cota voltar. O auto-challenge achou dois furos, e a sabotagem de cada conserto
+  devolve exatamente o exit 5 indevido — prova de que eram alcançáveis: **(1)** o fechamento só lia
+  strings `./` dos configs, e `"@edge": path.resolve(__dirname, "supabase/functions/_shared")`
+  passava (o import `@edge/x` parece pacote para quem só lê `src/`) — agora string sem `./` num config
+  conta quando NOMEIA caminho existente, o que cobre alias, `publicDir`, `envDir` e `root`, sem recusa
+  falsa no repo real; **(2)** o carimbo era "o primeiro" `__BUILD_SHA__="<hex>"` do entry, e um
+  literal desses no código viraria o SHA do ar — mais de um distinto ⇒ `CARIMBO_AMBIGUO`. Rede: 24
+  cenários, 17 sabotagens, 34 controles verdes nos 2 locales.
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/evals/monitor-deploy-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/monitor-deploy-eval.sh
@@ -40,7 +40,8 @@ cat > "$TMP/bin/curl" <<'FAKE'
 #!/usr/bin/env bash
 url=""; for a in "$@"; do url="$a"; done
 case "$url" in
-  */assets/index-*.js) printf 'var a=1;window.__BUILD_SHA__="%s";\n' "${FAKE_AR_SHA:?}" ;;
+  */assets/index-*.js) printf 'var a=1;window.__BUILD_SHA__="%s";\n' "${FAKE_AR_SHA:?}"
+                       [ -z "${FAKE_AR_SHA2:-}" ] || printf "var b='__BUILD_SHA__=\"%s\"';\n" "$FAKE_AR_SHA2" ;;
   */) printf '<html><script type="module" src="/assets/index-Fx1234.js"></script></html>\n' ;;
   *) exit 22 ;;
 esac
@@ -126,11 +127,18 @@ parte_de "$BASE"
 escreve package.json "$(pkg '' 18.3.1 'vite build && node scripts/gera.js')"; escreve scripts/gera.js 'console.log(1)'
 SUJO_BASE=$(commit build-sujo-base)
 escreve scripts/gera.js 'console.log(2)'; SUJO=$(commit build-sujo)
+# alias SEM `./` apontando para pasta inerte: o import `@edge/janela` parece pacote para quem só lê
+# src/ — o caminho está na string do vite.config (achado do auto-challenge, Caminho B, 2026-09-10)
+parte_de "$BASE"
+escreve vite.config.ts 'import path from "path"; export default { resolve: { alias: { "@": path.resolve(__dirname, "./src"), "@edge": path.resolve(__dirname, "supabase/functions/_shared") } } };'
+escreve src/lib/usa-alias.ts 'import { j } from "@edge/janela"; export const a = j;'
+ALIAS_BASE=$(commit alias-base)
+escreve supabase/functions/_shared/janela.ts 'export const j = 4;'; ALIAS=$(commit alias)
 g branch deadbee1 "$BASE"   # ref com cara de SHA: `deadbee1^{commit}` resolve o BRANCH
 if ! { g remote add origin "$O" && g push -q origin 'refs/tags/*:refs/tags/*'; }; then
   echo "❌ push do fixture falhou"; exit 2
 fi
-for v in BASE SO_DOCS C2445 SRC PKG_DEPS PKG_SCRIPTS PKG_BUILD PKG_FMT LATERAL RENAME DESC EDGE VAZA_BASE VAZA SUJO_BASE SUJO; do
+for v in BASE SO_DOCS C2445 SRC PKG_DEPS PKG_SCRIPTS PKG_BUILD PKG_FMT LATERAL RENAME DESC EDGE VAZA_BASE VAZA SUJO_BASE SUJO ALIAS_BASE ALIAS; do
   val=${!v:-}
   [ "${#val}" -eq 40 ] || [ "${#val}" -eq 64 ] || { echo "❌ fixture incompleto: $v='$val'"; exit 2; }
 done
@@ -160,6 +168,8 @@ cenario() {
     fetch_falhou)     echo "$BASE $SO_DOCS fetch_falhou" ;;
     carimbo_alheio)   echo "deadbee2 $SO_DOCS -" ;;
     carimbo_e_branch) echo "deadbee1 $SO_DOCS -" ;;
+    alias_inerte)     echo "$ALIAS_BASE $ALIAS -" ;;
+    carimbo_duplo)    echo "$BASE $SO_DOCS carimbo_duplo" ;;
   esac
 }
 
@@ -185,7 +195,9 @@ classify_mudo|3|motivo: CLASSIFY_FALHOU
 python_mudo|3|motivo: PROVA_INDISPONIVEL
 fetch_falhou|3|motivo: FETCH_FALHOU
 carimbo_alheio|3|motivo: CARIMBO_NAO_RESOLVE
-carimbo_e_branch|3|motivo: CARIMBO_NAO_RESOLVE'
+carimbo_e_branch|3|motivo: CARIMBO_NAO_RESOLVE
+alias_inerte|3|motivo: ALCANCE_VAZA
+carimbo_duplo|3|motivo: CARIMBO_AMBIGUO'
 
 esperado_de() { printf '%s\n' "$CASOS" | awk -F'|' -v c="$1" '$1 == c { print $2 "|" $3; achou = 1 } END { exit !achou }'; }
 
@@ -205,6 +217,7 @@ roda() {
     git_mudo)      caminho="$TMP/bin-git:$caminho"; envs+=(GIT_DIFF_MODO=mudo) ;;
     python_mudo)   caminho="$TMP/bin-py:$caminho" ;;
     classify_mudo) envs+=(DEPLOY_MONITOR_CLASSIFY="$TMP/classify-mudo.sh") ;;
+    carimbo_duplo) envs+=(FAKE_AR_SHA2="${SRC:0:8}") ;;   # 1º carimbo = BASE (delta só docs)
     fetch_falhou)  g remote set-url origin "$TMP/origem-que-nao-existe.git"
                    g update-ref refs/remotes/origin/main "$main" ;;
   esac
@@ -292,7 +305,7 @@ while IFS='|' read -r nome esp marca; do
   fi
 done <<< "$CASOS"
 echo "$n_ok/$n_tot cenários passaram"
-[ "$n_tot" -ge 22 ] || { echo "  [XX ] só $n_tot cenário(s) rodaram — a rede encolheu"; rc=1; }
+[ "$n_tot" -ge 24 ] || { echo "  [XX ] só $n_tot cenário(s) rodaram — a rede encolheu"; rc=1; }
 
 # ── falsificação ────────────────────────────────────────────────────────────────────────────────
 if [ "$FALSIFY" = 1 ]; then
@@ -372,6 +385,10 @@ PY
     # helper em __tests__/ (padrão real do repo) vira "vazamento" — o cenário verde fica vermelho
     sab teste-fora-do-bundle scripts/alcance-bundle.py edge_so_teste '3|motivo: ALCANCE_VAZA' \
       'and not RE_TESTE.search(p)' 'and True'
+    sab nome-no-config scripts/alcance-bundle.py alias_inerte "$VERDE_INDEVIDO" \
+      '        return nome_no_config(spec, uniao, dirs_uniao)' '        return None'
+    sab carimbo-ambiguo scripts/monitor-deploy.sh carimbo_duplo "$VERDE_INDEVIDO" \
+      '[ "${N_CARIMBOS:-0}" -le 1 ] || atrasado CARIMBO_AMBIGUO' '[ "${N_CARIMBOS:-0}" -ge 0 ] || atrasado CARIMBO_AMBIGUO'
   }
 
   # (A) CONTROLE — a mesma invocação do laço (espelho, cenário, locale), sabotagem trocada por
@@ -437,7 +454,7 @@ PY
     fi
   done
   echo "  falsificações que pegaram: $fals/$total"
-  [ "$total" -ge 15 ] && [ "$fals" -eq "$total" ] || rc=1
+  [ "$total" -ge 17 ] && [ "$fals" -eq "$total" ] || rc=1
 
   # (C) CONTROLE DE SAÍDA — pelo CONTEÚDO: o laço nunca mutou o versionado.
   # shellcheck disable=SC2086

--- a/.claude/skills/lovable-deploy-verify/scripts/alcance-bundle.py
+++ b/.claude/skills/lovable-deploy-verify/scripts/alcance-bundle.py
@@ -170,24 +170,46 @@ def ler_blobs(ref, paths):
 
 
 def specs_de(path, texto):
-    """(spec, só_relativo) de toda string que o arquivo usa como CAMINHO. Comentário entra de
-    propósito: varrer a mais só segura o alarme; limpar comentário com regex local é o que cega
-    gate textual (docs/historico/gates-textuais-cegos.md)."""
-    specs = [(m.group(2), False) for m in RE_IMPORT.finditer(texto)]
-    specs += [(m.group(2), True) for m in RE_URL.finditer(texto)]
+    """(spec, modo) de toda string que o arquivo usa como CAMINHO. Comentário entra de propósito:
+    varrer a mais só segura o alarme; limpar comentário com regex local é o que cega gate textual
+    (docs/historico/gates-textuais-cegos.md). modo: "qualquer" (import/glob/CSS/HTML), "relativo"
+    (só `./`/`../` contam) ou "config" (config de build: ver alvo_de)."""
+    specs = [(m.group(2), "qualquer") for m in RE_IMPORT.finditer(texto)]
+    specs += [(m.group(2), "relativo") for m in RE_URL.finditer(texto)]
     for m in RE_GLOB.finditer(texto):
-        specs += [(s.group(2).lstrip("!"), False) for s in RE_STR.finditer(m.group(1))]
+        specs += [(s.group(2).lstrip("!"), "qualquer") for s in RE_STR.finditer(m.group(1))]
     if path.endswith(".css"):
-        specs += [(m.group(2), False) for m in RE_CSS.finditer(texto)]
+        specs += [(m.group(2), "qualquer") for m in RE_CSS.finditer(texto)]
     if path.endswith(".html"):
-        specs += [(m.group(2), False) for m in RE_HTML.finditer(texto)]
+        specs += [(m.group(2), "qualquer") for m in RE_HTML.finditer(texto)]
     if "/" not in path and RE_CONFIG_RAIZ.fullmatch(path):
-        # config de build: TODA string relativa conta (alias, content do Tailwind, readFileSync).
-        specs += [(m.group(2), True) for m in RE_STR.finditer(texto)]
+        # config de build: TODA string conta (alias, content do Tailwind, publicDir, readFileSync).
+        specs += [(m.group(2), "config") for m in RE_STR.finditer(texto)]
     return specs
 
 
-def alvo_de(arq, spec, so_relativo, uniao, dirs_uniao):
+def nome_no_config(spec, uniao, dirs_uniao):
+    """String SEM `./` num config de build: vale se NOMEIA caminho que existe na raiz. É assim que
+    `path.resolve(__dirname, "supabase/functions/_shared")` vira alias, publicDir, envDir ou root
+    fora de src/ — e o import `@edge/x` que ele habilita parece PACOTE para quem lê só o src/.
+    Glob vale pelo diretório estático (`"docs/**/*.md"` → docs/); `"**/*.js"` do Workbox (relativo
+    ao dist) não nomeia nada e passa."""
+    if spec.startswith(("/", "@")) or spec in (".", ".."):
+        return None
+    curinga = re.search(r"[*{\[]", spec)
+    nome = spec[:curinga.start()] if curinga else spec
+    nome = (nome[:nome.rfind("/")] if "/" in nome else "") if curinga else nome.rstrip("/")
+    if not nome:
+        return None
+    nome = posixpath.normpath(nome)
+    if nome == "." or nome.startswith(".."):
+        return None
+    if curinga:
+        return nome + "/" if nome in dirs_uniao else None
+    return nome if (nome in uniao or nome in dirs_uniao) else None
+
+
+def alvo_de(arq, spec, modo, uniao, dirs_uniao):
     """Caminho (relativo à raiz) que `spec` referencia a partir de `arq`, ou None se não é arquivo
     do repo. Prefixo de glob volta terminado em "/". `uniao` = árvores do ar E da main: arquivo
     apagado no delta ainda é referência do bundle que o ar serve."""
@@ -195,7 +217,9 @@ def alvo_de(arq, spec, so_relativo, uniao, dirs_uniao):
     if not spec or spec.startswith("//") or re.match(r"[A-Za-z][A-Za-z0-9+.-]*:", spec):
         return None                          # http:, data:, virtual:, node:, protocolo-relativo
     relativo = spec in (".", "..") or spec.startswith(("./", "../"))
-    if so_relativo and not relativo:
+    if modo == "config" and not relativo:
+        return nome_no_config(spec, uniao, dirs_uniao)
+    if modo == "relativo" and not relativo:
         return None
     if spec.startswith("@/"):
         base = "src/" + spec[2:]
@@ -258,8 +282,8 @@ def provar_fechamento(ar, main, classify):
     conteudo = ler_blobs(main, varridos + links_bundle)
     refs = []
     for p in varridos:
-        for spec, so_relativo in specs_de(p, conteudo[p]):
-            alvo = alvo_de(p, spec, so_relativo, uniao, dirs_uniao)
+        for spec, modo in specs_de(p, conteudo[p]):
+            alvo = alvo_de(p, spec, modo, uniao, dirs_uniao)
             if alvo is not None:
                 refs.append((p, alvo))
     for p in links_bundle:                   # symlink no bundle: o build lê o ALVO

--- a/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
@@ -30,7 +30,7 @@
 #        4 = deploy novo detectado mas versão indeterminada (sem carimbo nem sentinela)
 #        2 = site fora do ar / HTML mudou de forma
 # Marcas do motivo (exit 3): ALCANCA_BUNDLE · SEM_CLASSIFICACAO · PACKAGE_JSON_ALCANCA ·
-#   BUILD_NAO_RECONHECIDO · ALCANCE_VAZA · NAO_ANCESTRAL · CARIMBO_NAO_RESOLVE · FETCH_FALHOU ·
+#   BUILD_NAO_RECONHECIDO · ALCANCE_VAZA · NAO_ANCESTRAL · CARIMBO_NAO_RESOLVE · CARIMBO_AMBIGUO · FETCH_FALHOU ·
 #   GIT_FALHOU · DIFF_FALHOU · DELTA_VAZIO · CLASSIFY_FALHOU · PROVA_INDISPONIVEL
 # Estado: último hash de entry visto em $DEPLOY_MONITOR_STATE
 #         (default ~/.config/afiacao/deploy-monitor.state) — pra detectar "mudou desde a última vez".
@@ -62,6 +62,9 @@ if [ "$PREV" != "$ENTRY_HASH" ]; then DEPLOY="SIM (${PREV:-1a-vez} -> $ENTRY_HAS
 
 BODY=$(curl -fsS "$APP$ENTRY" 2>/dev/null || echo "")
 AIR_SHA=$(printf '%s' "$BODY" | grep -oE '__BUILD_SHA__="[0-9a-f]{7,8}"' | grep -oE '[0-9a-f]{7,8}' | head -1)
+# Carimbos DISTINTOS no entry: com mais de um, "o primeiro" é arbitrário — um literal
+# `__BUILD_SHA__="<hex>"` qualquer no código viraria o SHA do ar (medido 2026-09-10: 1 no ar, 0 em src/).
+N_CARIMBOS=$(printf '%s' "$BODY" | grep -oE '__BUILD_SHA__="[0-9a-f]{7,8}"' | sort -u | awk 'END { print NR }')
 IS_DEV=$(printf '%s' "$BODY" | grep -cE '__BUILD_SHA__="dev"' || true)
 
 echo "[$TS] main=$MAIN_SHA  ar=${AIR_SHA:-$([ "${IS_DEV:-0}" -gt 0 ] && echo dev || echo sem-carimbo)}  deploy-novo=$DEPLOY"
@@ -151,7 +154,8 @@ analisar_delta() {
   exit 5
 }
 
-# Caminho determinístico: carimbo de SHA real no ar
+# Caminho determinístico: carimbo de SHA real no ar — e UM só (ambíguo não pode virar verde nenhum)
+[ "${N_CARIMBOS:-0}" -le 1 ] || atrasado CARIMBO_AMBIGUO "o entry tem $N_CARIMBOS carimbos __BUILD_SHA__ distintos — não dá para saber qual commit o ar serve"
 if [ -n "$AIR_SHA" ]; then
   if [ "$AIR_SHA" = "$MAIN_SHA" ]; then echo "  ✅ sincronizado: ar serve $AIR_SHA == origin/main"; exit 0; fi
   analisar_delta


### PR DESCRIPTION
Seguimento do #2465. **REVISÃO INDEPENDENTE PENDENTE**: a 2ª opinião do Codex (`challenge` restrito a "exit 5 falso") voltou com **exit 75, cota esgotada**; o plano declarado no token é `prolite`. Como não é money-path, o consult fica adiado, e este PR cobre o intervalo pelo **Caminho B** (auto-challenge nos mesmos eixos). O mesmo prompt deve rodar quando a cota voltar.

## Dois caminhos para um exit 5 FALSO
1. **Alias sem `./` no `vite.config`.** O fechamento só lia strings `./` dos configs de build. Com `"@edge": path.resolve(__dirname, "supabase/functions/_shared")`, o import `@edge/janela` parece **pacote** para quem só lê `src/`, e um delta só na edge dava exit 5 com o bundle mudando. Agora uma string sem `./` num config conta como referência quando **nomeia** um caminho existente (arquivo, pasta ou diretório estático de um glob). Isso cobre alias, `publicDir`, `envDir` e `root`. No repo real continua **0 vazamento**: as referências dos configs são `./src` e os globs de `content` do Tailwind, e o `**/*.js` do Workbox não nomeia nada.
2. **Carimbo duplicado no entry.** O SHA do ar era o *primeiro* `__BUILD_SHA__="<hex>"` do entry, então um literal desses no código viraria o SHA do ar. Com mais de um carimbo distinto, o monitor dá `CARIMBO_AMBIGUO` (exit 3) antes de qualquer verde. Medido: 1 carimbo no ar, 0 literais em `src/`.

## Evidência
- `evals/monitor-deploy-eval.sh`: **24/24** cenários (+`alias_inerte`, +`carimbo_duplo`). O `--falsify` pegou **17/17**, com **34 controles verdes** antes, nos 2 locales. As duas sabotagens novas devolvem exatamente o `SINCRONIZADO_EM_BUNDLE` indevido, o que prova que os furos eram alcançáveis e estão fechados.
- Produção agora: ar `70fc305f`, main `fd29d1bf` (4 commits, 18 arquivos, nenhum no bundle) → **exit 5**.
- shellcheck 0.11.0 limpo; `docs:links` verde.

Só `.claude/skills/**`: não há Publish, edge nem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
