### PR TITLE
fix(backfill-desconto): ja_apuradas contava as escritas da própria chamada — a contagem vai para antes do UPDATE, e a prova que certificava o número errado entra no CI [money-path]

### DIFF
--- a/db/nucleo-ci.txt
+++ b/db/nucleo-ci.txt
@@ -71,6 +71,13 @@ db/test-claim-disparo-cenario-b.sh         76
 db/test-disparado-simulado-pos-disparo.sh  59
 db/test-fin-sync-lease.sh                  22
 db/test-pedido-venda-coerencia.sh          31
+# A escrita do backfill de desconto: o plano é lido ANTES e escrito depois, e o que atravessa a
+# janela são as marcas da própria linha — o trio (SKU, qtd, preço) e o `desconto_valor IS NULL`,
+# DENTRO do `WHERE` do UPDATE: base que mudou, ou linha já apurada por outro writer, não é escrita.
+# E o que ela DEVOLVE: `ja_apuradas` contado ANTES do UPDATE. Entrou em 2026-09-10, quando se viu
+# que a contagem somava as escritas da própria chamada e que esta prova CONFIRMAVA o número errado
+# (o esperado fora transcrito da saída). Até então rodava só no laptop.
+db/test-desconto-backfill-aplicar.sh       30
 
 # ── Eixo 5 — VEREDITO DE DEPLOY ──────────────────────────
 # O SQL que responde "a edge está REALMENTE no ar?". O dano aqui é acreditar num

--- a/db/test-desconto-backfill-aplicar.sh
+++ b/db/test-desconto-backfill-aplicar.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
-# ╔═══════════════════════════════════════════════════════════════════════════════════╗
-# ║ PROVA PG17 — desconto_backfill_aplicar (a escrita do backfill)                     ║
-# ║ Rode: bash db/test-desconto-backfill-aplicar.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
-# ╚═══════════════════════════════════════════════════════════════════════════════════╝
+# ══════════════════════════════════════════════════════════════════════════════════════
+# PROVA PG17 — desconto_backfill_aplicar (a escrita do backfill)
+#
+#     bash db/test-desconto-backfill-aplicar.sh > /tmp/t.log 2>&1; echo $?
+# (NÃO pipe pra tail — engole o exit≠0.) Dois locales (lição #1483):
+#     HARNESS_LC=pt_BR.UTF-8 bash db/test-desconto-backfill-aplicar.sh
+#
+#  F  escrita e precondição por linha — base que mudou não é escrita; comparação NULL-safe
+#  I  concorrência — linha JÁ apurada por outro writer não é sobrescrita
+#  J  `ja_apuradas` conta o que JÁ estava preenchido, não o que a própria chamada escreveu.
+#     J3 é a LINHA DE BASE do defeito: o corpo VELHO real devolve 3 no cenário em que o
+#     novo devolve 1. Sem J3, J1 verde não prova nada — o cenário poderia nem exercitar o
+#     defeito.
+#  P  paridade — o arquivo do `db:aplicar` instala o MESMO corpo da migration de DR
+#  G  ACL — escrita de money-path fechada na fronteira
+#  H  falsificação — sabota cada guard, exige VERMELHO, restaura
+# ══════════════════════════════════════════════════════════════════════════════════════
 #
 # O QUE ESTA PROVA EXISTE PARA PEGAR: o plano de apuração é montado a partir de uma leitura que
 # aconteceu ANTES da escrita. Nesse intervalo o sync, uma edição ou a reconciliação podem ter
@@ -13,38 +26,58 @@
 # A defesa é a precondição por linha, dentro da MESMA transação da escrita. Ela é NULL-safe de
 # propósito: `unit_price` é nullable desde 2026-09-05, e um `coalesce(...,0)` nos dois lados
 # casaria "preço desconhecido" com "preço zero" — que é a fabricação canônica deste repo.
+#
+# E o que a função DEVOLVE também é contrato: `ja_apuradas` separa, dentro de `recusadas`,
+# "corrida perdida" de "base mudou". Até 2026-09-10 ele era contado depois do UPDATE e somava as
+# linhas que a própria chamada tinha escrito (grupo J) — e o F6 desta prova CONFIRMAVA o número
+# errado, porque o esperado tinha sido transcrito da saída em vez de derivado da regra.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PGVER=17
-PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+. "$REPO_ROOT/db/lib/pg-harness.sh"
 PORT="${PGPORT_TEST:-5474}"
 SLUG="desconto-backfill-aplicar"
-DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+# Os três arquivos são NOMEADOS, não achados por glob — a prova diz o que testa: a migration de
+# DR vigente; a anterior, cujo corpo é o que a PROD rodava até esta correção (md5 do `prosrc`
+# conferido via psql-ro em 2026-09-10); e o arquivo que o `db:aplicar` de fato manda para a PROD.
+MIG="$REPO_ROOT/supabase/migrations/20260910214850_desconto_backfill_aplicar_ja_apuradas.sql"
+MIG_VELHA="$REPO_ROOT/supabase/migrations/20260908220625_desconto_backfill_aplicar.sql"
+DBF="$REPO_ROOT/db/aplicar-desconto-backfill-rpc.sql"
+for f in "$MIG" "$MIG_VELHA" "$DBF"; do
+  [ -f "$f" ] || { echo "INFRA: arquivo ausente: $f — a prova testaria o NADA"; exit 1; }
+done
+
+# Tudo o que a execução gera (cluster, log, cópias sabotadas) mora num diretório SÓ DELA: as
+# duas rodadas de locale podem correr em paralelo sem uma sobrescrever a sabotagem da outra.
+WORK="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")"
+DATA="$WORK/data"
 export LC_ALL=C LANG=C
 
