### PR TITLE
fix(sonda): a allowlist do cron é comportamento do relé — e o `sonda:bump` não a via por morar em `_shared/` [money-path]

### DIFF
--- a/docs/historico/sonda-marcador-congelado.md
+++ b/docs/historico/sonda-marcador-congelado.md
@@ -612,3 +612,73 @@ coberto nem por este gate nem pelo fingerprint. O desenho que fecha é o da `gen
 — servir o marcador da canária no campo `versao`, o mesmo símbolo da sonda, e herdar os dois
 mecanismos de graça. Este gate cobre a disciplina do marcador na janela do PR; ele não substitui
 isso.
+
+## O congelamento que o gate não via: a fatia do relé morava em `_shared/` (2026-09-10)
+
+**O que aconteceu.** O `sonda-relay` importa a allowlist `_shared/sonda-cron-alvos.ts`, e o que ele
+faz em runtime é função do conjunto de slugs dela (`slugsDaAllowlist()`). As ondas 2 a 5 da
+allowlist (`89887025b`, `d96b69f06`, `a73641e9c`, `f4578bbff`) mudaram esse conjunto; o `fonte` do
+relé mudou em todas, o `versao.ts` em nenhuma, e o `sonda:bump` passou verde — `_shared/` fica fora
+dele. O ledger de prod registra quatro `fonte` servidos sob o mesmo `v1.1-alvos-da-onda-1` (`d01c`,
+`a92f`, `b736`, `0c4d`). A onda 1 tinha bumpado por conta própria (`v1.0` → `v1.1`), e o PR da onda
+5 listou o relé À MÃO na tabela de deploy: o humano via o fingerprint, não o marcador.
+
+**Desenho ou descuido?** A exclusão de `_shared/` é desenho, medido em 2026-08-25 contra helpers
+COMPARTILHADOS, e continua certa para eles. A allowlist nasceu doze dias depois, fora da população
+medida, e nenhuma das duas premissas vale para ela: um consumidor só, e toda mudança desde o
+nascimento foi comportamento do relé. O descuido foi não reabrir a exclusão quando nasceu em
+`_shared/` um arquivo de dono único cujo conteúdo é comportamento.
+
+**Não era só o marcador humano.** O `pendencias:deploy` escolhe a FILA pelo `VERSAO`: `fonte` novo
+com `VERSAO` igual é DIVERGE_P2 (leva agrupada, só escala após 7 dias). Mas relé sem deploy responde
+`fora-da-allowlist` às alvos novas — o pré-requisito da onda ia para a fila opcional. Falha aberta
+não era: o par `(versao, fonte)` acusa a divergência de bundle; o que errava era a prioridade.
+
+**A medição que escolheu o conserto** — as 682 fatias first-parent da `main` desde o 1º
+`versao.ts` (`02fdad342`..`70fc305f3`), com a `fecharGrafo` do fingerprint sobre a árvore de cada
+fatia. Calibrada contra o `sonda:fanout`: reproduz os `SEM_BUMP=18` do #2132.
+
+| régua | cobranças sem bump | fatias | leitura |
+|---|---|---|---|
+| grafo completo (fecho inteiro, `_shared/` incluso) | 135 | 22 | picos de 32, 23, 18 e 16 numa fatia: a exclusão fica de pé |
+| estrutural, "UM consumidor **instrumentado**" | 5 | 5 | uma FALSA: no `f6ac6055a` a `leitura-critica.ts` ganhou `exigirLista` para a `recommend` (ainda sem `versao.ts`); nada que a `fin-cashflow-engine` chamava mudou |
+| estrutural, "UM consumidor entre **todas** as edges" | 4 | 4 | 4 de 4 — empata com o par |
+| par explícito `sonda-relay` × allowlist | 4 | 4 | 4 de 4 — as ondas 2 a 5 |
+
+**Por que o par, se a estrutural por todas as edges empatou.** Ela compara o arquivo inteiro, e a
+allowlist precisa de projeção (abaixo); e poria o fecho das ~100 edges dentro do gate, com veredito
+que muda quando OUTRO PR passa a importar o arquivo. Os outros arquivos de dono único mudaram 3
+vezes na janela, nenhuma sem bump — são lógica de UMA edge extraída para teste, e quem os muda
+percebe que está mudando a edge. A allowlist parece DADO sobre as alvos, não código do relé: é
+isso que a fez escapar quatro vezes.
+
+**O conserto.** `FATIAS_EM_SHARED` no gate: `(edge, arquivo, projeção)`. A projeção do relé é o
+conjunto de slugs — a allowlist também carrega `controles`/`desde`/`nota`, que só a prova lê, e
+mudar só isso segue DIVERGE_P2 honesto em vez de cobrar bump. O `contaComoCorpo` ficou intacto: os
+gates irmãos (`canaria:bump`, `sonda-edge-nova`) o importam com o sentido "está na pasta da edge".
+Gate velho × novo, fatia a fatia nas mesmas 682: **678 veredictos iguais, 4 divergentes =
+exatamente as ondas 2 a 5**. As 7 em que os dois reprovam são todas pré-gate (o #1938 entre elas).
+
+**Os dentes.** No `.test.ts`: a CALIBRAÇÃO da projeção contra o `slugsDaAllowlist()` do arquivo real
+(pega sobre- e sub-limpeza — a allowlist carrega candidatas comentadas); duas PREMISSAS — o arquivo
+está no fecho da edge dona (pega a declaração órfã, que não reprovaria ninguém) e, no fecho do
+relé, a allowlist só é lida por `slugsDaAllowlist` (se o relé passar a ler `controles`, a projeção
+fica estreita); e as 4 fatias REAIS com controle na onda 1, casando a lista inteira de achados. No
+`.mut`: 6 mutações novas, cada uma desfazendo uma peça — 14/14 PEGA, em `LC_ALL=C` e em
+`pt_BR.UTF-8`.
+
+**O relé NÃO foi bumpado neste conserto — e o porquê é um dado de prod.** O marcador segue dizendo
+`v1.1-alvos-da-onda-1`, e isso é falso. Mas às 23:14 UTC de 09-10 o relé foi deployado com a
+allowlist da onda 5: prod serve `(v1.1-alvos-da-onda-1, 6ca1)`, o par da `main` — CONFERE. Bumpar
+agora viraria DIVERGE_P1 e um deploy só para trocar a string, logo depois de um deploy: o
+redundante que o ledger existe para evitar. O marcador fica velho até a próxima mudança de alvos —
+e essa o gate agora obriga a bumpar.
+
+**Revisão independente PENDENTE.** O challenge do Codex (`gpt-6-astra`, `max`) voltou
+`COTA_ESGOTADA` com o plano do token = o assinado ⇒ Caminho B: auto-challenge (ele achou a 2ª
+premissa acima, que faltava) + falsificação. Rodar o Codex retroativo quando a cota voltar.
+
+**O que continua aberto.** Os outros 20 arquivos de dono único de `_shared/` não estão na lista. Se
+um escapar, o próximo passo medido é a estrutural por todas as edges (4 de 4 na janela), mantendo a
+projeção para as fatias declaradas. Quem mostra o candidato no PR já existe: o `sonda:fanout` lista
+o arquivo com UMA consumidora e `SEM_BUMP`.

--- a/scripts/mutcheck.d/sonda-versao-bump-gate.mut
+++ b/scripts/mutcheck.d/sonda-versao-bump-gate.mut
@@ -19,3 +19,13 @@ PEGA      | nada mais conta como corpo servido         | s/const EXT_CORPO = \['
 PEGA      | fronteira de string, nao de segmento       | s/if \(!caminho\.startsWith\(prefixo\)\) return false;/if (!caminho.startsWith(prefixo.slice(0, -1))) return false;/
 PEGA      | comentario passa a pedir bump (ruido)      | s/return removerComentarios\(fonte\)/return (fonte)/
 SOBREVIVE | largura do sha no texto do OK (cosmetico)  | s/base\.slice\(0, 9\)/base.slice(0, 7)/
+#
+# FATIAS_EM_SHARED (2026-09-10): a allowlist do cron é o comportamento do `sonda-relay`, e as ondas
+# 2 a 5 passaram com o marcador congelado porque `_shared/` inteiro ficava fora. Cada mutação abaixo
+# desfaz UMA peça do conserto; a suíte tem de nomear a peça (testes sintéticos + as 4 fatias REAIS).
+PEGA      | fatia em _shared volta a ser ignorada      | s/if \(declaradas\.length > 0\) \{/if (declaradas.length > 999) {/
+PEGA      | nucleo esquece a fatia declarada           | s/contaComoCorpo\(a\.caminho, e\.edge\) \|\| fatiaEmShared\(a\.caminho, e\.edge\) !== undefined/contaComoCorpo(a.caminho, e.edge)/
+PEGA      | fatia vale para QUALQUER edge              | s/f\.arquivo === caminho && f\.edge === edge/f.arquivo === caminho/
+PEGA      | arquivo inteiro no lugar da projecao       | s/return fatia \? fatia\.projetar\(fonte\) : normalizarFonte\(fonte\);/return normalizarFonte(fonte);/
+PEGA      | projecao cega (verde por cegueira)         | s/return \[\.\.\.slugs\]\.sort\(\)\.join\('\\n'\);/return '';/
+PEGA      | projecao sem stripper (sub-limpeza)        | s/removerComentarios\(fonte\)\.matchAll/fonte.matchAll/

--- a/scripts/sonda-versao-bump-gate.test.ts
+++ b/scripts/sonda-versao-bump-gate.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+import { slugsDaAllowlist } from '../supabase/functions/_shared/sonda-cron-alvos';
+import { fecharGrafo } from './sonda-fingerprint';
 import {
   auditarBump,
   coletarEstado,
   contaComoCorpo,
   extrairVersao,
+  FATIAS_EM_SHARED,
   main,
   montarEstado,
   normalizarFonte,
+  projetarAlvosDoRele,
   type EstadoEdge,
 } from './sonda-versao-bump-gate';
 
@@ -249,5 +255,160 @@ describe('main — fail-CLOSED de verdade: lista vazia por ERRO não é lista va
 
   it('controle: o MESMO par com --head válido mede e passa', () => {
     expect(main(['--base', 'HEAD', '--head', 'HEAD'])).toBe(0);
+  });
+});
+
+// ─── A fatia de UMA edge que mora em `_shared/`: a allowlist do cron é o comportamento do relé ───
+
+const ALLOWLIST = 'supabase/functions/_shared/sonda-cron-alvos.ts';
+const MARCADOR_RELE = 'supabase/functions/sonda-relay/versao.ts';
+
+/** Fonte mínima com a FORMA da allowlist real: tipo, controle nomeado, entradas, função de slugs. */
+function allowlist(slugs: string[], opcoes: { extra?: string; corpoControle?: string } = {}): string {
+  return [
+    'type AlvoSondaCron = { edge: string; desde: string | null; controles: readonly unknown[] };',
+    `const CRON = { metodo: "POST", headers: {}, corpo: ${JSON.stringify(opcoes.corpoControle ?? '{}')}, nota: "x" };`,
+    opcoes.extra ?? '',
+    'export const SONDA_CRON_ALVOS: readonly AlvoSondaCron[] = [',
+    ...slugs.map((s) => `  { edge: "${s}", desde: null, controles: [CRON] },`),
+    '];',
+    'export function slugsDaAllowlist() { return new Set(SONDA_CRON_ALVOS.map((a) => a.edge)); }',
+  ].join('\n');
+}
+
+describe('projetarAlvosDoRele — o pedaço da allowlist que o relé LÊ em runtime', () => {
+  it('é o conjunto de slugs, sem ordem', () => {
+    expect(projetarAlvosDoRele(allowlist(['b', 'a']))).toBe(projetarAlvosDoRele(allowlist(['a', 'b'])));
+    expect(projetarAlvosDoRele(allowlist(['a', 'b']))).not.toBe(projetarAlvosDoRele(allowlist(['a'])));
+  });
+
+  it('SUB-limpeza: candidata COMENTADA não é alvo (a allowlist real carrega candidatas em comentário)', () => {
+    const comCandidatas = allowlist(['a'], {
+      extra: '// { edge: "candidata-de-linha", desde: null, controles: [] },\n/* { edge: "candidata-de-bloco" } */',
+    });
+    expect(projetarAlvosDoRele(comCandidatas)).toBe(projetarAlvosDoRele(allowlist(['a'])));
+  });
+
+  it('mudar só `controles` NÃO muda a projeção — é dado da PROVA, não do relé', () => {
+    expect(projetarAlvosDoRele(allowlist(['a'], { corpoControle: '{"action":"reprocess_all"}' })))
+      .toBe(projetarAlvosDoRele(allowlist(['a'])));
+  });
+
+  it('CALIBRAÇÃO contra o runtime: no arquivo REAL, a projeção é exatamente `slugsDaAllowlist()`', () => {
+    // O eixo POR FORA da regex: se alguém reestruturar a allowlist (constante no lugar do literal,
+    // entrada montada por função), a projeção fica cega e este teste é quem denuncia — sem ele, a
+    // fatia voltaria a passar sem bump com o gate verde.
+    const esperado = [...slugsDaAllowlist()].sort();
+    expect(esperado.length).toBeGreaterThan(1);
+    expect(projetarAlvosDoRele(readFileSync(ALLOWLIST, 'utf8')).split('\n')).toEqual(esperado);
+  });
+});
+
+describe('FATIAS_EM_SHARED — a declaração confere com o repo', () => {
+  it('declara a allowlist do cron como fatia do relé', () => {
+    expect(FATIAS_EM_SHARED.map((f) => [f.edge, f.arquivo])).toContainEqual(['sonda-relay', ALLOWLIST]);
+  });
+
+  it('PREMISSA: cada arquivo declarado está no FECHO da edge dona (a MESMA `fecharGrafo` do `fonte`)', () => {
+    // Pega a declaração órfã: arquivo renomeado, typo no caminho, ou a edge que parou de importá-lo.
+    // Órfã não reprova ninguém — o par simplesmente nunca mais casa e o gate volta a ser cego.
+    for (const f of FATIAS_EM_SHARED) {
+      expect(fecharGrafo(`supabase/functions/${f.edge}/index.ts`)).toContain(f.arquivo);
+    }
+  });
+
+  it('PREMISSA da projeção: no fecho do relé, a allowlist só é lida por `slugsDaAllowlist`', () => {
+    // A projeção compara SÓ o conjunto de slugs. Se o relé (ou um módulo do fecho dele) passar a
+    // ler `SONDA_CRON_ALVOS` — `controles`, `desde` —, mudança nesses campos vira comportamento do
+    // relé que a projeção não enxerga, e o gate fica verde por cegueira. Este teste é quem avisa
+    // que a projeção precisa crescer junto.
+    const importadores = fecharGrafo('supabase/functions/sonda-relay/index.ts')
+      .filter((a) => a !== ALLOWLIST)
+      .map((a) => ({ a, fonte: removerComentarios(readFileSync(a, 'utf8')) }))
+      .filter(({ fonte }) => /sonda-cron-alvos\.ts["']/.test(fonte));
+    expect(importadores.map((i) => i.a)).toEqual(['supabase/functions/sonda-relay/index.ts']);
+    const nomes = importadores[0].fonte
+      .match(/import\s*\{([^}]*)\}\s*from\s*["'][^"']*sonda-cron-alvos\.ts["']/)?.[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+    expect(nomes).toEqual(['slugsDaAllowlist']);
+  });
+});
+
+describe('auditarBump — a fatia declarada entra no corpo da edge DONA', () => {
+  const rele = (base: string | null, head: string | null, versaoHead = 'v1.1-alvos-da-onda-1') =>
+    estado({
+      edge: 'sonda-relay',
+      versaoBase: 'v1.1-alvos-da-onda-1',
+      versaoHead,
+      corpo: [{ caminho: ALLOWLIST, base, head }],
+    });
+
+  it('onda que ACRESCENTA alvo sem bumpar o relé → REPROVA nomeando o relé e a allowlist', () => {
+    expect(auditarBump([rele(allowlist(['a']), allowlist(['a', 'b']))])).toEqual([
+      { edge: 'sonda-relay', versao: 'v1.1-alvos-da-onda-1', motivo: 'sem-bump', arquivos: [ALLOWLIST] },
+    ]);
+  });
+
+  it('a mesma onda COM bump do relé → passa', () => {
+    expect(auditarBump([rele(allowlist(['a']), allowlist(['a', 'b']), 'v1.2-alvos-da-onda-2')])).toEqual([]);
+  });
+
+  it('alvo REMOVIDO também é comportamento do relé → reprova', () => {
+    expect(auditarBump([rele(allowlist(['a', 'b']), allowlist(['a']))])).toHaveLength(1);
+  });
+
+  it('só `controles` mudou → passa: o `fonte` do relé muda (DIVERGE_P2 honesto), o comportamento não', () => {
+    expect(auditarBump([rele(allowlist(['a']), allowlist(['a'], { corpoControle: '{"x":1}' }))])).toEqual([]);
+  });
+
+  it('a fatia é de UMA edge: a allowlist no corpo de OUTRA edge não conta', () => {
+    expect(
+      auditarBump([
+        estado({ edge: 'recommend', corpo: [{ caminho: ALLOWLIST, base: allowlist(['a']), head: allowlist(['a', 'b']) }] }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe('montarEstado — a allowlist tocada vira estado do RELÉ; o resto de `_shared/` continua fora', () => {
+  const ler = (rev: string | null, caminho: string): string | null => {
+    if (caminho === MARCADOR_RELE) return 'export const VERSAO = "v1.1-alvos-da-onda-1";';
+    if (caminho === ALLOWLIST) return rev === 'BASE' ? allowlist(['a']) : allowlist(['a', 'b']);
+    if (caminho === 'supabase/functions/_shared/auth.ts') return rev === 'BASE' ? 'const a = 1;' : 'const a = 2;';
+    return null;
+  };
+
+  it('allowlist + helper comum tocados → só o relé vira estado, e reprova pela allowlist', () => {
+    const estados = montarEstado([ALLOWLIST, 'supabase/functions/_shared/auth.ts'], 'BASE', 'HEAD', ler);
+    expect(estados.map((e) => e.edge)).toEqual(['sonda-relay']);
+    expect(auditarBump(estados)).toEqual([
+      { edge: 'sonda-relay', versao: 'v1.1-alvos-da-onda-1', motivo: 'sem-bump', arquivos: [ALLOWLIST] },
+    ]);
+  });
+
+  it('controle: helper comum de `_shared/` sozinho continua FORA do gate (a exclusão medida fica de pé)', () => {
+    expect(montarEstado(['supabase/functions/_shared/auth.ts'], 'BASE', 'HEAD', ler)).toEqual([]);
+  });
+});
+
+describe('a história REAL — as ondas 2 a 5 passaram com o marcador do relé congelado', () => {
+  // Commits squash da `main`, imutáveis. O job `testes` do CI tem `fetch-depth: 0`; história rasa
+  // faz o `coletarEstado` LANÇAR (vermelho) — nunca devolver lista vazia (verde por acidente). E o
+  // assert casa a LISTA INTEIRA: prova também que nenhuma outra edge dessas fatias passa a reprovar.
+  const congelado = { edge: 'sonda-relay', versao: 'v1.1-alvos-da-onda-1', motivo: 'sem-bump', arquivos: [ALLOWLIST] };
+
+  it.each([
+    ['89887025b', 'onda 2 (#2388)'],
+    ['d96b69f06', 'onda 3 (#2404)'],
+    ['a73641e9c', 'onda 4 (#2415)'],
+    ['f4578bbff', 'onda 5 (#2461)'],
+  ])('%s — %s: reprova o relé, e só ele', (sha) => {
+    expect(auditarBump(coletarEstado(`${sha}^`, sha))).toEqual([congelado]);
+  });
+
+  it('controle: a onda 1 (54679dc35, #2313) BUMPOU o relé → nenhum achado', () => {
+    expect(auditarBump(coletarEstado('54679dc35^', '54679dc35'))).toEqual([]);
   });
 });

--- a/scripts/sonda-versao-bump-gate.ts
+++ b/scripts/sonda-versao-bump-gate.ts
@@ -56,6 +56,42 @@
  * O que cobre essa metade hoje é humano + o gate `nenhuma edge que serve o paginate.ts fica SEM
  * prova de deploy`, no `_shared/sonda-versao-contrato_test.ts`.
  *
+ * ## A exceção MEDIDA: arquivo de `_shared/` que É a fatia de UMA edge (`FATIAS_EM_SHARED`)
+ *
+ * A medição acima (2026-08-25) é de helpers COMPARTILHADOS. A allowlist do cron
+ * (`_shared/sonda-cron-alvos.ts`) nasceu em 2026-09-06, fora dessa população, e nenhuma das duas
+ * premissas vale para ela: tem UM consumidor (o `sonda-relay`, não ~12), e o conjunto de alvos É o
+ * que o relé aceita em runtime (`slugsDaAllowlist()`). As ondas 2 a 5 (`89887025b`, `d96b69f06`,
+ * `a73641e9c`, `f4578bbff`) mudaram esse conjunto sem bumpar o relé, e o ledger de prod registra
+ * quatro `fonte` servidos sob o mesmo `v1.1-alvos-da-onda-1`. A onda 1 tinha bumpado por conta
+ * própria: disciplina sem gate durou uma onda.
+ *
+ * O custo não é só o marcador humano. `pendencias:deploy` lê o `VERSAO` para escolher a FILA —
+ * `fonte` novo com `VERSAO` igual é DIVERGE_P2 (leva agrupada, só escala após 7 dias) —, e relé sem
+ * deploy responde `fora-da-allowlist` às alvos da onda: é comportamento declarado, P1 pela
+ * definição do próprio `scripts/lib/pendencias-deploy.ts`.
+ *
+ * Por que LISTA explícita, e não "todo `_shared/` com um consumidor" — medido nas 682 fatias da
+ * `main` desde o 1º `versao.ts` (`02fdad342`..`70fc305f3`): fechar o grafo daria 135 cobranças em
+ * 22 fatias, com picos de 32, 23, 18 e 16 numa só (a exclusão acima fica de pé). A regra
+ * estrutural "um consumidor INSTRUMENTADO" daria 5, uma FALSA — no `f6ac6055a` a
+ * `leitura-critica.ts` ganhou `exigirLista` para a `recommend`, que ainda não tinha `versao.ts`, e
+ * nada do que a `fin-cashflow-engine` chamava mudou. Contando TODAS as edges como consumidoras, a
+ * estrutural dá 4 de 4 — o mesmo que o par explícito. Ela perde em duas coisas: compara o arquivo
+ * inteiro (a allowlist precisa de projeção, abaixo) e poria o fecho das ~100 edges dentro deste
+ * gate, com veredito que muda quando OUTRO PR passa a importar o arquivo. Os outros arquivos de
+ * dono único mudaram 3 vezes na janela, nenhuma sem bump; se um escapar, é ela o próximo passo.
+ *
+ * Por que PROJEÇÃO, e não o arquivo inteiro: a allowlist é dupla — slugs (runtime do relé) e
+ * `controles`/`desde`/`nota` (dados da PROVA, que só o `sonda:cron-prova` lê). Mudar só `controles`
+ * muda o `fonte` do relé (o arquivo está no fecho) sem mudar o que ele faz: DIVERGE_P2 honesto.
+ * Cobrar bump ali faria o marcador mentir no sentido oposto.
+ *
+ * Quem vigia a declaração, no `.test.ts`: a CALIBRAÇÃO (projeção do arquivo real ===
+ * `slugsDaAllowlist()`, que pega sobre- e sub-limpeza) e a PREMISSA (o arquivo está no fecho da
+ * edge dona — pega a declaração órfã, que não reprova ninguém: só nunca mais casa). Um arquivo
+ * entra na lista quando a MEDIÇÃO mostra que ele é a fatia de uma edge só, não pelo nome.
+ *
  * ## Por que um script e não um teste
  *
  * Precisa do DIFF. O vitest lê edge como TEXTO mas não tem base de comparação; o `test:edges` roda
@@ -161,8 +197,56 @@ export function normalizarFonte(fonte: string): string {
     .join('\n');
 }
 
-function normalizarOuNull(fonte: string | null): string | null {
-  return fonte === null ? null : normalizarFonte(fonte);
+/**
+ * Arquivo de `_shared/` cuja mudança É a fatia de UMA edge — a exceção medida no cabeçalho.
+ */
+export interface FatiaEmShared {
+  /** a edge cujo comportamento o arquivo carrega */
+  edge: string;
+  /** caminho relativo à raiz do repo */
+  arquivo: string;
+  /**
+   * O pedaço do arquivo que é comportamento DESTA edge, em forma comparável: duas fontes com a
+   * mesma projeção são o mesmo comportamento para ela, mude o que mudar no resto do arquivo.
+   */
+  projetar: (fonte: string) => string;
+  /** o que a projeção mede, em uma frase — entra na mensagem de reprovação */
+  oQueConta: string;
+}
+
+/**
+ * Os slugs de `SONDA_CRON_ALVOS`, ordenados — a ÚNICA coisa da allowlist que o relé lê em runtime.
+ *
+ * Lê sobre o fonte limpo pelo stripper COMPARTILHADO: a allowlist carrega candidatas em
+ * comentário, e uma entrada comentada lida como alvo seria sub-limpeza — o gate cobraria bump por
+ * uma mudança que o relé nunca vê. Quem garante que a regex enxerga o que o runtime enxerga é a
+ * calibração do `.test.ts`, contra o próprio `slugsDaAllowlist()`.
+ */
+export function projetarAlvosDoRele(fonte: string): string {
+  const slugs = new Set<string>();
+  for (const m of removerComentarios(fonte).matchAll(/\bedge:\s*(["'])([^"'\n]+)\1/g)) slugs.add(m[2]);
+  return [...slugs].sort().join('\n');
+}
+
+export const FATIAS_EM_SHARED: readonly FatiaEmShared[] = [
+  {
+    edge: 'sonda-relay',
+    arquivo: `${RAIZ_EDGES}/_shared/sonda-cron-alvos.ts`,
+    projetar: projetarAlvosDoRele,
+    oQueConta: 'o conjunto de alvos da allowlist, que é o que o relé aceita em runtime',
+  },
+];
+
+/** A declaração que faz `caminho` contar no corpo de `edge`, se houver. */
+export function fatiaEmShared(caminho: string, edge: string): FatiaEmShared | undefined {
+  return FATIAS_EM_SHARED.find((f) => f.arquivo === caminho && f.edge === edge);
+}
+
+/** A forma que o núcleo compara: a projeção, para fatia declarada; a fonte normalizada, no resto. */
+function comparavel(caminho: string, edge: string, fonte: string | null): string | null {
+  if (fonte === null) return null;
+  const fatia = fatiaEmShared(caminho, edge);
+  return fatia ? fatia.projetar(fonte) : normalizarFonte(fonte);
 }
 
 /**
@@ -172,13 +256,18 @@ function normalizarOuNull(fonte: string | null): string | null {
  * filtro é o que separa "mudou o bundle" de "mudou um teste", e deixá-lo só no chamador significa
  * que um chamador futuro (uma auditoria, um harness) monta o estado sem ele e o gate passa a
  * gritar por `*_test.ts`. Gate que grita errado treina a ignorar — a regra mora no núcleo.
+ *
+ * Pela mesma razão a fatia declarada em `_shared/` é reconhecida AQUI, e não por um
+ * `contaComoCorpo` alargado: aquele predicado é importado pelos gates irmãos
+ * (`canaria-contrato-bump-gate.ts`, `sonda-edge-nova-gate.ts`) com o sentido "está na pasta da
+ * edge", e alargá-lo mudaria o que eles medem sem ninguém ter decidido isso.
  */
 export function auditarBump(edges: EstadoEdge[]): Achado[] {
   const achados: Achado[] = [];
   for (const e of edges) {
     const arquivos = e.corpo
-      .filter((a) => contaComoCorpo(a.caminho, e.edge))
-      .filter((a) => normalizarOuNull(a.base) !== normalizarOuNull(a.head))
+      .filter((a) => contaComoCorpo(a.caminho, e.edge) || fatiaEmShared(a.caminho, e.edge) !== undefined)
+      .filter((a) => comparavel(a.caminho, e.edge, a.base) !== comparavel(a.caminho, e.edge, a.head))
       .map((a) => a.caminho)
       .sort();
     if (arquivos.length === 0) continue;
@@ -262,13 +351,23 @@ export function montarEstado(
   ler: LeitorFonte,
 ): EstadoEdge[] {
   const porEdge = new Map<string, string[]>();
+  const adicionar = (edge: string, caminho: string) => {
+    const lista = porEdge.get(edge) ?? [];
+    lista.push(caminho);
+    porEdge.set(edge, lista);
+  };
   for (const caminho of tocados) {
+    // Fatia declarada em `_shared/` vai para o corpo da edge DONA; o resto de `_shared/` continua
+    // fora, de propósito (cabeçalho).
+    const declaradas = FATIAS_EM_SHARED.filter((f) => f.arquivo === caminho);
+    if (declaradas.length > 0) {
+      for (const f of declaradas) adicionar(f.edge, caminho);
+      continue;
+    }
     const m = caminho.match(new RegExp(`^${RAIZ_EDGES}/([^/]+)/`));
     if (!m || m[1] === '_shared') continue;
     if (!contaComoCorpo(caminho, m[1])) continue;
-    const lista = porEdge.get(m[1]) ?? [];
-    lista.push(caminho);
-    porEdge.set(m[1], lista);
+    adicionar(m[1], caminho);
   }
 
   const estados: EstadoEdge[] = [];
@@ -379,6 +478,12 @@ export function main(argv: string[]): number {
         `  outra prova de qual bundle está no ar. Bumpe \`VERSAO\` em ${RAIZ_EDGES}/${a.edge}/${ARQ_MARCADOR}\n` +
         '  nomeando a FATIA desta entrega (formato `vN.N-slug`), ANTES do deploy.',
     );
