### PR TITLE
fix(deploy-verify): sem fetch, nenhum verde — o monitor dava "sincronizado" com a main LOCAL velha

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -986,6 +986,7 @@ O build **carimba o commit no bundle** (`vite.config` → `define __COMMIT_SHA__
 .claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh [url] [sentinela]
 # exit 0 = sincronizado (MESMO commit) · 5 = SINCRONIZADO_EM_BUNDLE (SHA atrás, delta provado fora do bundle)
 #      3 = ATRASADO (Publish pendente; a linha "motivo:" diz qual elo) · 4 = deploy novo, versão indeterminada
+#      git fetch da main falhou ⇒ 3 "motivo: FETCH_FALHOU" em QUALQUER caminho — nunca 0/5/4 (só o 2 vem antes)
 ```
 
 - **Determinístico** quando o ar tem `__BUILD_SHA__="<sha>"` — compara com `origin/main`, e se o SHA
@@ -1046,7 +1047,7 @@ inalcançável, e a transição que conta é a do `ar=` (e do entry). Detalhe em
 ✅ **SHA atrás ≠ bundle atrás — o monitor PROVA o delta antes de pedir Publish (2026-09-10).** O caso
 acima (ar `eee71c80`, delta sem `src/`) agora sai **exit 5 `SINCRONIZADO_EM_BUNDLE`**. Só rebaixa se
 TODO elo responder positivamente — senão fica `ATRASADO` com a marca do elo em `motivo:`:
-fetch ok (`FETCH_FALHOU`) · o entry tem UM carimbo só e ele resolve e é **ancestral** da main
+fetch ok (`FETCH_FALHOU` — pré-condição de TODO verde, o 0 inclusive) · o entry tem UM carimbo só e ele resolve e é **ancestral** da main
 (`CARIMBO_AMBIGUO`, `CARIMBO_NAO_RESOLVE`, `NAO_ANCESTRAL`) · `git diff --no-renames` sai 0 e não vazio (`DIFF_FALHOU`, `DELTA_VAZIO`) · todo arquivo
 é INERTE na tabela de `classify.sh --bundle` (`ALCANCA_BUNDLE`, `SEM_CLASSIFICACAO`) ·
 [`scripts/alcance-bundle.py`](scripts/alcance-bundle.py) prova na main que nada do bundle importa de fora
@@ -1263,4 +1264,26 @@ de que um Publish aconteceu continua sendo a mudança do `ar=`/entry, não a tra
   falsa no repo real; **(2)** o carimbo era "o primeiro" `__BUILD_SHA__="<hex>"` do entry, e um
   literal desses no código viraria o SHA do ar — mais de um distinto ⇒ `CARIMBO_AMBIGUO`. Rede: 24
   cenários, 17 sabotagens, 34 controles verdes nos 2 locales.
+- [x] **Sem fetch, NENHUM verde — o exit 0 comparava o ar com a main LOCAL velha (2026-09-10;
+  pré-existente, visto durante o #2465).** O guard `FETCH_FALHOU` morava no `analisar_delta`, depois
+  do atalho do SHA cheio, e só fechava a porta do exit 5. Com `git fetch origin main` falho sobravam
+  **três portas para o exit 0**, as três medidas vermelhas antes do conserto: a igualdade de string
+  do carimbo (8 chars), o atalho do SHA cheio (carimbo de 7 chars do mesmo commit) e o fallback sem
+  carimbo (`"dev"` + entry igual ao do estado → "nada a relatar"). Ar == main velha e a main real já
+  andou com `src/` ⇒ "sincronizado" — o cron lê o EXIT e recebia 0, com uma linha "(git fetch …
+  FALHOU)" que ninguém lê. Agora o guard é **único e vem antes de todo veredito**: `FETCH_OK=0` ⇒
+  exit 3 `motivo: FETCH_FALHOU`, nunca 0/5 (o 4 também vira 3; só o 2, site fora do ar, é medido
+  antes) — mesmo quando a resposta calharia de ser "sim": nos 2 cenários de carimbo a main real É o ar. O
+  guard interno saiu (ficaria inalcançável, e camada inalcançada não se falsifica). Rede: 27 cenários
+  (+3, um por porta) e 20 sabotagens (+3: a MESMA mutação do guard, cada uma exigindo o verde
+  PREVISTO da sua porta — `0|sincronizado: ar serve` ×2 e `0|nada a relatar`), 40 controles verdes
+  nos 2 locales. Fora da rede: o fallback de **sentinela** (exigiria o `verify-frontend.sh` com
+  rede) fica atrás do mesmo guard — coberto pela POSIÇÃO, não por um caso.
+- [ ] (latente) **`FETCH_OK=1` não prova que a `origin/main` andou.** `git fetch origin main` só move
+  `refs/remotes/origin/main` se o refspec configurado mapear `main`: num clone `--single-branch` de
+  outro branch ele sai **0** e só o `FETCH_HEAD` anda (medido em scratch, 2026-09-10: rc 0,
+  `origin/main` parada em `010535f0`, remoto em `0211030a`) — e o monitor compara com a main velha.
+  O repo usa o refspec padrão (`+refs/heads/*:refs/remotes/origin/*`), então hoje não morde. Fechar =
+  fetch com refspec explícito (`+refs/heads/main:refs/remotes/origin/main`) + cenário de refspec
+  estreito + sabotagem.
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/evals/monitor-deploy-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/monitor-deploy-eval.sh
@@ -166,6 +166,12 @@ cenario() {
     classify_mudo)    echo "$BASE $SO_DOCS classify_mudo" ;;
     python_mudo)      echo "$BASE $SO_DOCS python_mudo" ;;
     fetch_falhou)     echo "$BASE $SO_DOCS fetch_falhou" ;;