-[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
-CELLAR="$(brew --prefix "postgresql@${PGVER}")"
-cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
-mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
-cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
-
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$WORK"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
-"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "$WORK/pg.log" -w start >/dev/null
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+# O SERVIDOR sempre arranca sob LC_ALL=C (no macOS, sem isso o postmaster aborta). O eixo que a
+# lição #1483 manda variar é a LÍNGUA DAS MENSAGENS do servidor, e essa é GUC do BANCO.
+HARNESS_LC="${HARNESS_LC:-C}"
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d postgres -q -c "ALTER DATABASE prove SET lc_messages='$HARNESS_LC';" \
+  || { echo "INFRA: lc_messages='$HARNESS_LC' indisponível neste servidor"; exit 1; }
+
 P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
 Pq() { P -tA "$@"; }
 
 P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
 PASS=0; FAIL=0
-ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
-bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
-eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+ok()  { PASS=$((PASS+1)); echo "  OK   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 -- esperado [$3], veio [$2]"; fi; }
 
-echo "═══ setup pronto (PG17 :$PORT) ═══"
+# Controle do próprio eixo de locale: provoca um erro do SERVIDOR e mostra em que língua vem.
+AMOSTRA_MSG=$("$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -tA -c "SELECT 1/0;" 2>&1 | head -1) || true
+echo "═══ setup pronto (PG17 :$PORT) lc_messages=$HARNESS_LC ═══"
+echo "═══ controle do eixo de locale, mensagem do servidor: $AMOSTRA_MSG"
 
 # `desconto_valor` NULLABLE e SEM DEFAULT, como em produção. Um default aqui faria os asserts de
 # NULL passarem por acidente do stub.
@@ -54,13 +87,11 @@ CREATE TABLE public.order_items (
   omie_codigo_produto bigint, quantity numeric, unit_price numeric, desconto_valor numeric);
 SQL
 
-# `find`, não `ls`: SC2012 — e aqui não é purismo, o gate `lint:shell` entra em ZERO.
-# `sort` porque a ordem do find não é garantida, e o alvo é a migration mais RECENTE
-# com este slug (se um dia houver uma correção posterior, é ela que vale).
-MIG="$(find "$REPO_ROOT/supabase/migrations" -name "*_desconto_backfill_aplicar.sql" | sort | tail -1)"
-[ -n "$MIG" ] || { echo "migration não encontrada — o harness testaria o NADA"; exit 1; }
+md5_corpo() { Pq -c "SELECT md5(prosrc) FROM pg_proc WHERE oid = to_regprocedure('public.desconto_backfill_aplicar(jsonb)');"; }
+
 P -q -f "$MIG"
-echo "migration aplicada: $(basename "$MIG")"
+MD5_NOVO="$(md5_corpo)"
+echo "migration aplicada: $(basename "$MIG") (md5 do corpo ${MD5_NOVO:0:12})"
 
 L1="bbbbbbbb-0000-0000-0000-000000000001"  # base bate
 L2="bbbbbbbb-0000-0000-0000-000000000002"  # quantidade mudou
@@ -97,13 +128,19 @@ F4=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L4';")
 eq "F4 preço NULL dos DOIS lados casa (IS NOT DISTINCT FROM), não é descartado" "$F4" "40"
 F5=$(Pq -c "SELECT desconto_valor IS NULL FROM public.order_items WHERE id='$L5';")
 eq "F5 plano com desconto null NÃO escreve (não apaga apuração alheia)" "$F5" "t"
+# Nenhuma das 5 linhas tinha desconto ANTES da chamada ⇒ ja_apuradas=0. Até 2026-09-10 este
+# assert esperava 2 — o número que o corpo defeituoso devolve (L1 e L4, escritas por ESTA
+# chamada), transcrito da saída em vez de derivado da regra.
 F6=$(echo "$R" | tr -d ' ')
-eq "F6 contagens: 5 pedidas, 2 aplicadas, 3 recusadas, 2 já apuradas" "$F6" '{"pedidas":5,"aplicadas":2,"recusadas":3,"ja_apuradas":2}'
+eq "F6 contagens: 5 pedidas, 2 aplicadas, 3 recusadas, 0 já apuradas" "$F6" '{"pedidas":5,"aplicadas":2,"recusadas":3,"ja_apuradas":0}'
 
-# Idempotência: reaplicar o MESMO plano não acumula nem alterna.
-Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
+# Idempotência: reaplicar o MESMO plano não acumula nem alterna — e o reenvio é contado como o
+# que é: linha que já tinha desconto quando a chamada começou.
+R7=$(Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);")
 F7=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L1';")
 eq "F7 reaplicar o mesmo plano é idempotente" "$F7" "10"
+F8=$(echo "$R7" | tr -d ' ')
+eq "F8 o reenvio conta como JÁ APURADA, não como base mudou" "$F8" '{"pedidas":1,"aplicadas":0,"recusadas":1,"ja_apuradas":1}'
 
 echo "═══ I · concorrência: linha JÁ APURADA não é sobrescrita ═══"
 
@@ -119,7 +156,7 @@ eq "I2 e o motivo vem SEPARADO de 'base mudou'" "$I2" '{"pedidas":1,"aplicadas":
 P -q -c "UPDATE public.order_items SET desconto_valor = NULL WHERE id='$L1';" >/dev/null
 
 # Falsificação: sem o guard, a sobrescrita acontece — é o dano que I1 barra.
-SABI="/tmp/sabotado-concorrencia-${SLUG}.sql"
+SABI="$WORK/sabotado-concorrencia.sql"
 sed 's/       AND oi.desconto_valor IS NULL/       AND true/' "$MIG" > "$SABI"
 if ! grep -q "AND true" "$SABI"; then
   bad "I3.0 a sabotagem do guard de concorrência NÃO alterou o arquivo — assert seria teatro"
@@ -129,11 +166,88 @@ else
   P -q -c "UPDATE public.order_items SET desconto_valor = 55 WHERE id='$L1';" >/dev/null
   Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":10,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
   I3=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L1';")
-  if [ "$I3" = "10" ]; then ok "I3 sem o guard, a apuração de outro writer é SOBRESCRITA — I1 tem dente"; PASS=$((PASS+1));
+  if [ "$I3" = "10" ]; then ok "I3 sem o guard, a apuração de outro writer é SOBRESCRITA — I1 tem dente"
   else bad "I3 sem o guard não houve sobrescrita (veio [$I3]) — I1 pode passar por inércia"; fi
   P -q -f "$MIG" >/dev/null
   P -q -c "UPDATE public.order_items SET desconto_valor = NULL WHERE id='$L1';" >/dev/null
 fi
+
+echo "═══ J · ja_apuradas conta o que JÁ estava preenchido — não o que a chamada escreveu ═══"
+
+# O cenário do achado de 2026-09-10: 3 linhas no plano, 1 já preenchida por outro writer (com a
+# base batendo, para ser recusada SÓ pelo guard de concorrência), 2 aplicáveis.
+J_A="cccccccc-0000-0000-0000-000000000001"  # outro writer já gravou 55
+J_B="cccccccc-0000-0000-0000-000000000002"  # aplicável
+J_C="cccccccc-0000-0000-0000-000000000003"  # aplicável
+PLANO_J="[
+  {\"id\":\"$J_A\",\"desconto_valor\":5,\"base_quantity\":1,\"base_unit_price\":50,\"base_sku\":777},
+  {\"id\":\"$J_B\",\"desconto_valor\":6,\"base_quantity\":2,\"base_unit_price\":50,\"base_sku\":777},
+  {\"id\":\"$J_C\",\"desconto_valor\":7,\"base_quantity\":3,\"base_unit_price\":50,\"base_sku\":777}
+]"
+semeia_j() {
+  P -q -c "DELETE FROM public.order_items WHERE id IN ('$J_A','$J_B','$J_C');" >/dev/null
+  P -q -c "INSERT INTO public.order_items(id, omie_codigo_produto, quantity, unit_price, desconto_valor) VALUES
+    ('$J_A', 777, 1, 50, 55), ('$J_B', 777, 2, 50, NULL), ('$J_C', 777, 3, 50, NULL);" >/dev/null
+}
+chama_j() { Pq -c "SELECT public.desconto_backfill_aplicar('$PLANO_J'::jsonb);" | tr -d ' '; }
+
+semeia_j
+J1=$(chama_j)
+eq "J1 cenário misto (1 já preenchida + 2 aplicáveis) → ja_apuradas=1" "$J1" '{"pedidas":3,"aplicadas":2,"recusadas":1,"ja_apuradas":1}'
+J2=$(Pq -c "SELECT string_agg(coalesce(desconto_valor::text,'NULL'), ',' ORDER BY id) FROM public.order_items WHERE id IN ('$J_A','$J_B','$J_C');")
+eq "J2 a escrita segue a de sempre: o 55 do outro writer fica, as 2 aplicáveis recebem o plano" "$J2" "55,6,7"
+
+# Id REPETIDO no plano (mesmo valor, base batendo). É o caso que separa "contar antes" de
+# "subtrair depois": o UPDATE escreve a linha UMA vez e o RETURNING devolve UMA linha.
+J_D="cccccccc-0000-0000-0000-000000000004"
+PLANO_DUP="[
+  {\"id\":\"$J_D\",\"desconto_valor\":8,\"base_quantity\":4,\"base_unit_price\":50,\"base_sku\":777},
+  {\"id\":\"$J_D\",\"desconto_valor\":8,\"base_quantity\":4,\"base_unit_price\":50,\"base_sku\":777}
+]"
+semeia_dup() {
+  P -q -c "DELETE FROM public.order_items WHERE id='$J_D';" >/dev/null
+  P -q -c "INSERT INTO public.order_items(id, omie_codigo_produto, quantity, unit_price, desconto_valor) VALUES ('$J_D', 777, 4, 50, NULL);" >/dev/null
+}
+chama_dup() { Pq -c "SELECT public.desconto_backfill_aplicar('$PLANO_DUP'::jsonb);" | tr -d ' '; }
+
+semeia_dup
+J3D=$(chama_dup)
+eq "J3 id repetido, aplicado por ESTA chamada, NÃO é 'já apurado'" "$J3D" '{"pedidas":2,"aplicadas":1,"recusadas":1,"ja_apuradas":0}'
+
+# LINHA DE BASE DO DEFEITO — o corpo VELHO real (a migration anterior, byte a byte o que a PROD
+# rodava) nos MESMOS cenários. Ele TEM de devolver os números errados: é isso que mostra que os
+# cenários exercitam o defeito. Se devolvesse os certos, J1/J3 verdes seriam inércia.
+P -q -f "$MIG_VELHA" >/dev/null
+MD5_VELHO="$(md5_corpo)"
+semeia_j
+J4=$(chama_j)
+eq "J4 (linha de base) o corpo VELHO conta as próprias escritas: 3 onde o certo é 1" "$J4" '{"pedidas":3,"aplicadas":2,"recusadas":1,"ja_apuradas":3}'
+semeia_dup
+J5D=$(chama_dup)
+# O corpo velho conta DEPOIS do UPDATE, então o `ja_apuradas` dele É o "preenchidas_depois". A
+# alternativa `preenchidas_depois - aplicadas` sai daqui sem reimplementar nada.
+SUBTRACAO=$(Pq -c "SELECT ('$J5D'::jsonb->>'ja_apuradas')::int - ('$J5D'::jsonb->>'aplicadas')::int;")
+eq "J5 (contrafactual) a subtração preenchidas_depois − aplicadas daria 1 onde o certo é 0 — não é equivalente" "$SUBTRACAO" "1"
+
+P -q -f "$MIG" >/dev/null
+J6=$(md5_corpo)
+eq "J6 restauração: o corpo voltou a ser o da migration nova" "$J6" "$MD5_NOVO"
+if [ -n "$MD5_VELHO" ] && [ "$MD5_VELHO" != "$MD5_NOVO" ]; then
+  ok "J7 (controle) os corpos velho e novo DIFEREM — J6 e P1 não passam por md5 constante"
+else
+  bad "J7 os corpos velho e novo têm o MESMO md5 [$MD5_VELHO] — J6/P1 seriam verdes por construção"
+fi
+
+echo "═══ P · paridade: o arquivo do db:aplicar instala o MESMO corpo da migration de DR ═══"
+
+# Tudo acima testa a MIGRATION; quem vai para a PROD é o arquivo do `db:aplicar`. Sem esta
+# paridade a prova certificaria um arquivo que ninguém aplica. Parte do corpo VELHO, para P1
+# medir uma TROCA e não inércia. `-1` = uma transação só, como o executor (o arquivo não traz
+# BEGIN/COMMIT — o `db:aplicar` o recusaria se trouxesse).
+P -q -f "$MIG_VELHA" >/dev/null
+P -q -1 -f "$DBF" >/dev/null
+P1=$(md5_corpo)
+eq "P1 o arquivo do db:aplicar instala o corpo da migration nova (md5)" "$P1" "$MD5_NOVO"
 
 echo "═══ G · ACL: escrita de money-path fechada na fronteira ═══"
 G1=$(Pq -c "SELECT has_function_privilege('anon','public.desconto_backfill_aplicar(jsonb)','EXECUTE');")
@@ -149,7 +263,7 @@ echo "═══ H · FALSIFICAÇÃO: sabota → exige VERMELHO → restaura ═�
 
 # H1 — a precondição some. Se F2/F3 não ficarem vermelhos aqui, eles estavam passando por outro
 # motivo e a linha desatualizada seria escrita em produção sem que nada acusasse.
-SAB="/tmp/sabotado-${SLUG}.sql"
+SAB="$WORK/sabotado-precondicao.sql"
 sed -e 's/       AND oi.quantity            IS NOT DISTINCT FROM pl.base_quantity/       AND true/' \
     -e 's/       AND oi.unit_price          IS NOT DISTINCT FROM pl.base_unit_price/       AND true/' "$MIG" > "$SAB"
 if [ "$(grep -c 'AND true' "$SAB")" -ne 2 ]; then
@@ -160,7 +274,7 @@ else
   P -q -c "UPDATE public.order_items SET desconto_valor = NULL;" >/dev/null
   Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L2\",\"desconto_valor\":20,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
   H1=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='$L2';")
-  if [ "$H1" = "20" ]; then ok "H1 sem a precondição, a linha DESATUALIZADA é escrita — F2 tem dente"; PASS=$((PASS+1));
+  if [ "$H1" = "20" ]; then ok "H1 sem a precondição, a linha DESATUALIZADA é escrita — F2 tem dente"
   else bad "H1 sem a precondição a linha não foi escrita (veio [$H1]) — F2 pode passar por inércia"; fi
   P -q -f "$MIG" >/dev/null
 fi
@@ -168,7 +282,7 @@ fi
 # H2 — o `coalesce(...,0)` na comparação de preço: "desconhecido" passa a casar com "zero".
 # Este é o defeito que o `IS NOT DISTINCT FROM` existe para impedir, e ele é invisível: a linha
 # de preço NULL simplesmente deixa de casar com o plano que a descreve corretamente.
-SAB2="/tmp/sabotado2-${SLUG}.sql"
+SAB2="$WORK/sabotado-null-safe.sql"
 sed 's/       AND oi.unit_price          IS NOT DISTINCT FROM pl.base_unit_price/       AND coalesce(oi.unit_price, 0) = coalesce(pl.base_unit_price, 0)/' "$MIG" > "$SAB2"
 if ! grep -q "coalesce(oi.unit_price, 0)" "$SAB2"; then
   bad "H2.0 a sabotagem do NULL-safe NÃO alterou o arquivo — assert seria teatro"
@@ -181,13 +295,13 @@ else
   P -q -c "INSERT INTO public.order_items(id, omie_codigo_produto, quantity, unit_price) VALUES ('bbbbbbbb-0000-0000-0000-000000000006', 555, 2, 0);" >/dev/null
   Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"bbbbbbbb-0000-0000-0000-000000000006\",\"desconto_valor\":77,\"base_quantity\":2,\"base_unit_price\":null,\"base_sku\":555}]'::jsonb);" >/dev/null
   H2=$(Pq -c "SELECT desconto_valor FROM public.order_items WHERE id='bbbbbbbb-0000-0000-0000-000000000006';")
-  if [ "$H2" = "77" ]; then ok "H2 com coalesce, preço ZERO casa com preço DESCONHECIDO — o NULL-safe tem dente"; PASS=$((PASS+1));
+  if [ "$H2" = "77" ]; then ok "H2 com coalesce, preço ZERO casa com preço DESCONHECIDO — o NULL-safe tem dente"
   else bad "H2 o coalesce não produziu o casamento errado (veio [$H2]) — a sabotagem não exercitou o eixo"; fi
   P -q -f "$MIG" >/dev/null
 fi
 
 # H3 — o guard do plano-null some: um bug do chamador passaria a APAGAR apuração em massa.
-SAB3="/tmp/sabotado3-${SLUG}.sql"
+SAB3="$WORK/sabotado-plano-null.sql"
 sed -e 's/       AND pl.desconto_valor IS NOT NULL/       AND true/' \
     -e 's/       AND oi.desconto_valor IS NULL/       AND true/' "$MIG" > "$SAB3"
 # DOIS guards protegem este eixo desde o achado de concorrência (Codex): `pl...IS NOT NULL` barra
@@ -202,10 +316,11 @@ else
   P -q -c "UPDATE public.order_items SET desconto_valor = 99 WHERE id='$L1';" >/dev/null
   Pq -c "SELECT public.desconto_backfill_aplicar('[{\"id\":\"$L1\",\"desconto_valor\":null,\"base_quantity\":2,\"base_unit_price\":100,\"base_sku\":555}]'::jsonb);" >/dev/null
   H3=$(Pq -c "SELECT desconto_valor IS NULL FROM public.order_items WHERE id='$L1';")
-  if [ "$H3" = "t" ]; then ok "H3 sem o guard, um plano com null APAGA apuração existente — F5 tem dente"; PASS=$((PASS+1));
+  if [ "$H3" = "t" ]; then ok "H3 sem o guard, um plano com null APAGA apuração existente — F5 tem dente"
   else bad "H3 sem o guard a apuração não foi apagada (IS NULL=[$H3]) — F5 pode passar por inércia"; fi
   P -q -f "$MIG" >/dev/null
 fi
 
-echo "═══ RESULTADO: $PASS ok · $FAIL falhas ═══"
+# O formato da linha abaixo é o que `db/roda-nucleo-ci.sh` extrai — `<pass> ok / <fail> fail`.
+echo "═══ RESULTADO: $PASS ok / $FAIL fail ═══"
 [ "$FAIL" -eq 0 ]

--- a/db/test-desconto-backfill-aplicar.sh
+++ b/db/test-desconto-backfill-aplicar.sh
@@ -34,6 +34,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091  # o gate roda sem -x; o helper é versionado ao lado, em db/lib/
 . "$REPO_ROOT/db/lib/pg-harness.sh"
 PORT="${PGPORT_TEST:-5474}"
 SLUG="desconto-backfill-aplicar"

--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -855,3 +855,38 @@ sem guarda de finitude ×2 → `NaN` no item) — cada uma vermelha e restaurada
 falsificação saboteia a função **extraída da própria migration** (não um fixture paralelo): o corpo que
 vai a produção é o que fica vermelho. (4) O harness da primeira rodada reprovou por `duplicate key` em
 `company_config` — a migration-base já semeia as chaves; seed de config é `ON CONFLICT DO UPDATE`.
+
+## `ja_apuradas` contava as escritas da própria chamada — e a prova certificava o número errado (2026-09-10, [PR #2475](https://github.com/LucasSardenbergL/afiacao/pull/2475), migration `20260910214850` — APLICADA via `db:aplicar`, recibo #58)
+
+**Problema.** `desconto_backfill_aplicar` devolve `{pedidas, aplicadas, recusadas, ja_apuradas}`; o
+`ja_apuradas` existe para separar, dentro de `recusadas`, "outro writer preencheu antes" de "a base
+mudou". Durante a execução do backfill Oben/TTM, lendo o `pg_get_functiondef` da PROD, viu-se que ele era
+contado num `SELECT` DEPOIS do `UPDATE` — e em plpgsql o statement seguinte enxerga o que a própria
+transação escreveu. Reproduzido em PG17 com o corpo da PROD (md5 idêntico): 3 linhas no plano, 1 já
+preenchida, 2 aplicáveis → `ja_apuradas=3` contra `recusadas=1`, estado impossível; o certo é 1. A edge só
+lê `aplicadas`/`recusadas`: nenhuma escrita saiu errada, o dano era de observabilidade.
+
+**Fix.** A contagem vai para ANTES do `UPDATE`; o resto da função fica igual. A alternativa
+`preenchidas_depois − aplicadas` foi recusada com contraexemplo EXECUTADO: com um id repetido no plano, o
+`UPDATE … FROM` escreve a linha uma vez e a subtração dá 1 onde o certo é 0. Limite aceito e escrito no
+corpo: entre os dois statements há uma janela de microssegundos; fechá-la pediria `FOR UPDATE` nas linhas
+recusadas — lock a mais num writer de money-path pela exatidão de um contador.
+
+**Prova.** `db/test-desconto-backfill-aplicar.sh` (30 asserts, dois locales, agora no `db/nucleo-ci.txt`):
+grupo J com a **linha de base** — o corpo VELHO real devolvendo 3 no mesmo cenário em que o novo devolve 1
+—, o contrafactual da subtração, e o grupo P, que exige que o arquivo do `db:aplicar` instale o md5 do
+corpo da migration. Falsificação por fora, num espelho, com controle verde na mesma invocação: com o corpo
+da PROD a prova fica vermelha em F6, J1, J3, J7 e P1; com o `db/` antigo, só em P1.
+
+**Lições.** (1) **O esperado do teste tinha sido TRANSCRITO DA SAÍDA.** O F6 esperava `ja_apuradas:2`
+num cenário em que nenhuma linha tinha desconto antes da chamada — as 2 eram escritas da própria chamada.
+A prova não deixava de pegar o defeito: ela o CERTIFICAVA. O esperado se deriva da regra ("quantas linhas
+tinham desconto antes?" ⇒ 0), e cenário que diz provar um defeito precisa da linha de base — o corpo velho
+devolvendo o número errado —, senão o verde pode ser só o cenário não exercitar nada. (2) Prova fora do
+núcleo tinha outros dois defeitos que ninguém via: a linha de fechamento (`n ok · m falhas`) nem casaria
+com o extrator do runner, e as sabotagens contavam `PASS` duas vezes. (3) Nada provava que o arquivo que
+vai para a PROD (`db/`) é o que a prova testa (a migration) — agora o grupo P prova. (4) O ledger
+`db_aplicacoes` não é inventário do que roda em prod: a versão anterior da RPC (a do #2448, com o guard de
+concorrência) estava em prod sem recibo — o ledger só tinha a 1ª versão (sha `0b414eb8d1`). Aqui não mudou
+nada, porque a PROD batia byte a byte com o repo antes da troca, mas quem ler o ledger como "o que está
+aplicado" erra.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **544** custom migrations totais
-- **1810** objetos esperados (criados por estas migrations)
+- **546** custom migrations totais
+- **1811** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 581
+  - `function`: 582
   - `rls_policy`: 462
   - `index`: 257
   - `cron_job`: 171
@@ -4490,6 +4490,16 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `view` | `public.v_titulo_baixas` | — |
+
+### `20260909222423_deploy_sonda_alvos_onda5.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260910214850_desconto_backfill_aplicar_ja_apuradas.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.desconto_backfill_aplicar` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 544
+-- Total de custom migrations: 546
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -585,7 +585,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260908220625', 'desconto_backfill_aplicar', '20260908220625_desconto_backfill_aplicar.sql'),
   ('20260908222500', 'snapshot_transporta_desconto_valor', '20260908222500_snapshot_transporta_desconto_valor.sql'),
   ('20260908223555', 'deploy_sonda_alvos_onda4', '20260908223555_deploy_sonda_alvos_onda4.sql'),
-  ('20260909074613', 'v_titulo_baixas_otica_canonica', '20260909074613_v_titulo_baixas_otica_canonica.sql')
+  ('20260909074613', 'v_titulo_baixas_otica_canonica', '20260909074613_v_titulo_baixas_otica_canonica.sql'),
+  ('20260909222423', 'deploy_sonda_alvos_onda5', '20260909222423_deploy_sonda_alvos_onda5.sql'),
+  ('20260910214850', 'desconto_backfill_aplicar_ja_apuradas', '20260910214850_desconto_backfill_aplicar_ja_apuradas.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2384,7 +2386,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('desconto_valor_atravessa_os_escritores', 'function', 'public', 'reconciliar_pedidos_omie', ''),
   ('desconto_backfill_aplicar', 'function', 'public', 'desconto_backfill_aplicar', ''),
   ('snapshot_transporta_desconto_valor', 'function', 'public', 'cockpit_itens_snapshot', ''),
-  ('v_titulo_baixas_otica_canonica', 'view', 'public', 'v_titulo_baixas', '')
+  ('v_titulo_baixas_otica_canonica', 'view', 'public', 'v_titulo_baixas', ''),
+  ('desconto_backfill_aplicar_ja_apuradas', 'function', 'public', 'desconto_backfill_aplicar', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -4231,7 +4234,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('desconto_valor_atravessa_os_escritores', 'function', 'public', 'reconciliar_pedidos_omie', ''),
   ('desconto_backfill_aplicar', 'function', 'public', 'desconto_backfill_aplicar', ''),
   ('snapshot_transporta_desconto_valor', 'function', 'public', 'cockpit_itens_snapshot', ''),
-  ('v_titulo_baixas_otica_canonica', 'view', 'public', 'v_titulo_baixas', '')
+  ('v_titulo_baixas_otica_canonica', 'view', 'public', 'v_titulo_baixas', ''),
+  ('desconto_backfill_aplicar_ja_apuradas', 'function', 'public', 'desconto_backfill_aplicar', '')
 )
 SELECT
   e.migration,
@@ -4259,7 +4263,7 @@ ORDER BY status DESC, e.migration, e.kind, e.object_name;
 -- sem o apply da última. Aqui o md5 do corpo vivo é comparado com o histórico:
 --   ✅ em dia · ❌ NAO APLICADA (corpo é de uma migration anterior) · 🔴 DERIVA
 -- DERIVA (corpo que nenhuma migration declara) NÃO é "falta colar": é edição manual.
--- Funções redefinidas com corpo extraível: 110.
+-- Funções redefinidas com corpo extraível: 111.
 
 WITH corpo_esperado (schema_name, object_name, ordem, migration, body_md5) AS (VALUES
   ('public', 'has_role', 1, '20260207192203_1ed442e5-a224-456e-9d94-cfe50e88c670.sql', 'c63a92e3cfa92e6aab8cb894ad505e30'),
@@ -4674,7 +4678,9 @@ WITH corpo_esperado (schema_name, object_name, ordem, migration, body_md5) AS (V
   ('public', 'corrigir_cancelamento_pos_disparo', 2, '20260906172718_cancelamento_pos_disparo_gate_canonico.sql', '4ca937b4befd086a05b610e4619db24c'),
   ('public', 'corrigir_cancelamento_pos_disparo', 3, '20260907095841_disparado_simulado_e_estado_pos_disparo.sql', '6cee6f8e6d6bc57286597dd6de9150d7'),
   ('public', 'aplicar_edicao_pedido_omie', 1, '20260907210000_pedido_edicao_omie_atomica.sql', '8531ed39f6bf2c7d5725342bc782c8fb'),
-  ('public', 'aplicar_edicao_pedido_omie', 2, '20260908215704_desconto_valor_atravessa_os_escritores.sql', '31c4fce633bf9a7363a45770e4d514c3')
+  ('public', 'aplicar_edicao_pedido_omie', 2, '20260908215704_desconto_valor_atravessa_os_escritores.sql', '31c4fce633bf9a7363a45770e4d514c3'),
+  ('public', 'desconto_backfill_aplicar', 1, '20260908220625_desconto_backfill_aplicar.sql', '59d9c1e4482bf524c5da1eff2700aa08'),
+  ('public', 'desconto_backfill_aplicar', 2, '20260910214850_desconto_backfill_aplicar_ja_apuradas.sql', '09e34b475c6f2b9cfd832b90e62d9b77')
 ),
 ultima AS (
   SELECT schema_name, object_name, max(ordem) AS ordem FROM corpo_esperado GROUP BY 1, 2

--- a/supabase/migrations/20260910214850_desconto_backfill_aplicar_ja_apuradas.sql
+++ b/supabase/migrations/20260910214850_desconto_backfill_aplicar_ja_apuradas.sql
@@ -1,24 +1,19 @@
 -- ============================================================
--- APLICAÇÃO via `bun run db:aplicar` — desconto_backfill_aplicar — a RPC que escreve o plano de apuração
+-- desconto_backfill_aplicar — `ja_apuradas` contada ANTES do UPDATE
 --
--- Mesmo EFEITO da migration de DR mais recente desta função,
--- `20260910214850_desconto_backfill_aplicar_ja_apuradas.sql`, SEM o envelope `BEGIN;`/`COMMIT;`:
--- a transação é do `db:aplicar`, que executa o corpo via `aplicar_sql()` — e lá comandos de
--- transação são proibidos. Os dois caminhos coexistem de propósito (#2434): a migration com
--- envelope é a que se cola no SQL Editor.
+-- Correção da `20260908220625_desconto_backfill_aplicar.sql` (que continua lá: é DR, imutável).
+-- Muda UMA coisa: a contagem de `ja_apuradas` passa para antes do UPDATE. A escrita, a
+-- precondição por linha, o guard de concorrência e o ACL ficam como estavam.
 --
--- Este arquivo é o ESTADO ATUAL da função, não o histórico. A cada correção ele é reescrito; o
--- histórico fica nas migrations (a anterior, `20260908220625_desconto_backfill_aplicar.sql`,
--- contava `ja_apuradas` DEPOIS do UPDATE) e no ledger `db_aplicacoes`, que guarda o sha de cada
--- versão aplicada. A paridade com a migration é PROVADA, não prometida:
--- `db/test-desconto-backfill-aplicar.sh` aplica este arquivo e exige o md5 do corpo da migration.
+-- O DEFEITO (achado em 2026-09-10 na execução do backfill Oben/TTM; conferido no
+-- `pg_get_functiondef` da PROD): a contagem rodava no statement seguinte ao UPDATE e enxergava
+-- as linhas que a própria chamada tinha acabado de aplicar. No cenário misto — 3 linhas no plano,
+-- 1 já preenchida por outro writer, 2 aplicáveis — ela devolvia ja_apuradas=3, e o certo é 1.
+-- A edge `omie-desconto-backfill` não lê `ja_apuradas` (só `aplicadas`/`recusadas`), então nada
+-- foi escrito errado. O dano era de observabilidade: o campo que existe para separar "corrida
+-- perdida" de "base mudou" dizia que toda linha aplicada tinha perdido a corrida.
 --
--- NÃO desenvelopar no cliente: `aplicar_sql()` recalcula o sha256 do corpo recebido e o
--- compara com o declarado. Qualquer transformação na hora do envio quebra a cadeia que
--- prova que o executado é byte a byte o que está no repo. Daí este arquivo ser COMMITADO.
---
--- Idempotente: só `CREATE OR REPLACE` e REVOKE/GRANT. A postcondição confere o ESTADO final
--- (corpo e ACL), não o caminho — reaplicar é seguro e dá o mesmo veredito.
+-- Prova executada e falsificação: db/test-desconto-backfill-aplicar.sh (grupo J).
 -- ============================================================
 
 -- ============================================================
@@ -47,6 +42,7 @@
 -- IDEMPOTENTE: reaplicar o mesmo plano reescreve os mesmos valores. Não há acumulação.
 -- ============================================================
 
+BEGIN;
 
 CREATE OR REPLACE FUNCTION public.desconto_backfill_aplicar(p_linhas jsonb)
 RETURNS jsonb
@@ -190,3 +186,4 @@ BEGIN
 END
 $post$;
 
+COMMIT;


### PR DESCRIPTION
## O defeito

`desconto_backfill_aplicar(p_linhas jsonb)` devolve `{pedidas, aplicadas, recusadas, ja_apuradas}`. O `ja_apuradas` existe para separar, dentro de `recusadas`, "outro writer preencheu antes" (corrida perdida) de "a base mudou". Ele era contado num `SELECT` **depois** do `UPDATE`, e em plpgsql o statement seguinte enxerga o que a própria transação acabou de escrever: a contagem somava as linhas que **esta** chamada aplicou.

Reproduzido em PG17 com o corpo da PROD (md5 do `prosrc` idêntico ao da migration `20260908220625`): 3 linhas no plano, 1 já preenchida por outro writer, 2 aplicáveis →

```
{"pedidas": 3, "aplicadas": 2, "recusadas": 1, "ja_apuradas": 3}   ← hoje (ja_apuradas > recusadas: estado impossível)
{"pedidas": 3, "aplicadas": 2, "recusadas": 1, "ja_apuradas": 1}   ← com a correção
```

A edge `omie-desconto-backfill` só lê `aplicadas`/`recusadas`, então **nenhuma escrita saiu errada**. O dano era de observabilidade. A edge não foi tocada.

## A correção

- A contagem de `ja_apuradas` passa para **antes** do `UPDATE`. A escrita, a precondição por linha, o guard de concorrência e o ACL não mudam.
- **Por que não `preenchidas_depois − aplicadas`:** as duas só coincidem quando cada id aparece uma vez no plano. Com um id repetido, o `UPDATE … FROM` escreve a linha uma vez e a subtração dá **1 onde o certo é 0**. Isso está provado executando (J5, medido no próprio corpo velho, sem reimplementar nada).
- **Limite aceito (e escrito no corpo):** a contagem e o `UPDATE` são dois statements. Um writer que comite nos microssegundos entre eles faz a linha cair em `recusadas` sem entrar em `ja_apuradas`. Fechar essa janela pediria `FOR UPDATE` também nas linhas recusadas: é lock a mais num writer de money-path só para acertar um contador de observabilidade, e não vale a pena.
- `supabase/migrations/20260910214850_desconto_backfill_aplicar_ja_apuradas.sql` é a migration de DR. A anterior fica como está, porque é imutável.
- `db/aplicar-desconto-backfill-rpc.sql` foi reescrito como o **estado atual** da função (sem envelope, para o `db:aplicar`). Ele é gerado a partir da migration, e a paridade entre os dois é **provada** pelo grupo P.

## A prova — `db/test-desconto-backfill-aplicar.sh` (30 asserts, entra no `db/nucleo-ci.txt`)

- **O F6 esperava `ja_apuradas: 2`**, que é o número do corpo defeituoso: o esperado foi transcrito da saída em vez de derivado da regra (nenhuma das 5 linhas tinha desconto antes). Ou seja, a prova **certificava** o bug. Agora espera `0`.
- **Grupo J:** J1 é o cenário misto (→ 1); J3 é o id repetido (→ 0); J4 é a **linha de base**, em que o corpo VELHO real devolve 3 no mesmo cenário, provando que o cenário exercita o defeito; J5 é o contrafactual da subtração; J6/J7 conferem a restauração e servem de controle de md5.
- **Grupo P:** partindo do corpo velho, o arquivo do `db:aplicar` tem de instalar o md5 do corpo da migration. Sem isso a prova certificaria um arquivo que ninguém aplica.
- A prova foi portada para `db/lib/pg-harness.sh` (antes tinha `PGBIN` de Homebrew fixo e rodava só no laptop) e ganhou `HARNESS_LC` para os dois locales. As sabotagens I3/H1/H2/H3 contavam `PASS` duas vezes; corrigido. A linha de fechamento virou `n ok / m fail`, que é o que o extrator do runner casa (a antiga, `n ok · m falhas`, não casava).

Evidência local:

| rodada | resultado |
|---|---|
| `bash db/test-desconto-backfill-aplicar.sh` (C) | exit 0 · 30 ok / 0 fail |
| `HARNESS_LC=pt_BR.UTF-8 …` (servidor responde `ERRO: divisão por zero`) | exit 0 · 30 ok / 0 fail |
| **falsificação por fora, num espelho em tmpdir**, com controle verde na MESMA invocação, nos dois locales | ✅ 6/6 passos |
| · espelho com a migration nova = corpo que a PROD rodava | 🔴 exit 1 — FAIL em F6, J1, J3, J7, P1 (exatamente os previstos) |
| · espelho com o `db/` antigo (versão da main) | 🔴 exit 1 — FAIL só em P1 |

## Banco — ✅ JÁ APLICADO (o merge não toca o banco, e não há nada a colar)

Entrou pelo envelope da sessão (idempotente + transacional + postcondição + pré-voo 🟢):

1. **Pré-voo PROD (psql-ro):** `pg_get_functiondef` bateu byte a byte com o repo (md5 `41546c88…`). O ACL estava fechado (PUBLIC/anon/authenticated = f, service_role = t). Triggers de `order_items`: só um `BEFORE INSERT` e uma constraint trigger `DEFERRED`, e nenhuma delas mexe em `desconto_valor` dentro da função. O predicado da postcondição, rodado contra a PROD antiga, falha em **exatamente um** ponto (a ordem); com esse ponto neutralizado, existência e ACL passam.
2. `bun run db:aplicar … --ensaio`: a postcondição rodou na PROD e fez ROLLBACK.
3. `bun run db:aplicar db/aplicar-desconto-backfill-rpc.sql` → **recibo #58**, sha `ab616bea7c15`, commit `3b7d38968`, 2026-09-11 01:13:37 UTC.
4. **2ª testemunha (psql-ro, depois do commit):** o md5 do corpo em prod é igual ao da migration (`c0aa1595…`, o mesmo que o PG17 provou), a contagem vem antes do UPDATE, `SECURITY DEFINER` e `search_path` estão preservados, e o `proacl` não mudou.

Para reconferir quando quiser (read-only):

```sql
SELECT CASE WHEN md5(prosrc) = 'c0aa159558d48b2aac391e0e8c9517c0'
            THEN '✅ desconto_backfill_aplicar conta ja_apuradas ANTES do UPDATE'
            ELSE '❌ corpo diferente do da migration 20260910214850' END AS status
  FROM pg_proc WHERE oid = to_regprocedure('public.desconto_backfill_aplicar(jsonb)');
```

Gates rodados localmente: `authz:check` ✅ · `authz:carimbo` ✅ (contrato intocado; a âncora `fechadaPor` vigia da `20260908220625` em diante, inclusive) · shellcheck 0.11.0 ✅ · `wt:preflight --full` 🟡 (só evolução serial da antecessora commitada) · `audit:migrations` regenerado.

## Coordenação

- **#2467** (edge `omie-desconto-backfill`): usa só contadores próprios, não lê o `ja_apuradas` da RPC. Sem sobreposição de arquivo.
- **#2469 e #2472** (drafts) editam o `db/nucleo-ci.txt`. A entrada nova foi posta no Eixo 4, longe dos trechos deles, e o merge de 3 vias simulado sai **limpo** com cada um e com os dois encadeados. A prova não contém `--falsificar`, então vale no formato de 2 campos, com ou sem o #2472.
- O backfill em execução (branch `desconto-backfill-oben-execucao`): os SQLs dele não leem `ja_apuradas` nem chamam a RPC direto. Trocar a função no meio não mexe na contabilidade deles.

## Fora do escopo — registrado, não mexido

- A edge soma `recusadas` em `escrita_recusada_base_mudou`, mas `recusadas` também inclui as linhas já apuradas. Hoje ela não usa o `ja_apuradas` para separar os dois fatos.
- A RPC não recusa id repetido no plano: com valores diferentes, o `UPDATE … FROM` grava um deles, e qual é imprevisível. A edge monta o plano com unicidade, então o risco é teórico. Mudar isso é mudança de escrita no money-path e pede decisão própria.

## Atualização — retomada em 2026-09-14

- **CI no head `84f44641a`: `validate` SUCCESS** (typecheck, testes, edges-e-build, gates-e-falsificacao, provas-sql — este último já rodando a prova nova no Ubuntu). O vermelho do `gates-e-falsificacao` no head anterior era SC1091 no `source` do `pg-harness.sh`: faltava a diretiva que as outras 18 provas portadas trazem. Corrigido em `84f44641a`.
- **O `mutation-check` vermelho não vem deste PR:** quem falha é o contrato `scripts/mutcheck.d/sonda-versao-bump-gate.mut`, cujo baseline já está vermelho sem mutação nenhuma. Ele fica fora do `validate` (na main aparece como `skipped`).
- **PROD re-medida em 2026-09-14 13:50 UTC** (psql-ro): o corpo é `c0aa1595…` (o da correção), `ja_apuradas` é contado antes do UPDATE, e o ACL segue `PUBLIC/anon/authenticated = f` · `service_role = t`.
- **O #2467 mergeou e reestruturou a edge.** Conferido no código da main: a edge continua lendo só `aplicadas`/`recusadas` do retorno da RPC, e todo `ja_apuradas*` dela é contador próprio.
- **Manifesto:** #2469 e #2472 seguem em draft, com heads inalterados desde 10/09. O merge de 3 vias do `db/nucleo-ci.txt` foi re-simulado e sai sem conflito.

## Pendência com destino — chip aberto no /fecho

O chip **"Separar corrida perdida de base mudou na edge do backfill"** foi aberto nesta sessão. Chip vale só enquanto a sessão existe e some se ela for arquivada antes do clique, por isso o prompt completo fica guardado aqui. Para retomar, basta colar numa sessão nova.

<details><summary>Prompt auto-contido do chip</summary>

Responda em português brasileiro.

## Contexto
A RPC `public.desconto_backfill_aplicar(p_linhas jsonb)` devolve `{pedidas, aplicadas, recusadas, ja_apuradas}`.

- `recusadas = pedidas − aplicadas` mistura dois fatos:
  - (a) a base da linha mudou desde a leitura que montou o plano (trio SKU/quantidade/preço diferente);
  - (b) a linha JÁ tinha desconto gravado por outro writer, ou por um run anterior (corrida perdida).
- Desde o PR #2475, `ja_apuradas` conta corretamente o fato (b): as linhas do plano que já tinham `desconto_valor` quando a chamada começou.
  - Migration `supabase/migrations/20260910214850_desconto_backfill_aplicar_ja_apuradas.sql`.
  - Aplicada em prod em 2026-09-11 via `bun run db:aplicar db/aplicar-desconto-backfill-rpc.sql`, recibo #58 no ledger `db_aplicacoes`.
  - Antes, `ja_apuradas` contava junto as linhas que a própria chamada tinha escrito.
- Prova da RPC: `db/test-desconto-backfill-aplicar.sh`, que está no núcleo de CI `db/nucleo-ci.txt`.

## O defeito a corrigir
A edge `supabase/functions/omie-desconto-backfill/index.ts` lê do retorno da RPC só `aplicadas` e `recusadas`:
- no lote, por volta da linha 244: `db.rpc("desconto_backfill_aplicar", { p_linhas: linhas })`;
- no fallback linha a linha, por volta da linha 254.

Nos dois caminhos ela soma TODO `recusadas` em `contagem.escrita_recusada_base_mudou`. Quando há corrida perdida, esse rótulo mente: "base mudou" e "corrida perdida" pedem consertos opostos. Atenção: os contadores `ja_apuradas_puladas` / `ja_apuradas_conferem` / `ja_apuradas_divergem` que já existem na edge são contagens PRÓPRIAS dela, sobre a leitura que monta o plano. Não são o campo da RPC.

## Tarefa
1. Fazer a edge ler `ja_apuradas` do retorno da RPC nos DOIS caminhos (lote e fallback) e separar em dois contadores:
   - base mudou = `recusadas − ja_apuradas`;
   - já apurada na escrita = `ja_apuradas`.
2. Money-path: ausente ≠ zero. Se `ja_apuradas` vier ausente ou não numérico (RPC antiga, resposta inesperada), NÃO fabrique 0 com `Number(undefined ?? 0)`. Degrade explicitamente: um contador de "não classificado", ou null com um sinal visível. Não jogue tudo em "base mudou" em silêncio.
3. Não altere a RPC nem a migration.

## Regras do repo (leia o CLAUDE.md)
- Antes de tocar a edge, confira `gh pr list` e `git log origin/main -- supabase/functions/omie-desconto-backfill supabase/functions/_shared/desconto-backfill.ts`. O #2467 mexeu nela recentemente, e pode haver PR em voo.
- Edge tem 5 gates no CI:
  - `bun run test:edges` (Deno);
  - `bun run edges:typecheck`;
  - vitest;
  - `bun run sonda:bump` (bump de `VERSAO` em `versao.ts` da edge);
  - `bun run sonda:fingerprint -- --write`.
- Há contrato de mutação em `scripts/mutcheck.d/desconto-backfill.mut`.
- Deploy da edge é manual (Lovable). Quem decide se precisa é `bun run pendencias:deploy`, e o merge não publica nada.
- PR não-draft auto-mergeia com o CI verde. Arme `scripts/pr-watch.sh <nº>` em background.

## Observação para avaliar, mas decidir à parte
A RPC não recusa id repetido no plano. Com valores diferentes, o `UPDATE … FROM` grava um deles, e qual é imprevisível. A edge monta o plano com unicidade, então o risco é teórico. Mudar isso é mudança de escrita no money-path: só registre se achar pertinente, não implemente nesta tarefa.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