+    for (const f of a.arquivos.map((c) => fatiaEmShared(c, a.edge)).filter((f) => f !== undefined)) {
+      console.error(
+        `  ${f.arquivo} mora em \`_shared/\` mas é fatia declarada de \`${a.edge}\` (FATIAS_EM_SHARED):\n` +
+          `  o que mudou foi ${f.oQueConta}.`,
+      );
+    }
   }
   console.error(`\nsonda-bump-gate: ${achados.length} edge(s) alterada(s) sem bump do marcador.`);
   return 1;


### PR DESCRIPTION
## Resumo

O `sonda:bump` deixa `_shared/` fora de propósito — e a allowlist do cron (`_shared/sonda-cron-alvos.ts`) é, na prática, o comportamento do `sonda-relay`. As ondas 2 a 5 mudaram o conjunto de alvos sem bumpar o relé, com o gate verde. Este PR declara essa fatia no gate (`FATIAS_EM_SHARED`), comparando só a **projeção** que o relé lê em runtime (o conjunto de slugs).

**Zero deploy:** só `scripts/` e `docs/` mudam. `supabase/functions/` fica idêntico à `main`.

## O que estava errado (medido)

| onda | commit | `fonte` do relé | `versao.ts` do relé | `sonda:bump` |
|---|---|---|---|---|
| 1 | `54679dc35` | `d01c` | bumpado → `v1.1-alvos-da-onda-1` | ✓ |
| 2 | `89887025b` | `a92f` | intocado | ✓ (cego) |
| 3 | `d96b69f06` | `b736` | intocado | ✓ (cego) |
| 4 | `a73641e9c` | `0c4d` | intocado | ✓ (cego) |
| 5 | `f4578bbff` (#2461) | `6ca1` | intocado | ✓ (cego) |

Ledger de prod (`deploy_atestacoes`, psql-ro): o relé serviu **quatro `fonte` distintos sob o mesmo `v1.1-alvos-da-onda-1`**.

Falha aberta não era, porque o par `(versao, fonte)` acusa a divergência. O custo real é a **fila**: `pendencias:deploy` classifica `fonte` novo com `VERSAO` igual como **DIVERGE_P2** (leva agrupada, só escala após 7 dias), e relé sem deploy responde `fora-da-allowlist` às alvos da onda. Ou seja, o pré-requisito da onda caía na fila opcional. O PR da onda 5 listou o relé à mão na tabela de deploy: o humano via o fingerprint, não o marcador.

## Desenho ou descuido?

Os dois, em camadas diferentes. A exclusão de `_shared/` é **desenho**, medido em 2026-08-25 contra helpers COMPARTILHADOS, e continua certa para eles. A allowlist nasceu em 2026-09-06, **fora da população medida**, e nenhuma das premissas vale para ela: tem **um** consumidor (não ~12), e toda mudança desde que nasceu foi comportamento do relé. O descuido foi não reabrir a exclusão quando um arquivo desse tipo apareceu em `_shared/`.

## A medição que escolheu o conserto

682 fatias first-parent da `main` desde o 1º `versao.ts` (`02fdad342`..`70fc305f3`), fechando o grafo com a `fecharGrafo` do fingerprint sobre a árvore de cada fatia. Calibrada contra o `sonda:fanout`: reproduz os `SEM_BUMP=18` do #2132.

| régua | cobranças sem bump | fatias | leitura |
|---|---|---|---|
| grafo completo (`_shared/` incluso) | 135 | 22 | picos de 32, 23, 18 e 16 numa fatia: a exclusão fica de pé |
| estrutural, "UM consumidor **instrumentado**" | 5 | 5 | uma **falsa** (`f6ac6055a`: `leitura-critica.ts` ganhou `exigirLista` para a `recommend`, ainda sem `versao.ts`; nada que a `fin-cashflow-engine` chama mudou) |
| estrutural, "UM consumidor entre **todas** as edges" | 4 | 4 | empata com o par |
| **par explícito** `sonda-relay` × allowlist | 4 | 4 | as ondas 2 a 5 |

**Por que o par, se a estrutural por todas as edges empatou:** ela compara o arquivo inteiro (a allowlist precisa de projeção: `controles`/`desde`/`nota` são dados da prova, e mudar só isso é P2 honesto), e poria o fecho de ~100 edges dentro do gate, com um veredito que muda quando OUTRO PR passa a importar o arquivo. Os outros arquivos de dono único mudaram 3 vezes na janela, e todas as vezes com bump. Se um deles escapar, a estrutural é o próximo passo medido.

## O conserto

- `FATIAS_EM_SHARED` = `(edge, arquivo, projetar, oQueConta)`; `montarEstado` leva o arquivo declarado ao estado da edge dona; o núcleo compara a projeção.
- `contaComoCorpo` **intacto**: `canaria-contrato-bump-gate.ts` e `sonda-edge-nova-gate.ts` o importam no sentido "está na pasta da edge".
- A mensagem de reprovação explica por que um arquivo de `_shared/` está cobrando o bump.
- Cabeçalho do gate e `docs/historico/sonda-marcador-congelado.md` registram a medição, para ninguém ter de redescobrir.

### Por que o relé NÃO é bumpado aqui

O marcador `v1.1-alvos-da-onda-1` segue falso. Mas o relé foi **deployado às 23:14 UTC de 09-10** com a allowlist da onda 5: prod serve `(v1.1-alvos-da-onda-1, 6ca1)`, que é o par da `main` (CONFERE). Bumpar agora viraria DIVERGE_P1 e pediria um deploy só para trocar a string, logo depois de outro deploy. O marcador fica velho até a próxima mudança de alvos, e essa agora é **obrigada** a bumpar.

## Evidência (exit codes capturados sem pipe)

- TDD: 13 testes **vermelhos** antes da implementação, depois 46/46 verdes, em `LC_ALL=C` **e** em `pt_BR.UTF-8`.
- CLI contra os commits reais: ondas 2 a 5 → `exit=1`, com **um** `✗` cada (`sonda-relay`); onda 1 → `exit=0`; HEAD deste branch → `exit=0`.
- **Gate velho × novo nas 682 fatias:** 678 veredictos iguais e 4 divergentes, que são exatamente as ondas 2 a 5. As 7 fatias em que os dois reprovam são todas pré-gate (#1938 entre elas). Controle discriminante: o gate velho dá `exit=0` na onda 2.
- `typecheck` (app + scripts) 0 · `eslint` 0 · `knip` 0 (sem achados) · vitest de forma (16 arquivos, 278 testes) 0 · `test:edges` 1084/0 · `test:sonda-rollback` 9/0 · `sonda:fingerprint` 0 · `sonda:cron-prova --gate` 0.

## Falsificação

- `mutcheck` (`.mut` com **6 mutações novas**, uma para cada peça do conserto): **14/14 PEGA**, 1 SOBREVIVE esperada (cosmética), 0 inválidas, controle+ ✓ — em `LC_ALL=C` **e** em `pt_BR.UTF-8`, com baseline verde na mesma invocação.
- A premissa da projeção vigia o código do **relé**, então o `mutcheck` do gate não a alcança. Rodei um laço manual, numa invocação só: controle verde → o relé passa a importar `SONDA_CRON_ALVOS` → **vermelho só na premissa** → restaura → outro módulo do fecho passa a importar a allowlist → **vermelho só na premissa** → restaura → controle verde.

## ⚠️ Revisão independente PENDENTE (Caminho B)

O challenge do Codex (`gpt-6-astra`, `max`, via `codex-async.sh`) voltou `COTA_ESGOTADA`. O plano declarado no token é `prolite`, o mesmo assinado, então o limite é real e o ritual manda seguir o Caminho B: auto-challenge mais falsificação. O auto-challenge **achou um furo no meu próprio desenho**: a projeção só vale enquanto o relé ler apenas `slugsDaAllowlist`. Esse furo virou a premissa testada acima. O Codex tem de rodar retroativamente quando a cota voltar.

<details><summary>Reproduzir a medição</summary>

Para cada fatia first-parent `c` em `02fdad342^..70fc305f3`: arquivos de `_shared/` alterados entre `c^` e `c` (sem `*_test.ts`, sem o mapa de fingerprint, comparados por `normalizarFonte`) × edges instrumentadas na base cujo fecho (`fecharGrafo`, lendo a árvore de `c` via `git ls-tree`/`cat-file --batch` numa `ArvoreDeFonte`) contém o arquivo × `VERSAO` igual entre `c^` e `c`. "Dono único" conta as consumidoras no fecho de `c`: só as instrumentadas, ou todas as edges com `index.ts`. Calibração: `c = 5362ec761` dá 18 pares, igual ao `bun run sonda:fanout --base 5362ec761^ --head 5362ec761`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