+    # remote quebrado e a origin/main LOCAL = o commit do ar: cada um por uma porta do verde — a
+    # igualdade de string (carimbo de 8), o atalho do SHA cheio (carimbo de 7, dentro do delta) e o
+    # fallback sem carimbo ("dev" + entry igual ao do estado = "nada a relatar")
+    fetch_falhou_mesmo_commit) echo "$SO_DOCS $SO_DOCS fetch_falhou" ;;
+    fetch_falhou_carimbo_curto) echo "${SO_DOCS:0:7} $SO_DOCS fetch_falhou" ;;
+    fetch_falhou_sem_carimbo) echo "dev $SO_DOCS fetch_falhou" ;;
     carimbo_alheio)   echo "deadbee2 $SO_DOCS -" ;;
     carimbo_e_branch) echo "deadbee1 $SO_DOCS -" ;;
     alias_inerte)     echo "$ALIAS_BASE $ALIAS -" ;;
@@ -194,6 +200,9 @@ diff_mudo|3|motivo: DELTA_VAZIO
 classify_mudo|3|motivo: CLASSIFY_FALHOU
 python_mudo|3|motivo: PROVA_INDISPONIVEL
 fetch_falhou|3|motivo: FETCH_FALHOU
+fetch_falhou_mesmo_commit|3|motivo: FETCH_FALHOU
+fetch_falhou_carimbo_curto|3|motivo: FETCH_FALHOU
+fetch_falhou_sem_carimbo|3|motivo: FETCH_FALHOU
 carimbo_alheio|3|motivo: CARIMBO_NAO_RESOLVE
 carimbo_e_branch|3|motivo: CARIMBO_NAO_RESOLVE
 alias_inerte|3|motivo: ALCANCE_VAZA
@@ -210,6 +219,9 @@ roda() {
   if ! { git -C "$O" update-ref refs/heads/main "$main" && g remote set-url origin "$O"; }; then
     echo "fixture: não apontei a main" > "$out"; return 98
   fi
+  # estado = o entry que o curl falso serve: sem isto o 1º cenário da rodada vê "deploy novo" e o
+  # desfecho do fallback sem carimbo (o único que lê o estado) dependeria da ORDEM dos cenários
+  printf 'index-Fx1234\n' > "$TMP/estado"
   envs=(FAKE_AR_SHA="$carimbo" DEPLOY_MONITOR_STATE="$TMP/estado")
   [ -n "$loc" ] && envs+=(LC_ALL="$loc")
   case "$extra" in
@@ -305,7 +317,7 @@ while IFS='|' read -r nome esp marca; do
   fi
 done <<< "$CASOS"
 echo "$n_ok/$n_tot cenários passaram"
-[ "$n_tot" -ge 24 ] || { echo "  [XX ] só $n_tot cenário(s) rodaram — a rede encolheu"; rc=1; }
+[ "$n_tot" -ge 27 ] || { echo "  [XX ] só $n_tot cenário(s) rodaram — a rede encolheu"; rc=1; }
 
 # ── falsificação ────────────────────────────────────────────────────────────────────────────────
 if [ "$FALSIFY" = 1 ]; then
@@ -357,8 +369,18 @@ PY
       '[ "$narq" -gt 0 ] 2>/dev/null' '[ "$narq" -ge 0 ] 2>/dev/null'
     sab no-renames scripts/monitor-deploy.sh rename_src_docs "$VERDE_INDEVIDO" \
       '--no-renames --no-relative' '--find-renames --no-relative'
-    sab fetch scripts/monitor-deploy.sh fetch_falhou "$VERDE_INDEVIDO" \
-      '[ "$FETCH_OK" = 1 ] || atrasado FETCH_FALHOU' '[ "$FETCH_OK" = 1 ] || true || atrasado FETCH_FALHOU'
+    # o guard do fetch é UM só e fecha QUATRO portas do verde: um cenário por porta, cada um com o
+    # verde que ela daria sem ele — o 5 do delta, o 0 da igualdade de string, o 0 do atalho do SHA
+    # cheio e o 0 do fallback. Até 2026-09-10 o guard morava no delta e só fechava a primeira.
+    guard_fetch='[ "$FETCH_OK" = 1 ] || atrasado FETCH_FALHOU'
+    sem_guard_fetch='[ "$FETCH_OK" = 1 ] || true || atrasado FETCH_FALHOU'
+    sab fetch scripts/monitor-deploy.sh fetch_falhou "$VERDE_INDEVIDO" "$guard_fetch" "$sem_guard_fetch"
+    sab fetch-mesmo-commit scripts/monitor-deploy.sh fetch_falhou_mesmo_commit \
+      '0|sincronizado: ar serve' "$guard_fetch" "$sem_guard_fetch"
+    sab fetch-carimbo-curto scripts/monitor-deploy.sh fetch_falhou_carimbo_curto \
+      '0|sincronizado: ar serve' "$guard_fetch" "$sem_guard_fetch"
+    sab fetch-sem-carimbo scripts/monitor-deploy.sh fetch_falhou_sem_carimbo \
+      '0|nada a relatar' "$guard_fetch" "$sem_guard_fetch"
     sab prefixo-do-carimbo scripts/monitor-deploy.sh carimbo_e_branch "$VERDE_INDEVIDO" \
       'case "$ar_full" in "$AIR_SHA"?*)' 'case "$ar_full" in ?*)'
     sab marca-positiva scripts/monitor-deploy.sh python_mudo "$VERDE_INDEVIDO" \
@@ -454,7 +476,7 @@ PY
     fi
   done
   echo "  falsificações que pegaram: $fals/$total"
-  [ "$total" -ge 17 ] && [ "$fals" -eq "$total" ] || rc=1
+  [ "$total" -ge 20 ] && [ "$fals" -eq "$total" ] || rc=1
 
   # (C) CONTROLE DE SAÍDA — pelo CONTEÚDO: o laço nunca mutou o versionado.
   # shellcheck disable=SC2086

--- a/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
@@ -11,7 +11,7 @@
 # docs/scripts o dia todo, o exit 3 cru ficava ligado quase sempre, e alarme que dispara com a
 # resposta certa vira alarme ignorado. Quando ar ≠ main o monitor tenta PROVAR que o delta não
 # alcança o bundle, elo a elo, e só rebaixa se TODOS responderem positivamente:
-#   1. o `git fetch` desta rodada deu certo (main velha fabricaria o veredito);
+#   1. o `git fetch` desta rodada deu certo — pré-condição de TODO verde, não só deste (abaixo);
 #   2. o carimbo resolve para um commit local e ele é ANCESTRAL da main;
 #   3. `git diff --no-renames --name-only ar main` sai 0 e lista ≥1 arquivo (sem --no-renames,
 #      `git mv src/x.ts docs/` apareceria só como `docs/x.ts`);
@@ -22,6 +22,15 @@
 #      scripts que o pipeline não executa (build, pre/post e ganchos de install ALCANÇAM).
 # Elo sem resposta POSITIVA ⇒ ATRASADO (exit 3) com o motivo numa marca ASCII (linha "motivo:").
 #
+# Sem fetch, NENHUM verde (2026-09-10): o guard do elo 1 vivia só no caminho do exit 5, e com o
+# `git fetch origin main` falho sobravam três portas para o exit 0 que comparavam o ar com a main
+# LOCAL, possivelmente velha — a igualdade de string do carimbo, o atalho do SHA cheio (carimbo de
+# 7 chars do mesmo commit) e o fallback sem carimbo ("nada a relatar"). Ar == main velha e a main
+# real já andou com `src/` ⇒ "sincronizado", com uma linha de aviso que o cron não lê (ele lê o
+# EXIT). Agora FETCH_OK=0 ⇒ exit 3 FETCH_FALHOU ANTES de qualquer veredito: sem a main desta
+# rodada não há "ar == main?", e ausência de dado não vira verde nem quando a resposta calharia de
+# ser sim. Só o exit 2 (site fora do ar) é medido antes.
+#
 # Exit:  0 = sincronizado: o ar serve o MESMO commit da main (ou nada a relatar)
 #        5 = SINCRONIZADO_EM_BUNDLE: SHA atrás por N commits, delta PROVADO fora do bundle —
 #            Publish desnecessário. Não é 0 de propósito: "mesmo commit" ≠ "bundle equivalente",
@@ -29,6 +38,7 @@
 #        3 = ar ATRASADO (Publish pendente) — inclui "não consegui provar" (ver "motivo:")
 #        4 = deploy novo detectado mas versão indeterminada (sem carimbo nem sentinela)
 #        2 = site fora do ar / HTML mudou de forma
+#        Fetch desta rodada falhou ⇒ nem 0, nem 5, nem 4: sai 3 FETCH_FALHOU (só o 2 vem antes).
 # Marcas do motivo (exit 3): ALCANCA_BUNDLE · SEM_CLASSIFICACAO · PACKAGE_JSON_ALCANCA ·
 #   BUILD_NAO_RECONHECIDO · ALCANCE_VAZA · NAO_ANCESTRAL · CARIMBO_NAO_RESOLVE · CARIMBO_AMBIGUO · FETCH_FALHOU ·
 #   GIT_FALHOU · DIFF_FALHOU · DELTA_VAZIO · CLASSIFY_FALHOU · PROVA_INDISPONIVEL
@@ -67,12 +77,12 @@ AIR_SHA=$(printf '%s' "$BODY" | grep -oE '__BUILD_SHA__="[0-9a-f]{7,8}"' | grep 
 N_CARIMBOS=$(printf '%s' "$BODY" | grep -oE '__BUILD_SHA__="[0-9a-f]{7,8}"' | sort -u | awk 'END { print NR }')
 IS_DEV=$(printf '%s' "$BODY" | grep -cE '__BUILD_SHA__="dev"' || true)
 
-echo "[$TS] main=$MAIN_SHA  ar=${AIR_SHA:-$([ "${IS_DEV:-0}" -gt 0 ] && echo dev || echo sem-carimbo)}  deploy-novo=$DEPLOY"
-[ "$FETCH_OK" = 1 ] || echo "  (git fetch origin main FALHOU nesta rodada: a main acima pode estar velha)"
+AR_ROTULO=${AIR_SHA:-$([ "${IS_DEV:-0}" -gt 0 ] && echo dev || echo sem-carimbo)}
+echo "[$TS] main=$MAIN_SHA  ar=$AR_ROTULO  deploy-novo=$DEPLOY"
 
 # ATRASADO com o motivo numa marca ASCII — destino de TODO elo que não responde positivamente.
 atrasado() {
-  echo "  ⚠️ ATRASADO: ar serve $AIR_SHA, main em $MAIN_SHA → Publish pendente"
+  echo "  ⚠️ ATRASADO: ar serve $AR_ROTULO, main em $MAIN_SHA → Publish pendente"
   echo "     motivo: $1 — $2"
   exit 3
 }
@@ -88,7 +98,6 @@ analisar_delta() {
   # carimbo de 7 chars do MESMO commit: a comparação de string não enxerga, o SHA cheio sim
   if [ "$ar_full" = "$main_full" ]; then echo "  ✅ sincronizado: ar serve $AIR_SHA == origin/main"; exit 0; fi
 
-  [ "$FETCH_OK" = 1 ] || atrasado FETCH_FALHOU "git fetch origin main falhou nesta rodada — a main local pode estar velha"
   # `<hex>^{commit}` também resolve NOME de ref (um branch chamado "abcdef12"): exija o prefixo
   case "$ar_full" in "$AIR_SHA"?*) eh_sha "$ar_full" ;; *) false ;; esac \
     || atrasado CARIMBO_NAO_RESOLVE "o carimbo $AIR_SHA não resolve para um commit local (ambíguo, fora da main ou não buscado)"
@@ -153,6 +162,12 @@ analisar_delta() {
   echo "     prova: ${prova#PROVA_INERCIA_OK }"
   exit 5
 }
+
+# Elo 1 vale para TODO veredito, não só para o delta: sem o fetch desta rodada a origin/main local
+# pode estar velha, e sem a main não há "ar == main?" — nem por igualdade de string, nem pelo atalho
+# do SHA cheio, nem pelo fallback. Guard ÚNICO e ANTES de tudo: dentro de um caminho, ele deixava os
+# outros abertos (era o caso até 2026-09-10 — ver cabeçalho).
+[ "$FETCH_OK" = 1 ] || atrasado FETCH_FALHOU "git fetch origin main falhou nesta rodada — a main acima é a LOCAL e pode estar velha; sem ela não há verde"
 
 # Caminho determinístico: carimbo de SHA real no ar — e UM só (ambíguo não pode virar verde nenhum)
 [ "${N_CARIMBOS:-0}" -le 1 ] || atrasado CARIMBO_AMBIGUO "o entry tem $N_CARIMBOS carimbos __BUILD_SHA__ distintos — não dá para saber qual commit o ar serve"


### PR DESCRIPTION
## O defeito (pré-existente, visto em 2026-09-10 durante o #2465)

`monitor-deploy.sh` guarda `FETCH_OK` do `git fetch origin main`, mas o guard `FETCH_FALHOU` morava **dentro do `analisar_delta`, depois do atalho do SHA cheio** — só fechava a porta do exit 5. Com o fetch falho sobravam **três portas para o exit 0**, todas comparando o ar com a `origin/main` **LOCAL** (possivelmente velha):

| porta | como chegava ao verde com fetch falho |
|---|---|
| igualdade de string (carimbo de 8) | `AIR_SHA == MAIN_SHA` → `✅ sincronizado` |
| atalho do SHA cheio (carimbo de 7) | `ar_full == main_full` dentro do `analisar_delta`, **antes** do guard |
| fallback sem carimbo | `"dev"` + entry igual ao do estado → `nada a relatar` |

Se o ar == main velha e a main real já andou com `src/`, o monitor dizia "sincronizado". Só havia uma linha `(git fetch origin main FALHOU nesta rodada …)` — e o cron lê o **EXIT**, que era 0.

## O conserto

- **Guard único, antes de todo veredito:** `FETCH_OK=0` ⇒ `exit 3` com `motivo: FETCH_FALHOU`, em qualquer caminho — nunca 0/5 (o 4 também vira 3; só o 2, site fora do ar, é medido antes). Vale mesmo quando a resposta calharia de ser "sim": nos 2 cenários de carimbo a main real **é** o ar, e o monitor ainda assim recusa — sem a main desta rodada não há "ar == main?".
- O guard interno do `analisar_delta` saiu: ficaria inalcançável, e camada inalcançada não se falsifica. A linha de aviso também saiu (o `motivo:` a substitui).
- `AR_ROTULO` na mensagem do `atrasado`: no fallback sem carimbo o cabeçalho sai `ar serve dev`, não `ar serve ,`.
- Cabeçalho do script documenta a regra; SKILL.md: linha de exit codes do §Smoke E2E + §Estado / pendências.

## Rede (`evals/monitor-deploy-eval.sh`, já no gate `evals/run.sh`)

- **+3 cenários, um por porta:** `fetch_falhou_mesmo_commit` (o pedido), `fetch_falhou_carimbo_curto` e `fetch_falhou_sem_carimbo`. O de 7 chars existe porque um conserto que tapasse só a igualdade de string passaria com um cenário só — foi exatamente assim que o defeito nasceu. O fallback entrou porque o guard único muda o comportamento dele também, e mudança sem vermelho antes não entra.
- **+3 sabotagens:** a MESMA mutação do guard (`|| true ||`), cada uma exigindo o verde **PREVISTO** da sua porta — `0|sincronizado: ar serve` ×2 e `0|nada a relatar`. A `fetch` existente (previsto `5|SINCRONIZADO_EM_BUNDLE`) passou a apontar o guard novo.
- O estado do monitor é pré-carregado com o entry servido em cada `roda`, para o fallback não depender da ORDEM dos cenários.

### Evidência (local, colada)

| passo | comando | resultado |
|---|---|---|
| RED (código antigo) | `monitor-deploy-eval.sh` | `EVAL_RC=1` · 24/27 · as 3 novas saem **exit 0** (`✅ sincronizado` ×2, `nada a relatar`) com a linha de aviso logo acima |
| GREEN | `monitor-deploy-eval.sh` | `EVAL_RC=0` · 27/27 + tabela · as 4 de fetch saem `exit 3 motivo: FETCH_FALHOU` |
| falsificação (commitado antes) | `monitor-deploy-eval.sh --falsify` | `FALSIFY_RC=0` · controle 40 execuções verdes (C + pt_BR.UTF-8) · **20/20** vermelhas pela marca prevista nos 2 locales · cksum de saída intacto |
| gate do CI | `bun run evals:deploy-verify` / `:falsificacao` | `GATE_RC=0 GATE_FALS_RC=0` (no agregador: 40 controles verdes, 20/20, cksum intacto) |
| outros | `shellcheck` (os 2 scripts) · `bun run docs:links` | rc 0 · rc 0 (759 docs) |

## Fora do escopo — registrado como pendência latente no §Estado

`FETCH_OK=1` não prova que a `origin/main` andou: com refspec que não mapeia `main` (clone `--single-branch` de outro branch), `git fetch origin main` sai **0** e só o `FETCH_HEAD` anda — medido em scratch (rc 0, `origin/main` parada em `010535f0`, remoto em `0211030a`). O repo usa o refspec padrão, então hoje não morde.

## Coordenação multi-sessão

A worktree `practical-gauss-b2c1b0` (branch `claude/monitor-deploy-pr-ancestralidade`, ainda sem PR) tem mudança não commitada no mesmo `monitor-deploy.sh` — cabeçalho, bloco do fetch, depois do `analisar_delta`, bloco do carimbo e fallback. Quem mergear depois rebaseia. Ponto de desenho para esse rebase: o guard `FETCH_FALHOU` agora é **único e fica antes de todo veredito**. Um modo novo posto depois dele herda o "sem fetch, nenhum verde"; posto antes, precisa de uma resposta própria para o fetch falho (ancestralidade contra um commit que o clone não buscou dá rc 128, não veredito).

Não toca `supabase/migrations/` nem edges; nada a deployar (skill local, sem bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
